### PR TITLE
Update ETC_en.tsv

### DIFF
--- a/ETC_en.tsv
+++ b/ETC_en.tsv
@@ -985,17 +985,17 @@ ETC_20150312_002483
 ETC_20150312_002484	
 ETC_20150312_002485	
 ETC_20150312_002486	Can be activated through the items.
-ETC_20150312_002487	
-ETC_20150312_002488	
-ETC_20150312_002489	
-ETC_20150312_002490	
+ETC_20150312_002487	Items can be acquired in various ways and if used
+ETC_20150312_002488	added to.
+ETC_20150312_002489	Registered
+ETC_20150312_002490	can be confirmed by using {img F8 40 40} key.
 ETC_20150312_002491	
 ETC_20150312_002492	
-ETC_20150312_002493	
+ETC_20150312_002493	Collection effect
 ETC_20150312_002494	
-ETC_20150312_002495	
-ETC_20150312_002496	
-ETC_20150312_002497	
-ETC_20150312_002498	
-ETC_20150312_002499	
-ETC_20150312_002500	
+ETC_20150312_002495	When the correct item for the Collection is in your inventory, drag the item to the applicable empty slot to mount.
+ETC_20150312_002496	Completed collection below
+ETC_20150312_002497	bestow to character.
+ETC_20150312_002498	Only in completed Collections
+ETC_20150312_002499	can be obtained.
+ETC_20150312_002500	Slotted items can be removed by clicking with the mouse {img mouseclick_right 40 40}


### PR DESCRIPTION
Most of the original Korean is incomplete. So, the English is fragmented and missing key words. I assume the coding slots in interchangeable words in those places?
