### PR TITLE
Typographically correct quotation marks. Grammar edit 1 – 364.

### DIFF
--- a/QUEST_LV_0100_en.tsv
+++ b/QUEST_LV_0100_en.tsv
@@ -1,13 +1,13 @@
-﻿QUEST_LV_0100_20150317_000001	Sentinel
-QUEST_LV_0100_20150317_000002	You better go straight to the Shadow Forest Road if you want to go to Klaipeda. {nl} It is dangerous in the deep woods so try to stay away if you can. 
+QUEST_LV_0100_20150317_000001	Sentinel
+QUEST_LV_0100_20150317_000002	You better go straight to Shadow Forest Road if you want to go to Klaipeda. {nl} It’s dangerous in the deep woods. Stay away if you can.
 QUEST_LV_0100_20150317_000003	Man in hiding
-QUEST_LV_0100_20150317_000004	Fi... Finally! Have the rescue arrived? {nl} What! It's just a kid? Hey, are Vubbes still outside?
-QUEST_LV_0100_20150317_000005	Ughh ... Go away! Do not talk to me! We're going to get caught by the Vubbes! {nl} This is my place so get out of here!
-QUEST_LV_0100_20150317_000006	What? Do not lie to me! Vubbe's odor is stinging my nose. What!! {nl} Hey, you don't fool adults! Go away! Do not come around near this barrel!
-QUEST_LV_0100_20150317_000007	Fi... Finally! Have the rescue arrived? {nl} What! It's just a kid? What are you looking at? Close the lid and just go on your way! {nl}
-QUEST_LV_0100_20150317_000008	But the paper you're holding.. It looks familiar? {nl} Let me see that! What are you doing? There's an adult speaking to you!
-QUEST_LV_0100_20150317_000009	This!! It's mine?! I will never give it again!! {nl} It's not something you need, I'm gonna rip it apart!
-QUEST_LV_0100_20150317_000010	Sheesh, that's lame..
+QUEST_LV_0100_20150317_000004	Fi… Finally! Have the rescue team arrived? {nl} What! It’s just a kid? Hey, is Vubbes still outside?
+QUEST_LV_0100_20150317_000005	Ughh... Go away! Don’t talk to me! We’re going to get caught by the Vubbes! {nl} This is my place so get out of here!
+QUEST_LV_0100_20150317_000006	What? Don’t lie to me! Vubbe’s odor is stinging my nose. What!! {nl} Hey, you ca’Æt fool adults! Go away! Do not come near this barrel!
+QUEST_LV_0100_20150317_000007	Fi... Finally! Have the rescue team arrived? {nl} What! It’s just a kid? What are you looking at? Close the lid and just go on your way! {nl}
+QUEST_LV_0100_20150317_000008	But the paper you’re holding.. It looks familiar? {nl} Let me see that! What are you doing? There’s an adult speaking to you!
+QUEST_LV_0100_20150317_000009	This!! It’s mine?! I will never give it again!! {nl} It’s not something you need. I’m gonna rip it apart!
+QUEST_LV_0100_20150317_000010	Sheesh, that’s lame..
 QUEST_LV_0100_20150317_000011	
 QUEST_LV_0100_20150317_000012	Soldier Blag
 QUEST_LV_0100_20150317_000013	
@@ -18,7 +18,7 @@ QUEST_LV_0100_20150317_000017
 QUEST_LV_0100_20150317_000018	
 QUEST_LV_0100_20150317_000019	
 QUEST_LV_0100_20150317_000020	Officer Luders
-QUEST_LV_0100_20150317_000021	Ah, you must be the rumored revelator. Nice to meet you.{nl}Is this Blag's report?{nl}
+QUEST_LV_0100_20150317_000021	Ah, you must be the rumored revelator. Nice to meet you.{nl}Is this Blag’s report?{nl}
 QUEST_LV_0100_20150317_000022	
 QUEST_LV_0100_20150317_000023	
 QUEST_LV_0100_20150317_000024	
@@ -196,13 +196,13 @@ QUEST_LV_0100_20150317_000195
 QUEST_LV_0100_20150317_000196	
 QUEST_LV_0100_20150317_000197	
 QUEST_LV_0100_20150317_000198	Vaidotas
-QUEST_LV_0100_20150317_000199	The smell.. I think the purifying device in the mine is broken. {nl}We better repair it quickly. The people taken away might suffocate. 
-QUEST_LV_0100_20150317_000200	Do you know the legend Cunningham? {nl} It's a legend about the great demon sealed here in the Crystal Mine. {nl} For more details, there is a book about it in the miners lounge of 2nd Gallery so try reading it. {nl}
-QUEST_LV_0100_20150317_000201	Anyway, my guess is that the demon has re-awakening and controlling the Vubbes. {nl} The dream the bishop had and the legends of Cunningham ... l feel maybe it's a sign of something huge that's about to happen. {nl}
-QUEST_LV_0100_20150317_000202	Only the Goddess would know if it's hope or despair. {nl}
-QUEST_LV_0100_20150317_000203	The purifier be fixed easily by anyone but it may be hard to find the parts. {nl} In that case, use the compass that I gave you. {nl}
-QUEST_LV_0100_20150317_000204	Well then, I have some other things to do so I will meet you in the 3rd Gallery. {nl} I wish for your fortune of war in the name of the Goddess .
-QUEST_LV_0100_20150317_000205	If you can't repair the purifier, use the compass I gave you. {nl}You'll be able to find a way.
+QUEST_LV_0100_20150317_000199	The smell.. I think the purifying device in the mine is broken. {nl}We’d better repair it quickly. The captives will suffocate.
+QUEST_LV_0100_20150317_000200	Do you know the legend Cunningham? {nl} It’s a legend about the great demon sealed here in the Crystal Mine. {nl} To find out more, try reading the book on the second floor of the miners lounge. {nl}
+QUEST_LV_0100_20150317_000201	Anyway, my guess is that the demon has re-awakened and is controlling the Vubbes. {nl} The dream the bishop had and the legends of Cunningham ... l feel maybe it’s a sign that something huge is about to happen. {nl}
+QUEST_LV_0100_20150317_000202	Only the Goddess would know if it’s hope or despair. {nl}
+QUEST_LV_0100_20150317_000203	The purifier can be fixed easily by anyone but it may be hard to find the parts. {nl} In that case, use the compass I gave you. {nl}
+QUEST_LV_0100_20150317_000204	Well then, I have some other things to do so I will meet you on the third floor. {nl} I wish you fortune in war, in the name of the Goddess .
+QUEST_LV_0100_20150317_000205	If you have trouble repairing the purifier, try using the compass I gave you. {nl}You’d be able to find a way.
 QUEST_LV_0100_20150317_000206	Village Aunt
 QUEST_LV_0100_20150317_000207	Did you come to save us ? Did you?
 QUEST_LV_0100_20150317_000208	
@@ -210,8 +210,8 @@ QUEST_LV_0100_20150317_000209	Village Girl
 QUEST_LV_0100_20150317_000210	
 QUEST_LV_0100_20150317_000211	
 QUEST_LV_0100_20150317_000212	Mr. Juan
-QUEST_LV_0100_20150317_000213	I feel mad whenever I see those Vubbes that ruined my hometown. {Nl} That's why I want to help people like you who fight againt the Vubbes.
-QUEST_LV_0100_20150317_000214	I would have left already if this wasn't my hometown. {nl} Where on earth have all the Vubbes been hiding before they crawled out.
+QUEST_LV_0100_20150317_000213	I feel mad whenever I see those Vubbes that ruined my hometown. {Nl} That’s why I want to help those like you who fight againt the Vubbes.
+QUEST_LV_0100_20150317_000214	I would have left already if this wasn’t my hometown. {nl} Where on earth have all the Vubbes been hiding before they crawled out.
 QUEST_LV_0100_20150317_000215	Pharmacist lady
 QUEST_LV_0100_20150317_000216	
 QUEST_LV_0100_20150317_000217	
@@ -222,19 +222,19 @@ QUEST_LV_0100_20150317_000221	Soldier Edgar
 QUEST_LV_0100_20150317_000222	
 QUEST_LV_0100_20150317_000223	
 QUEST_LV_0100_20150317_000224	Knight Commander Uska
-QUEST_LV_0100_20150317_000225	Is this slate the evidence of salvation? {nl} It just looks like an old slate to me.
+QUEST_LV_0100_20150317_000225	Is this tablet the evidence of salvation? {nl} It just looks like an old tablet to me.
 QUEST_LV_0100_20150317_000226	1
-QUEST_LV_0100_20150317_000227	You better ask Master Bokor about this slate. {Nl} She lives at the end of Klaipeda Residential Area so go pay her a visit.
-QUEST_LV_0100_20150317_000228	Use your time wisely. {nl} No one can know everything about one's own future.
+QUEST_LV_0100_20150317_000227	You better ask Master Bokor about this tablet. {Nl} She lives at the end of the Klaipeda Residential Area so go pay her a visit.
+QUEST_LV_0100_20150317_000228	Use your time wisely. {nl} No one can know everything about one’s own future.
 QUEST_LV_0100_20150317_000229	
-QUEST_LV_0100_20150317_000230	I'm also curious about the girl who cracked the seal. {nl} This is not a seal that can easily be unsealed. 
+QUEST_LV_0100_20150317_000230	I’m also curious about the girl who cracked the seal. {nl} This is not a seal that can easily be undone.
 QUEST_LV_0100_20150317_000231	
 QUEST_LV_0100_20150317_000232	2
-QUEST_LV_0100_20150317_000233	Miner's Village Mayor
-QUEST_LV_0100_20150317_000234	Welcome. Aren't you our town's savior. {nl}
+QUEST_LV_0100_20150317_000233	Miner’s Village Mayor
+QUEST_LV_0100_20150317_000234	Welcome. The savior of our town. {nl}
 QUEST_LV_0100_20150317_000235	3
 QUEST_LV_0100_20150317_000236	So this revelation is Goddess Laima and we have to collect all these for the Goddess to regain her powers? {nl} That is amazing.
-QUEST_LV_0100_20150317_000237	Oh, please do not reveal the fact that the Revelator has been found unless absolutely necessary. {nl} It may only create confusion if the rumors spread. 
+QUEST_LV_0100_20150317_000237	Oh, please do not reveal the fact that the Revelator has been found unless absolutely necessary. {nl} It may only create confusion if the rumors spread.
 QUEST_LV_0100_20150317_000238	
 QUEST_LV_0100_20150317_000239	
 QUEST_LV_0100_20150317_000240	
@@ -243,7 +243,7 @@ QUEST_LV_0100_20150317_000242
 QUEST_LV_0100_20150317_000243	
 QUEST_LV_0100_20150317_000244	
 QUEST_LV_0100_20150317_000245	
-QUEST_LV_0100_20150317_000246	I have not heard of anything else about the bishop's dream. {nl} Sorry, I can't be much of help.
+QUEST_LV_0100_20150317_000246	I have not heard of anything else about the bishop’s dream. {nl} Sorry, I can’t be of much help.
 QUEST_LV_0100_20150317_000247	Klaipeda Guard Captain
 QUEST_LV_0100_20150317_000248	Go ahead to Klaipeda. {nl} Commander Uska is waiting for you in Klaipeda Central Plaza. {nl} I heard the bishop also had a dream about the Goddess...  And I think it has to do with it.
 QUEST_LV_0100_20150317_000249	Klaipeda Guard
@@ -259,164 +259,164 @@ QUEST_LV_0100_20150317_000258
 QUEST_LV_0100_20150317_000259	
 QUEST_LV_0100_20150317_000260	Supply Officer
 QUEST_LV_0100_20150317_000261	Thank you for your help. {nl} I think this is enough. {nl}
-QUEST_LV_0100_20150317_000262	)} {nl} If you have time, please tell our troops to assemble.{nl} If you don't want to, you may just go ahead to Klaipeda. 
+QUEST_LV_0100_20150317_000262	)} {nl} If you have time, please tell our troops to assemble.{nl} If you don’t want to, you may just go ahead to Klaipeda.
 QUEST_LV_0100_20150317_000263	Scout
-QUEST_LV_0100_20150317_000264	Go back, it's dangerous. {nl} Kepas will soon be marching in. 
-QUEST_LV_0100_20150317_000265	Oh, you're the Revelator. {nl} Since it's some fate that we fought together, let me give you a scoop of good information. 
-QUEST_LV_0100_20150317_000266	Oh, you mentioned that we need to assemble right? {nl}Help me find the missing luggage and I'll go as soon as I can.
-QUEST_LV_0100_20150317_000267	Isn't the luggage ready yet? {nl} I can't go back without it.
+QUEST_LV_0100_20150317_000264	Go back, itÆs dangerous. {nl} Kepas will soon be marching in.
+QUEST_LV_0100_20150317_000265	Oh, you’re the Revelator. {nl} Since it’s some fate that we fought together, I’ll let you in on some scoop.
+QUEST_LV_0100_20150317_000266	Oh, you mentioned that we need to assemble right? {nl}Help me find the missing luggage and I’ll go as soon as I can.
+QUEST_LV_0100_20150317_000267	Isn’t the luggage ready yet? {nl} I can’t go back without it.
 QUEST_LV_0100_20150317_000268	Thank you. You found it sooner than I expected. {nl}
-QUEST_LV_0100_20150317_000269	If you follow the road to the north, you will find the search scout. {nl} Well then, good luck. 
+QUEST_LV_0100_20150317_000269	If you follow the road to the north, you will find the search scout. {nl} Well then, good luck.
 QUEST_LV_0100_20150317_000270	Raimonas
-QUEST_LV_0100_20150317_000271	Have you ever offered worship to the Statue? {nl} If not, I'd really recommend you to.
-QUEST_LV_0100_20150317_000272	That depends on which Goddess it is. {nl} Go straight along way on the right.{nl} That's where Statue of Goddess Zemyna is so feel her blessings yourself. 
-QUEST_LV_0100_20150317_000273	I do worry that the monsters might harm the Statue of the Goddess. 
+QUEST_LV_0100_20150317_000271	Have you ever offered worship to the Statue? {nl} If not, I’d really recommend you to.
+QUEST_LV_0100_20150317_000272	That depends on which Goddess it is. {nl} Go straight along way on the right.{nl} That’s where the Statue of Goddess Zemyna is so feel her blessings yourself.
+QUEST_LV_0100_20150317_000273	I do worry that monsters might harm the Statue of the Goddess.
 QUEST_LV_0100_20150317_000274	Good thing to hear that the Statue is fine. {nl} The monsters should know that they should be afraid of the Goddess. {nl}
 QUEST_LV_0100_20150317_000275	Go down the Shadow Forest Road and you should arrive at Klaipeda shortly. {nl} Well then, may be blessings of Goddess be with you
-QUEST_LV_0100_20150317_000276	Plese do me a favor if you are headed to Klaipeda. {nl} It's not easy to go back and forth Kalipeda because of the Infro Rocktors nowadays. 
-QUEST_LV_0100_20150317_000277	Maybe taking care of the Statues will make the Goddesses return sooner... 
-QUEST_LV_0100_20150317_000278	Follow the road on the left of the camp crossroads. {nl}{-scp SCR_DIALOG_NPC_ANIM( 
-QUEST_LV_0100_20150317_000279	)}You'll meet the troops right away.
-QUEST_LV_0100_20150317_000280	)}Alright, good job.{nl}You'll arrive at Klaipeda shortly when you follow the Shadow Forest Road.{nl}Don't forget to drop by Sir Uska.
+QUEST_LV_0100_20150317_000276	Plese do me a favor if you are headed to Klaipeda. {nl} It’s not easy to go back and forth Kalipeda because of the Infro Rocktors nowadays.
+QUEST_LV_0100_20150317_000277	Maybe taking care of the Statues will make the Goddesses return sooner...
+QUEST_LV_0100_20150317_000278	Follow the road on the left of the camp crossroads. {nl}{-scp SCR_DIALOG_NPC_ANIM(
+QUEST_LV_0100_20150317_000279	)}You’ll meet the troops right away.
+QUEST_LV_0100_20150317_000280	)}Alright, good job.{nl}You’ll arrive at Klaipeda shortly when you follow the Shadow Forest Road.{nl}Don’t forget to drop by Sir Uska.
 QUEST_LV_0100_20150317_000281	Battle Commander
 QUEST_LV_0100_20150317_000282	I will have my men notify the troops to assemble. {nl} You may return to sir Titas and let him know.
-QUEST_LV_0100_20150317_000283	It's nothing difficult. {nl} If you don't want, I'll let you go to Kalipeda right away.
+QUEST_LV_0100_20150317_000283	It’s nothing difficult. {nl} If you don’t want, I’ll let you go to Kalipeda right away.
 QUEST_LV_0100_20150317_000284	Search Scout
-QUEST_LV_0100_20150317_000285	It sure is a problem. {nl} I didn't know Kepas could grow that big.
-QUEST_LV_0100_20150317_000286	Shouldn't Revelators go to Klaipeda instead of here?
-QUEST_LV_0100_20150317_000287	I feel so relieved to be positioned in the Western Woods. {nl} There are some places where you'd rather die than be positioned there. 
-QUEST_LV_0100_20150317_000288	When you see a Statue of Goddess, try offering a worship. {nl} Surely, something nice will happen. 
+QUEST_LV_0100_20150317_000285	It sure is a problem. {nl} I didn’t know Kepas could grow that big.
+QUEST_LV_0100_20150317_000286	Shouldn’t Revelators go to Klaipeda instead of here?
+QUEST_LV_0100_20150317_000287	I feel so relieved to be positioned in the Western Woods. {nl} There are some places where you’d rather die than be positioned there.
+QUEST_LV_0100_20150317_000288	When you see a Statue of Goddess, try offering a worship. {nl} Surely, something good will happen.
 QUEST_LV_0100_20150317_000289	This is a dangerous area. What are you doing here?
 QUEST_LV_0100_20150317_000290	Thank you for your help. {nl} The Large Kepa appearing here.. Must report to Titas about it.
-QUEST_LV_0100_20150317_000291	Weird.. That is not a type of monster you'd face in a place like this. {nl} It must be hard to just walk around
-QUEST_LV_0100_20150317_000292	Assemble already? {nl} That's tough. There's still a pile of missions.
-QUEST_LV_0100_20150317_000293	Please kill the Hanamings roaming around. {nl} And collect the flowers of Hanaming while you're at it.
+QUEST_LV_0100_20150317_000291	Weird.. That is not a type of monster you’d face in a place like this. {nl} It must be hard to just walk around
+QUEST_LV_0100_20150317_000292	Assemble already? {nl} That’s tough. There’s still a pile of missions.
+QUEST_LV_0100_20150317_000293	Please kill the Hanamings roaming around. {nl} And collect the flowers of Hanaming while you’re at it.
 QUEST_LV_0100_20150317_000294	Even if the Goddess arrived, I will not go until the mission is completed.
 QUEST_LV_0100_20150317_000295	Yes. This should be enough. {nl} This is a pill that will restore your stamina instantly... I have enough of it so I will give you this as a gift. {nl}
-QUEST_LV_0100_20150317_000296	Stamina is consumed when you move. {nl}You can recover stamina by destroying Tree Root Crystal or when you are in rest mode. {nl} But you don't have time for that when you are chased by monsters isn't it? {nl} And that's when this pill comes in handy.
+QUEST_LV_0100_20150317_000296	Stamina is consumed as you move. {nl}You can recover stamina by destroying Tree Root Crystal or when you are in rest mode. {nl} But you don’t have time for that when you are chased by monsters isn’t it? {nl} And that’s when this pill comes in handy.
 QUEST_LV_0100_20150317_000297	I heard the news from my men and was starting to become worried. {nl} All is well if it ended up good.
 QUEST_LV_0100_20150317_000298	Klaipeda Resident
 QUEST_LV_0100_20150317_000299	)} {nl} When do you think the Goddess is coming back? {nl} Even if I ask the Revelators, all they say is that they must go to Klaipeda..
-QUEST_LV_0100_20150317_000300	Are you the Revelator? {nl} You said the Goddess appeared in your dream. {nl}It's what the soldiers were saying.
+QUEST_LV_0100_20150317_000300	Are you the Revelator? {nl} You said the Goddess appeared in your dream. {nl}It’s what the soldiers were saying.
 QUEST_LV_0100_20150317_000301	Trooper
-QUEST_LV_0100_20150317_000302	I wonder where and what the Goddess is doing...
-QUEST_LV_0100_20150317_000303	Thank you for making your way until here. {nl}I am Uska, the Knight-Commander in charge of Siaulai and Klaipeda.
-QUEST_LV_0100_20150317_000304	The bishop also dreamed of revelation. {nl} He said send the revelator to the Crystal Mine. {nl}
-QUEST_LV_0100_20150317_000305	Let me know when you are ready to go to the Crystal Mine. {nl} I'll tell you the location and how to get into the Crystal Mine.
-QUEST_LV_0100_20150317_000306	The Bishope told us to send the Revelator to Crystal Mine. {nl} He said the Goddess told him to do so. {nl}
-QUEST_LV_0100_20150317_000307	But the Miner's Village is at war with the Vubbes {nl}and entrance is limited to authorized people only. {nl} Aras is the one in charge of Eastern Woods so try talking to him
+QUEST_LV_0100_20150317_000302	What are you doing and where is the goddess..
+QUEST_LV_0100_20150317_000303	Thank you for making your way here. {nl}I am Uska, the Knight-Commander in charge of Siaulai and Klaipeda.
+QUEST_LV_0100_20150317_000304	The Bishop also dreamt of revelation. {nl} He said send the revelator to the Crystal Mine. {nl}
+QUEST_LV_0100_20150317_000305	Let me know when you are ready to go to the Crystal Mine. {nl} I’ll tell you the location and how to get into the Crystal Mine.
+QUEST_LV_0100_20150317_000306	The Bishop told us to send the Revelator to Crystal Mine. {nl} He said the Goddess told him to do so. {nl}
+QUEST_LV_0100_20150317_000307	But the Miner’s Village is at war with the Vubbes {nl}and entrance is limited to authorized personnel only. {nl} Aras is the one in charge of Eastern Woods so try talking to him
 QUEST_LV_0100_20150317_000308	Monsters have been around for long but they started becoming violent four years ago. {nl} The one that was affected the most would be plant types.{nl} They did not exist before. {nl}
 QUEST_LV_0100_20150317_000309	Of course, beasts were no exception. {nl} When the monster that seemed like a fusion of the demon appeared, I thought it was all over.
 QUEST_LV_0100_20150317_000310	Knight Aras
-QUEST_LV_0100_20150317_000311	Aren't you hurt? {nl} Thank you for getting rid of the Poatas but you're so reckless.
-QUEST_LV_0100_20150317_000312	You want to get into the Crystal Mine? {nl} The Miner's Village is currently at war with the Vubbes and it's very dangerous {nl}so I cannot permit that. 
-QUEST_LV_0100_20150317_000313	And our troops are in no condition to guard you. {nl} I'm sorry but you have to go back.
-QUEST_LV_0100_20150317_000314	If you can't get rid of the Pokubus, you'll have to give up going into the Miner's Village.
-QUEST_LV_0100_20150317_000315	Thank you. {nl} Do not worry, I'll keep my promise.
+QUEST_LV_0100_20150317_000311	Aren’t you hurt? {nl} Thank you for getting rid of the Poatas but you’re so reckless.
+QUEST_LV_0100_20150317_000312	You want to get into the Crystal Mine? {nl} The Miner’s Village is currently at war with the Vubbes and it’s very dangerous {nl}so I cannot permit that.
+QUEST_LV_0100_20150317_000313	And our troops are in no condition to guard you. {nl} I’m sorry but you have to go back.
+QUEST_LV_0100_20150317_000314	If you can’t get rid of the Pokubus, you’ll have to give up going into the Miner’s Village.
+QUEST_LV_0100_20150317_000315	Thank you. {nl} Do not worry, I’ll keep my promise.
 QUEST_LV_0100_20150317_000316	Outpost Sentinel
-QUEST_LV_0100_20150317_000317	The Village is a problem but we also haven't had a rest because of the continuous battle.{nl}It will be much better if you can get rid of those Chupacabras.
-QUEST_LV_0100_20150317_000318	Other monsters also show up when there are Chupacabras. {nl} Miner's Village is a problem on its own but there are just too many things to pay attention to.
-QUEST_LV_0100_20150317_000319	Thank you. {nl} It really helps lifting our spirits. 
-QUEST_LV_0100_20150317_000320	With your abilities, I have one more favor to ask. {nl} Can you help us drive out the Chupacabras in the supplies camp too? 
-QUEST_LV_0100_20150317_000321	The Miners' Village is a problem but out situation here is not so good either. {nl}We have to prepare some measures before the number of  monsters increase even more..
+QUEST_LV_0100_20150317_000317	The Village is a problem but we also haven’t had a rest because of the continuous battle.{nl}It will be much better if you can get rid of those Chupacabras.
+QUEST_LV_0100_20150317_000318	Other monsters also show up when there are Chupacabras. {nl} Miner’s Village is a problem on its own but there are just too many things to attend to.
+QUEST_LV_0100_20150317_000319	Thank you. {nl} It really helps lift our spirits.
+QUEST_LV_0100_20150317_000320	With your abilities, I have one more favor to ask. {nl} Can you help us drive out the Chupacabras in the supplies camp too?
+QUEST_LV_0100_20150317_000321	The Miners’ Village is a problem but our situation here is not so good either. {nl}We have to prepare some measures before the number of monsters grows even more..
 QUEST_LV_0100_20150317_000322	Are you done already? {nl} No one has completed as fast before.
-QUEST_LV_0100_20150317_000323	I'm in the mission to find out why the monsters in the East woords suddenly increased. {nl}Also, I act as the intermediate in supplying the Miner's Village. {nl}
-QUEST_LV_0100_20150317_000324	Other knight is out in the Miner's Village but.. {nl} To be honest, It would have ended sooner if it was Sir Aras but the battle is taking longer than expected.
-QUEST_LV_0100_20150317_000325	Since you're going to help, please get rid of the Giant Gray Chupacabras too. {nl}They are the culprits stealing our supplies.
+QUEST_LV_0100_20150317_000323	I’m in the mission to find out why the monsters in the East woords had suddenly increased. {nl}Also, I act as the intermediate in supplying the Miner’s Village. {nl}
+QUEST_LV_0100_20150317_000324	Other knight is out in the Miner’s Village but.. {nl} To be honest, It would have ended sooner if it was Sir Aras but the battle is taking longer than expected.
+QUEST_LV_0100_20150317_000325	Since you’re going to help, please get rid of the Giant Gray Chupacabras too. {nl}They are the culprits stealing our supplies.
 QUEST_LV_0100_20150317_000326	Giant Gray Chupacabras appear when you kill normal chupacabras. {nl} Well then, thanks for your help.
 QUEST_LV_0100_20150317_000327	Thank you. {nl} Now we can finally get to work easily.
-QUEST_LV_0100_20150317_000328	Finding the cause of the monsters is important, {nl} but I'm more worried supplies not making it to the Miners' Village. 
-QUEST_LV_0100_20150317_000329	The movement of weavers in the lower area of the stream seems suspicious . {nl} Just like they're trying to interfere with supplying the Miners' Village.
-QUEST_LV_0100_20150317_000330	It's not a usual situation. {nl} But we might have to give up our current supplies and support ourselves until the next batch of supplies arrive. 
-QUEST_LV_0100_20150317_000331	Thank you. {nl} With you Helping us out like this, we will not be defeated.
-QUEST_LV_0100_20150317_000332	The next mission is to find the cause of the monsters increasing. {nl} Popolions have a big appetitle so we may be able to find crucial clue.
-QUEST_LV_0100_20150317_000333	Miners' Village is already in trouble and if the East Woods is in this situation, we can't assure the safety of Klaipeda . {nl}We can just hope that Klaipeda is doing well.
+QUEST_LV_0100_20150317_000328	Finding the cause of the monsters is important, {nl} but I’m more worried about supplies not making it to the Miners’ Village.
+QUEST_LV_0100_20150317_000329	The movement of weavers in the lower area of the stream seems suspicious . {nl} Just like they’re trying to interfere with supplying the Miners’ Village.
+QUEST_LV_0100_20150317_000330	It’s not a usual situation. {nl} But we might have to give up our current supplies and support ourselves until the next batch of supplies arrive. 
+QUEST_LV_0100_20150317_000331	Thank you. {nl} With you helping us out like this, we will not be defeated.
+QUEST_LV_0100_20150317_000332	The next mission is to find the cause of the increasing monsters. {nl} Popolions have a big appetitle so we may be able to find some crucial clues.
+QUEST_LV_0100_20150317_000333	Miners’ Village is already in trouble and if the East Woods is in this situation, we can’t assure the safety of Klaipeda . {nl}We can just hope that Klaipeda is doing well.
 QUEST_LV_0100_20150317_000334	Operations officer
-QUEST_LV_0100_20150317_000335	Were you sent by Aras? {nl} It's a piece of Vubbe clothing. Hmm... Is that so...
-QUEST_LV_0100_20150317_000336	I think the Vubbes of the Miner's Village have made their way into the woods. {nl} Maybe that's the reason behind the sudden increase in monsters too. {nl}
+QUEST_LV_0100_20150317_000335	Were you sent by Aras? {nl} It’s a piece of Vubbe clothing. Hmm... Is that so...
+QUEST_LV_0100_20150317_000336	I think the Vubbes of the Miner’s Village have made their way into the woods. {nl} Maybe that’s the reason behind the sudden increase in monsters too. {nl}
 QUEST_LV_0100_20150317_000337	I better ask Sir Aras to search for Vubbes in other areas too. {nl} In the meantime, please take a look at the upper side.
-QUEST_LV_0100_20150317_000338	We haven't searched the upper side yet. {nl} Of course, we should be sending troops but I ask for your help as this is an urgent matter. 
+QUEST_LV_0100_20150317_000338	We haven’t searched the upper side yet. {nl} Of course, we should be sending troops but I ask for your help as this is an urgent matter.
 QUEST_LV_0100_20150317_000339	You saw the Vubbe fighter but missed it? {nl} We also got a report that the Vubbe fighter appeared in the area below. {nl}
-QUEST_LV_0100_20150317_000340	First, talk to the search scout in the lower bridge of Bulvjes. {nl} This will become a tedious long term war if  we miss the Vubbe fighter.
+QUEST_LV_0100_20150317_000340	First, talk to the search scout in the lower bridge of Bulvjes. {nl} This will become a tedious long term war if we miss the Vubbe fighter.
 QUEST_LV_0100_20150317_000341	So Vubbe Fighter was the reason behind the increase of monsters. {nl} Please find out how many Vubbe Fighters there are. {nl}
-QUEST_LV_0100_20150317_000342	Under the circumstances, it makes sense that the monsters are controlled by Vubbe Fighter. {nl} But deep down, you just don't want to believe it. 
+QUEST_LV_0100_20150317_000342	Under the circumstances, it makes sense that the monsters are controlled by Vubbe Fighter. {nl} But deep down, you just cant to believe it.
 QUEST_LV_0100_20150317_000343	Following your report, there is no more Vubbe Fighter in this woods. {nl}
-QUEST_LV_0100_20150317_000344	Let's get rid of the Vubbe Fighter. {nl} The search scouts are on standby in Nudegi Felled Area
+QUEST_LV_0100_20150317_000344	Let’s get rid of the Vubbe Fighter. {nl} The search scouts are on standby in Nudegi Felled Area
 QUEST_LV_0100_20150317_000345	Supply Solider
-QUEST_LV_0100_20150317_000346	We need Weaver Claws as a part of supplies to be sent to Miners' Village {nl}but we just don't have time to look for those. {nl} What do we do? 
-QUEST_LV_0100_20150317_000347	Actually, it doesn't make sense for the supply solider to get the supplies.  {nl}It should have come from Klaipeda. 
-QUEST_LV_0100_20150317_000348	Thank you. {nl} Unexpected help always feels good. 
-QUEST_LV_0100_20150317_000349	In fact, everything would have been fine if Pokubus weren't around. {nl} The Pokubus were running wild and that's why were weren't able to retrieve all the supplies. 
-QUEST_LV_0100_20150317_000350	I don't know why they suddenly prey on the supplies. {nl} Could something be commanding them?
+QUEST_LV_0100_20150317_000346	We need Weaver Claws as a part of supplies to be sent to Miners’ Village {nl}but we just don’t have time to look for those. {nl} What do we do?
+QUEST_LV_0100_20150317_000347	Actually, it doesn’t make sense for the supply solider to get the supplies. {nl}It should have come from Klaipeda.
+QUEST_LV_0100_20150317_000348	Thank you. {nl} Unexpected help always feels good.
+QUEST_LV_0100_20150317_000349	In fact, everything would have been fine if Pokubus weren’t around. {nl} The Pokubus were running wild and that’s why were weren’t able to retrieve all the supplies. 
+QUEST_LV_0100_20150317_000350	I don’t know why they suddenly prey on the supplies. {nl} Could something be commanding them?
 QUEST_LV_0100_20150317_000351	Thank you. {nl} I envy your ability.
 QUEST_LV_0100_20150317_000352	Eastern Woods Search Scout
-QUEST_LV_0100_20150317_000353	Oh, it's you. {nl} I have heard from the operations officer. {nl}
+QUEST_LV_0100_20150317_000353	Oh, it’s you. {nl} I have heard from the operations officer. {nl}
 QUEST_LV_0100_20150317_000354	Vubbe Fighter is hiding deep in the Nudegi Felled Area. {nl} We got the orders to kill but it may be safer to wait for additional troops.
-QUEST_LV_0100_20150317_000355	I'm just a search scout but it was my first time to see the Vubbe Fighter so near.
-QUEST_LV_0100_20150317_000356	Awesome. You got rid of it by yourself. {nl} Go ahead and report to sir Aras. He'll be very pleased.
+QUEST_LV_0100_20150317_000355	I’m just a search scout but it was my first time to see the Vubbe Fighter so near.
+QUEST_LV_0100_20150317_000356	Awesome. You got rid of it by yourself. {nl} Go ahead and report to sir Aras. He’ll be very pleased.
 QUEST_LV_0100_20150317_000357	You mean you really killed the Vubbe Fighter? {nl}Well then, now we can be relieved since the number of monsters will no longer grow.
-QUEST_LV_0100_20150317_000358	Of course. As promised, I will grant your access to the Miners' Village. {nl} Please wait.
+QUEST_LV_0100_20150317_000358	Of course. As promised, I will grant your access to the Miners’ Village. {nl} Please wait.
 QUEST_LV_0100_20150317_000359	If you find any clues, let the Operations Officer in the northern area know about it.
-QUEST_LV_0100_20150317_000360	I think the Miners' Village is not in a good situation. {nl}It's too late to move the troops so you go first to support the Miners' Village.
+QUEST_LV_0100_20150317_000360	I think the Miners’ Village is not in a good situation. {nl}It’s too late to move the troops so you go first to support the Miners’ Village.
 QUEST_LV_0100_20150317_000361	They have low IQ but these monsters build groups and live as a community. {nl} They used to appear only occasionally in the deeper areas of the mines... Could they be expanding their forces? {nl}
-QUEST_LV_0100_20150317_000362	Whatever the reason is, Vubbes expanding their territory is a big problem. {nl} The monster that lose  territory to Vubbes will be forced to make their way into our base.
-QUEST_LV_0100_20150317_000363	It's a single road from here on so you'll be able to find the people easily. {nl}
-QUEST_LV_0100_20150317_000364	Oh, let me give you some helpful information in return to your kind act for our village. {nl} The evidence of salvation that the Revelators are looking for can be found in the Closed Area. 
-QUEST_LV_0100_20150317_000365	One thing, there's something that keeps bothering me. {nl} A vague feeling of something alien.
+QUEST_LV_0100_20150317_000362	Whatever the reason is, Vubbes expanding their territory is a big problem. {nl} The monster that lose territory to Vubbes will be forced to make their way into our base.
+QUEST_LV_0100_20150317_000363	It’s a single road from here on so you’ll be able to find the people easily. {nl}
+QUEST_LV_0100_20150317_000364	Oh, let me give you some helpful information in return for your kind act to our village. {nl} The evidence of salvation that the Revelators are looking for can be found in the Closed Area.
+QUEST_LV_0100_20150317_000365	One thing, there’s something that keeps bothering me. {nl} A vague feeling of something alien.
 QUEST_LV_0100_20150317_000366	Miner
-QUEST_LV_0100_20150317_000367	Thank you for saving me. {nl} The revelator has come to save us. It's like a dream. {nl}
+QUEST_LV_0100_20150317_000367	Thank you for saving me. {nl} The revelator has come to save us. It’s like a dream. {nl}
 QUEST_LV_0100_20150317_000368	The Closed Area? {nl} If you insist to get in..  Gather the mysterious stones the Vubbes have. {nl} The walls just open when you touch the crystal clogged wall with it.
-QUEST_LV_0100_20150317_000369	I'm collecting the supplies to be sent to the Miners Village. {nl} The monsters stole it all. {nl}
+QUEST_LV_0100_20150317_000369	I’m collecting the supplies to be sent to the Miners Village. {nl} The monsters stole it all. {nl}
 QUEST_LV_0100_20150317_000370	But supply box also contains dangerous explosives and collecting them is not an easy task.
-QUEST_LV_0100_20150317_000371	They couldn't have gone far. {nl}It would have been better it exploded on their way.
+QUEST_LV_0100_20150317_000371	They couldn’t have gone far. {nl}It would have been better it exploded on their way.
 QUEST_LV_0100_20150317_000372	
 QUEST_LV_0100_20150317_000373	
 QUEST_LV_0100_20150317_000374	I knew you would. {nl} One more thing, the ground of the Closed Area is weak so the entrance have been blocked for a long time. {nl}
 QUEST_LV_0100_20150317_000375	The kidnapped people are veteran miners so they may know how to get in. {nl} Well then, may be blessings of Goddess be with you.
-QUEST_LV_0100_20150317_000376	It wasn't long ago. {nl} I felt a strange power while performing various experiments in the Closed Area. {nl}It was different from the mana that we know but it was very warm. {nl}
+QUEST_LV_0100_20150317_000376	It wasn’t long ago. {nl} I felt a strange power while performing various experiments in the Closed Area. {nl}It was different from the mana that we know but it was very warm. {nl}
 QUEST_LV_0100_20150317_000377	But the force that did not allow me to approach it as if it had an owner already. {nl} A few days after the incident, the bishop dreamed about the evidence of salvation. {nl}
-QUEST_LV_0100_20150317_000378	Perhaps the evidence of salvation is the force I felt .. {nl} That's what I think.
-QUEST_LV_0100_20150317_000379	All I see are monsters and we're out of supplies. {nl}I'm also curious how the battle situation is in Miners' Village.
-QUEST_LV_0100_20150317_000380	Until I'm assigned a new task, I'm thinking of going back to my duties as a search scout. {nl} Observing the monsters, you know. 
-QUEST_LV_0100_20150317_000381	The Miners' Village is under battle and entrance is prohibited for civilians. {nl}Remember that we can't guarantee your safety if you do not get my permission.
+QUEST_LV_0100_20150317_000378	Perhaps the evidence of salvation is the force I felt .. {nl} That’s what I think.
+QUEST_LV_0100_20150317_000379	All I see are monsters and we’re out of supplies. {nl}I’m also curious how the battle situation is in Miners’ Village.
+QUEST_LV_0100_20150317_000380	Until I’m assigned a new task, I’m thinking of going back to my duties as a search scout. {nl} Observing the monsters, you know. 
+QUEST_LV_0100_20150317_000381	The Miners’ Village is under battle and entrance is prohibited for civilians. {nl}Remember that we can’t guarantee your safety if you do not get my permission.
 QUEST_LV_0100_20150317_000382	You have to cheer up.{nl} Even sir Aras is holding on.
-QUEST_LV_0100_20150317_000383	Goddess Zemyna overlooks the earth. {nl}There are rumors that the Goddess has abandoned us but that's nonsense. {nl}Her statue still shines beautifully when you pray to it. 
-QUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods. {nl} That's why the Mining Village located in the middle of it turned to a battlefield. {nl}
-QUEST_LV_0100_20150317_000385	That's why I can't permit entrance to the Miners Village for safety reasons. {nl} Of course it will be a different story if your skill are good enough to ensure your safety even without the protection of guards.
+QUEST_LV_0100_20150317_000383	Goddess Zemyna overlooks the earth. {nl}There are rumors that the Goddess has abandoned us but that’s nonsense. {nl}Her statue still shines beautifully when you pray to it. 
+QUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods. {nl} That’s why the Mining Village located in the middle of it turned to a battlefield. {nl}
+QUEST_LV_0100_20150317_000385	That’s why I can’t permit entrance to the Miners Village for safety reasons. {nl} Of course it will be a different story if your skill are good enough to ensure your safety even without the protection of guards.
 QUEST_LV_0100_20150317_000386	Gosh, it could have been really dangerous. {nl} That huge thing was hiding so well.
-QUEST_LV_0100_20150317_000387	It's very important to study monsters at times like this. {nl}It's like weather forecasts where you try to find out the cause and see what would happen.
-QUEST_LV_0100_20150317_000388	I'm sure the leaf bugs in Uoros farm stole it. {nl}They did steal from us once before. 
+QUEST_LV_0100_20150317_000387	It’s very important to study monsters at times like this. {nl}It’s like weather forecasts where you try to find out the cause and see what would happen.
+QUEST_LV_0100_20150317_000388	I’m sure the leaf bugs in Uoros farm stole it. {nl}They did steal from us once before. 
 QUEST_LV_0100_20150317_000389	Send my regards to the Guard Captain when you meet him.
 QUEST_LV_0100_20150317_000390	Then, in order to test if your skills are good enough to enter the Miners Village.. {nl} I need you to help us solve a problem we have. {nl}
 QUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus. {nl} I believe this would be a fairly easy task
 QUEST_LV_0100_20150317_000392	There seems to be a gap in the rock where you can insert something.
-QUEST_LV_0100_20150317_000393	Let's search the Bulvjes farm first. {nl}But don't chase them or something as it can be dangerous. 
-QUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess. {nl} Anyway, supplies camp is located further below the farm.
+QUEST_LV_0100_20150317_000393	Let’s search the Bulvjes farm first. {nl}But don’t chase them or something as it can be dangerous. 
+QUEST_LV_0100_20150317_000394	It makes me wonder if you’re an envoy of the Goddess. {nl} Anyway, supplies camp is located further below the farm.
 QUEST_LV_0100_20150317_000395	4
 QUEST_LV_0100_20150317_000396	Vubbes are emerging inside the Mine Gallery so be sure to stay together in groups of 5.
 QUEST_LV_0100_20150317_000397	Equipment  Merchant
-QUEST_LV_0100_20150317_000398	Even at times like this, I struggle to find the best items I can. You can't go easy in terms of dealing with your customers. 
+QUEST_LV_0100_20150317_000398	Even at times like this, I struggle to find the best items I can. You can’t go easy in terms of dealing with your customers. 
 QUEST_LV_0100_20150317_000399	Monsters attack and steal from people who buy items from me. I think they know can tell which items are good. I feel sorry for those who were attacked but it also proves that the items are worth it. 
-QUEST_LV_0100_20150317_000400	The monsters never raided into Klaipeda but with sir Uska gone, it's hard to be at ease. You have you watch out for yourself at times like this.
-QUEST_LV_0100_20150317_000401	I want to travel with a single weapon in hand like an adventurer.. But I guess that's hard..
-QUEST_LV_0100_20150317_000402	If you listen to the soldiers, they use terms only they can understand and make it sound difficult. And when I ask a friend soldier, it's not like they are talking about anything important.
+QUEST_LV_0100_20150317_000400	The monsters never raided into Klaipeda but with sir Uska gone, it’s hard to be at ease. You have you watch out for yourself at times like this.
+QUEST_LV_0100_20150317_000401	I want to travel with a single weapon in hand like an adventurer.. But I guess that’s hard..
+QUEST_LV_0100_20150317_000402	If you listen to the soldiers, they use terms only they can understand and make it sound difficult. And when I ask a friend soldier, it’s not like they are talking about anything important.
 QUEST_LV_0100_20150317_000403	Be cautious of people who sell weapons from monsters without permit. They scam you to buy useless things or sell at ridiculously high prices. 
 QUEST_LV_0100_20150317_000404	Item Merchant
-QUEST_LV_0100_20150317_000405	It's the little things you miss out that makes you regret when you travel. Better to buy enough of it when you can.
-QUEST_LV_0100_20150317_000406	I feel sorry for those who were injured. Can't we get along with the monsters?
-QUEST_LV_0100_20150317_000407	I'd rather want to stay safe and at peace even if the sales would be lower rather than sales going up because of people worrying when the monsters would attack.
+QUEST_LV_0100_20150317_000405	It’s the little things you miss out that makes you regret when you travel. Better to buy enough of it when you can.
+QUEST_LV_0100_20150317_000406	I feel sorry for those who were injured. Can’t we get along with the monsters?
+QUEST_LV_0100_20150317_000407	I’d rather want to stay safe and at peace even if the sales would be lower rather than sales going up because of people worrying when the monsters would attack.
 QUEST_LV_0100_20150317_000408	I sell things that people need but I sometimes think it would have been better if i was a healer because you can be closer to the explorers to help them.
 QUEST_LV_0100_20150317_000409	I hear strange howling from a distance. Could it be the sound of the monstesr?
-QUEST_LV_0100_20150317_000410	People say I'm weird and I talk too much but i don't mind. Even if I'm really weird like they say, that doesn't mean even the items I sell are also weird.
+QUEST_LV_0100_20150317_000410	People say I’m weird and I talk too much but i don’t mind. Even if I’m really weird like they say, that doesn’t mean even the items I sell are also weird.
 QUEST_LV_0100_20150317_000411	Blacksmith
-QUEST_LV_0100_20150317_000412	Hello. {nl} I can help you repair items but I can't craft new ones because I don't have the materials.  {nl} Go on and choose from whatever is available.
+QUEST_LV_0100_20150317_000412	Hello. {nl} I can help you repair items but I can’t craft new ones because I don’t have the materials.  {nl} Go on and choose from whatever is available.
 QUEST_LV_0100_20150317_000413	Klaipeda resident
-QUEST_LV_0100_20150317_000414	It's true we're in tough times but everyone looking after the soldiers only.
-QUEST_LV_0100_20150317_000415	Aside from anything else, I want to eat till i'm full. {nl} You need to eat to have strength.
-QUEST_LV_0100_20150317_000416	Why have the Goddess disappeared? {nl} Everyone is looking for where they've gone but no one is asking why they disappeared.
-QUEST_LV_0100_20150317_000417	I can't eat, wear, or rest freely because of those monsters. {nl} In the old days, we used gather herbs or pick fruits in Siaulai Forest you know.
-QUEST_LV_0100_20150317_000418	Everyone is talking about the war wherever you go. {nl} Like who and how much people are hurt or who's assigned to where. {nl} All the stories about the war makes me sick!
-QUEST_LV_0100_20150317_000419	I heard they will send soldiers who aren't even trained into the nest of monsters. {nl} It might be better to gather the old people and make them soldiers. 
+QUEST_LV_0100_20150317_000414	It’s true we’re in tough times but everyone looking after the soldiers only.
+QUEST_LV_0100_20150317_000415	Aside from anything else, I want to eat till i’m full. {nl} You need to eat to have strength.
+QUEST_LV_0100_20150317_000416	Why have the Goddess disappeared? {nl} Everyone is looking for where they’ve gone but no one is asking why they disappeared.
+QUEST_LV_0100_20150317_000417	I can’t eat, wear, or rest freely because of those monsters. {nl} In the old days, we used gather herbs or pick fruits in Siaulai Forest you know.
+QUEST_LV_0100_20150317_000418	Everyone is talking about the war wherever you go. {nl} Like who and how much people are hurt or who’s assigned to where. {nl} All the stories about the war makes me sick!
+QUEST_LV_0100_20150317_000419	I heard they will send soldiers who aren’t even trained into the nest of monsters. {nl} It might be better to gather the old people and make them soldiers. 
 QUEST_LV_0100_20150317_000420	My life is just a repetition of worries and anger. {nl} The Goddess should return soon.
 QUEST_LV_0100_20150317_000421	There are suddenly many people who dreamed about the revelation. {nl} Could it be a sign of something about to happen again? {nl}
 QUEST_LV_0100_20150317_000422	Bishop of Klaipeda also dreamed about the Goddess. {nl} Could it be the same dream with the Revelators?
@@ -424,68 +424,68 @@ QUEST_LV_0100_20150317_000423	Mother of Soldier
 QUEST_LV_0100_20150317_000424	)} My son had enlisted to the Army. {nl} He said who would if not him at such difficult times like this. 
 QUEST_LV_0100_20150317_000425	)} Monster are growing and the forest is too chaotic for people to live in. {nl} At least, Klaipeda is safe. 
 QUEST_LV_0100_20150317_000426	)} At least Klaipeda is safe but other cities are in chaos? {nl} Well, putting aside the capital, Fedimian has totally collapsed except for the Sacred Area. 
-QUEST_LV_0100_20150317_000427	)} It's a good thing that my son accomplished his dream of becoming a solder.. {nl} But the monsters are rising and I'm worried he might get hurt.
+QUEST_LV_0100_20150317_000427	)} It’s a good thing that my son accomplished his dream of becoming a solder.. {nl} But the monsters are rising and I’m worried he might get hurt.
 QUEST_LV_0100_20150317_000428	)} Maybe Klaipeda is where the Goddess has bestowed her blessings. {nl} I hope the blessings would also reach my son who enlisted in the army.
-QUEST_LV_0100_20150317_000429	)} My husband used to be a miner and how relieved I am that he isn't anymore. {nl} It would be too dangerous if the monsters raid at times like this isn't it?
+QUEST_LV_0100_20150317_000429	)} My husband used to be a miner and how relieved I am that he isn’t anymore. {nl} It would be too dangerous if the monsters raid at times like this isn’t it?
 QUEST_LV_0100_20150317_000430	)} Many refugees came from the fallen town. {nl} Our food supplies are also running short but we still have to help each other.
-QUEST_LV_0100_20150317_000431	I may not bring in the items with best quality but isn't having all the items necessary a skill of its own? Gotta work hard to get through tough times.
+QUEST_LV_0100_20150317_000431	I may not bring in the items with best quality but isn’t having all the items necessary a skill of its own? Gotta work hard to get through tough times.
 QUEST_LV_0100_20150317_000432	I think the best weapons and armors are the ones that you get used to over a long period time. In order to do so, you must start first by buying good items. 
 QUEST_LV_0100_20150317_000433	I used to pack my things and go around on travel in the past but I guess that would be difficult now. 
-QUEST_LV_0100_20150317_000434	Try using a variety of weapons. Eventually, you'll find one that a fits you.
+QUEST_LV_0100_20150317_000434	Try using a variety of weapons. Eventually, you’ll find one that a fits you.
 QUEST_LV_0100_20150317_000435	The armors that suit you guarantees your safety.
 QUEST_LV_0100_20150317_000436	Difference in a single armor can result in life and death. Look around if you have anything you need. 
-QUEST_LV_0100_20150317_000437	It's free to look around.
+QUEST_LV_0100_20150317_000437	It’s free to look around.
 QUEST_LV_0100_20150317_000438	Look around and see if you need anything.
 QUEST_LV_0100_20150317_000439	Look around carefully. You might find something that can help you. 
 QUEST_LV_0100_20150317_000440	Sometimes, things that you just look at without any thoughts can actually fit you very well so take a look and think about it.
 QUEST_LV_0100_20150317_000441	You can just look around. Find me anytime you need. 
 QUEST_LV_0100_20150317_000442	We have enough items so take a look.
-QUEST_LV_0100_20150317_000443	You need good weapons and armors to prepare for the monsters. That is what I'm selling.
+QUEST_LV_0100_20150317_000443	You need good weapons and armors to prepare for the monsters. That is what I’m selling.
 QUEST_LV_0100_20150317_000444	Items I have for sale are flawless. These are all new.
-QUEST_LV_0100_20150317_000445	If you don't prepare the equipments now, you might regret it later when you're surrounded by the monsters. Look around when you can.
-QUEST_LV_0100_20150317_000446	I've prepared the best items I can find. The prices aren't bad either so look around.
+QUEST_LV_0100_20150317_000445	If you don’t prepare the equipments now, you might regret it later when you’re surrounded by the monsters. Look around when you can.
+QUEST_LV_0100_20150317_000446	I’ve prepared the best items I can find. The prices aren’t bad either so look around.
 QUEST_LV_0100_20150317_000447	The things I sell are good both in price and quality.
-QUEST_LV_0100_20150317_000448	Care to look at the items I'm selling if you have time?
+QUEST_LV_0100_20150317_000448	Care to look at the items I’m selling if you have time?
 QUEST_LV_0100_20150317_000449	I hope good items will find good owners.
 QUEST_LV_0100_20150317_000450	Yes this was originally a bustling shopping area. But everyone left as it became difficult to live..
 QUEST_LV_0100_20150317_000451	I was too busy to afford to talk to the people when they gathered.
-QUEST_LV_0100_20150317_000452	A lot of people seem to be coming thanks to sir Uska's recruitment notice.
-QUEST_LV_0100_20150317_000453	There's a lot to prepare when you go to battle with the monsters.
+QUEST_LV_0100_20150317_000452	A lot of people seem to be coming thanks to sir Uska’s recruitment notice.
+QUEST_LV_0100_20150317_000453	There’s a lot to prepare when you go to battle with the monsters.
 QUEST_LV_0100_20150317_000454	Times are difficult but I decided not to raise the prices. Have a look.
 QUEST_LV_0100_20150317_000455	Monsters mistake things for food and swallow just swallow it. They must be really hungry.
 QUEST_LV_0100_20150317_000456	I once encountered a monster in Siauliai Woods. I just stood still and the monster went away... I guess there are monsters that do not make the first attack on people.
-QUEST_LV_0100_20150317_000457	I've heard that some people sell things that are dropped from those who were running away from the monsters. Things I sell are not like that so no need to worry about that.
+QUEST_LV_0100_20150317_000457	I’ve heard that some people sell things that are dropped from those who were running away from the monsters. Things I sell are not like that so no need to worry about that.
 QUEST_LV_0100_20150317_000458	Everything aside, I do not lie about my items being cheap. The stuff I sell are priced just right.
 QUEST_LV_0100_20150317_000459	Feel free to look around anytime.
-QUEST_LV_0100_20150317_000460	It can be hard if you don't prepare enough potions.
-QUEST_LV_0100_20150317_000461	It's free to look around the things I sell.
-QUEST_LV_0100_20150317_000462	How do continue business if you don't make profits?
+QUEST_LV_0100_20150317_000460	It can be hard if you don’t prepare enough potions.
+QUEST_LV_0100_20150317_000461	It’s free to look around the things I sell.
+QUEST_LV_0100_20150317_000462	How do continue business if you don’t make profits?
 QUEST_LV_0100_20150317_000463	I thought about moving my business to somewhere else but I had to stay for the people who come to me. 
-QUEST_LV_0100_20150317_000464	I don't think of making a lot of money. You just need what's enough to get live by.
+QUEST_LV_0100_20150317_000464	I don’t think of making a lot of money. You just need what’s enough to get live by.
 QUEST_LV_0100_20150317_000465	I think we have to help each other at difficult times like this. I hope could be of help.
-QUEST_LV_0100_20150317_000466	Can I help you? I'll show you what we have prepared.
+QUEST_LV_0100_20150317_000466	Can I help you? I’ll show you what we have prepared.
 QUEST_LV_0100_20150317_000467	Please feel free to come back if you need anything.
-QUEST_LV_0100_20150317_000468	You don't necessarily have to buy things so feel free to look around
+QUEST_LV_0100_20150317_000468	You don’t necessarily have to buy things so feel free to look around
 QUEST_LV_0100_20150317_000469	I sold items even before the monsters appeared. 
-QUEST_LV_0100_20150317_000470	Don't you feel good just looking at the items even if you don't buy them? 
-QUEST_LV_0100_20150317_000471	You can find me anytime if you want a look at the items I'm selling.
+QUEST_LV_0100_20150317_000470	Don’t you feel good just looking at the items even if you don’t buy them? 
+QUEST_LV_0100_20150317_000471	You can find me anytime if you want a look at the items I’m selling.
 QUEST_LV_0100_20150317_000472	What would it be like to go on an adventure fighting monsters? I was born and raised here so I sometimes wonder how it would be in other areas.
-QUEST_LV_0100_20150317_000473	When I see the soldiers who protect from the monsters, I want to give them for free sometimes. Although it's really not easy to do so..
+QUEST_LV_0100_20150317_000473	When I see the soldiers who protect from the monsters, I want to give them for free sometimes. Although it’s really not easy to do so..
 QUEST_LV_0100_20150317_000474	Better were the days when Commander Uska took care of Klaipeda himself. 
-QUEST_LV_0100_20150317_000475	Isn't there a way to get rid of all the monsters running wild in Siauliai Forest?
+QUEST_LV_0100_20150317_000475	Isn’t there a way to get rid of all the monsters running wild in Siauliai Forest?
 QUEST_LV_0100_20150317_000476	I hope some skilled person could drive out all the monsters.
-QUEST_LV_0100_20150317_000477	Living in a place where monsters are running wild outside is driving me nuts. {nl} And I can't think of going anywhere else because of the monsters..
-QUEST_LV_0100_20150317_000478	I'd wipe out all the monsters if I had the skills. {nl} Why are soldiers leaving the monsters alone?
+QUEST_LV_0100_20150317_000477	Living in a place where monsters are running wild outside is driving me nuts. {nl} And I can’t think of going anywhere else because of the monsters..
+QUEST_LV_0100_20150317_000478	I’d wipe out all the monsters if I had the skills. {nl} Why are soldiers leaving the monsters alone?
 QUEST_LV_0100_20150317_000479	I am tired of living a life running away from the monsters.
-QUEST_LV_0100_20150317_000480	Thinking of the peaceful days in the past make me feel like I'm dreaming . {nl} Like a very long nightmare. 
+QUEST_LV_0100_20150317_000480	Thinking of the peaceful days in the past make me feel like I’m dreaming . {nl} Like a very long nightmare. 
 QUEST_LV_0100_20150317_000481	I want to run away to another place if I can. {nl} Is there a future for the kingdom.
-QUEST_LV_0100_20150317_000482	I can't sleep well nowadays. {nl} It's all because of those monsters.
+QUEST_LV_0100_20150317_000482	I can’t sleep well nowadays. {nl} It’s all because of those monsters.
 QUEST_LV_0100_20150317_000483	To live at peace in a world where monsters are running wild ... Impossible.
 QUEST_LV_0100_20150317_000484	Does salvation even exist? {nl} Hanging on each day in hopes of the Goddess is really miserable.
-QUEST_LV_0100_20150317_000485	We can't go out nor just stay. Is this really ok? {nl}I can't seem to find an answer no matter how much I think about it. 
+QUEST_LV_0100_20150317_000485	We can’t go out nor just stay. Is this really ok? {nl}I can’t seem to find an answer no matter how much I think about it. 
 QUEST_LV_0100_20150317_000486	Getting used to a world living together with monsters, what a terrible and scary thing is that?
 QUEST_LV_0100_20150317_000487	I heard that there are people who study monsters. {nl} What is wrong with them. {nl} Those monsters are bad creatures that could attack us any moment.
-QUEST_LV_0100_20150317_000488	I'm afraid that Klaipeda might become like the capital. {nl}It's now being called the fallen city, right? 
+QUEST_LV_0100_20150317_000488	I’m afraid that Klaipeda might become like the capital. {nl}It’s now being called the fallen city, right? 
 QUEST_LV_0100_20150317_000489	Many people are afraid of Bokors for summoning the zombies. {nl} But we curse of the enemy of the Goddess.
 QUEST_LV_0100_20150317_000490	Intelligence. calm judgment, and objective rationality. {nl} These are the qualities required of us, the Cryomancers.
 QUEST_LV_0100_20150317_000491	Fire is grace sent to us by the Goddess Gabija. {nl} You cannot become a great Pyromancer if you overlook that. 
@@ -498,23 +498,23 @@ QUEST_LV_0100_20150317_000497
 QUEST_LV_0100_20150317_000498	Master Wizard
 QUEST_LV_0100_20150317_000499	No matter how much magic talent you have, it is useless unless you train hard. 
 QUEST_LV_0100_20150317_000500	You must be brave in order to protect the kingdom. {nl} But for that bravery to be different from recklessness, your skills should be good enough.
-QUEST_LV_0100_20150317_000501	The Goddesses may be all gone but my powers are still doing fine, right? {nl} I'm sure it must be proof that Goddess Gabija is at least safe somewhere.
+QUEST_LV_0100_20150317_000501	The Goddesses may be all gone but my powers are still doing fine, right? {nl} I’m sure it must be proof that Goddess Gabija is at least safe somewhere.
 QUEST_LV_0100_20150317_000502	Master Elementalist
 QUEST_LV_0100_20150317_000503	The simplest things are the strongest.{nl}If you want to find out the root of everything, take the path of Elementalist.
 QUEST_LV_0100_20150317_000504	Master Quarrelshooter
-QUEST_LV_0100_20150317_000505	It's painful to see people who come to Klaipeda seeking refuge from the monsters. {nl} That wouldn't have been necessary if you were a Quarrelshooter.
+QUEST_LV_0100_20150317_000505	It’s painful to see people who come to Klaipeda seeking refuge from the monsters. {nl} That wouldn’t have been necessary if you were a Quarrelshooter.
 QUEST_LV_0100_20150317_000506	Master Ranger
 QUEST_LV_0100_20150317_000507	I heard monsters swarm in flocks outside of Klaipeda.{nl} It would be better to learn/train my skill rather than foolishly attack them one by one.
 QUEST_LV_0100_20150317_000508	Sapper Master
-QUEST_LV_0100_20150317_000509	People shouldn't do things they'll regret. {nl} I lost even the ones whom I want to ask for forgiveness on the Divine Day four years ago. {nl}
+QUEST_LV_0100_20150317_000509	People shouldn’t do things they’ll regret. {nl} I lost even the ones whom I want to ask for forgiveness on the Divine Day four years ago. {nl}
 QUEST_LV_0100_20150317_000510	Master Archer
-QUEST_LV_0100_20150317_000511	Killing enemies one by one from a distance is the beauty of the bow and arrow. {nl} No matter how many shots you make, it's the actual shots that count, isn't it?
+QUEST_LV_0100_20150317_000511	Killing enemies one by one from a distance is the beauty of the bow and arrow. {nl} No matter how many shots you make, it’s the actual shots that count, isn’t it?
 QUEST_LV_0100_20150317_000512	Master Priest 
 QUEST_LV_0100_20150317_000513	Priest does not suspect the Goddess. {nl} Only faith can support the priest.
 QUEST_LV_0100_20150317_000514	Sadhu Master
 QUEST_LV_0100_20150317_000515	
 QUEST_LV_0100_20150317_000516	Rexipher
-QUEST_LV_0100_20150317_000517	You're late . {Nl} Want to save a woman?
+QUEST_LV_0100_20150317_000517	You’re late . {Nl} Want to save a woman?
 QUEST_LV_0100_20150317_000518	
 QUEST_LV_0100_20150317_000519	
 QUEST_LV_0100_20150317_000520	
@@ -531,13 +531,13 @@ QUEST_LV_0100_20150317_000530
 QUEST_LV_0100_20150317_000531	
 QUEST_LV_0100_20150317_000532	
 QUEST_LV_0100_20150317_000533	When you level up, you can increase a status of your choice and become stronger. {nl} Would you like to check it now?
-QUEST_LV_0100_20150317_000534	It's important to think ahead about what you would want to be. {nl} It's never an easy thing.
-QUEST_LV_0100_20150317_000535	Yes. That's how you do it. {nl} Pretty simple, huh?
-QUEST_LV_0100_20150317_000536	Sir Aras is in the center area of the Woods. {nl} But there has been a tremendous increase in monsters around here so I suggest you don't go in.
+QUEST_LV_0100_20150317_000534	It’s important to think ahead about what you would want to be. {nl} It’s never an easy thing.
+QUEST_LV_0100_20150317_000535	Yes. That’s how you do it. {nl} Pretty simple, huh?
+QUEST_LV_0100_20150317_000536	Sir Aras is in the center area of the Woods. {nl} But there has been a tremendous increase in monsters around here so I suggest you don’t go in.
 QUEST_LV_0100_20150317_000537	The monster that somehow coming into the Klaipeda but has received. {Nl} If you do not want to delete monster increases were due to Locate and it will be a difficult. {Nl}
 QUEST_LV_0100_20150317_000538	The strange feeling I had in the Crystal Mine 3rd Gallery, {nl} it keeps occurring to me that it might be related to the girl that town people are talking about. {nl}
-QUEST_LV_0100_20150317_000539	I just feel bad that I wasn't able to meet 
-QUEST_LV_0100_20150317_000540	Thank you for saving the villagers but, {nl} you're not going to the Closed Area, are you?
+QUEST_LV_0100_20150317_000539	I just feel bad that I wasn’t able to meet 
+QUEST_LV_0100_20150317_000540	Thank you for saving the villagers but, {nl} you’re not going to the Closed Area, are you?
 QUEST_LV_0100_20150317_000541	
 QUEST_LV_0100_20150317_000542	
 QUEST_LV_0100_20150317_000543	I smell was BiteRegina I underwriting. and {nl} It was good because as not hurt.
@@ -578,8 +578,8 @@ QUEST_LV_0100_20150317_000577	Linker is someone who connects people with the rop
 QUEST_LV_0100_20150317_000578	Cataphract master
 QUEST_LV_0100_20150317_000579	Cataphract program, has the power to proceed through all the enemies that confront before. {Nl} and brave warriors to fight on the front lines.
 QUEST_LV_0100_20150317_000580	May I help you? Fortunately, we have some potions left in stock.
-QUEST_LV_0100_20150317_000581	Looking for some good equipment? {nl} I have prepared the best ones available. {nl} Look around, the prices aren't bad either.
-QUEST_LV_0100_20150317_000582	Oh, this anvil is my small gift to you for saving me. {nl} It's a useful item that can upgrade your equipment. {nl}
+QUEST_LV_0100_20150317_000581	Looking for some good equipment? {nl} I have prepared the best ones available. {nl} Look around, the prices aren’t bad either.
+QUEST_LV_0100_20150317_000582	Oh, this anvil is my small gift to you for saving me. {nl} It’s a useful item that can upgrade your equipment. {nl}
 QUEST_LV_0100_20150317_000583	Well then, see you in the mines.
 QUEST_LV_0100_20150317_000584	
 QUEST_LV_0100_20150317_000585	
@@ -706,53 +706,53 @@ QUEST_LV_0100_20150317_000705	Press the {Img F10 40 40} key to open the Help men
 QUEST_LV_0100_20150317_000706	Press the {Img F3 40 40} key to open the Skill window. Use available skill points on the skills you want to enhance, then click Apply. {nl}
 QUEST_LV_0100_20150317_000707	Finding and offering a worship to all the Statues of Goddess scattered around the world while you travel,  will surely have you compensated. {nl}
 QUEST_LV_0100_20150317_000708	Press the {Img F10 40 40} key to open the Help window for more information.
-QUEST_LV_0100_20150317_000709	Other troops are fighting in the Miners' Village and we are blocking the monsters from here. {nl}I don't think the Vubbes are smart enough to make use of tactics... I am concerned about that.
-QUEST_LV_0100_20150317_000710	We have problems here, but I'm also worried about the other troops fighting in the Miners' Village. {nl} Normally, it should have been cleared up pretty fast.
+QUEST_LV_0100_20150317_000709	Other troops are fighting in the Miners’ Village and we are blocking the monsters from here. {nl}I don’t think the Vubbes are smart enough to make use of tactics... I am concerned about that.
+QUEST_LV_0100_20150317_000710	We have problems here, but I’m also worried about the other troops fighting in the Miners’ Village. {nl} Normally, it should have been cleared up pretty fast.
 QUEST_LV_0100_20150317_000711	Guard Gilbert
-QUEST_LV_0100_20150317_000712	It's the Pantos again. {nl} They even stole the working parts. {nl} Well then, we've got to take them back, right?
-QUEST_LV_0100_20150317_000713	I could handle it myself. {nl}Those weaklings would come trembling on their knees to return the parts. {nl} But what if more thieves come while I'm at it?
+QUEST_LV_0100_20150317_000712	It’s the Pantos again. {nl} They even stole the working parts. {nl} Well then, we’ve got to take them back, right?
+QUEST_LV_0100_20150317_000713	I could handle it myself. {nl}Those weaklings would come trembling on their knees to return the parts. {nl} But what if more thieves come while I’m at it?
 QUEST_LV_0100_20150317_000714	Well done. {nl} Now put this on and grease it then it will work as it should. 
-QUEST_LV_0100_20150317_000715	The Pantos hid some parts in the grasslands of Mieguista Hills. {nl} Try to get me those for the time being since it's urgent.
+QUEST_LV_0100_20150317_000715	The Pantos hid some parts in the grasslands of Mieguista Hills. {nl} Try to get me those for the time being since it’s urgent.
 QUEST_LV_0100_20150317_000716	The Pantos think the grassland hides everything. {nl} I used to find that cute about them.
 QUEST_LV_0100_20150317_000717	Guard Matthew
 QUEST_LV_0100_20150317_000718	I am looking for cable car parts but nothings seems to be in sight. {nl} Maybe the Zignuts of Nepavy sun swallowed it. {nl}
 QUEST_LV_0100_20150317_000719	6
 QUEST_LV_0100_20150317_000720	
-QUEST_LV_0100_20150317_000721	If it wasn't for me, uncle Gilbert would have been going around looking through this huge area. {nl} I'm truly worried.
+QUEST_LV_0100_20150317_000721	If it wasn’t for me, uncle Gilbert would have been going around looking through this huge area. {nl} I’m truly worried.
 QUEST_LV_0100_20150317_000722	This is a sacred place we have enshrined for generations. {nl} We used to hold prayer and important meetings whenever there was a disaster {nl}
-QUEST_LV_0100_20150317_000723	But it's been like this since it fell to evil forces four years ago. {nl} I guess the elders couldn't have helped it either.
+QUEST_LV_0100_20150317_000723	But it’s been like this since it fell to evil forces four years ago. {nl} I guess the elders couldn’t have helped it either.
 QUEST_LV_0100_20150317_000724	In the past, it was just a rope on a lax basket. {nl} You had to put your life on the line whenever you crossed it. {nl}
-QUEST_LV_0100_20150317_000725	So I went to Klaipeda and learned the skills myself. {nl} I have to start looking for a successor, but Matthew doesn't seem interested.
+QUEST_LV_0100_20150317_000725	So I went to Klaipeda and learned the skills myself. {nl} I have to start looking for a successor, but Matthew doesn’t seem interested.
 QUEST_LV_0100_20150317_000726	Guard Basil
 QUEST_LV_0100_20150317_000727	The curse doll will be filled with the mine of Mushcaria. {nl} It is in the Tustanti Plateu, can you get it for me?
 QUEST_LV_0100_20150317_000728	They used to be considered mysterious creatures, worthy of respect. {nl} But nowadays you just go a few steps outside town and they are everywhere, preying on people.
 QUEST_LV_0100_20150317_000729	I forgot that Mushcaria is still alive. {nl} Anyway, good job.
 QUEST_LV_0100_20150317_000730	There is enough time, so visit Algis first.
-QUEST_LV_0100_20150317_000731	Now I will head this way to the church. {nl} Our Paladin friend likes the word 'if' a lot. {nl}
+QUEST_LV_0100_20150317_000731	Now I will head this way to the church. {nl} Our Paladin friend likes the word ’if’ a lot. {nl}
 QUEST_LV_0100_20150317_000732	If our mission goes as planned, then we will have no need to meet again. {nl} Well, it sounds like it would be unpleasant to meet you again, haha.
 QUEST_LV_0100_20150317_000733	Guard Allen
 QUEST_LV_0100_20150317_000734	The Mazas barrier which should the Demons have been destroyed. {nl} Would you help me repair it?
-QUEST_LV_0100_20150317_000735	The barriers were made a long time ago. {nl} And now that I wasn't able to protect it well, what do I tell our ancestors?
-QUEST_LV_0100_20150317_000736	I'm not smart enough to know anything about restoring the barrier so tell that to sir Kayetonas.
+QUEST_LV_0100_20150317_000735	The barriers were made a long time ago. {nl} And now that I wasn’t able to protect it well, what do I tell our ancestors?
+QUEST_LV_0100_20150317_000736	I’m not smart enough to know anything about restoring the barrier so tell that to sir Kayetonas.
 QUEST_LV_0100_20150317_000737	
 QUEST_LV_0100_20150317_000738	No wonder. I was bewildered when the Demons suddenly appeared out of nowhere. {nl} I better let the Brothers know about this. Thank you.
 QUEST_LV_0100_20150317_000739	Guard Kenneth
-QUEST_LV_0100_20150317_000740	You can't let your guard down just because the Demon summoners are gone. {nl} We don't even know when this appeared in the first place. {nl}
+QUEST_LV_0100_20150317_000740	You can’t let your guard down just because the Demon summoners are gone. {nl} We don’t even know when this appeared in the first place. {nl}
 QUEST_LV_0100_20150317_000741	Anyway, please tell Sir Kayetonas in Flower Hill about this.
-QUEST_LV_0100_20150317_000742	It might be a bit extreme, but I'm thinking about getting rid of all the Demon souls.{nl}
+QUEST_LV_0100_20150317_000742	It might be a bit extreme, but I’m thinking about getting rid of all the Demon souls.{nl}
 QUEST_LV_0100_20150317_000743	Make the demons weak enough to extract the soul using the power of the barrier. {nl} Then, killing the soul afterwards. Would you give it a try?
-QUEST_LV_0100_20150317_000744	You'd better get rid of the extracted souls quickly. {nl} Wouldn't it be scary to see them come back to life?
+QUEST_LV_0100_20150317_000744	You’d better get rid of the extracted souls quickly. {nl} Wouldn’t it be scary to see them come back to life?
 QUEST_LV_0100_20150317_000745	Actually, I had some doubts, but it seems to work? {nl} Please let Sir Kayetonas know about this. {nl} I think he will be pleased, he is in Flower Hill.
-QUEST_LV_0100_20150317_000746	Now, I think I can live. {nl} We have to keep and stop the Demons. {nl} Please tell Sir Kayetonas that protecting this place isn't easy.
+QUEST_LV_0100_20150317_000746	Now, I think I can live. {nl} We have to keep and stop the Demons. {nl} Please tell Sir Kayetonas that protecting this place isn’t easy.
 QUEST_LV_0100_20150317_000747	
-QUEST_LV_0100_20150317_000748	Welcome, I'm glad to see that you've had a safe journey here. {nl}Before anything else, there are things about this place that the Revelator should know. {nl}
+QUEST_LV_0100_20150317_000748	Welcome, I’m glad to see that you’ve had a safe journey here. {nl}Before anything else, there are things about this place that the Revelator should know. {nl}
 QUEST_LV_0100_20150317_000749	My old friend, Algis, will explain. Please listen to him.
 QUEST_LV_0100_20150317_000750	
 QUEST_LV_0100_20150317_000751	The broken barrier pieces are scattered in the Mazas shelter. {nl} Collect it and give it to sir Kayetonas in flower hill. {nl}
 QUEST_LV_0100_20150317_000752	
 QUEST_LV_0100_20150317_000753	
 QUEST_LV_0100_20150317_000754	7
-QUEST_LV_0100_20150317_000755	That's why if there are guards struggling with the barrier, I want you to help.
+QUEST_LV_0100_20150317_000755	That’s why if there are guards struggling with the barrier, I want you to help.
 QUEST_LV_0100_20150317_000756	Heard the plan failed. {nl} I guess we have to do something before the Gesti recovers.
 QUEST_LV_0100_20150317_000757	Guard Ella
 QUEST_LV_0100_20150317_000758	
@@ -797,7 +797,7 @@ QUEST_LV_0100_20150317_000796
 QUEST_LV_0100_20150317_000797	
 QUEST_LV_0100_20150317_000798	Thank you. {nl} This is sufficient to make a transformation scroll.
 QUEST_LV_0100_20150317_000799	You can transform into a Demon by using this scroll. {nl} Persuade the Demons to go to the altar on their own.
-QUEST_LV_0100_20150317_000800	I get caught every time, maybe the Demons know my scent. {nl} I'm sure it'll be easier for you since you haven't been around for long.
+QUEST_LV_0100_20150317_000800	I get caught every time, maybe the Demons know my scent. {nl} I’m sure it’ll be easier for you since you haven’t been around for long.
 QUEST_LV_0100_20150317_000801	Alright. {nl} I think that would be enough for you to take a grasp of it. 
 QUEST_LV_0100_20150317_000802	The power of the altar makes conversion simple. {nl} First, you activate the power of Globejas altar. {nl} Then, stay within the influence of the altar and fight the Demons.
 QUEST_LV_0100_20150317_000803	The Demons have stronger minds than you might think. {nl}It will take a lot of effort to make them forget Gesti.
@@ -805,7 +805,7 @@ QUEST_LV_0100_20150317_000804
 QUEST_LV_0100_20150317_000805	
 QUEST_LV_0100_20150317_000806	
 QUEST_LV_0100_20150317_000807	
-QUEST_LV_0100_20150317_000808	Oh, they will find out if you are not confident enough. {nl}So it's better to fight the Demons to gain some self confidence before using the scroll.
+QUEST_LV_0100_20150317_000808	Oh, they will find out if you are not confident enough. {nl}So it’s better to fight the Demons to gain some self confidence before using the scroll.
 QUEST_LV_0100_20150317_000809	
 QUEST_LV_0100_20150317_000810	
 QUEST_LV_0100_20150317_000811	
@@ -864,80 +864,80 @@ QUEST_LV_0100_20150317_000863
 QUEST_LV_0100_20150317_000864	
 QUEST_LV_0100_20150317_000865	I came to say that the Gesti went up to the 2nd floor and let my guard down. {nl} I would have been in a big trouble if not for you.
 QUEST_LV_0100_20150317_000866	I studied the barrier of the gate but power of the basement altar will not be enough. {nl} Unless you add the power of crytal held by Corylus.
-QUEST_LV_0100_20150317_000867	Maybe the Goddess knew it'd fail and that's why she said wait for the Revelator. {nl} At least, we got the Gesti hurt so it can also be good.
+QUEST_LV_0100_20150317_000867	Maybe the Goddess knew it’d fail and that’s why she said wait for the Revelator. {nl} At least, we got the Gesti hurt so it can also be good.
 QUEST_LV_0100_20150317_000868	Well done. {nl} Making the crystal of light with this will enough power to break the barrier.
 QUEST_LV_0100_20150317_000869	Prepare yourself before bringing the crystal of light to the gate. {nl}It can attract powerful monsters.
-QUEST_LV_0100_20150317_000870	I think I'll stay here to stop the Demons from entering the basement.
+QUEST_LV_0100_20150317_000870	I think I’ll stay here to stop the Demons from entering the basement.
 QUEST_LV_0100_20150317_000871	It is an honor to fight with you, Revelator. {nl} Could you drive the Demons from this area while Sir Algis investigates?
 QUEST_LV_0100_20150317_000872	
 QUEST_LV_0100_20150317_000873	
 QUEST_LV_0100_20150317_000874	
 QUEST_LV_0100_20150317_000875	
-QUEST_LV_0100_20150317_000876	The barrier of main entrance in 1st floor can be offset by the power of the church so don't worry. {nl}That's what the altars are for. {nl}
-QUEST_LV_0100_20150317_000877	Let's take care of the Unknocker first. {nl} I'll lead the Unknocker so you try to find a chance. 
+QUEST_LV_0100_20150317_000876	The barrier of main entrance in 1st floor can be offset by the power of the church so don’t worry. {nl}That’s what the altars are for. {nl}
+QUEST_LV_0100_20150317_000877	Let’s take care of the Unknocker first. {nl} I’ll lead the Unknocker so you try to find a chance. 
 QUEST_LV_0100_20150317_000878	
 QUEST_LV_0100_20150317_000879	
 QUEST_LV_0100_20150317_000880	Good job. {nl}The babbling laughter seems to have stopped.
-QUEST_LV_0100_20150317_000881	I'm trying to disguise myself as a Demon to confuse them. {nl} First, can you kill the Pawnd and take their clothes?
-QUEST_LV_0100_20150317_000882	It's a bit blasphemous, but we don't have much choice.
+QUEST_LV_0100_20150317_000881	I’m trying to disguise myself as a Demon to confuse them. {nl} First, can you kill the Pawnd and take their clothes?
+QUEST_LV_0100_20150317_000882	It’s a bit blasphemous, but we don’t have much choice.
 QUEST_LV_0100_20150317_000883	Well done. {nl} It will probably be difficult to trust each other from now on. {nl}
-QUEST_LV_0100_20150317_000884	I'm thinking of converting the Demons using the power of the altar. {nl} The converted Demons will absorb the divine power and slowly start to die. {nl}
-QUEST_LV_0100_20150317_000885	But before that, it's important to understand the Demons. {nl} Collect the souls of the Demons
+QUEST_LV_0100_20150317_000884	I’m thinking of converting the Demons using the power of the altar. {nl} The converted Demons will absorb the divine power and slowly start to die. {nl}
+QUEST_LV_0100_20150317_000885	But before that, it’s important to understand the Demons. {nl} Collect the souls of the Demons
 QUEST_LV_0100_20150317_000886	I remember the first time I converted the Demons. {nl} I pray for their poor souls.
 QUEST_LV_0100_20150317_000887	Great job. {nl} If there are any good Demons, the Goddess will look after them.
-QUEST_LV_0100_20150317_000888	The Central Altar suppressing the power of the Demons suddenly stopped. {nl} Could you take a look at what's going on?
+QUEST_LV_0100_20150317_000888	The Central Altar suppressing the power of the Demons suddenly stopped. {nl} Could you take a look at what’s going on?
 QUEST_LV_0100_20150317_000889	Strange, it was definitely working.
 QUEST_LV_0100_20150317_000890	It was an ambush. {nl} We would have been in big trouble without your help.
-QUEST_LV_0100_20150317_000891	You need the seal of space to enter the hidden sanctuary. {nl} It's hidden in Sventove Central Altar but i hope it's not too late. 
+QUEST_LV_0100_20150317_000891	You need the seal of space to enter the hidden sanctuary. {nl} It’s hidden in Sventove Central Altar but i hope it’s not too late. 
 QUEST_LV_0100_20150317_000892	Structures in the Tenet Cathedral are placed to ward against the Demons. {nl} Each one in itself is a small barrier that contributes to a huge barrier. {nl}
 QUEST_LV_0100_20150317_000893	The most powerful barrier is in the 2nd floor. {nl} I heard that it can exert the greatest force when the  divine sphere is there.
 QUEST_LV_0100_20150317_000894	Gesti made the first move. {nl} It will be difficult to approach secretly.
 QUEST_LV_0100_20150317_000895	I must change the plan. {nl} First you need to go watch the movement of the Gesti. {nl}
-QUEST_LV_0100_20150317_000896	Let's start by occupying the bell tower.
+QUEST_LV_0100_20150317_000896	Let’s start by occupying the bell tower.
 QUEST_LV_0100_20150317_000897	From here, we can see what Gesti is going to do. 
 QUEST_LV_0100_20150317_000898	Alright, bring the seal of space from Sventove Central Altar. {nl} You can do it, right?
 QUEST_LV_0100_20150317_000899	You must know that the revelation is hidden in the sanctuary. {nl} The seal of the space is the only key that get you to the sanctuary. {nl}
 QUEST_LV_0100_20150317_000900	It;s not just the Tenet Cathedral. {nl} You can enter all the places that the Goddess hid. 
-QUEST_LV_0100_20150317_000901	The seal of space can only be used by the Revelator so you won't be able to find the revelation right away. {nl}
+QUEST_LV_0100_20150317_000901	The seal of space can only be used by the Revelator so you won’t be able to find the revelation right away. {nl}
 QUEST_LV_0100_20150317_000902	
-QUEST_LV_0100_20150317_000903	We can't do anything about the destroyed altar but the fragments still have power. {nl} Gather the pieces and insert it in the 8 pillars of the Sventove Central Hall.
-QUEST_LV_0100_20150317_000904	When you are done, I will be able to tie up Gesti through the power of the divine crystal and the church. {nl} It may be for a short while but that's the best option we have.
+QUEST_LV_0100_20150317_000903	We can’t do anything about the destroyed altar but the fragments still have power. {nl} Gather the pieces and insert it in the 8 pillars of the Sventove Central Hall.
+QUEST_LV_0100_20150317_000904	When you are done, I will be able to tie up Gesti through the power of the divine crystal and the church. {nl} It may be for a short while but that’s the best option we have.
 QUEST_LV_0100_20150317_000905	So you activated the Malda altar? {nl} Now it will be safe to stay here for the time being. Good work.
 QUEST_LV_0100_20150317_000906	Demon are going around the second floor searching every corner. {nl} Activating the Auka altar will be able to turn their attention.
-QUEST_LV_0100_20150317_000907	I'm relieved you're beside me. {nl} I think it was a good thing that Laima chose you.
+QUEST_LV_0100_20150317_000907	I’m relieved you’re beside me. {nl} I think it was a good thing that Laima chose you.
 QUEST_LV_0100_20150317_000908	Good job. {nl} When this is over, I should gather all brothers and drive them away at once.
-QUEST_LV_0100_20150317_000909	I'll ring the bell and let you know when the Gesti show up so have a safe trip on your way.
+QUEST_LV_0100_20150317_000909	I’ll ring the bell and let you know when the Gesti show up so have a safe trip on your way.
 QUEST_LV_0100_20150317_000910	So you found the seal of space. {nl}Use the seal on the pillar beside me to go to the sanctuary. {nl} It is prepared for the Revelator only.
 QUEST_LV_0100_20150317_000911	May the blessings of the Goddess be with you.
-QUEST_LV_0100_20150317_000912	So Gesti just ran away. {nl} Fine. Since you got the revelation, we've completed the mission. {nl}
+QUEST_LV_0100_20150317_000912	So Gesti just ran away. {nl} Fine. Since you got the revelation, we’ve completed the mission. {nl}
 QUEST_LV_0100_20150317_000913	To find the Salue Goddess.. {nl} The colorful valley mentioned in the revelation should start from the Grass Brook Side in the northern area. {nl} Alright then, may be blessings of the Goddess be with you.
-QUEST_LV_0100_20150317_000914	When you find the revelation, tell Mater Paladin of the story you've been through so far. {nl} May the blessings of the Goddess be with you.
+QUEST_LV_0100_20150317_000914	When you find the revelation, tell Mater Paladin of the story you’ve been through so far. {nl} May the blessings of the Goddess be with you.
 QUEST_LV_0100_20150317_000915	Seems like Gesti did not notice yet. {nl}Better prepare the divine crystal.
 QUEST_LV_0100_20150317_000916	All the preparations made. {nl} Barriers of the church will soon weaken the Gesti. {nl}
 QUEST_LV_0100_20150317_000917	The weakened Gesti will be enough for you to handle. {nl} When the Gesti is cornered, I will make the final strike with the divine sphere.
-QUEST_LV_0100_20150317_000918	This is a piece of Mazas shelter barrier. {nl} Do not worry. {nl} There are ways to recover the barrier so I'm sure it will be alright.
-QUEST_LV_0100_20150317_000919	I didn't know the Demons will use the summoner to come across here. {nl} Better get rid of them all before they seige us.
-QUEST_LV_0100_20150317_000920	Even with so many Demons, you still managed to make it through. {nl} You may be the Revelator, but that's still impressive. {nl}
-QUEST_LV_0100_20150317_000921	It's the revelation. {nl} Cherish it and do not show it to anyone else. {nl}
+QUEST_LV_0100_20150317_000918	This is a piece of Mazas shelter barrier. {nl} Do not worry. {nl} There are ways to recover the barrier so I’m sure it will be alright.
+QUEST_LV_0100_20150317_000919	I didn’t know the Demons will use the summoner to come across here. {nl} Better get rid of them all before they seige us.
+QUEST_LV_0100_20150317_000920	Even with so many Demons, you still managed to make it through. {nl} You may be the Revelator, but that’s still impressive. {nl}
+QUEST_LV_0100_20150317_000921	It’s the revelation. {nl} Cherish it and do not show it to anyone else. {nl}
 QUEST_LV_0100_20150317_000922	Come on. Go to Master Paladin. {nl} He will tell you the way you must go.
-QUEST_LV_0100_20150317_000923	I asked my precious friend Algis for Tenet Church. {nl} I won't lose to Gesti but it is important to have some back up plan just in case.
+QUEST_LV_0100_20150317_000923	I asked my precious friend Algis for Tenet Church. {nl} I won’t lose to Gesti but it is important to have some back up plan just in case.
 QUEST_LV_0100_20150317_000924	8
 QUEST_LV_0100_20150317_000925	In the kingdom, there are several valuable weapons aside from this divine sphere. {nl} Those weapons saved many lives on the Divine Day four years ago.
-QUEST_LV_0100_20150317_000926	From now on, I will focus on the divine crystal. {nl} In the meanwhile, please use your skills so that I won't be disturbed.
-QUEST_LV_0100_20150317_000927	I'm sorry. It's all my fault. {nl}The Gesti found out the divine heal is not the revelation so it will head straight to the church. {nl}
+QUEST_LV_0100_20150317_000926	From now on, I will focus on the divine crystal. {nl} In the meanwhile, please use your skills so that I won’t be disturbed.
+QUEST_LV_0100_20150317_000927	I’m sorry. It’s all my fault. {nl}The Gesti found out the divine heal is not the revelation so it will head straight to the church. {nl}
 QUEST_LV_0100_20150317_000928	But his old body of mine does not follow my will anymore. {nl} Now I can only trust my old friend Algis and you. {nl}
 QUEST_LV_0100_20150317_000929	9
-QUEST_LV_0100_20150317_000930	It is too much for me to handle alone without any help from other brothers. {nl} I'd better run the Malda Altar. {nl}
-QUEST_LV_0100_20150317_000931	Using the Malda Altar will stun any Demons nearby. {nl} You'll have to finish them off.
+QUEST_LV_0100_20150317_000930	It is too much for me to handle alone without any help from other brothers. {nl} I’d better run the Malda Altar. {nl}
+QUEST_LV_0100_20150317_000931	Using the Malda Altar will stun any Demons nearby. {nl} You’ll have to finish them off.
 QUEST_LV_0100_20150317_000932	
-QUEST_LV_0100_20150317_000933	The world still needs more experience. {nl} We probably wouldn't have made it this far without the help of the Goddess.
-QUEST_LV_0100_20150317_000934	The activation of tree guard post is taking longer than I thought. {nl} We have no time, let's use a Demon's soul instead.
-QUEST_LV_0100_20150317_000935	All souls are pure. {nl} So even if it's a Demon's soul, it can still provide some divine power.
-QUEST_LV_0100_20150317_000936	Oh the Tree guard post was filled with soul of the Demon. {nl} It still needs some final touches to complete but I'll take care of it. {nl}Great job.
-QUEST_LV_0100_20150317_000937	It's amazing you can use the barrier like that. {nl} Even the Paladins did not know about that. {nl}
-QUEST_LV_0100_20150317_000938	I'm tired, I need to rest a moment. {nl} Will you kill the Demons around here while I catch my breath?
-QUEST_LV_0100_20150317_000939	Standing against this much enemies itself is a great deal. {nl} It's all thanks to Master Paladin.
-QUEST_LV_0100_20150317_000940	Even though he's still young, Kenneth is amazing. {nl}I think we can entrust him a little more.
+QUEST_LV_0100_20150317_000933	The world still needs more experience. {nl} We probably wouldn’t have made it this far without the help of the Goddess.
+QUEST_LV_0100_20150317_000934	The activation of tree guard post is taking longer than I thought. {nl} We have no time, let’s use a Demon’s soul instead.
+QUEST_LV_0100_20150317_000935	All souls are pure. {nl} So even if it’s a Demon’s soul, it can still provide some divine power.
+QUEST_LV_0100_20150317_000936	Oh the Tree guard post was filled with soul of the Demon. {nl} It still needs some final touches to complete but I’ll take care of it. {nl}Great job.
+QUEST_LV_0100_20150317_000937	It’s amazing you can use the barrier like that. {nl} Even the Paladins did not know about that. {nl}
+QUEST_LV_0100_20150317_000938	I’m tired, I need to rest a moment. {nl} Will you kill the Demons around here while I catch my breath?
+QUEST_LV_0100_20150317_000939	Standing against this much enemies itself is a great deal. {nl} It’s all thanks to Master Paladin.
+QUEST_LV_0100_20150317_000940	Even though he’s still young, Kenneth is amazing. {nl}I think we can entrust him a little more.
 QUEST_LV_0100_20150317_000941	
 QUEST_LV_0100_20150317_000942	
 QUEST_LV_0100_20150317_000943	
@@ -946,7 +946,7 @@ QUEST_LV_0100_20150317_000945
 QUEST_LV_0100_20150317_000946	
 QUEST_LV_0100_20150317_000947	
 QUEST_LV_0100_20150317_000948	This barrier is impossible to open from the inside. {nl} Fortunately, the entrance to the basement looks safe. {nl}
-QUEST_LV_0100_20150317_000949	However, it's too dangerous to in the basement with the divine sphere. {nl} I'll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
+QUEST_LV_0100_20150317_000949	However, it’s too dangerous to in the basement with the divine sphere. {nl} I’ll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
 QUEST_LV_0100_20150317_000950	
 QUEST_LV_0100_20150317_000951	
 QUEST_LV_0100_20150317_000952	
@@ -957,14 +957,14 @@ QUEST_LV_0100_20150317_000956
 QUEST_LV_0100_20150317_000957	
 QUEST_LV_0100_20150317_000958	
 QUEST_LV_0100_20150317_000959	
-QUEST_LV_0100_20150317_000960	Please put the pieces to the Ruklys memorial in front of preparing me rubbings. {Nl} because had been working with us and listening together, you'll be able to simplify. {Nl}
+QUEST_LV_0100_20150317_000960	Please put the pieces to the Ruklys memorial in front of preparing me rubbings. {Nl} because had been working with us and listening together, you’ll be able to simplify. {Nl}
 QUEST_LV_0100_20150317_000961	
 QUEST_LV_0100_20150317_000962	
 QUEST_LV_0100_20150317_000963	The capital may already be in ruins, but I will protect Klaipeda.
-QUEST_LV_0100_20150317_000964	Using all your power to crush any enemy that would threaten the Kingdom. {nl} That's how Highlanders fight in battle. {nl}
+QUEST_LV_0100_20150317_000964	Using all your power to crush any enemy that would threaten the Kingdom. {nl} That’s how Highlanders fight in battle. {nl}
 QUEST_LV_0100_20150317_000965	Good work, guys. {nl} Actually, I was also an adventure but the results seem to be fine. {nl} You just need to tell it like that to sir Kayetos in Flower hill.
 QUEST_LV_0100_20150317_000966	Seems like even Auka altar lost its powers. {nl} There were stories about its powers wiping out dozens of Demons in the past.
-QUEST_LV_0100_20150317_000967	It's hard to watch the Egnomes running around the Atgaila chapel.{nl} Please clean up the Egnomes.
+QUEST_LV_0100_20150317_000967	It’s hard to watch the Egnomes running around the Atgaila chapel.{nl} Please clean up the Egnomes.
 QUEST_LV_0100_20150317_000968	Many Treasures of the Paladin which should not go into the hands of the Demons are also here. {nl} You should not fall into it.
 QUEST_LV_0100_20150317_000969	
 QUEST_LV_0100_20150317_000970	
@@ -1013,7 +1013,7 @@ QUEST_LV_0100_20150317_001012
 QUEST_LV_0100_20150317_001013	
 QUEST_LV_0100_20150317_001014	
 QUEST_LV_0100_20150317_001015	
-QUEST_LV_0100_20150317_001016	Agailla Flurry's is not found is successor, I heard and was borne away instead. To refer it 's in order to ensure that a {nl} something important .. it Mu~onjin not I well known.
+QUEST_LV_0100_20150317_001016	Agailla Flurry’s is not found is successor, I heard and was borne away instead. To refer it ’s in order to ensure that a {nl} something important .. it Mu~onjin not I well known.
 QUEST_LV_0100_20150317_001017	The Divine Day can strike anytime again whether it is in your hometown or my kingdom. {nl} The culprit of the plague would be something worthy of my sword.
 QUEST_LV_0100_20150317_001018	Owyn
 QUEST_LV_0100_20150317_001019	
@@ -1101,59 +1101,59 @@ QUEST_LV_0100_20150317_001100
 QUEST_LV_0100_20150317_001101	
 QUEST_LV_0100_20150317_001102	
 QUEST_LV_0100_20150317_001103	Look at this busted cable car.{nl} The damage is pretty serious. {nl}
-QUEST_LV_0100_20150317_001104	It's obviously the work of Grummer and Zignuts from the Cholras road. {nl}Give them a taste of your skills while I fix this. 
-QUEST_LV_0100_20150317_001105	This would not have happened if the old people lent their ears on what the young men say. {nl} But what's done is already done. What can we do about it?
-QUEST_LV_0100_20150317_001106	Good work. {nl} It's the parts the pantos stole before. {nl} I didn't know I'd be seeing it again like this.
+QUEST_LV_0100_20150317_001104	It’s obviously the work of Grummer and Zignuts from the Cholras road. {nl}Give them a taste of your skills while I fix this. 
+QUEST_LV_0100_20150317_001105	This would not have happened if the old people lent their ears on what the young men say. {nl} But what’s done is already done. What can we do about it?
+QUEST_LV_0100_20150317_001106	Good work. {nl} It’s the parts the pantos stole before. {nl} I didn’t know I’d be seeing it again like this.
 QUEST_LV_0100_20150317_001107	Guard Molly
 QUEST_LV_0100_20150317_001108	The Pantos were not always such violent monsters. {nl}There must be a way to change them back. {nl}
 QUEST_LV_0100_20150317_001109	I want you to give young pantos the highland beets in Nyosalrus Street.{nl}then they would come to me to remind something? 
-QUEST_LV_0100_20150317_001110	It a bitter thing indeed. {nl} No matter how troubled the world is, they weren't like that before.
-QUEST_LV_0100_20150317_001111	That's right. Thank you very much! {nl} Have you seen a broken cable car there? I used to ride that when I was a kid. 
-QUEST_LV_0100_20150317_001112	Thank you! {nl} You've saved me and my friends from spending more than half of our lives just protecting the cable car. {nl}
-QUEST_LV_0100_20150317_001113	Since I'm the only one who can fix the cable car, I'll consider it clear. {nl} Oh, of course, thanks for your help.
+QUEST_LV_0100_20150317_001110	It a bitter thing indeed. {nl} No matter how troubled the world is, they weren’t like that before.
+QUEST_LV_0100_20150317_001111	That’s right. Thank you very much! {nl} Have you seen a broken cable car there? I used to ride that when I was a kid. 
+QUEST_LV_0100_20150317_001112	Thank you! {nl} You’ve saved me and my friends from spending more than half of our lives just protecting the cable car. {nl}
+QUEST_LV_0100_20150317_001113	Since I’m the only one who can fix the cable car, I’ll consider it clear. {nl} Oh, of course, thanks for your help.
 QUEST_LV_0100_20150317_001114	Please bring me the Mally seeds in the way to Labure roads. {nl} They would be a good source of magic for the shaman doll. {nl} {nl}
 QUEST_LV_0100_20150317_001115	So exciting. {nl} Some straws, seeds, and a bit of rope and those kinds of things can go around alive.
 QUEST_LV_0100_20150317_001116	Guard Mory
 QUEST_LV_0100_20150317_001117	The Simorph popping out is a bit frightening. {nl} So the pantos can fall this bad.
-QUEST_LV_0100_20150317_001118	Won't you help me purify Labure road? {nl} The shaman doll finds the evil force but we have to purify it ourselves.
-QUEST_LV_0100_20150317_001119	Contamination is everywhere, but I think Labure Road is the worst. {nl} Maybe it's spreading through the roots?
-QUEST_LV_0100_20150317_001120	Look at these gentle pantos. {nl} It's insane that we have to make the pantos our enemies when the evils are charging in.
-QUEST_LV_0100_20150317_001121	We need the rope for ceremony to make the shaman doll. {nl} It's on the waist of the Panto Shaman in the Cottage. {nl} Bring it to me.
+QUEST_LV_0100_20150317_001118	Won’t you help me purify Labure road? {nl} The shaman doll finds the evil force but we have to purify it ourselves.
+QUEST_LV_0100_20150317_001119	Contamination is everywhere, but I think Labure Road is the worst. {nl} Maybe it’s spreading through the roots?
+QUEST_LV_0100_20150317_001120	Look at these gentle pantos. {nl} It’s insane that we have to make the pantos our enemies when the evils are charging in.
+QUEST_LV_0100_20150317_001121	We need the rope for ceremony to make the shaman doll. {nl} It’s on the waist of the Panto Shaman in the Cottage. {nl} Bring it to me.
 QUEST_LV_0100_20150317_001122	If you persuade the Capria, the Pantos will be tamed. {nl}Capri is the leader of pantos. {nl}
-QUEST_LV_0100_20150317_001123	Let's follow the baby pantos. {nl}It will definitely lead the way to Capri.
+QUEST_LV_0100_20150317_001123	Let’s follow the baby pantos. {nl}It will definitely lead the way to Capri.
 QUEST_LV_0100_20150317_001124	I hope the Capria would understand us. {nl} We should do whatever we can.
 QUEST_LV_0100_20150317_001125	Got angry right away when seeing the baby Pantos? {nl} Would it really not work.
-QUEST_LV_0100_20150317_001126	I worked so hard to fix it but I'm worried for the Poatas. {nl} Monsters of that size can destroy the cable car.
+QUEST_LV_0100_20150317_001126	I worked so hard to fix it but I’m worried for the Poatas. {nl} Monsters of that size can destroy the cable car.
 QUEST_LV_0100_20150317_001127	Our guards love to fight {Nl}Pantos were not this reckless before. {nl}I wonder if we should be like this when the Demons waiting to march in.
-QUEST_LV_0100_20150317_001128	The Poatas also destroyed the cable car in Nepavy. {nl}But it's not like we can guard it all the time. {nl}
-QUEST_LV_0100_20150317_001129	Even if we stay on guards, a fight with the Poatas? {nl} That's not easy.
+QUEST_LV_0100_20150317_001128	The Poatas also destroyed the cable car in Nepavy. {nl}But it’s not like we can guard it all the time. {nl}
+QUEST_LV_0100_20150317_001129	Even if we stay on guards, a fight with the Poatas? {nl} That’s not easy.
 QUEST_LV_0100_20150317_001130	
 QUEST_LV_0100_20150317_001131	
 QUEST_LV_0100_20150317_001132	
 QUEST_LV_0100_20150317_001133	This place has a very sacred meaning for us. {nl} And we have called ourselves the watchmen for protecting this place. {nl}
 QUEST_LV_0100_20150317_001134	It has been protected since the day the promised by the first Paladin. {nl} And now that the Demons have invaded, it is time to keep that promise.
-QUEST_LV_0100_20150317_001135	Pantos changed and became wild after the Divine Day four years ago. {nl} Before that, we didn't really mind each other and even joked around together. {nl}
+QUEST_LV_0100_20150317_001135	Pantos changed and became wild after the Divine Day four years ago. {nl} Before that, we didn’t really mind each other and even joked around together. {nl}
 QUEST_LV_0100_20150317_001136	I really wonder what has happened to the sacred land? 
-QUEST_LV_0100_20150317_001137	The Caprias were the first to change after the incident four years ago. {nl} And then the Pantos.. now it's only the babies left.
+QUEST_LV_0100_20150317_001137	The Caprias were the first to change after the incident four years ago. {nl} And then the Pantos.. now it’s only the babies left.
 QUEST_LV_0100_20150317_001138	
 QUEST_LV_0100_20150317_001139	Thank you for helping out like your own work. {nl} My workload has reduced a lot.
 QUEST_LV_0100_20150317_001140	
-QUEST_LV_0100_20150317_001141	We used to be on good terms with the Pantos. {nl} These days, we're constantly at each other's throats.
+QUEST_LV_0100_20150317_001141	We used to be on good terms with the Pantos. {nl} These days, we’re constantly at each other’s throats.
 QUEST_LV_0100_20150317_001142	
 QUEST_LV_0100_20150317_001143	Thank you. {nl} We might be able to go get more when more young men come.
-QUEST_LV_0100_20150317_001144	I can't stand seeing the Panto totems pressed with evil forces. {nl} I'm going to break it through the shaman doll. Want to give it a try?
-QUEST_LV_0100_20150317_001145	We can't do anything until Basil restores the shaman doll perfectly. {nl} Unless for special situations like this, we can use, uhm, nothing. 
-QUEST_LV_0100_20150317_001146	If would have been a disaster if the Carnivore had legs. {nl} I'm glad it was killed beforehand.
+QUEST_LV_0100_20150317_001144	I can’t stand seeing the Panto totems pressed with evil forces. {nl} I’m going to break it through the shaman doll. Want to give it a try?
+QUEST_LV_0100_20150317_001145	We can’t do anything until Basil restores the shaman doll perfectly. {nl} Unless for special situations like this, we can use, uhm, nothing. 
+QUEST_LV_0100_20150317_001146	If would have been a disaster if the Carnivore had legs. {nl} I’m glad it was killed beforehand.
 QUEST_LV_0100_20150317_001147	I heard we promised the first Paladin three things in return for saving our family. {nl}
 QUEST_LV_0100_20150317_001148	To help build the Tenet Cathedral, {nl} protecting the divine relics by having watchmen guard the sacred land, {nl} and lastly, to protect each other together when great danger is foreseen. {nl}
-QUEST_LV_0100_20150317_001149	I do not know what curse it was. {nl} There's got to be a record in the Tenet Cathedral.
-QUEST_LV_0100_20150317_001150	Our Shaman dolls and Bokor's Shaman dolls have different meanings. {nl}
-QUEST_LV_0100_20150317_001151	It does not curse like the Bokor's. {nl} It moves by itself to attack, or something like that. 
+QUEST_LV_0100_20150317_001149	I do not know what curse it was. {nl} There’s got to be a record in the Tenet Cathedral.
+QUEST_LV_0100_20150317_001150	Our Shaman dolls and Bokor’s Shaman dolls have different meanings. {nl}
+QUEST_LV_0100_20150317_001151	It does not curse like the Bokor’s. {nl} It moves by itself to attack, or something like that. 
 QUEST_LV_0100_20150317_001152	The Demons could have used their hand to make it easier for them to attack. {nl} Or maybe they were eyeing on the divine heal. {nl}
-QUEST_LV_0100_20150317_001153	Since the diving heal was hidden deep below the ground. {nl} Who could have known that the reason for the world's overturn was because of the plants?
-QUEST_LV_0100_20150317_001154	You may use a bit of force if words won't do. {nl}We can't grow any further from each other anymore.
+QUEST_LV_0100_20150317_001153	Since the diving heal was hidden deep below the ground. {nl} Who could have known that the reason for the world’s overturn was because of the plants?
+QUEST_LV_0100_20150317_001154	You may use a bit of force if words won’t do. {nl}We can’t grow any further from each other anymore.
 QUEST_LV_0100_20150317_001155	You can summon the shaman doll with this summon scroll. {nl}
-QUEST_LV_0100_20150317_001156	If possible, get rid of the Carnivore too. {nl} It was contaminated by the Magi and I can't stand watching it anymore.
+QUEST_LV_0100_20150317_001156	If possible, get rid of the Carnivore too. {nl} It was contaminated by the Magi and I can’t stand watching it anymore.
 QUEST_LV_0100_20150317_001157	Make a mess in the nest of Poatas in Margas Hill and it will appear. {nl}
 QUEST_LV_0100_20150317_001158	
 QUEST_LV_0100_20150317_001159	Rexipher? {Nl} Although it is the first time I hear the name. {Nl}
@@ -1186,9 +1186,9 @@ QUEST_LV_0100_20150317_001185
 QUEST_LV_0100_20150317_001186	
 QUEST_LV_0100_20150317_001187	
 QUEST_LV_0100_20150317_001188	
-QUEST_LV_0100_20150317_001189	You're a brave guy. {nl} There are five clues in 1st Mine Lot . {nl} No need for hurry. It will take a long time.
-QUEST_LV_0100_20150317_001190	Found it. {nl} Then I'll start from now.
-QUEST_LV_0100_20150317_001191	I'll give you a riddle. {nl} It is something you must do, have done most, and will have to do.  {nl} Show your answer in action. 
+QUEST_LV_0100_20150317_001189	You’re a brave guy. {nl} There are five clues in 1st Mine Lot . {nl} No need for hurry. It will take a long time.
+QUEST_LV_0100_20150317_001190	Found it. {nl} Then I’ll start from now.
+QUEST_LV_0100_20150317_001191	I’ll give you a riddle. {nl} It is something you must do, have done most, and will have to do.  {nl} Show your answer in action. 
 QUEST_LV_0100_20150317_001192	Good work. {nl} You will be rewarded with proper compensation.
 QUEST_LV_0100_20150317_001193	
 QUEST_LV_0100_20150317_001194	
@@ -1208,27 +1208,27 @@ QUEST_LV_0100_20150317_001207
 QUEST_LV_0100_20150317_001208	Silver of Fedimian
 QUEST_LV_0100_20150317_001209	
 QUEST_LV_0100_20150317_001210	The spear is itself a pure weapon of destruction.{nl} It is the best weapon anyone can easily learn and master.
-QUEST_LV_0100_20150317_001211	Golem, that's awesome. {nl} And you remember what I taught you?
+QUEST_LV_0100_20150317_001211	Golem, that’s awesome. {nl} And you remember what I taught you?
 QUEST_LV_0100_20150317_001212	I guess the Revelator really is different. {nl} You you seem to be different from the other Revelators too...
 QUEST_LV_0100_20150317_001213	Defeating the Golem was so cool. {nl} Where did you learn to do that?
-QUEST_LV_0100_20150317_001214	I'm grateful for your help. {nl} Commander Uska is waiting for you in Klaipeda, so go find him.
+QUEST_LV_0100_20150317_001214	I’m grateful for your help. {nl} Commander Uska is waiting for you in Klaipeda, so go find him.
 QUEST_LV_0100_20150317_001215	I firmly believe that the Goddess will return someday. No doubt about it. {nl} We have to believe it. If we do not believe in the Goddess then who will?
-QUEST_LV_0100_20150317_001216	Please hurry and support the Miners' Village. {nl} Someone like you will be of great help.
-QUEST_LV_0100_20150317_001217	I heard the stories. So you defeated the Vubbe Fighter, huh? {nl} That's incredible.
+QUEST_LV_0100_20150317_001216	Please hurry and support the Miners’ Village. {nl} Someone like you will be of great help.
+QUEST_LV_0100_20150317_001217	I heard the stories. So you defeated the Vubbe Fighter, huh? {nl} That’s incredible.
 QUEST_LV_0100_20150317_001218	I was anxious watching from a distance but it was really awesome.
-QUEST_LV_0100_20150317_001219	Frankly, I'm scared. {nl}Miners' Village, and then the East Woods... Even Klaipeda is becoming dangerous.
-QUEST_LV_0100_20150317_001220	Although I am very concerned for Miners' Village, {nl}at least it has calm down this much thanks to you. 
+QUEST_LV_0100_20150317_001219	Frankly, I’m scared. {nl}Miners’ Village, and then the East Woods... Even Klaipeda is becoming dangerous.
+QUEST_LV_0100_20150317_001220	Although I am very concerned for Miners’ Village, {nl}at least it has calm down this much thanks to you. 
 QUEST_LV_0100_20150317_001221	Healer Lady
 QUEST_LV_0100_20150317_001222	We pray that the blessings of the Goddess will always be with the Revelator who saved us
-QUEST_LV_0100_20150317_001223	I'm helping the refugees. {nl} The monsters attacked the village 
+QUEST_LV_0100_20150317_001223	I’m helping the refugees. {nl} The monsters attacked the village 
 QUEST_LV_0100_20150317_001224	
 QUEST_LV_0100_20150317_001225	Still anxious. {nl} But thanks to you things are better than before.
-QUEST_LV_0100_20150317_001226	I can't believe the Cunningham's story is true... I think it needs more research.
-QUEST_LV_0100_20150317_001227	Everything has a source called Mana. {nl} And everyone can connect to each other's Mana if they want. {nl} Just like digging a canal.
+QUEST_LV_0100_20150317_001226	I can’t believe the Cunningham’s story is true... I think it needs more research.
+QUEST_LV_0100_20150317_001227	Everything has a source called Mana. {nl} And everyone can connect to each other’s Mana if they want. {nl} Just like digging a canal.
 QUEST_LV_0100_20150317_001228	Have you ever seen Vubbes using pickaxes? {nl} What are they trying to find...
 QUEST_LV_0100_20150317_001229	
 QUEST_LV_0100_20150317_001230	If you still want to enter the Closed Area, collect the strange stone from the Vubbes. {nl} Stic it to the wall and the crystal wals open.
-QUEST_LV_0100_20150317_001231	What are you doing here? {nl} Go into the mines quickly. {nl} Weren't we supposed to meet in 1st Gallery?
+QUEST_LV_0100_20150317_001231	What are you doing here? {nl} Go into the mines quickly. {nl} Weren’t we supposed to meet in 1st Gallery?
 QUEST_LV_0100_20150317_001232	
 QUEST_LV_0100_20150317_001233	
 QUEST_LV_0100_20150317_001234	
@@ -1291,7 +1291,7 @@ QUEST_LV_0100_20150317_001290
 QUEST_LV_0100_20150317_001291	
 QUEST_LV_0100_20150317_001292	
 QUEST_LV_0100_20150317_001293	
-QUEST_LV_0100_20150317_001294	I heard the story but I can't really believe it. {nl} Getting rid of the Vubbe Fighter. 
+QUEST_LV_0100_20150317_001294	I heard the story but I can’t really believe it. {nl} Getting rid of the Vubbe Fighter. 
 QUEST_LV_0100_20150317_001295	
 QUEST_LV_0100_20150317_001296	
 QUEST_LV_0100_20150317_001297	
@@ -1350,28 +1350,28 @@ QUEST_LV_0100_20150317_001349
 QUEST_LV_0100_20150317_001350	
 QUEST_LV_0100_20150317_001351	
 QUEST_LV_0100_20150317_001352	Thank you for the regards from sir Laimonas. {nl} Come on in to Klaipeda. Sir Uska is waiting.
-QUEST_LV_0100_20150317_001353	Don't forget to send my regards to the Klaipeda Chief Commander.
+QUEST_LV_0100_20150317_001353	Don’t forget to send my regards to the Klaipeda Chief Commander.
 QUEST_LV_0100_20150317_001354	When you are ready, please go to Aras in the Eastern Woods.
-QUEST_LV_0100_20150317_001355	Welcome! {nl} Oh, you're the Revelator. I really wanted to meet you. {nl}
+QUEST_LV_0100_20150317_001355	Welcome! {nl} Oh, you’re the Revelator. I really wanted to meet you. {nl}
 QUEST_LV_0100_20150317_001356	This is a warp scroll. {nl} You can go to any Goddess Statue or return to previous location by using it. {nl}
-QUEST_LV_0100_20150317_001357	We'll give you more than what the Knights asked for so please help us find the Goddesses.
+QUEST_LV_0100_20150317_001357	We’ll give you more than what the Knights asked for so please help us find the Goddesses.
 QUEST_LV_0100_20150317_001358	I think Large Kepa is still out there. {nl} Would you take a look?
 QUEST_LV_0100_20150317_001359	It was there right? {nl} My senses are never wrong. 
 QUEST_LV_0100_20150317_001360	Even though Klaipeda is just around the corner, the supply situation is not good enough. {nl} Think how worse it would be in other areas. 
-QUEST_LV_0100_20150317_001361	My men should have returned by now but there is no sign of them. {nl} They know well that I'm too busy to check on them myself. 
+QUEST_LV_0100_20150317_001361	My men should have returned by now but there is no sign of them. {nl} They know well that I’m too busy to check on them myself. 
 QUEST_LV_0100_20150317_001362	My men said they are going to the Delon shelter . {nl} The Golem may appear anytime and yet they are so carefree. 
 QUEST_LV_0100_20150317_001363	Rocktortuga will ambush this area soon. {nl} We must stop it from crossing the barrier. 
-QUEST_LV_0100_20150317_001364	Have you seen baby Poatas? {nl} We better drive them out quickly so that the mother Poatas won't keep showing up. 
-QUEST_LV_0100_20150317_001365	Vubbes have built their base outside the village. {nl} Now that we don't even have troops, {nl}something serious might happen if we don't drive them out of their base. 
+QUEST_LV_0100_20150317_001364	Have you seen baby Poatas? {nl} We better drive them out quickly so that the mother Poatas won’t keep showing up. 
+QUEST_LV_0100_20150317_001365	Vubbes have built their base outside the village. {nl} Now that we don’t even have troops, {nl}something serious might happen if we don’t drive them out of their base. 
 QUEST_LV_0100_20150317_001366	Thank you so much for your bravery. 
-QUEST_LV_0100_20150317_001367	How could I express my gratitude. {nl}I'm sure the Goddess sent you to us.
+QUEST_LV_0100_20150317_001367	How could I express my gratitude. {nl}I’m sure the Goddess sent you to us.
 QUEST_LV_0100_20150317_001368	This patient told us the Chafer must have appeared. {nl} Can you help us and check on it?
 QUEST_LV_0100_20150317_001369	Now, I have to treat this patient... So thank you.
 QUEST_LV_0100_20150317_001370	Those refugees are probably having a hard time getting here because of the monsters.
-QUEST_LV_0100_20150317_001371	I can't help but think about it since he's worked here for so long.
+QUEST_LV_0100_20150317_001371	I can’t help but think about it since he’s worked here for so long.
 QUEST_LV_0100_20150317_001372	Thank you. Now I can feel at ease and return to the village. {nl} May the blessing of the Goddess be with you always.
 QUEST_LV_0100_20150317_001373	Being attacked by the Golems will get them back to their senses. 
-QUEST_LV_0100_20150317_001374	Usually, you can't find them no matter how hard you try. {nl} Strange huh?
+QUEST_LV_0100_20150317_001374	Usually, you can’t find them no matter how hard you try. {nl} Strange huh?
 QUEST_LV_0100_20150317_001375	I am pleased that the friends went back home safely. Was Mashi anxiety to hear the story of {nl} is the Molich close on the prowl.
 QUEST_LV_0100_20150317_001376	
 QUEST_LV_0100_20150317_001377	
@@ -1403,10 +1403,10 @@ QUEST_LV_0100_20150317_001402	And if seen by looking at the stone will appear cl
 QUEST_LV_0100_20150317_001403	
 QUEST_LV_0100_20150317_001404	
 QUEST_LV_0100_20150317_001405	
-QUEST_LV_0100_20150317_001406	What is that? {nl} The eyes of the Succubus...? It's good that you killed it but show me that!
-QUEST_LV_0100_20150317_001407	Like I said.. I had a talent in doing with my hands so I was interested since I was young. {nl} Alchemy, magic, medicine... I know a bit about the eyes of the Succubus! {nl} It's the eyes that the Succubus put in my eyes in envy of the pretty necklace bearing the blessing of the cathedral! {nl} I'll make you a necklace with it again!
-QUEST_LV_0100_20150317_001408	It won't take long. {nl} Excuse me.
-QUEST_LV_0100_20150317_001409	It's done! {nl} It would look good on you!
+QUEST_LV_0100_20150317_001406	What is that? {nl} The eyes of the Succubus...? It’s good that you killed it but show me that!
+QUEST_LV_0100_20150317_001407	Like I said.. I had a talent in doing with my hands so I was interested since I was young. {nl} Alchemy, magic, medicine... I know a bit about the eyes of the Succubus! {nl} It’s the eyes that the Succubus put in my eyes in envy of the pretty necklace bearing the blessing of the cathedral! {nl} I’ll make you a necklace with it again!
+QUEST_LV_0100_20150317_001408	It won’t take long. {nl} Excuse me.
+QUEST_LV_0100_20150317_001409	It’s done! {nl} It would look good on you!
 QUEST_LV_0100_20150317_001410	
 QUEST_LV_0100_20150317_001411	The Asmodian attacked the tower is not the first time, but did Mase long earthquake up here. Thanks to {nl}, and whether they are by but Gabija disappeared in the world?
 QUEST_LV_0100_20150317_001412	
@@ -1414,21 +1414,21 @@ QUEST_LV_0100_20150317_001413
 QUEST_LV_0100_20150317_001414	
 QUEST_LV_0100_20150317_001415	
 QUEST_LV_0100_20150317_001416	
-QUEST_LV_0100_20150317_001417	Soon Let's go to the next floor. {Nl} Gabija budget is awaiting us. {Nl}
+QUEST_LV_0100_20150317_001417	Soon Let’s go to the next floor. {Nl} Gabija budget is awaiting us. {Nl}
 QUEST_LV_0100_20150317_001418	Refugee
-QUEST_LV_0100_20150317_001419	I lost everything. {nl} I don't know how I can go on anymore. {nl} Would my life have become this miserable if not for the Divine Day?
-QUEST_LV_0100_20150317_001420	Four years ago, it was on the eve of the so called 'Divine Day'. {nl} Suddenly, a huge tree emerged in the middle of the capital and the earth and sky reversed. {nl}
+QUEST_LV_0100_20150317_001419	I lost everything. {nl} I don’t know how I can go on anymore. {nl} Would my life have become this miserable if not for the Divine Day?
+QUEST_LV_0100_20150317_001420	Four years ago, it was on the eve of the so called ’Divine Day’. {nl} Suddenly, a huge tree emerged in the middle of the capital and the earth and sky reversed. {nl}
 QUEST_LV_0100_20150317_001421	I never knew a tree could grow that big. {nl} And the destruction of the capital began. {nl}
-QUEST_LV_0100_20150317_001422	Everything happened so fast, and nobody knew what to do. {nl} We didn't know whether to run away or try to stop it... Our minds just became blank.
+QUEST_LV_0100_20150317_001422	Everything happened so fast, and nobody knew what to do. {nl} We didn’t know whether to run away or try to stop it... Our minds just became blank.
 QUEST_LV_0100_20150317_001423	The destruction of the capital was just the beginning. {nl} Divine Day was simply a prelude to the catastrophes coming ahead. {nl}
 QUEST_LV_0100_20150317_001424	Monstrous plants sprouted up all over and began devouring people.{nl} Everyone started running, but before I knew it I was the only person left.{nl}
-QUEST_LV_0100_20150317_001425	Enough... Don't ask any more questions. {nl} I don't want to think about it anymore.
+QUEST_LV_0100_20150317_001425	Enough... Don’t ask any more questions. {nl} I don’t want to think about it anymore.
 QUEST_LV_0100_20150317_001426	
 QUEST_LV_0100_20150317_001427	
 QUEST_LV_0100_20150317_001428	
 QUEST_LV_0100_20150317_001429	
 QUEST_LV_0100_20150317_001430	
-QUEST_LV_0100_20150317_001431	There is Fedimian, but there are interesting ruins around If you look it's too old city. {Nl} I will have city Toka .. Cathedral cursed Toka tower of the wizard.
+QUEST_LV_0100_20150317_001431	There is Fedimian, but there are interesting ruins around If you look it’s too old city. {Nl} I will have city Toka .. Cathedral cursed Toka tower of the wizard.
 QUEST_LV_0100_20150317_001432	Hundreds of years skip a name to the large witch before it is Agailla Flurry vertical tower. Most of the magic to existing {nl}, either came out from the tower, but it is there is no difference.
 QUEST_LV_0100_20150317_001433	
 QUEST_LV_0100_20150317_001434	It was the place where people lived and supported the previous rebel Ruklys. {Nl} the curse would be hard while you went so still valid.
@@ -1438,7 +1438,7 @@ QUEST_LV_0100_20150317_001437	Here, Chengdu Fedimian God, is the Earth. Please a
 QUEST_LV_0100_20150317_001438	
 QUEST_LV_0100_20150317_001439	
 QUEST_LV_0100_20150317_001440	
-QUEST_LV_0100_20150317_001441	Since follow believe the Saule goddess, you'll be able to accept this as a high difficulty such. {Nl} impiety to, do you think want to who stay like this terrible place?
+QUEST_LV_0100_20150317_001441	Since follow believe the Saule goddess, you’ll be able to accept this as a high difficulty such. {Nl} impiety to, do you think want to who stay like this terrible place?
 QUEST_LV_0100_20150317_001442	
 QUEST_LV_0100_20150317_001443	
 QUEST_LV_0100_20150317_001444	
@@ -1447,10 +1447,10 @@ QUEST_LV_0100_20150317_001446
 QUEST_LV_0100_20150317_001447	
 QUEST_LV_0100_20150317_001448	
 QUEST_LV_0100_20150317_001449	
-QUEST_LV_0100_20150317_001450	There are rumors about Golems appearing so don't go far too deep. {nl} It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
-QUEST_LV_0100_20150317_001451	So, I guess there is actually someone good among those who say they've dreamed of the Goddess.
-QUEST_LV_0100_20150317_001452	I'm relieved that there are people who dreamed of the Goddess. {nl} But there seems to be too many of them.
-QUEST_LV_0100_20150317_001453	A dream of the disappeared Goddess. Isn't that something amazing?
+QUEST_LV_0100_20150317_001450	There are rumors about Golems appearing so don’t go far too deep. {nl} It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
+QUEST_LV_0100_20150317_001451	So, I guess there is actually someone good among those who say they’ve dreamed of the Goddess.
+QUEST_LV_0100_20150317_001452	I’m relieved that there are people who dreamed of the Goddess. {nl} But there seems to be too many of them.
+QUEST_LV_0100_20150317_001453	A dream of the disappeared Goddess. Isn’t that something amazing?
 QUEST_LV_0100_20150317_001454	
 QUEST_LV_0100_20150317_001455	
 QUEST_LV_0100_20150317_001456	
@@ -1477,8 +1477,8 @@ QUEST_LV_0100_20150317_001476
 QUEST_LV_0100_20150317_001477	
 QUEST_LV_0100_20150317_001478	
 QUEST_LV_0100_20150317_001479	
-QUEST_LV_0100_20150317_001480	There's nothing better than a trap when you want to gather the enemies and strike them at once. {nl} Of course, it's also the best for running away. 
-QUEST_LV_0100_20150317_001481	If you think companion is just a pet, that's a huge mistake. {nl} It's like an inseparable friend to the hunters.
+QUEST_LV_0100_20150317_001480	There’s nothing better than a trap when you want to gather the enemies and strike them at once. {nl} Of course, it’s also the best for running away. 
+QUEST_LV_0100_20150317_001481	If you think companion is just a pet, that’s a huge mistake. {nl} It’s like an inseparable friend to the hunters.
 QUEST_LV_0100_20150317_001482	
 QUEST_LV_0100_20150317_001483	
 QUEST_LV_0100_20150317_001484	
@@ -1532,42 +1532,42 @@ QUEST_LV_0100_20150317_001531
 QUEST_LV_0100_20150317_001532	
 QUEST_LV_0100_20150317_001533	What do we do? {nl} To add to all the chaos in the village, the Vubbes kidnapped the village people.
 QUEST_LV_0100_20150317_001534	
-QUEST_LV_0100_20150317_001535	Oh, you're just in time. We need your help. {nl} Monsters stole all the aids and supplies meant for the refugees. {nl}
+QUEST_LV_0100_20150317_001535	Oh, you’re just in time. We need your help. {nl} Monsters stole all the aids and supplies meant for the refugees. {nl}
 QUEST_LV_0100_20150317_001536	Fortunately, we found it quickly.
-QUEST_LV_0100_20150317_001537	I'll stay and help the people left here. {nl}You should go ahead and help others who need more help that I do.
-QUEST_LV_0100_20150317_001538	I'm holding it because it looked like it's going to collapse. {nl}We need some stones to do something about it.
-QUEST_LV_0100_20150317_001539	We won't be able to handle it if they siege this place . {nl}How will you stop it then if people are running away even now?
-QUEST_LV_0100_20150317_001540	Alright. That'll be enough.
+QUEST_LV_0100_20150317_001537	I’ll stay and help the people left here. {nl}You should go ahead and help others who need more help that I do.
+QUEST_LV_0100_20150317_001538	I’m holding it because it looked like it’s going to collapse. {nl}We need some stones to do something about it.
+QUEST_LV_0100_20150317_001539	We won’t be able to handle it if they siege this place . {nl}How will you stop it then if people are running away even now?
+QUEST_LV_0100_20150317_001540	Alright. That’ll be enough.
 QUEST_LV_0100_20150317_001541	I must go back to the village. {nl} But as you can see my arms are shaking. {nl} Can you kill the monsters while I rest my arms for a while?
-QUEST_LV_0100_20150317_001542	So heartless of the Goddess. {nl} If the Goddess wouldn't have disappeared, the monsters wouldn't have come attacking. 
+QUEST_LV_0100_20150317_001542	So heartless of the Goddess. {nl} If the Goddess wouldn’t have disappeared, the monsters wouldn’t have come attacking. 
 QUEST_LV_0100_20150317_001543	Now I can return to village with peace of mind. {nl} This grace I shall never forget.
-QUEST_LV_0100_20150317_001544	I came here to hide from the monsters but even this area is becoming dangerous. {nl} I'm trying to go back to the village so can you bring the other refugees to me?
-QUEST_LV_0100_20150317_001545	I see you've traveled safe. {nl} Well then, I must also prepare to leave. 
+QUEST_LV_0100_20150317_001544	I came here to hide from the monsters but even this area is becoming dangerous. {nl} I’m trying to go back to the village so can you bring the other refugees to me?
+QUEST_LV_0100_20150317_001545	I see you’ve traveled safe. {nl} Well then, I must also prepare to leave. 
 QUEST_LV_0100_20150317_001546	What do we do? I think there are even more monsters now than when we first came. {nl} And the patients have not recovered yet. {nl}
-QUEST_LV_0100_20150317_001547	Somehow I'll treat this man. Can you get rid of the monsters around?
+QUEST_LV_0100_20150317_001547	Somehow I’ll treat this man. Can you get rid of the monsters around?
 QUEST_LV_0100_20150317_001548	
 QUEST_LV_0100_20150317_001549	Thank you. The patient also regained his consciousness. {nl} But.. I think there is a problem.
-QUEST_LV_0100_20150317_001550	This is all because of that evidence of salvation or something. {nl}I'm sure that's where the village people were taken away to.
-QUEST_LV_0100_20150317_001551	The Goddess must have helped us. {nl}Follow the way on the right to find vubbe's outpost.
-QUEST_LV_0100_20150317_001552	Thank you for your saving me. {nl} Seems like you're the Revelator who's looking for the evidence of salvation. {nl}
+QUEST_LV_0100_20150317_001550	This is all because of that evidence of salvation or something. {nl}I’m sure that’s where the village people were taken away to.
+QUEST_LV_0100_20150317_001551	The Goddess must have helped us. {nl}Follow the way on the right to find vubbe’s outpost.
+QUEST_LV_0100_20150317_001552	Thank you for your saving me. {nl} Seems like you’re the Revelator who’s looking for the evidence of salvation. {nl}
 QUEST_LV_0100_20150317_001553	I was left here because I was late but the rest of the people were all taken into the mine. {nl} I tell you the rest of the story in the Crystal Mine entrance.
-QUEST_LV_0100_20150317_001554	Well, you've come. {nl} Let us first remove the wagon from blocking the way into the mines. {nl}
-QUEST_LV_0100_20150317_001555	The wagons can be destroyed with the explosives that I have prepared. {nl}I'm concerned about the Vubbes that will come running hearing the explosion {nl}but with your skills, I think we'll be fine.
+QUEST_LV_0100_20150317_001554	Well, you’ve come. {nl} Let us first remove the wagon from blocking the way into the mines. {nl}
+QUEST_LV_0100_20150317_001555	The wagons can be destroyed with the explosives that I have prepared. {nl}I’m concerned about the Vubbes that will come running hearing the explosion {nl}but with your skills, I think we’ll be fine.
 QUEST_LV_0100_20150317_001556	Take care of the Vubbes yourself. {nl} I have other businesses to attend to inside. {nl}
-QUEST_LV_0100_20150317_001557	Thank you. Thank you very much. {nl} You're a savior of our town. {nl}
+QUEST_LV_0100_20150317_001557	Thank you. Thank you very much. {nl} You’re a savior of our town. {nl}
 QUEST_LV_0100_20150317_001558	Oh, have you seen a girl about 5 years of age? {nl} I heard she was together with them when the villagers were kidnapped. 
-QUEST_LV_0100_20150317_001559	Don't just stand there. {nl} Move if you want to help or go away. 
+QUEST_LV_0100_20150317_001559	Don’t just stand there. {nl} Move if you want to help or go away. 
 QUEST_LV_0100_20150317_001560	
-QUEST_LV_0100_20150317_001561	I'm hanging on somehow but I'm losing strength in my arms. 
-QUEST_LV_0100_20150317_001562	I should have seen more careful. {nl} It's all my fault. 
+QUEST_LV_0100_20150317_001561	I’m hanging on somehow but I’m losing strength in my arms. 
+QUEST_LV_0100_20150317_001562	I should have seen more careful. {nl} It’s all my fault. 
 QUEST_LV_0100_20150317_001563	I have my roots deep in the hunting area. {nl} Do not worry about me and better look after the others. 
-QUEST_LV_0100_20150317_001564	As the Mayor, I can't just leave the village like this. {nl} How indifferent of the Goddesses.
-QUEST_LV_0100_20150317_001565	Aren't you the Revelator? The Goddess must have helped us. {nl} In order to enter the mine, you must save a young man name Vaidotas first. {nl}He was kidnapped to the Vubbe outpost. {nl} Please, I ask for your help.
+QUEST_LV_0100_20150317_001564	As the Mayor, I can’t just leave the village like this. {nl} How indifferent of the Goddesses.
+QUEST_LV_0100_20150317_001565	Aren’t you the Revelator? The Goddess must have helped us. {nl} In order to enter the mine, you must save a young man name Vaidotas first. {nl}He was kidnapped to the Vubbe outpost. {nl} Please, I ask for your help.
 QUEST_LV_0100_20150317_001566	
 QUEST_LV_0100_20150317_001567	
 QUEST_LV_0100_20150317_001568	
 QUEST_LV_0100_20150317_001569	
-QUEST_LV_0100_20150317_001570	What's the problem? {nl} um ... it's big, very much.
+QUEST_LV_0100_20150317_001570	What’s the problem? {nl} um ... it’s big, very much.
 QUEST_LV_0100_20150317_001571	
 QUEST_LV_0100_20150317_001572	
 QUEST_LV_0100_20150317_001573	
@@ -1630,7 +1630,7 @@ QUEST_LV_0100_20150317_001629
 QUEST_LV_0100_20150317_001630	
 QUEST_LV_0100_20150317_001631	
 QUEST_LV_0100_20150317_001632	
-QUEST_LV_0100_20150317_001633	There are some purifying devices that doesn't activate right away. {nl}I've put in a guide for it so you just have to follow that.
+QUEST_LV_0100_20150317_001633	There are some purifying devices that doesn’t activate right away. {nl}I’ve put in a guide for it so you just have to follow that.
 QUEST_LV_0100_20150317_001634	There is a shopping plaza in the lower part of Klaipeda. {nl} Stop by and look around if you need anything.
 QUEST_LV_0100_20150317_001635	
 QUEST_LV_0100_20150317_001636	
@@ -1706,25 +1706,25 @@ QUEST_LV_0100_20150317_001705
 QUEST_LV_0100_20150317_001706	
 QUEST_LV_0100_20150317_001707	
 QUEST_LV_0100_20150317_001708	
-QUEST_LV_0100_20150317_001709	I've been waiting for you. I'm Master Swordsman, the one who will help you. {nl} I'm not sure if you know about attribute training. {nl}
+QUEST_LV_0100_20150317_001709	I’ve been waiting for you. I’m Master Swordsman, the one who will help you. {nl} I’m not sure if you know about attribute training. {nl}
 QUEST_LV_0100_20150317_001710	Attributes can give additional abilities to stats and skills. {nl} You can learn attributes from each class master by paying them silver. 
-QUEST_LV_0100_20150317_001711	You'll be able to fight easier if you learn attributes. {nl}
-QUEST_LV_0100_20150317_001712	You've come to the right place. I'm the Wizard Master. {nl} I'm going to teach you about attribute training. {nl}
+QUEST_LV_0100_20150317_001711	You’ll be able to fight easier if you learn attributes. {nl}
+QUEST_LV_0100_20150317_001712	You’ve come to the right place. I’m the Wizard Master. {nl} I’m going to teach you about attribute training. {nl}
 QUEST_LV_0100_20150317_001713	Attributes can give additional abilities to stats and skills. {nl} You can learn attributes from each class master by paying them silver. 
-QUEST_LV_0100_20150317_001714	So did you understand the attributes? Now you'll be able to fight the enemies easier.
+QUEST_LV_0100_20150317_001714	So did you understand the attributes? Now you’ll be able to fight the enemies easier.
 QUEST_LV_0100_20150317_001715	How you become strong depends on what choice you make. {nl}It differs depending on your choice and thoughts.
 QUEST_LV_0100_20150317_001716	Good to see you. I am Mater Archer. {nl} Do you know about attribute training? {nl}
 QUEST_LV_0100_20150317_001717	Attributes can give additional abilities to stats and skills. {nl} You can learn attributes from each class master by paying them silver. 
 QUEST_LV_0100_20150317_001718	Mastering this attribute will help your skills in combat.
 QUEST_LV_0100_20150317_001719	Will is the force to create magic power. {nl} There is not a stronger weapon for a wizard than that. 
 QUEST_LV_0100_20150317_001720	Archers give arrow as a present but the enemies take it as death.
-QUEST_LV_0100_20150317_001721	There are ones who fit with the sword and there are those who don't. {nl} It means find something more valuable than your life. 
-QUEST_LV_0100_20150317_001722	A ranger's arrow does not aim at just one target {nl}
-QUEST_LV_0100_20150317_001723	It's very likely to be exposed to the enemy when you shoot arrows. {nl} So my theory is that you have to use whatever that comes in handy like shields or stones. 
-QUEST_LV_0100_20150317_001724	One thing I'd like to tell you... I think your attack lacks something. {nl} If you learn skills, you'll be able to make more powerful attacks when you need.
+QUEST_LV_0100_20150317_001721	There are ones who fit with the sword and there are those who don’t. {nl} It means find something more valuable than your life. 
+QUEST_LV_0100_20150317_001722	A ranger’s arrow does not aim at just one target {nl}
+QUEST_LV_0100_20150317_001723	It’s very likely to be exposed to the enemy when you shoot arrows. {nl} So my theory is that you have to use whatever that comes in handy like shields or stones. 
+QUEST_LV_0100_20150317_001724	One thing I’d like to tell you... I think your attack lacks something. {nl} If you learn skills, you’ll be able to make more powerful attacks when you need.
 QUEST_LV_0100_20150317_001725	There are different skill for each class but you will be able to fight better when you learn it. {nl} Also, you can do a lot of things aside from attacking.
 QUEST_LV_0100_20150317_001726	What do you think? There are a lot of useful skills right? {nl} Using the skills effectively will be a great help in combat. {nl}
-QUEST_LV_0100_20150317_001727	Oh, you said we need to assemble? {nl} Please let the battle commander know about it too. He's over there on the right.
+QUEST_LV_0100_20150317_001727	Oh, you said we need to assemble? {nl} Please let the battle commander know about it too. He’s over there on the right.
 QUEST_LV_0100_20150317_001728	
 QUEST_LV_0100_20150317_001729	
 QUEST_LV_0100_20150317_001730	
@@ -1990,59 +1990,59 @@ QUEST_LV_0100_20150317_001989
 QUEST_LV_0100_20150317_001990	
 QUEST_LV_0100_20150317_001991	
 QUEST_LV_0100_20150317_001992	
-QUEST_LV_0100_20150317_001993	You're the Savior Goddess sent. What an honor. {nl} Are you ready to fight Bramble?
+QUEST_LV_0100_20150317_001993	You’re the Savior Goddess sent. What an honor. {nl} Are you ready to fight Bramble?
 QUEST_LV_0100_20150317_001994	You need to be prepared if you want to defeat Bramble. {nl} First, take this.
 QUEST_LV_0100_20150317_001995	
-QUEST_LV_0100_20150317_001996	Try to hold it in even if it's dirty. {nl} This is the best I can do.
-QUEST_LV_0100_20150317_001997	You found the revelation. {nl} Aren't you hurt? {nl}
+QUEST_LV_0100_20150317_001996	Try to hold it in even if it’s dirty. {nl} This is the best I can do.
+QUEST_LV_0100_20150317_001997	You found the revelation. {nl} Aren’t you hurt? {nl}
 QUEST_LV_0100_20150317_001998	Bramble. {nl} Poor thing trying to go against its fate. 
 QUEST_LV_0100_20150317_001999	
-QUEST_LV_0100_20150317_002000	So you're the one who wanted to meet Goddess Saule. {nl} Do not worry about the pond. Our priests are preparing it. {nl}
+QUEST_LV_0100_20150317_002000	So you’re the one who wanted to meet Goddess Saule. {nl} Do not worry about the pond. Our priests are preparing it. {nl}
 QUEST_LV_0100_20150317_002001	The priest is located in Cerpe crossroads. {nl}I heard he needed the venom of Black Maize so try to get him that as a present.
-QUEST_LV_0100_20150317_002002	We wouldn't have dreamed about the portal if it wasn't for you. {nl} You truly are the blessing of God.
+QUEST_LV_0100_20150317_002002	We wouldn’t have dreamed about the portal if it wasn’t for you. {nl} You truly are the blessing of God.
 QUEST_LV_0100_20150317_002003	
-QUEST_LV_0100_20150317_002004	Isn't this the venom of the black maize? {nl} Thank you very much. {nl}
+QUEST_LV_0100_20150317_002004	Isn’t this the venom of the black maize? {nl} Thank you very much. {nl}
 QUEST_LV_0100_20150317_002005	You can leave meeting Goddess Saule with me. {nl} Now that the diving pond is purified, we just need to solve the obelisk.
 QUEST_LV_0100_20150317_002006	Magic letters are carved on the Obelisk. {nl} But some letters were erased as the divine pond became contaminated. {nl}
-QUEST_LV_0100_20150317_002007	If the letters are gone, we just need to write it back on. {nl} Now that you've collected the venom of Black Maize, we just need the sap of the oak tree.
+QUEST_LV_0100_20150317_002007	If the letters are gone, we just need to write it back on. {nl} Now that you’ve collected the venom of Black Maize, we just need the sap of the oak tree.
 QUEST_LV_0100_20150317_002008	We just need to restore the Obelisk to meet Goddess Saule.
 QUEST_LV_0100_20150317_002009	Please bring that poison to the Village priest in Cerpe crossroad.
 QUEST_LV_0100_20150317_002010	The dye is complete. {nl} Follow the trail vaguely left in the Obelisk and draw a new one. {nl}
 QUEST_LV_0100_20150317_002011	Ovelisk is in the Slepingas stream.
-QUEST_LV_0100_20150317_002012	I'm sure God will be satisfied with you.
-QUEST_LV_0100_20150317_002013	It's almost done. {nl} After completing the rituals to cleanse your body, you will be able to meet the Goddess soon. {nl}
+QUEST_LV_0100_20150317_002012	I’m sure God will be satisfied with you.
+QUEST_LV_0100_20150317_002013	It’s almost done. {nl} After completing the rituals to cleanse your body, you will be able to meet the Goddess soon. {nl}
 QUEST_LV_0100_20150317_002014	13
 QUEST_LV_0100_20150317_002015	Use this tranquilizer on the black maize and extract its poison. {nl} The Maize should be weakened for the tranquilizer to work.
 QUEST_LV_0100_20150317_002016	
 QUEST_LV_0100_20150317_002017	
-QUEST_LV_0100_20150317_002018	You're the Revelator right? {nl} Wupen is preying on the village so I don't we can hold the ritual right away. {nl}
-QUEST_LV_0100_20150317_002019	I'm thinking of making lazy flower bombs. {nl} Please bring me lazy flowers from the Narvas tracks.
+QUEST_LV_0100_20150317_002018	You’re the Revelator right? {nl} Wupen is preying on the village so I don’t we can hold the ritual right away. {nl}
+QUEST_LV_0100_20150317_002019	I’m thinking of making lazy flower bombs. {nl} Please bring me lazy flowers from the Narvas tracks.
 QUEST_LV_0100_20150317_002020	It is safe where the lazy flowers bloom so do not worry.
-QUEST_LV_0100_20150317_002021	Glad you're back safely. {nl} Didn't the monsters attack?
+QUEST_LV_0100_20150317_002021	Glad you’re back safely. {nl} Didn’t the monsters attack?
 QUEST_LV_0100_20150317_002022	Please get the flower of souls in Dvyni swamp too. {nl} Lazy flower alone will not be so effective. {nl}
-QUEST_LV_0100_20150317_002023	I hope we'll be successful this time.
-QUEST_LV_0100_20150317_002024	I'll do the ritual right away if you kill Wupent. {nl} So please get the flower of the soul.
-QUEST_LV_0100_20150317_002025	That is enough. {nl} I'll send the materials to the elderly so please go and get the explosives.
+QUEST_LV_0100_20150317_002023	I hope we’ll be successful this time.
+QUEST_LV_0100_20150317_002024	I’ll do the ritual right away if you kill Wupent. {nl} So please get the flower of the soul.
+QUEST_LV_0100_20150317_002025	That is enough. {nl} I’ll send the materials to the elderly so please go and get the explosives.
 QUEST_LV_0100_20150317_002026	
 QUEST_LV_0100_20150317_002027	Explosives? Ahh. {nl} Go to the warehouse lot in the upper side of the village.
-QUEST_LV_0100_20150317_002028	It's probably in the big container. {nl} It won't explode so don't worry.
-QUEST_LV_0100_20150317_002029	Don't worry, it's safe. It will not explode.
-QUEST_LV_0100_20150317_002030	Was is a small container? {nl} I'm old and I guess I got confused. {nl} Normally, people would have burnt and gone without a trace but a Revelator surely is different.
+QUEST_LV_0100_20150317_002028	It’s probably in the big container. {nl} It won’t explode so don’t worry.
+QUEST_LV_0100_20150317_002029	Don’t worry, it’s safe. It will not explode.
+QUEST_LV_0100_20150317_002030	Was is a small container? {nl} I’m old and I guess I got confused. {nl} Normally, people would have burnt and gone without a trace but a Revelator surely is different.
 QUEST_LV_0100_20150317_002031	If all the materials are gathered, synthesize it in the Thorn tree altar.
-QUEST_LV_0100_20150317_002032	God or Goddess, what you call her doesn't matter. {nl} Aren't we all one eventually. {nl}
+QUEST_LV_0100_20150317_002032	God or Goddess, what you call her doesn’t matter. {nl} Aren’t we all one eventually. {nl}
 QUEST_LV_0100_20150317_002033	Is it hard to understand? {nl} One day you will realize.
 QUEST_LV_0100_20150317_002034	Here, this is Lazy flower bomb. {nl} Take it to the cliff of Melagingas.
 QUEST_LV_0100_20150317_002035	Now, hurry. {nl} We can finally end it this time.
 QUEST_LV_0100_20150317_002036	This time, it can finally come to an end.
 QUEST_LV_0100_20150317_002037	Hmm. So. The procedue is. {nl} Wash your body in the water and pray then.. {nl}
-QUEST_LV_0100_20150317_002038	It's too complicated so I'll explain it later.
+QUEST_LV_0100_20150317_002038	It’s too complicated so I’ll explain it later.
 QUEST_LV_0100_20150317_002039	
-QUEST_LV_0100_20150317_002040	Can you step on the Statue of the Goddess? {nl} It doesn't matter. Why do you ask?
+QUEST_LV_0100_20150317_002040	Can you step on the Statue of the Goddess? {nl} It doesn’t matter. Why do you ask?
 QUEST_LV_0100_20150317_002041	
 QUEST_LV_0100_20150317_002042	
 QUEST_LV_0100_20150317_002043	
 QUEST_LV_0100_20150317_002044	
-QUEST_LV_0100_20150317_002045	You're the Revelator right? {nl}A very ominous voice is looking for you so please be careful.
+QUEST_LV_0100_20150317_002045	You’re the Revelator right? {nl}A very ominous voice is looking for you so please be careful.
 QUEST_LV_0100_20150317_002046	
 QUEST_LV_0100_20150317_002047	
 QUEST_LV_0100_20150317_002048	
@@ -2067,7 +2067,7 @@ QUEST_LV_0100_20150317_002066
 QUEST_LV_0100_20150317_002067	
 QUEST_LV_0100_20150317_002068	
 QUEST_LV_0100_20150317_002069	
-QUEST_LV_0100_20150317_002070	Saule goddess Quezon evil aura it is not willing to spread in the other forest. {Nl} Therefore, thing we're here.
+QUEST_LV_0100_20150317_002070	Saule goddess Quezon evil aura it is not willing to spread in the other forest. {Nl} Therefore, thing we’re here.
 QUEST_LV_0100_20150317_002071	
 QUEST_LV_0100_20150317_002072	
 QUEST_LV_0100_20150317_002073	
@@ -2077,16 +2077,16 @@ QUEST_LV_0100_20150317_002076
 QUEST_LV_0100_20150317_002077	
 QUEST_LV_0100_20150317_002078	
 QUEST_LV_0100_20150317_002079	
-QUEST_LV_0100_20150317_002080	Good. {nl} Now, we're going to destroy the roots of Bramble.
+QUEST_LV_0100_20150317_002080	Good. {nl} Now, we’re going to destroy the roots of Bramble.
 QUEST_LV_0100_20150317_002081	
 QUEST_LV_0100_20150317_002082	
 QUEST_LV_0100_20150317_002083	
 QUEST_LV_0100_20150317_002084	
 QUEST_LV_0100_20150317_002085	
-QUEST_LV_0100_20150317_002086	Put Merlog's saliva in this potion and shake it.  {nl} It will help you withstand the muddy aura of Bramble.
+QUEST_LV_0100_20150317_002086	Put Merlog’s saliva in this potion and shake it.  {nl} It will help you withstand the muddy aura of Bramble.
 QUEST_LV_0100_20150317_002087	Bramble is recovering by embedding roots around the Thorn Forest . {nl} Cutting those roots will be very painful.
-QUEST_LV_0100_20150317_002088	You can't let your guards down even if the Brambles weakened. {nl} It is the leader of the demons no matter how injured it is. 
-QUEST_LV_0100_20150317_002089	Now we'll make a full-scale attack on Bramble. {nl} I'll go in the Giliaii courtyard and watch on the Brambles first so follow me.
+QUEST_LV_0100_20150317_002088	You can’t let your guards down even if the Brambles weakened. {nl} It is the leader of the demons no matter how injured it is. 
+QUEST_LV_0100_20150317_002089	Now we’ll make a full-scale attack on Bramble. {nl} I’ll go in the Giliaii courtyard and watch on the Brambles first so follow me.
 QUEST_LV_0100_20150317_002090	The most important roots in the Sviesa hills and Tankinta lot. {nl} Cut them both. 
 QUEST_LV_0100_20150317_002091	
 QUEST_LV_0100_20150317_002092	
@@ -2131,33 +2131,33 @@ QUEST_LV_0100_20150317_002130
 QUEST_LV_0100_20150317_002131	
 QUEST_LV_0100_20150317_002132	
 QUEST_LV_0100_20150317_002133	
-QUEST_LV_0100_20150317_002134	It's embarrassing but I am also tricked and captured, losing all my strength. {nl} Please destroy the magic circle imprisoning me.
+QUEST_LV_0100_20150317_002134	It’s embarrassing but I am also tricked and captured, losing all my strength. {nl} Please destroy the magic circle imprisoning me.
 QUEST_LV_0100_20150317_002135	The magic circle of confinement is located in Drugys Courtyard and Vapsva lot. {nl} Hurry.
 QUEST_LV_0100_20150317_002136	Thank you for saving me. {nl}
 QUEST_LV_0100_20150317_002137	I am Saule, the Goddess of the sun. {nl} Everything is just like how Laima has forseen.
-QUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here. {nl} We've got to find the inspetor, Clymen, hiding in between the gap of dimensions. 
+QUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here. {nl} We’ve got to find the inspetor, Clymen, hiding in between the gap of dimensions. 
 QUEST_LV_0100_20150317_002139	Please bring me the sacrifice tools in the Grand Corridor. {nl} I will try to use the divine power that dwell in the tool.
 QUEST_LV_0100_20150317_002140	Thank you. {nl} This much divine power would be enough. 
 QUEST_LV_0100_20150317_002141	Now we will concentrate on finding Clymen. {nl} Suppress the Magis by killing the demons around.
 QUEST_LV_0100_20150317_002142	Just a bit more. Please suppress the Magi.
 QUEST_LV_0100_20150317_002143	The force of Clymen can be felt in Ishpirki entrance. {nl} Get rid of him. {nl}
-QUEST_LV_0100_20150317_002144	It's his key. {nl} Please let me free.
+QUEST_LV_0100_20150317_002144	It’s his key. {nl} Please let me free.
 QUEST_LV_0100_20150317_002145	Thank you in the name of Saule, the Goddess of the sun. {nl}
-QUEST_LV_0100_20150317_002146	It's a shame but the revelation is in the hands of Bramble. {nl} The reason he imprisoned me instead of killing me is to use my divinity to interpret the revelation. {nl}
+QUEST_LV_0100_20150317_002146	It’s a shame but the revelation is in the hands of Bramble. {nl} The reason he imprisoned me instead of killing me is to use my divinity to interpret the revelation. {nl}
 QUEST_LV_0100_20150317_002147	But the Bramble is also not in its normal condition due to the previous battle. {nl} Please stop the Bramble in the gateway with my followers and get the revelation back.
-QUEST_LV_0100_20150317_002148	Show me the revelation. {nl} I'll show you its meaning. 
-QUEST_LV_0100_20150317_002149	If it's the divine power dwelling on the sacrifice items, then we can surely use it to find Clymen. {nl}
+QUEST_LV_0100_20150317_002148	Show me the revelation. {nl} I’ll show you its meaning. 
+QUEST_LV_0100_20150317_002149	If it’s the divine power dwelling on the sacrifice items, then we can surely use it to find Clymen. {nl}
 QUEST_LV_0100_20150317_002150	Lyliana
 QUEST_LV_0100_20150317_002151	
-QUEST_LV_0100_20150317_002152	I really want to know how my family is doing but I'm too scared of the monsters to go back. {nl} I just ran out of the house and I regret it a lot. 
+QUEST_LV_0100_20150317_002152	I really want to know how my family is doing but I’m too scared of the monsters to go back. {nl} I just ran out of the house and I regret it a lot. 
 QUEST_LV_0100_20150317_002153	
 QUEST_LV_0100_20150317_002154	I just feel sorry to my brother.
 QUEST_LV_0100_20150317_002155	
 QUEST_LV_0100_20150317_002156	
 QUEST_LV_0100_20150317_002157	
-QUEST_LV_0100_20150317_002158	Aren't you the Revelator? {nl} So, what brings you to our village? {nl}
-QUEST_LV_0100_20150317_002159	Goddess Saule? {nl} We haven't seen her for a long time. {nl}
-QUEST_LV_0100_20150317_002160	The portal leading to Goddess Saule just won't open. {nl}I think it's all because the diving pond is contaminated.
+QUEST_LV_0100_20150317_002158	Aren’t you the Revelator? {nl} So, what brings you to our village? {nl}
+QUEST_LV_0100_20150317_002159	Goddess Saule? {nl} We haven’t seen her for a long time. {nl}
+QUEST_LV_0100_20150317_002160	The portal leading to Goddess Saule just won’t open. {nl}I think it’s all because the diving pond is contaminated.
 QUEST_LV_0100_20150317_002161	Tanu in Zvelgian vacant lot has the purifying stone. {nl} That would be able to purify the pond.
 QUEST_LV_0100_20150317_002162	Just like there are many demons, same goes for the Goddesses. {nl} The five Goddesses are just the ones who became well known.
 QUEST_LV_0100_20150317_002163	Our village serves Goddess Saule who overlooks the sun. {nl}We used to go see her a lot before through the portal but one day, the portal closed.
@@ -2186,12 +2186,12 @@ QUEST_LV_0100_20150317_002185	But, did you not see the young man of our village?
 QUEST_LV_0100_20150317_002186	Thank you. {nl} The portal is in the Nugria Sanctuary.
 QUEST_LV_0100_20150317_002187	
 QUEST_LV_0100_20150317_002188	Thank you for saving me.
-QUEST_LV_0100_20150317_002189	So you're the Revelator the Mayor spoke about. {nl} I'm fine so please check the portal of the Sanctuary.
+QUEST_LV_0100_20150317_002189	So you’re the Revelator the Mayor spoke about. {nl} I’m fine so please check the portal of the Sanctuary.
 QUEST_LV_0100_20150317_002190	The portal can be opened from the altar in Nugria Sanctuary
-QUEST_LV_0100_20150317_002191	It does not work. {nl} That's a big problem. {nl}
+QUEST_LV_0100_20150317_002191	It does not work. {nl} That’s a big problem. {nl}
 QUEST_LV_0100_20150317_002192	16
 QUEST_LV_0100_20150317_002193	That portal is.. a fantasy... No. A portal going to Goddess Saule. {nl} Anyway, opening the portal is very important.
-QUEST_LV_0100_20150317_002194	Injuries are not that severe so don't worry. Please check the portal in the sanctuary first.
+QUEST_LV_0100_20150317_002194	Injuries are not that severe so don’t worry. Please check the portal in the sanctuary first.
 QUEST_LV_0100_20150317_002195	
 QUEST_LV_0100_20150317_002196	
 QUEST_LV_0100_20150317_002197	
@@ -2208,64 +2208,64 @@ QUEST_LV_0100_20150317_002207
 QUEST_LV_0100_20150317_002208	
 QUEST_LV_0100_20150317_002209	
 QUEST_LV_0100_20150317_002210	
-QUEST_LV_0100_20150317_002211	Broker between the life and death of humans. {nl} That's what Bokor is, if you ask.
+QUEST_LV_0100_20150317_002211	Broker between the life and death of humans. {nl} That’s what Bokor is, if you ask.
 QUEST_LV_0100_20150317_002212	
 QUEST_LV_0100_20150317_002213	
-QUEST_LV_0100_20150317_002214	Kalipeda is a small and quite town. {nl} We haven't had so many people come to town before. 
+QUEST_LV_0100_20150317_002214	Kalipeda is a small and quite town. {nl} We haven’t had so many people come to town before. 
 QUEST_LV_0100_20150317_002215	Did the Goddess mention where she is in the dream of revelation?
 QUEST_LV_0100_20150317_002216	Go ahead to Klaipeda. {nl} Commander Uska is waiting for you in the Central Plaza.{nl}
 QUEST_LV_0100_20150317_002217	I heard the bishop also had a dream about the Goddess...  And I think it has to do with it.
 QUEST_LV_0100_20150317_002218	That girl. {nl} She just appeared in town some time ago. {nl}
-QUEST_LV_0100_20150317_002219	I mean she didn't speak and her clothes were all dirty. {nl} She seemed hungry so I brought her home to feed her some food and this happened.
+QUEST_LV_0100_20150317_002219	I mean she didn’t speak and her clothes were all dirty. {nl} She seemed hungry so I brought her home to feed her some food and this happened.
 QUEST_LV_0100_20150317_002220	I mean the girl who was confined together with us last time. {nl} Do you think she has a family? It seemed like she can not speak at all. {nl}
 QUEST_LV_0100_20150317_002221	If I was a parent, I probably would have gone around mad looking for my daughter. {nl} Parents nowadays are really irresponsible. {nl}
-QUEST_LV_0100_20150317_002222	The girl did not speak at all. {nl} In addition to that, a young lady all grown up walking all the way to this remote village barefoot. Doesn't it seem strange?
+QUEST_LV_0100_20150317_002222	The girl did not speak at all. {nl} In addition to that, a young lady all grown up walking all the way to this remote village barefoot. Doesn’t it seem strange?
 QUEST_LV_0100_20150317_002223	
 QUEST_LV_0100_20150317_002224	
-QUEST_LV_0100_20150317_002225	I'm also curious about the girl who cracked the seal. {nl} This is not a seal that can easily be unsealed.{nl}{nl}
+QUEST_LV_0100_20150317_002225	I’m also curious about the girl who cracked the seal. {nl} This is not a seal that can easily be unsealed.{nl}{nl}
 QUEST_LV_0100_20150317_002226	Husband of refugee family
-QUEST_LV_0100_20150317_002227	I came here with my wife escaping from the monster. {nl} Goddess Zemyna is protecting us but I don't know how long we can hold on.
+QUEST_LV_0100_20150317_002227	I came here with my wife escaping from the monster. {nl} Goddess Zemyna is protecting us but I don’t know how long we can hold on.
 QUEST_LV_0100_20150317_002228	Oh, the Accessory Merchant said she has a gift for you. {nl} Would you mind visiting her?
 QUEST_LV_0100_20150317_002229	You can meet the Accessory Merchant if you go straight to the left from here. 
 QUEST_LV_0100_20150317_002230	Accessory Merchant
-QUEST_LV_0100_20150317_002231	Nice to meet you! Are you the Revelator chasing the dream of the Goddess? {nl} I'm going to give you this accessory as a present. {nl}
+QUEST_LV_0100_20150317_002231	Nice to meet you! Are you the Revelator chasing the dream of the Goddess? {nl} I’m going to give you this accessory as a present. {nl}
 QUEST_LV_0100_20150317_002232	If the armors protect you from physical attacks, accessories protect you from magic attacks. {nl} I hope it would be useful for you.
 QUEST_LV_0100_20150317_002233	You can meet the Accessory Merchant if you go straight to the left from here.  {nl}
 QUEST_LV_0100_20150317_002234	
 QUEST_LV_0100_20150317_002235	
 QUEST_LV_0100_20150317_002236	Oh, seems like you have Yukopus leaves and Kepa stems. {Nl} I need a lot of those. Can you share some with me?
-QUEST_LV_0100_20150317_002237	Thank you very much. {Nl} I need these to treat the injured men in our village but I don't have enough.
+QUEST_LV_0100_20150317_002237	Thank you very much. {Nl} I need these to treat the injured men in our village but I don’t have enough.
 QUEST_LV_0100_20150317_002238	I know you tried hard but I need some more.
-QUEST_LV_0100_20150317_002239	I still need more Yukopus leaves and Kepa stems. {Nl} But I don't want to just take them from you. What about trading it with the potions I have?
+QUEST_LV_0100_20150317_002239	I still need more Yukopus leaves and Kepa stems. {Nl} But I don’t want to just take them from you. What about trading it with the potions I have?
 QUEST_LV_0100_20150317_002240	Your act of kindness really gives me a lot of strength.
 QUEST_LV_0100_20150317_002241	Thanks you! {nl}I hope it would be helpful for you.
-QUEST_LV_0100_20150317_002242	Yukopus and Kepas appear around the Miner's Village.
+QUEST_LV_0100_20150317_002242	Yukopus and Kepas appear around the Miner’s Village.
 QUEST_LV_0100_20150317_002243	Hey, are you going to take on those Vubbes? {nl} But your equipment seems a bit shabby... Do you mind if I help you with it?
-QUEST_LV_0100_20150317_002244	Get me a few materials and I'll help you craft some new armors. {nl} The materials needed can be obtained from Large Red Kepa, Yukofus, and Vubbe Thief.
-QUEST_LV_0100_20150317_002245	Large Red Kepa, Red Kepa, Yukopus, and Vubbe Thief. {nl} Not sure if it's a good thing but you can craft some pretty useful stuff with what the monsters drop.
-QUEST_LV_0100_20150317_002246	I'll give you the recipe so try crafting the armor with the materials I gave you. {nl} You will feel more reassured. Well then, may the Bless of Goddess be with you!
+QUEST_LV_0100_20150317_002244	Get me a few materials and I’ll help you craft some new armors. {nl} The materials needed can be obtained from Large Red Kepa, Yukofus, and Vubbe Thief.
+QUEST_LV_0100_20150317_002245	Large Red Kepa, Red Kepa, Yukopus, and Vubbe Thief. {nl} Not sure if it’s a good thing but you can craft some pretty useful stuff with what the monsters drop.
+QUEST_LV_0100_20150317_002246	I’ll give you the recipe so try crafting the armor with the materials I gave you. {nl} You will feel more reassured. Well then, may the Bless of Goddess be with you!
 QUEST_LV_0100_20150317_002247	
 QUEST_LV_0100_20150317_002248	Oh you brought it. {nl} This is the front plate. {nl} Keep it until we have all the parts ready to craft an armor.
-QUEST_LV_0100_20150317_002249	Oh, here we are. Let's see. {nl} Seems like you brought enough of what we needed. {nl} You can make a Mantle with it. {nl} This reminds me of the good old days.
+QUEST_LV_0100_20150317_002249	Oh, here we are. Let’s see. {nl} Seems like you brought enough of what we needed. {nl} You can make a Mantle with it. {nl} This reminds me of the good old days.
 QUEST_LV_0100_20150317_002250	
-QUEST_LV_0100_20150317_002251	This is the back plate. {nl} I'll let you craft when we have all the other materials ready.
+QUEST_LV_0100_20150317_002251	This is the back plate. {nl} I’ll let you craft when we have all the other materials ready.
 QUEST_LV_0100_20150317_002252	Here you go. This is a Chest protector made of leather. {nl}It was fun to do this in a long time.
 QUEST_LV_0100_20150317_002253	Bone fragments are seen in the well.
-QUEST_LV_0100_20150317_002254	I'm furious and upset. {nl} Only if we arrived earlier, we could have saved ourselves from being totally wiped out .. {nl}
+QUEST_LV_0100_20150317_002254	I’m furious and upset. {nl} Only if we arrived earlier, we could have saved ourselves from being totally wiped out .. {nl}
 QUEST_LV_0100_20150317_002255	Dear Revelator, I have a favor to ask of you. {nl}Can you get us back the keepstakes of my comrades?
-QUEST_LV_0100_20150317_002256	It's bad enough that they were killed by the Vubbes but even their keepstakes are being abused. What an awful thing.
+QUEST_LV_0100_20150317_002256	It’s bad enough that they were killed by the Vubbes but even their keepstakes are being abused. What an awful thing.
 QUEST_LV_0100_20150317_002257	Thank you. {nl} My comrades who passed away will now be able to rest in peace.
 QUEST_LV_0100_20150317_002258	Oh my God. The Vubbes stole all the food supplies. {nl} They took even our immediate food... Please help us with your strength.
-QUEST_LV_0100_20150317_002259	They stole the food meant for both the army and residents. {nl} What do we do if we can't get back our food.. {nl}
+QUEST_LV_0100_20150317_002259	They stole the food meant for both the army and residents. {nl} What do we do if we can’t get back our food.. {nl}
 QUEST_LV_0100_20150317_002260	Thank you. {nl} This will at least get us to live for the few days.
-QUEST_LV_0100_20150317_002261	Thank you very much for your help previously but there are more keepstakes that need to be retrieved. {nl} Think of my comrades who can't rest in peace.. {nl}
+QUEST_LV_0100_20150317_002261	Thank you very much for your help previously but there are more keepstakes that need to be retrieved. {nl} Think of my comrades who can’t rest in peace.. {nl}
 QUEST_LV_0100_20150317_002262	So please help us. {nl} If you get us back the rest of the keepstakes, we will compensate for it.
 QUEST_LV_0100_20150317_002263	Thank you, but we still need more... {nl} Sorry.. {nl}
 QUEST_LV_0100_20150317_002264	We collected almost all the keepsakes.. {nl} Please help us til the end.
-QUEST_LV_0100_20150317_002265	It hurts to think about giving these keepstakes to my dead comrades' families.
+QUEST_LV_0100_20150317_002265	It hurts to think about giving these keepstakes to my dead comrades’ families.
 QUEST_LV_0100_20150317_002266	Thank you very much. {nl} My comrades can now rest in peace with the Goddesses.
 QUEST_LV_0100_20150317_002267	We survived immediate danger with your help last time but we still need more. {nl} Could you help us out a bit more?
-QUEST_LV_0100_20150317_002268	I'm enraged thinking about the Vubbes who will be hearily satisfied with our food. {nl}Especially at such difficult times nowadays.
+QUEST_LV_0100_20150317_002268	I’m enraged thinking about the Vubbes who will be hearily satisfied with our food. {nl}Especially at such difficult times nowadays.
 QUEST_LV_0100_20150317_002269	Thank you. {nl} We still lack some but at least we got back this much.
 QUEST_LV_0100_20150317_002270	Fedimian Resident
 QUEST_LV_0100_20150317_002271	
@@ -2293,47 +2293,47 @@ QUEST_LV_0100_20150317_002292
 QUEST_LV_0100_20150317_002293	
 QUEST_LV_0100_20150317_002294	
 QUEST_LV_0100_20150317_002295	
-QUEST_LV_0100_20150317_002296	Do not be surprised. {nl} There's something to give you before returning to the Goddess. {nl}
-QUEST_LV_0100_20150317_002297	I want to apologize to my sister who left house because of me but now I can't even do that. {nl} Can you find my sister and give her this necklace for me?
+QUEST_LV_0100_20150317_002296	Do not be surprised. {nl} There’s something to give you before returning to the Goddess. {nl}
+QUEST_LV_0100_20150317_002297	I want to apologize to my sister who left house because of me but now I can’t even do that. {nl} Can you find my sister and give her this necklace for me?
 QUEST_LV_0100_20150317_002298	My brother asked you to give this necklace to me? {nl} Where is my brother?
 QUEST_LV_0100_20150317_002299	
 QUEST_LV_0100_20150317_002300	
 QUEST_LV_0100_20150317_002301	
 QUEST_LV_0100_20150317_002302	
-QUEST_LV_0100_20150317_002303	What. This isn't the Ripper? {nl}But since you've seen my face, you'll soon be cursed to death. {nl}
-QUEST_LV_0100_20150317_002304	Wait a minute. No. No. {nl} Deliver this letter and I'll bump it. {nl} You just have to deliver it to Ripper, the guard of Fedimian. Do not look at what's written in the letter.
+QUEST_LV_0100_20150317_002303	What. This isn’t the Ripper? {nl}But since you’ve seen my face, you’ll soon be cursed to death. {nl}
+QUEST_LV_0100_20150317_002304	Wait a minute. No. No. {nl} Deliver this letter and I’ll bump it. {nl} You just have to deliver it to Ripper, the guard of Fedimian. Do not look at what’s written in the letter.
 QUEST_LV_0100_20150317_002305	Letter forme? What is this.. {nl}
-QUEST_LV_0100_20150317_002306	Curse? I get it, I get it!{nl} I'll give you this money, so please tell him to not curse!
-QUEST_LV_0100_20150317_002307	huhu. Poor guy. He won't be able to see the light soon {nl} Whether it's in prison or coffin, only he will know. {nl} I feel sorry for the dead soldiers.
+QUEST_LV_0100_20150317_002306	Curse? I get it, I get it!{nl} I’ll give you this money, so please tell him to not curse!
+QUEST_LV_0100_20150317_002307	huhu. Poor guy. He won’t be able to see the light soon {nl} Whether it’s in prison or coffin, only he will know. {nl} I feel sorry for the dead soldiers.
 QUEST_LV_0100_20150317_002308	Oh, I really thank you for last time. {nl}My injury is getting better now that I can move. {nl}
-QUEST_LV_0100_20150317_002309	But, uh, I'm too hungry and do not have energy to go back to boss. If {nl} If you have anything to eat, can you share some?
-QUEST_LV_0100_20150317_002310	Oh, thank you so much! {nl} I'll take this to recover and return to the commander for sure. 
+QUEST_LV_0100_20150317_002309	But, uh, I’m too hungry and do not have energy to go back to boss. If {nl} If you have anything to eat, can you share some?
+QUEST_LV_0100_20150317_002310	Oh, thank you so much! {nl} I’ll take this to recover and return to the commander for sure. 
 QUEST_LV_0100_20150317_002311	
 QUEST_LV_0100_20150317_002312	
 QUEST_LV_0100_20150317_002313	
 QUEST_LV_0100_20150317_002314	
 QUEST_LV_0100_20150317_002315	
-QUEST_LV_0100_20150317_002316	I'm sorry but can you burn this oration in front of the epitaph in Dense Mist Plateau? {nl} Revelators like you who have explored the canyon area have the right to comfort their souls.
+QUEST_LV_0100_20150317_002316	I’m sorry but can you burn this oration in front of the epitaph in Dense Mist Plateau? {nl} Revelators like you who have explored the canyon area have the right to comfort their souls.
 QUEST_LV_0100_20150317_002317	The canyon area is like a grave for many explorers and historians. {nl} And we study to find more factual history on top of their graves.
 QUEST_LV_0100_20150317_002318	Thank you. {nl} Our academia will not forget him too. 
 QUEST_LV_0100_20150317_002319	
-QUEST_LV_0100_20150317_002320	Next time, be careful when using public utilities. {nl} Well that's that and you have some great power. 
-QUEST_LV_0100_20150317_002321	Oh.. It's absurdity gets me at loss for words every time I look at it. {nl} Was is really this fragile..
+QUEST_LV_0100_20150317_002320	Next time, be careful when using public utilities. {nl} Well that’s that and you have some great power. 
+QUEST_LV_0100_20150317_002321	Oh.. It’s absurdity gets me at loss for words every time I look at it. {nl} Was is really this fragile..
 QUEST_LV_0100_20150317_002322	
 QUEST_LV_0100_20150317_002323	
 QUEST_LV_0100_20150317_002324	
-QUEST_LV_0100_20150317_002325	Unfortunately... I don't know where my brother is. {nl} He also probably won't know my whereabouts too.
+QUEST_LV_0100_20150317_002325	Unfortunately... I don’t know where my brother is. {nl} He also probably won’t know my whereabouts too.
 QUEST_LV_0100_20150317_002326	
-QUEST_LV_0100_20150317_002327	He is so stupid. {nl} He could have given it sooner in good terms rather than getting on each other's nerves. {nl} Hmm. Maybe I belittled myself too much.
-QUEST_LV_0100_20150317_002328	Don't you act like you know me anymore! {nl} It not my fault. That's the one who's bad!
+QUEST_LV_0100_20150317_002327	He is so stupid. {nl} He could have given it sooner in good terms rather than getting on each other’s nerves. {nl} Hmm. Maybe I belittled myself too much.
+QUEST_LV_0100_20150317_002328	Don’t you act like you know me anymore! {nl} It not my fault. That’s the one who’s bad!
 QUEST_LV_0100_20150317_002329	Are we there yet? {nl} I think we need to eat something to regain strength.
-QUEST_LV_0100_20150317_002330	Frankly, I'm afraid of what the world will turn into.
+QUEST_LV_0100_20150317_002330	Frankly, I’m afraid of what the world will turn into.
 QUEST_LV_0100_20150317_002331	Cyrenia Odell
 QUEST_LV_0100_20150317_002332	
 QUEST_LV_0100_20150317_002333	
 QUEST_LV_0100_20150317_002334	Sincerity is our strength. {nl} There will be no problems if you sincerely believe and follow the goddess.
 QUEST_LV_0100_20150317_002335	I think being confined in there caused my throat and now my throat hurts. {nl} But what about the girl who was together? Where did she go?
-QUEST_LV_0100_20150317_002336	Aren't you the Revelator who saved us last time? {nl} We were more than glad to see you back then.
+QUEST_LV_0100_20150317_002336	Aren’t you the Revelator who saved us last time? {nl} We were more than glad to see you back then.
 QUEST_LV_0100_20150317_002337	
 QUEST_LV_0100_20150317_002338	It was horrible in captivity. {nl} Vubbes come and smell us.. {nl} and make us dig here and there using pickax..
 QUEST_LV_0100_20150317_002339	Rexipher .. he would have been really Asmodian?
@@ -2341,18 +2341,18 @@ QUEST_LV_0100_20150317_002340	You saved us. Thank you so much. {nl} But I have a
 QUEST_LV_0100_20150317_002341	Healing magic. {nl} Can people easily do it?
 QUEST_LV_0100_20150317_002342	But listen to me my story. {nl} When I was taken to the mine, I injured my knee. {nl}
 QUEST_LV_0100_20150317_002343	But a girl touched my knee and the pain was gone. {nl} Even the wound is gone. {nl}
-QUEST_LV_0100_20150317_002344	Amazing huh? I make her a flower ring if we meet again. {nl} But I don't know where she's gone to. 
+QUEST_LV_0100_20150317_002344	Amazing huh? I make her a flower ring if we meet again. {nl} But I don’t know where she’s gone to. 
 QUEST_LV_0100_20150317_002345	
 QUEST_LV_0100_20150317_002346	
 QUEST_LV_0100_20150317_002347	
 QUEST_LV_0100_20150317_002348	
 QUEST_LV_0100_20150317_002349	
 QUEST_LV_0100_20150317_002350	400 years would have passed by when this revelation reaches you. {nl} Thank you in advance for your continued pursuit of finding the revelation. . {nl}
-QUEST_LV_0100_20150317_002351	As I'm sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin. {nl} if you find this revelation, it would mean that he had done an excellent job in fulfilling his mission. {nl}
+QUEST_LV_0100_20150317_002351	As I’m sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin. {nl} if you find this revelation, it would mean that he had done an excellent job in fulfilling his mission. {nl}
 QUEST_LV_0100_20150317_002352	The demons have been chasing the revelation before I made this revelation. {nl} Gesti, the leader of the demons whom you have met is one of them. {nl}
 QUEST_LV_0100_20150317_002353	Three demon Kings and the demon leaders who follow them. {nl}Giltine is the one who controls all of them. {nl}
 QUEST_LV_0100_20150317_002354	All these catastrophes are her plans. {nl} The disasters will continue and at the end of it will be the end of human race. {nl}
-QUEST_LV_0100_20150317_002355	I am a very fatal existence for them as I can see all of this. {nl}That's why Giltine will try to revert me to the world's waters. {nl}
+QUEST_LV_0100_20150317_002355	I am a very fatal existence for them as I can see all of this. {nl}That’s why Giltine will try to revert me to the world’s waters. {nl}
 QUEST_LV_0100_20150317_002356	Also, they will extend their evil powers to the Goddesses who go against their will. {nl}
 QUEST_LV_0100_20150317_002357	But disasters are happening just as I saw them to be. {nl}And it means that the hope, which I saw further away, will also definitely come.  {nl}
 QUEST_LV_0100_20150317_002358	Dear Savior, our sister Saule is losing her light. {nl} Find her back the light from the colorful valley and you will be guided to the next revelation.
@@ -2368,11 +2368,11 @@ QUEST_LV_0100_20150317_002367	[Tutorial] Talk to Knight Titas (2)
 QUEST_LV_0100_20150317_002368	Offer to help gather soldiers
 QUEST_LV_0100_20150317_002369	
 QUEST_LV_0100_20150317_002370	To the scout (1)
-QUEST_LV_0100_20150317_002371	I'm just here to tell the troops to assemble
+QUEST_LV_0100_20150317_002371	I’m just here to tell the troops to assemble
 QUEST_LV_0100_20150317_002372	Quickly run away
 QUEST_LV_0100_20150317_002373	To the scout (2)
-QUEST_LV_0100_20150317_002374	I'll find the missing luggage
-QUEST_LV_0100_20150317_002375	I'll wait until you find it
+QUEST_LV_0100_20150317_002374	I’ll find the missing luggage
+QUEST_LV_0100_20150317_002375	I’ll wait until you find it
 QUEST_LV_0100_20150317_002376	key to check the map #7
 QUEST_LV_0100_20150317_002377	To Knight Titas (3)
 QUEST_LV_0100_20150317_002378	Alright
@@ -2381,65 +2381,65 @@ QUEST_LV_0100_20150317_002380	To the search scout
 QUEST_LV_0100_20150317_002381	Tell him there is an order to assemble
 QUEST_LV_0100_20150317_002382	Nothing, nevermind
 QUEST_LV_0100_20150317_002383	Notice/!/ Use jump to avoid attacks from Large Kepa!
-QUEST_LV_0100_20150317_002384	Laimonas's Favor
+QUEST_LV_0100_20150317_002384	Laimonas’s Favor
 QUEST_LV_0100_20150317_002385	
-QUEST_LV_0100_20150317_002386	I'm not interested
+QUEST_LV_0100_20150317_002386	I’m not interested
 QUEST_LV_0100_20150317_002387	About Goddess Statue
 QUEST_LV_0100_20150317_002388	Road to the Klaipeda (1)
 QUEST_LV_0100_20150317_002389	I can do that
 QUEST_LV_0100_20150317_002390	Road to the Klaipeda (2)
-QUEST_LV_0100_20150317_002391	 I'll help you with it
+QUEST_LV_0100_20150317_002391	 I’ll help you with it
 QUEST_LV_0100_20150317_002392	Enter Klaipeda
 QUEST_LV_0100_20150317_002393	To the Battle Commander (1)
-QUEST_LV_0100_20150317_002394	I'll help out with the missions
-QUEST_LV_0100_20150317_002395	I'll wait then
+QUEST_LV_0100_20150317_002394	I’ll help out with the missions
+QUEST_LV_0100_20150317_002395	I’ll wait then
 QUEST_LV_0100_20150317_002396	About the monsters
 QUEST_LV_0100_20150317_002397	To the Battle Commander (2)
 QUEST_LV_0100_20150317_002398	Accept
 QUEST_LV_0100_20150317_002399	
-QUEST_LV_0100_20150317_002400	I'll try to look for them
+QUEST_LV_0100_20150317_002400	I’ll try to look for them
 QUEST_LV_0100_20150317_002401	They will be back soon
 QUEST_LV_0100_20150317_002402	Something Fishy
-QUEST_LV_0100_20150317_002403	I'll take a look for you
+QUEST_LV_0100_20150317_002403	I’ll take a look for you
 QUEST_LV_0100_20150317_002404	Bishop dreams of the Revelation
 QUEST_LV_0100_20150317_002405	
 QUEST_LV_0100_20150317_002406	Crisis of the Camp
-QUEST_LV_0100_20150317_002407	I didn't see anything like that
+QUEST_LV_0100_20150317_002407	I didn’t see anything like that
 QUEST_LV_0100_20150317_002408	Not really my problem
 QUEST_LV_0100_20150317_002409	Threats of Eastern Woods
-QUEST_LV_0100_20150317_002410	Emphasize that it's important
+QUEST_LV_0100_20150317_002410	Emphasize that it’s important
 QUEST_LV_0100_20150317_002411	Wait until the problem is solved
-QUEST_LV_0100_20150317_002412	About the Miner's Village
-QUEST_LV_0100_20150317_002413	Sentinel's Favor (1)
-QUEST_LV_0100_20150317_002414	I'll get rid of the Chupacabra
+QUEST_LV_0100_20150317_002412	About the Miner’s Village
+QUEST_LV_0100_20150317_002413	Sentinel’s Favor (1)
+QUEST_LV_0100_20150317_002414	I’ll get rid of the Chupacabra
 QUEST_LV_0100_20150317_002415	You should take care of it yourself
-QUEST_LV_0100_20150317_002416	The role of Aras' Troops
-QUEST_LV_0100_20150317_002417	Sentinel's Favor (2)
-QUEST_LV_0100_20150317_002418	I'll get the supplies camp back
+QUEST_LV_0100_20150317_002416	The role of Aras’ Troops
+QUEST_LV_0100_20150317_002417	Sentinel’s Favor (2)
+QUEST_LV_0100_20150317_002418	I’ll get the supplies camp back
 QUEST_LV_0100_20150317_002419	Not as intended (3)
-QUEST_LV_0100_20150317_002420	I'll get rid of the large gray Chupacabra
+QUEST_LV_0100_20150317_002420	I’ll get rid of the large gray Chupacabra
 QUEST_LV_0100_20150317_002421	Not as intended (4)
-QUEST_LV_0100_20150317_002422	I'll get rid of the Weavers
+QUEST_LV_0100_20150317_002422	I’ll get rid of the Weavers
 QUEST_LV_0100_20150317_002423	Commission of Aras (1)
-QUEST_LV_0100_20150317_002424	I'll find something that might be a clue from the Popolions
-QUEST_LV_0100_20150317_002425	I'll do that later
+QUEST_LV_0100_20150317_002424	I’ll find something that might be a clue from the Popolions
+QUEST_LV_0100_20150317_002425	I’ll do that later
 QUEST_LV_0100_20150317_002426	Commission of Aras (2)
 QUEST_LV_0100_20150317_002427	I can check on that
 QUEST_LV_0100_20150317_002428	I think you should take care of it yourself
 QUEST_LV_0100_20150317_002429	About the Vubbes
 QUEST_LV_0100_20150317_002430	Commission of Aras (3)
-QUEST_LV_0100_20150317_002431	I'll find the traces of Vubbe Fighter
-QUEST_LV_0100_20150317_002432	Supply Solider's Favor (1)
-QUEST_LV_0100_20150317_002433	I'll help collecting weaver claws
-QUEST_LV_0100_20150317_002434	Supply Solider's Favor (2)
-QUEST_LV_0100_20150317_002435	I'll get rid of the Pokubus
-QUEST_LV_0100_20150317_002436	I'll just get rid of the Vubbe Fighter right away
-QUEST_LV_0100_20150317_002437	I'll wait for back up troops
+QUEST_LV_0100_20150317_002431	I’ll find the traces of Vubbe Fighter
+QUEST_LV_0100_20150317_002432	Supply Solider’s Favor (1)
+QUEST_LV_0100_20150317_002433	I’ll help collecting weaver claws
+QUEST_LV_0100_20150317_002434	Supply Solider’s Favor (2)
+QUEST_LV_0100_20150317_002435	I’ll get rid of the Pokubus
+QUEST_LV_0100_20150317_002436	I’ll just get rid of the Vubbe Fighter right away
+QUEST_LV_0100_20150317_002437	I’ll wait for back up troops
 QUEST_LV_0100_20150317_002438	
-QUEST_LV_0100_20150317_002439	Ask for the Miner's Village what he promised
+QUEST_LV_0100_20150317_002439	Ask for the Miner’s Village what he promised
 QUEST_LV_0100_20150317_002440	Give me some time to prepare
 QUEST_LV_0100_20150317_002441	Rescue Village residents 
-QUEST_LV_0100_20150317_002442	I'll find the village residents first
+QUEST_LV_0100_20150317_002442	I’ll find the village residents first
 QUEST_LV_0100_20150317_002443	Quit
 QUEST_LV_0100_20150317_002444	About the Closed Area
 QUEST_LV_0100_20150317_002445	Attack of NetherBovine
@@ -2484,8 +2484,8 @@ QUEST_LV_0100_20150317_002483
 QUEST_LV_0100_20150317_002484	
 QUEST_LV_0100_20150317_002485	
 QUEST_LV_0100_20150317_002486	
-QUEST_LV_0100_20150317_002487	I'll accep tthe offer
-QUEST_LV_0100_20150317_002488	I'm busy
+QUEST_LV_0100_20150317_002487	I’ll accep tthe offer
+QUEST_LV_0100_20150317_002488	I’m busy
 QUEST_LV_0100_20150317_002489	
 QUEST_LV_0100_20150317_002490	
 QUEST_LV_0100_20150317_002491	
@@ -2495,9 +2495,9 @@ QUEST_LV_0100_20150317_002494
 QUEST_LV_0100_20150317_002495	I think you better do it yourself
 QUEST_LV_0100_20150317_002496	
 QUEST_LV_0100_20150317_002497	
-QUEST_LV_0100_20150317_002498	I'd like to stop
+QUEST_LV_0100_20150317_002498	I’d like to stop
 QUEST_LV_0100_20150317_002499	Not as intended (1)
-QUEST_LV_0100_20150317_002500	I'll help you retrieve the supplies
+QUEST_LV_0100_20150317_002500	I’ll help you retrieve the supplies
 QUEST_LV_0100_20150317_002501	Barrier stone of the Closed Area
 QUEST_LV_0100_20150317_002502	Of looking at/LOOK/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002503	Notice/The Crystal wall blocking the Closed Area is falling down! #5
@@ -2508,9 +2508,9 @@ QUEST_LV_0100_20150317_002507
 QUEST_LV_0100_20150317_002508	
 QUEST_LV_0100_20150317_002509	
 QUEST_LV_0100_20150317_002510	
-QUEST_LV_0100_20150317_002511	I'll get back the Supplies
+QUEST_LV_0100_20150317_002511	I’ll get back the Supplies
 QUEST_LV_0100_20150317_002512	
-QUEST_LV_0100_20150317_002513	I'll get rid of the Sparnas
+QUEST_LV_0100_20150317_002513	I’ll get rid of the Sparnas
 QUEST_LV_0100_20150317_002514	Batch of handouts/STANDSPINKLE/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_002515	
 QUEST_LV_0100_20150317_002516	
@@ -2519,7 +2519,7 @@ QUEST_LV_0100_20150317_002518
 QUEST_LV_0100_20150317_002519	
 QUEST_LV_0100_20150317_002520	It feels like a burden
 QUEST_LV_0100_20150317_002521	
-QUEST_LV_0100_20150317_002522	Sure, I'll help
+QUEST_LV_0100_20150317_002522	Sure, I’ll help
 QUEST_LV_0100_20150317_002523	
 QUEST_LV_0100_20150317_002524	
 QUEST_LV_0100_20150317_002525	
@@ -2527,21 +2527,21 @@ QUEST_LV_0100_20150317_002526
 QUEST_LV_0100_20150317_002527	
 QUEST_LV_0100_20150317_002528	
 QUEST_LV_0100_20150317_002529	Endless Mission (1)
-QUEST_LV_0100_20150317_002530	Weird, but I'll go instead
-QUEST_LV_0100_20150317_002531	I'm not a new recruit
+QUEST_LV_0100_20150317_002530	Weird, but I’ll go instead
+QUEST_LV_0100_20150317_002531	I’m not a new recruit
 QUEST_LV_0100_20150317_002532	Endless Mission (2)
 QUEST_LV_0100_20150317_002533	Offer to deliver report
 QUEST_LV_0100_20150317_002534	Endless Mission (3)
-QUEST_LV_0100_20150317_002535	Weird, but I'll go
-QUEST_LV_0100_20150317_002536	Make it clear that I'm not a new recruit
+QUEST_LV_0100_20150317_002535	Weird, but I’ll go
+QUEST_LV_0100_20150317_002536	Make it clear that I’m not a new recruit
 QUEST_LV_0100_20150317_002537	Useless Honor (1)
-QUEST_LV_0100_20150317_002538	I'll gather Ducky's oil
-QUEST_LV_0100_20150317_002539	I'm not a new recruit so I'll refuse
+QUEST_LV_0100_20150317_002538	I’ll gather Ducky’s oil
+QUEST_LV_0100_20150317_002539	I’m not a new recruit so I’ll refuse
 QUEST_LV_0100_20150317_002540	Endless Mission (4)
 QUEST_LV_0100_20150317_002541	
 QUEST_LV_0100_20150317_002542	
 QUEST_LV_0100_20150317_002543	Useless Honor (2)
-QUEST_LV_0100_20150317_002544	I'll burn Duckey's oil
+QUEST_LV_0100_20150317_002544	I’ll burn Duckey’s oil
 QUEST_LV_0100_20150317_002545	Setting up firewood .../FIRE/3/TRACK_BEFORE
 QUEST_LV_0100_20150317_002546	
 QUEST_LV_0100_20150317_002547	
@@ -2562,7 +2562,7 @@ QUEST_LV_0100_20150317_002561
 QUEST_LV_0100_20150317_002562	
 QUEST_LV_0100_20150317_002563	
 QUEST_LV_0100_20150317_002564	Disappeared Researcher (2)
-QUEST_LV_0100_20150317_002565	I'll save Irine
+QUEST_LV_0100_20150317_002565	I’ll save Irine
 QUEST_LV_0100_20150317_002566	Call the mercenary 
 QUEST_LV_0100_20150317_002567	Disappeared Researcher (3)
 QUEST_LV_0100_20150317_002568	
@@ -2572,8 +2572,8 @@ QUEST_LV_0100_20150317_002571
 QUEST_LV_0100_20150317_002572	
 QUEST_LV_0100_20150317_002573	
 QUEST_LV_0100_20150317_002574	
-QUEST_LV_0100_20150317_002575	I'll get rid of the mosters
-QUEST_LV_0100_20150317_002576	I'll get going now
+QUEST_LV_0100_20150317_002575	I’ll get rid of the mosters
+QUEST_LV_0100_20150317_002576	I’ll get going now
 QUEST_LV_0100_20150317_002577	
 QUEST_LV_0100_20150317_002578	
 QUEST_LV_0100_20150317_002579	
@@ -2581,7 +2581,7 @@ QUEST_LV_0100_20150317_002580
 QUEST_LV_0100_20150317_002581	
 QUEST_LV_0100_20150317_002582	
 QUEST_LV_0100_20150317_002583	
-QUEST_LV_0100_20150317_002584	I'll find it for you
+QUEST_LV_0100_20150317_002584	I’ll find it for you
 QUEST_LV_0100_20150317_002585	Cheer up
 QUEST_LV_0100_20150317_002586	About the Gate of the Great King
 QUEST_LV_0100_20150317_002587	
@@ -2596,7 +2596,7 @@ QUEST_LV_0100_20150317_002595
 QUEST_LV_0100_20150317_002596	
 QUEST_LV_0100_20150317_002597	
 QUEST_LV_0100_20150317_002598	
-QUEST_LV_0100_20150317_002599	My work is done so I'll be going now
+QUEST_LV_0100_20150317_002599	My work is done so I’ll be going now
 QUEST_LV_0100_20150317_002600	
 QUEST_LV_0100_20150317_002601	
 QUEST_LV_0100_20150317_002602	
@@ -2626,7 +2626,7 @@ QUEST_LV_0100_20150317_002625	Checking Purifier /HANDLING_LEFT/3/TRACK_BEFORE/No
 QUEST_LV_0100_20150317_002626	Notice/Some parts of the purifier are missing. {nl} Chack for any parts on the floor! #5
 QUEST_LV_0100_20150317_002627	Of the component assembly/GROPE/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002628	Notice/Some parts are still missing. {nl} Find the missig parts from Vubbes with question marks on top of its head. #5
-QUEST_LV_0100_20150317_002629	Entrance Purifier's missing parts
+QUEST_LV_0100_20150317_002629	Entrance Purifier’s missing parts
 QUEST_LV_0100_20150317_002630	Notice/!/Some parts of the Purifier are missing. {nl} Find the parts from the Vubbe with a question mark on its head. #5
 QUEST_LV_0100_20150317_002631	Repairing Purifier/HANDLING_LEFT/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002632	Notice/Repair complete. {nl}Entrance Purifier is activated again. #5
@@ -2732,7 +2732,7 @@ QUEST_LV_0100_20150317_002731
 QUEST_LV_0100_20150317_002732	
 QUEST_LV_0100_20150317_002733	Take a rest before you go
 QUEST_LV_0100_20150317_002734	
-QUEST_LV_0100_20150317_002735	Then I'll help Eta
+QUEST_LV_0100_20150317_002735	Then I’ll help Eta
 QUEST_LV_0100_20150317_002736	That is impossible
 QUEST_LV_0100_20150317_002737	
 QUEST_LV_0100_20150317_002738	Notice /!/Poison amplifies the need for wood bang for the aura of stone! #8
@@ -2751,29 +2751,29 @@ QUEST_LV_0100_20150317_002750
 QUEST_LV_0100_20150317_002751	
 QUEST_LV_0100_20150317_002752	
 QUEST_LV_0100_20150317_002753	Retrieve the relief supplies
-QUEST_LV_0100_20150317_002754	I'll help retrieve the relief supplies
+QUEST_LV_0100_20150317_002754	I’ll help retrieve the relief supplies
 QUEST_LV_0100_20150317_002755	Dedication of Brinker (1)
-QUEST_LV_0100_20150317_002756	I'll gather some stones for it 
+QUEST_LV_0100_20150317_002756	I’ll gather some stones for it 
 QUEST_LV_0100_20150317_002757	Better run away quickly
 QUEST_LV_0100_20150317_002758	Dedication of Brinker (2)
-QUEST_LV_0100_20150317_002759	I'll get rid of the monsters around
+QUEST_LV_0100_20150317_002759	I’ll get rid of the monsters around
 QUEST_LV_0100_20150317_002760	Agony of the Healer Lady (1)
-QUEST_LV_0100_20150317_002761	I'll bring the refugees
+QUEST_LV_0100_20150317_002761	I’ll bring the refugees
 QUEST_LV_0100_20150317_002762	Description of the location of the healer lady/TALK/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002763	Agony of the Healer Lady (2)
-QUEST_LV_0100_20150317_002764	I'll get rid of the menacing monsters
+QUEST_LV_0100_20150317_002764	I’ll get rid of the menacing monsters
 QUEST_LV_0100_20150317_002765	Kidnapped villagers (1) Delete
-QUEST_LV_0100_20150317_002766	I'll save the village residents
+QUEST_LV_0100_20150317_002766	I’ll save the village residents
 QUEST_LV_0100_20150317_002767	Take time to think for a while
 QUEST_LV_0100_20150317_002768	Invasion of Vubbes
-QUEST_LV_0100_20150317_002769	I'll go to the Vubbe's base and get rid of them
+QUEST_LV_0100_20150317_002769	I’ll go to the Vubbe’s base and get rid of them
 QUEST_LV_0100_20150317_002770	Disregard
 QUEST_LV_0100_20150317_002771	Kidnapped villagers
 QUEST_LV_0100_20150317_002772	By freeing the degree of Tasman/MAKING/2/TRACK_AFTER/None
 QUEST_LV_0100_20150317_002773	
 QUEST_LV_0100_20150317_002774	To the Mines
-QUEST_LV_0100_20150317_002775	I'll destroy the wagons
-QUEST_LV_0100_20150317_002776	I'm not yet prepared
+QUEST_LV_0100_20150317_002775	I’ll destroy the wagons
+QUEST_LV_0100_20150317_002776	I’m not yet prepared
 QUEST_LV_0100_20150317_002777	
 QUEST_LV_0100_20150317_002778	
 QUEST_LV_0100_20150317_002779	
@@ -2813,7 +2813,7 @@ QUEST_LV_0100_20150317_002812
 QUEST_LV_0100_20150317_002813	
 QUEST_LV_0100_20150317_002814	
 QUEST_LV_0100_20150317_002815	
-QUEST_LV_0100_20150317_002816	Let's look for Achat
+QUEST_LV_0100_20150317_002816	Let’s look for Achat
 QUEST_LV_0100_20150317_002817	
 QUEST_LV_0100_20150317_002818	
 QUEST_LV_0100_20150317_002819	
@@ -2828,7 +2828,7 @@ QUEST_LV_0100_20150317_002827
 QUEST_LV_0100_20150317_002828	
 QUEST_LV_0100_20150317_002829	
 QUEST_LV_0100_20150317_002830	
-QUEST_LV_0100_20150317_002831	i'll burn the Vubbe Flag
+QUEST_LV_0100_20150317_002831	i’ll burn the Vubbe Flag
 QUEST_LV_0100_20150317_002832	Of the fire stick/MAKING/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002833	
 QUEST_LV_0100_20150317_002834	
@@ -2846,7 +2846,7 @@ QUEST_LV_0100_20150317_002845
 QUEST_LV_0100_20150317_002846	Key during installation .../MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002847	
 QUEST_LV_0100_20150317_002848	Agony of the Healer Lady (3)
-QUEST_LV_0100_20150317_002849	Okay, I'll go look around again
+QUEST_LV_0100_20150317_002849	Okay, I’ll go look around again
 QUEST_LV_0100_20150317_002850	That would not happen.
 QUEST_LV_0100_20150317_002851	Notice/!/Get rid of the Chafer!
 QUEST_LV_0100_20150317_002852	
@@ -2867,15 +2867,15 @@ QUEST_LV_0100_20150317_002866
 QUEST_LV_0100_20150317_002867	
 QUEST_LV_0100_20150317_002868	
 QUEST_LV_0100_20150317_002869	
-QUEST_LV_0100_20150317_002870	It's easy
+QUEST_LV_0100_20150317_002870	It’s easy
 QUEST_LV_0100_20150317_002871	Removing/MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002872	
 QUEST_LV_0100_20150317_002873	
-QUEST_LV_0100_20150317_002874	Sure, I'll get rid of it.
+QUEST_LV_0100_20150317_002874	Sure, I’ll get rid of it.
 QUEST_LV_0100_20150317_002875	
-QUEST_LV_0100_20150317_002876	okay, I'll collect them.
+QUEST_LV_0100_20150317_002876	okay, I’ll collect them.
 QUEST_LV_0100_20150317_002877	
-QUEST_LV_0100_20150317_002878	I'll be back quickly.
+QUEST_LV_0100_20150317_002878	I’ll be back quickly.
 QUEST_LV_0100_20150317_002879	It looks impossible.
 QUEST_LV_0100_20150317_002880	Lighting Fire/SITGROPE/1/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002881	
@@ -2885,27 +2885,27 @@ QUEST_LV_0100_20150317_002884	Trust him one more time
 QUEST_LV_0100_20150317_002885	I will not be fooled again.
 QUEST_LV_0100_20150317_002886	Igniting/SITGROPE/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002887	
-QUEST_LV_0100_20150317_002888	I'll get rid of the demons
-QUEST_LV_0100_20150317_002889	I can't do it all by myself.
+QUEST_LV_0100_20150317_002888	I’ll get rid of the demons
+QUEST_LV_0100_20150317_002889	I can’t do it all by myself.
 QUEST_LV_0100_20150317_002890	
-QUEST_LV_0100_20150317_002891	That's a reasonable opinion
+QUEST_LV_0100_20150317_002891	That’s a reasonable opinion
 QUEST_LV_0100_20150317_002892	
 QUEST_LV_0100_20150317_002893	I will chase it immediately
-QUEST_LV_0100_20150317_002894	I'm not yet ready.
+QUEST_LV_0100_20150317_002894	I’m not yet ready.
 QUEST_LV_0100_20150317_002895	Notice/Tenet Chapel 1st Floor was blocked by power of Gesti{nl}Find the way out to the 1st floor through the basement 1st floor!
 QUEST_LV_0100_20150317_002896	
-QUEST_LV_0100_20150317_002897	I'll restore it
+QUEST_LV_0100_20150317_002897	I’ll restore it
 QUEST_LV_0100_20150317_002898	Wait for a while
 QUEST_LV_0100_20150317_002899	Restoring memorial/LOOK/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002900	Notice/You restored the Ruklys memorial and obtained the legacy of ruklys.{nl}You 0earned 1 stats point.
 QUEST_LV_0100_20150317_002901	
-QUEST_LV_0100_20150317_002902	I'll stay with you till the end
+QUEST_LV_0100_20150317_002902	I’ll stay with you till the end
 QUEST_LV_0100_20150317_002903	
 QUEST_LV_0100_20150317_002904	Releasing the barrier/MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002905	
-QUEST_LV_0100_20150317_002906	Notice/You read Lydia Schaffen's tombstone and gained enlightenment.{nl}You earned 1 stat point
+QUEST_LV_0100_20150317_002906	Notice/You read Lydia Schaffen’s tombstone and gained enlightenment.{nl}You earned 1 stat point
 QUEST_LV_0100_20150317_002907	
-QUEST_LV_0100_20150317_002908	I'll help you.
+QUEST_LV_0100_20150317_002908	I’ll help you.
 QUEST_LV_0100_20150317_002909	
 QUEST_LV_0100_20150317_002910	Finish it yourself.
 QUEST_LV_0100_20150317_002911	Preparing sacrifice/MAKING/2/TRACK_BEFORE/None
@@ -2914,10 +2914,10 @@ QUEST_LV_0100_20150317_002913
 QUEST_LV_0100_20150317_002914	Starting conversation/TALK/1/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002915	Why are you roaming around?
 QUEST_LV_0100_20150317_002916	
-QUEST_LV_0100_20150317_002917	i'll get rid of Denoptic
+QUEST_LV_0100_20150317_002917	i’ll get rid of Denoptic
 QUEST_LV_0100_20150317_002918	Notice /Tomb is starting to shake. #4
 QUEST_LV_0100_20150317_002919	
-QUEST_LV_0100_20150317_002920	Let's find where it is collapsing.
+QUEST_LV_0100_20150317_002920	Let’s find where it is collapsing.
 QUEST_LV_0100_20150317_002921	Notice /Stop the guardians from destroying the Royal tomb.
 QUEST_LV_0100_20150317_002922	
 QUEST_LV_0100_20150317_002923	
@@ -2925,35 +2925,35 @@ QUEST_LV_0100_20150317_002924	Better stop them from destroying the Royal tomb.
 QUEST_LV_0100_20150317_002925	Notice /Stop the guardians from destroying the Royal tomb.
 QUEST_LV_0100_20150317_002926	
 QUEST_LV_0100_20150317_002927	Better stop them from destroying the Royal tomb.
-QUEST_LV_0100_20150317_002928	Notice/The tomb seems like it's going to crumble soon. Stop the guardians from destroying it #7
+QUEST_LV_0100_20150317_002928	Notice/The tomb seems like it’s going to crumble soon. Stop the guardians from destroying it #7
 QUEST_LV_0100_20150317_002929	
 QUEST_LV_0100_20150317_002930	Kill Bearkaras and stop the Royal tomb from collapsing
 QUEST_LV_0100_20150317_002931	
-QUEST_LV_0100_20150317_002932	Find the source of the Tomb's Evil Power
-QUEST_LV_0100_20150317_002933	I'm not yet ready
+QUEST_LV_0100_20150317_002932	Find the source of the Tomb’s Evil Power
+QUEST_LV_0100_20150317_002933	I’m not yet ready
 QUEST_LV_0100_20150317_002934	
-QUEST_LV_0100_20150317_002935	Let's pour the source of the evil power in the jar
-QUEST_LV_0100_20150317_002936	I'm not yet ready
+QUEST_LV_0100_20150317_002935	Let’s pour the source of the evil power in the jar
+QUEST_LV_0100_20150317_002936	I’m not yet ready
 QUEST_LV_0100_20150317_002937	Notice /There is a sound of someone crying #5
 QUEST_LV_0100_20150317_002938	
-QUEST_LV_0100_20150317_002939	Go to fill the jar with the guardian's will
+QUEST_LV_0100_20150317_002939	Go to fill the jar with the guardian’s will
 QUEST_LV_0100_20150317_002940	Installing the jar/MAKING/2.5/TRACK_BEFORE/None 
 QUEST_LV_0100_20150317_002941	
 QUEST_LV_0100_20150317_002942	
 QUEST_LV_0100_20150317_002943	
 QUEST_LV_0100_20150317_002944	Notice/The portal to the entrance of the Royal tomb is opened! #5
 QUEST_LV_0100_20150317_002945	
-QUEST_LV_0100_20150317_002946	Let's go get light the stone lantern
+QUEST_LV_0100_20150317_002946	Let’s go get light the stone lantern
 QUEST_LV_0100_20150317_002947	Loading power/ MAKING/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002948	
 QUEST_LV_0100_20150317_002949	
-QUEST_LV_0100_20150317_002950	Let's gather the active stones
+QUEST_LV_0100_20150317_002950	Let’s gather the active stones
 QUEST_LV_0100_20150317_002951	
 QUEST_LV_0100_20150317_002952	Go to destroy the evil power suppressor of the Royal tomb 
 QUEST_LV_0100_20150317_002953	
 QUEST_LV_0100_20150317_002954	
 QUEST_LV_0100_20150317_002955	
-QUEST_LV_0100_20150317_002956	Let's gather the force of the guardians and find the hidden treasure
+QUEST_LV_0100_20150317_002956	Let’s gather the force of the guardians and find the hidden treasure
 QUEST_LV_0100_20150317_002957	Not interested
 QUEST_LV_0100_20150317_002958	Notice /The royal guardian of the spell has opened his mouth. #7
 QUEST_LV_0100_20150317_002959	
@@ -2962,7 +2962,7 @@ QUEST_LV_0100_20150317_002961	Quit
 QUEST_LV_0100_20150317_002962	
 QUEST_LV_0100_20150317_002963	Gather the spel
 QUEST_LV_0100_20150317_002964	
-QUEST_LV_0100_20150317_002965	Let's light the royal stone lanterns
+QUEST_LV_0100_20150317_002965	Let’s light the royal stone lanterns
 QUEST_LV_0100_20150317_002966	Igniting/ MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002967	
 QUEST_LV_0100_20150317_002968	Go to guard the Spell reservoir
@@ -2977,42 +2977,42 @@ QUEST_LV_0100_20150317_002976	Notice /These are not the only contaminated lanter
 QUEST_LV_0100_20150317_002977	
 QUEST_LV_0100_20150317_002978	Go to destroy royal spell suppressor
 QUEST_LV_0100_20150317_002979	
-QUEST_LV_0100_20150317_002980	Let's gather token of Wheelen
-QUEST_LV_0100_20150317_002981	I don't need it
+QUEST_LV_0100_20150317_002980	Let’s gather token of Wheelen
+QUEST_LV_0100_20150317_002981	I don’t need it
 QUEST_LV_0100_20150317_002982	Obtaining power of the token/MAKING/1/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002983	Notice /Wheelen's strong force is wrapping the whole body #5
+QUEST_LV_0100_20150317_002983	Notice /Wheelen’s strong force is wrapping the whole body #5
 QUEST_LV_0100_20150317_002984	
-QUEST_LV_0100_20150317_002985	Let's kill the hostile Venucelos
+QUEST_LV_0100_20150317_002985	Let’s kill the hostile Venucelos
 QUEST_LV_0100_20150317_002986	
 QUEST_LV_0100_20150317_002987	Challenge the spell of the royal tomb
 QUEST_LV_0100_20150317_002988	Pass the challenge
 QUEST_LV_0100_20150317_002989	
-QUEST_LV_0100_20150317_002990	I'll try to do it
+QUEST_LV_0100_20150317_002990	I’ll try to do it
 QUEST_LV_0100_20150317_002991	
 QUEST_LV_0100_20150317_002992	Help find his brother
 QUEST_LV_0100_20150317_002993	
-QUEST_LV_0100_20150317_002994	I'll go and read the tombstone
+QUEST_LV_0100_20150317_002994	I’ll go and read the tombstone
 QUEST_LV_0100_20150317_002995	
 QUEST_LV_0100_20150317_002996	
 QUEST_LV_0100_20150317_002997	Read the tombstone and come back
 QUEST_LV_0100_20150317_002998	Checking tombstone/ MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002999	
-QUEST_LV_0100_20150317_003000	I'll read what's written on the tombstone
+QUEST_LV_0100_20150317_003000	I’ll read what’s written on the tombstone
 QUEST_LV_0100_20150317_003001	
-QUEST_LV_0100_20150317_003002	I'll charge the Spell device
+QUEST_LV_0100_20150317_003002	I’ll charge the Spell device
 QUEST_LV_0100_20150317_003003	
-QUEST_LV_0100_20150317_003004	Go and check what's written on the last tombstone
+QUEST_LV_0100_20150317_003004	Go and check what’s written on the last tombstone
 QUEST_LV_0100_20150317_003005	Checking/READ/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003006	
-QUEST_LV_0100_20150317_003007	I'll get rid of the  Cockatrice
+QUEST_LV_0100_20150317_003007	I’ll get rid of the  Cockatrice
 QUEST_LV_0100_20150317_003008	
-QUEST_LV_0100_20150317_003009	Which monster's act is it?
+QUEST_LV_0100_20150317_003009	Which monster’s act is it?
 QUEST_LV_0100_20150317_003010	I better get going
 QUEST_LV_0100_20150317_003011	
 QUEST_LV_0100_20150317_003012	
-QUEST_LV_0100_20150317_003013	I'll gather the sample first
+QUEST_LV_0100_20150317_003013	I’ll gather the sample first
 QUEST_LV_0100_20150317_003014	
-QUEST_LV_0100_20150317_003015	I'll get it 
+QUEST_LV_0100_20150317_003015	I’ll get it 
 QUEST_LV_0100_20150317_003016	Goddess Gabija (1)
 QUEST_LV_0100_20150317_003017	Go to Crystal Brook to help Grita
 QUEST_LV_0100_20150317_003018	Goddess Gabija (2)
@@ -3020,30 +3020,30 @@ QUEST_LV_0100_20150317_003019	Follow Grita to the tower of the wizard
 QUEST_LV_0100_20150317_003020	Reject
 QUEST_LV_0100_20150317_003021	About Goddess Gabija
 QUEST_LV_0100_20150317_003022	Goddess Gabija (3)
-QUEST_LV_0100_20150317_003023	Let's go ignite fire
-QUEST_LV_0100_20150317_003024	I'm not ready yet
+QUEST_LV_0100_20150317_003023	Let’s go ignite fire
+QUEST_LV_0100_20150317_003024	I’m not ready yet
 QUEST_LV_0100_20150317_003025	Goddess Gabija (4)
 QUEST_LV_0100_20150317_003026	
-QUEST_LV_0100_20150317_003027	Let's find a safer way 
+QUEST_LV_0100_20150317_003027	Let’s find a safer way 
 QUEST_LV_0100_20150317_003028	Goddess Gabija (5)
 QUEST_LV_0100_20150317_003029	
 QUEST_LV_0100_20150317_003030	Operation of/SITABSORB/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003031	Goddess Gabija (6)
-QUEST_LV_0100_20150317_003032	Let's just go up quickly
+QUEST_LV_0100_20150317_003032	Let’s just go up quickly
 QUEST_LV_0100_20150317_003033	
 QUEST_LV_0100_20150317_003034	
-QUEST_LV_0100_20150317_003035	Activate the closing device of the Wizard's Tower/ MAKING/3/TRACK_BEFORE/None/F_buff_Cleric_Limitation_Buff/1/MID
+QUEST_LV_0100_20150317_003035	Activate the closing device of the Wizard’s Tower/ MAKING/3/TRACK_BEFORE/None/F_buff_Cleric_Limitation_Buff/1/MID
 QUEST_LV_0100_20150317_003036	
 QUEST_LV_0100_20150317_003037	How do you make the Prominence?
 QUEST_LV_0100_20150317_003038	Better go up quickly
 QUEST_LV_0100_20150317_003039	
 QUEST_LV_0100_20150317_003040	
-QUEST_LV_0100_20150317_003041	I'll gather the vapor of fire
+QUEST_LV_0100_20150317_003041	I’ll gather the vapor of fire
 QUEST_LV_0100_20150317_003042	
-QUEST_LV_0100_20150317_003043	I'll fill the essence of fire
-QUEST_LV_0100_20150317_003044	Let's take rest for a while
+QUEST_LV_0100_20150317_003043	I’ll fill the essence of fire
+QUEST_LV_0100_20150317_003044	Let’s take rest for a while
 QUEST_LV_0100_20150317_003045	
-QUEST_LV_0100_20150317_003046	I'll gather the source of fire
+QUEST_LV_0100_20150317_003046	I’ll gather the source of fire
 QUEST_LV_0100_20150317_003047	
 QUEST_LV_0100_20150317_003048	Go to complete the Gem of Prominence
 QUEST_LV_0100_20150317_003049	Fusing the Gem of Prominence/ MAKING/2/TRACK_BEFORE/None
@@ -3051,23 +3051,23 @@ QUEST_LV_0100_20150317_003050	Notice /Gem of Prominence is complete! #5
 QUEST_LV_0100_20150317_003051	
 QUEST_LV_0100_20150317_003052	Say to go quickly
 QUEST_LV_0100_20150317_003053	
-QUEST_LV_0100_20150317_003054	Let's stop Antares
+QUEST_LV_0100_20150317_003054	Let’s stop Antares
 QUEST_LV_0100_20150317_003055	Just ignore it and go up 
 QUEST_LV_0100_20150317_003056	Notice /! /Destroy the spell control valve! #5
 QUEST_LV_0100_20150317_003057	
-QUEST_LV_0100_20150317_003058	I'll find the data
+QUEST_LV_0100_20150317_003058	I’ll find the data
 QUEST_LV_0100_20150317_003059	
 QUEST_LV_0100_20150317_003060	Go and find the second valve
 QUEST_LV_0100_20150317_003061	
 QUEST_LV_0100_20150317_003062	
-QUEST_LV_0100_20150317_003063	I agree to Grita's words
+QUEST_LV_0100_20150317_003063	I agree to Grita’s words
 QUEST_LV_0100_20150317_003064	It will be ok
 QUEST_LV_0100_20150317_003065	
-QUEST_LV_0100_20150317_003066	I'll find the spell stabilizing device
-QUEST_LV_0100_20150317_003067	Let's just go up
+QUEST_LV_0100_20150317_003066	I’ll find the spell stabilizing device
+QUEST_LV_0100_20150317_003067	Let’s just go up
 QUEST_LV_0100_20150317_003068	Operating/ MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003069	
-QUEST_LV_0100_20150317_003070	I'll collect the essence of fire
+QUEST_LV_0100_20150317_003070	I’ll collect the essence of fire
 QUEST_LV_0100_20150317_003071	It will be enough this way
 QUEST_LV_0100_20150317_003072	
 QUEST_LV_0100_20150317_003073	Checking magic circle/ MAKING/2/TRACK_BEFORE/None
@@ -3081,56 +3081,56 @@ QUEST_LV_0100_20150317_003080
 QUEST_LV_0100_20150317_003081	
 QUEST_LV_0100_20150317_003082	
 QUEST_LV_0100_20150317_003083	
-QUEST_LV_0100_20150317_003084	I'll try to meet commander Laimondas
+QUEST_LV_0100_20150317_003084	I’ll try to meet commander Laimondas
 QUEST_LV_0100_20150317_003085	
-QUEST_LV_0100_20150317_003086	I'll collect it
+QUEST_LV_0100_20150317_003086	I’ll collect it
 QUEST_LV_0100_20150317_003087	
-QUEST_LV_0100_20150317_003088	I'll spray the herbicide
+QUEST_LV_0100_20150317_003088	I’ll spray the herbicide
 QUEST_LV_0100_20150317_003089	Using herbicides/STANDSPINKLE/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003090	Archon of flame fuser
 QUEST_LV_0100_20150317_003091	Notice /Archon has suddenly attacked! #5
 QUEST_LV_0100_20150317_003092	
-QUEST_LV_0100_20150317_003093	I'll get rid of the Golem
+QUEST_LV_0100_20150317_003093	I’ll get rid of the Golem
 QUEST_LV_0100_20150317_003094	
-QUEST_LV_0100_20150317_003095	I'll go investigate on it
+QUEST_LV_0100_20150317_003095	I’ll go investigate on it
 QUEST_LV_0100_20150317_003096	
-QUEST_LV_0100_20150317_003097	I'll calm Pete down and check the body myself
+QUEST_LV_0100_20150317_003097	I’ll calm Pete down and check the body myself
 QUEST_LV_0100_20150317_003098	Checking/MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003099	
-QUEST_LV_0100_20150317_003100	Let's find it together
+QUEST_LV_0100_20150317_003100	Let’s find it together
 QUEST_LV_0100_20150317_003101	
 QUEST_LV_0100_20150317_003102	I will go meet Laimondas
 QUEST_LV_0100_20150317_003103	
 QUEST_LV_0100_20150317_003104	
-QUEST_LV_0100_20150317_003105	I'll open the front door
+QUEST_LV_0100_20150317_003105	I’ll open the front door
 QUEST_LV_0100_20150317_003106	
 QUEST_LV_0100_20150317_003107	
 QUEST_LV_0100_20150317_003108	
-QUEST_LV_0100_20150317_003109	I don't have time
+QUEST_LV_0100_20150317_003109	I don’t have time
 QUEST_LV_0100_20150317_003110	
 QUEST_LV_0100_20150317_003111	
-QUEST_LV_0100_20150317_003112	That's blasphemous
+QUEST_LV_0100_20150317_003112	That’s blasphemous
 QUEST_LV_0100_20150317_003113	
 QUEST_LV_0100_20150317_003114	It looks fun
-QUEST_LV_0100_20150317_003115	Looks like we'll be caught soon. Let just stop.
-QUEST_LV_0100_20150317_003116	Now that you've lost the spell, what are you going to do? 
+QUEST_LV_0100_20150317_003115	Looks like we’ll be caught soon. Let just stop.
+QUEST_LV_0100_20150317_003116	Now that you’ve lost the spell, what are you going to do? 
 QUEST_LV_0100_20150317_003117	I need some time to thinnk
 QUEST_LV_0100_20150317_003118	
-QUEST_LV_0100_20150317_003119	It could be difficult but I'll try
+QUEST_LV_0100_20150317_003119	It could be difficult but I’ll try
 QUEST_LV_0100_20150317_003120	I need to find out more about the demons
 QUEST_LV_0100_20150317_003121	
-QUEST_LV_0100_20150317_003122	I'll check on it
+QUEST_LV_0100_20150317_003122	I’ll check on it
 QUEST_LV_0100_20150317_003123	about the church altar
 QUEST_LV_0100_20150317_003124	Checking altar/ MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003125	
-QUEST_LV_0100_20150317_003126	I'll take care of it quickly
-QUEST_LV_0100_20150317_003127	I'll go when it is safer
+QUEST_LV_0100_20150317_003126	I’ll take care of it quickly
+QUEST_LV_0100_20150317_003127	I’ll go when it is safer
 QUEST_LV_0100_20150317_003128	
 QUEST_LV_0100_20150317_003129	
-QUEST_LV_0100_20150317_003130	I'm ready
-QUEST_LV_0100_20150317_003131	I can't believe it
+QUEST_LV_0100_20150317_003130	I’m ready
+QUEST_LV_0100_20150317_003131	I can’t believe it
 QUEST_LV_0100_20150317_003132	
-QUEST_LV_0100_20150317_003133	It doesn't seem like a good idea
+QUEST_LV_0100_20150317_003133	It doesn’t seem like a good idea
 QUEST_LV_0100_20150317_003134	
 QUEST_LV_0100_20150317_003135	Hmm, Ok
 QUEST_LV_0100_20150317_003136	I need more preparation
@@ -3138,79 +3138,79 @@ QUEST_LV_0100_20150317_003137
 QUEST_LV_0100_20150317_003138	I can help you
 QUEST_LV_0100_20150317_003139	Hold on a little longer
 QUEST_LV_0100_20150317_003140	
-QUEST_LV_0100_20150317_003141	That's too much to handle
+QUEST_LV_0100_20150317_003141	That’s too much to handle
 QUEST_LV_0100_20150317_003142	
 QUEST_LV_0100_20150317_003143	I will go to the 1st floor
 QUEST_LV_0100_20150317_003144	Look for another way
 QUEST_LV_0100_20150317_003145	Releasing/ SITGROPE/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003146	
-QUEST_LV_0100_20150317_003147	Let's go and find
+QUEST_LV_0100_20150317_003147	Let’s go and find
 QUEST_LV_0100_20150317_003148	
 QUEST_LV_0100_20150317_003149	
 QUEST_LV_0100_20150317_003150	Begin immediately
 QUEST_LV_0100_20150317_003151	Gesti might still be around
 QUEST_LV_0100_20150317_003152	
 QUEST_LV_0100_20150317_003153	I will bring it secretly
-QUEST_LV_0100_20150317_003154	I'll observe the situation a little more
+QUEST_LV_0100_20150317_003154	I’ll observe the situation a little more
 QUEST_LV_0100_20150317_003155	About the Seal of space
 QUEST_LV_0100_20150317_003156	
-QUEST_LV_0100_20150317_003157	I'll be cautious on my way
+QUEST_LV_0100_20150317_003157	I’ll be cautious on my way
 QUEST_LV_0100_20150317_003158	Check movement of the Gesti and go
 QUEST_LV_0100_20150317_003159	
-QUEST_LV_0100_20150317_003160	I'll activate the altar
+QUEST_LV_0100_20150317_003160	I’ll activate the altar
 QUEST_LV_0100_20150317_003161	It will be okay
 QUEST_LV_0100_20150317_003162	
 QUEST_LV_0100_20150317_003163	No problem
-QUEST_LV_0100_20150317_003164	I'll think about it for a while
+QUEST_LV_0100_20150317_003164	I’ll think about it for a while
 QUEST_LV_0100_20150317_003165	
 QUEST_LV_0100_20150317_003166	
-QUEST_LV_0100_20150317_003167	I'll trust Algis
-QUEST_LV_0100_20150317_003168	I'm not yet ready
+QUEST_LV_0100_20150317_003167	I’ll trust Algis
+QUEST_LV_0100_20150317_003168	I’m not yet ready
 QUEST_LV_0100_20150317_003169	About the scripture
 QUEST_LV_0100_20150317_003170	
 QUEST_LV_0100_20150317_003171	There is still more to do
 QUEST_LV_0100_20150317_003172	Checking/READ/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003173	
-QUEST_LV_0100_20150317_003174	I'll help if it's simple
-QUEST_LV_0100_20150317_003175	I'm busy on my way
+QUEST_LV_0100_20150317_003174	I’ll help if it’s simple
+QUEST_LV_0100_20150317_003175	I’m busy on my way
 QUEST_LV_0100_20150317_003176	17
 QUEST_LV_0100_20150317_003177	
-QUEST_LV_0100_20150317_003178	I'll help
+QUEST_LV_0100_20150317_003178	I’ll help
 QUEST_LV_0100_20150317_003179	
-QUEST_LV_0100_20150317_003180	I'll destroy the demon summoner
+QUEST_LV_0100_20150317_003180	I’ll destroy the demon summoner
 QUEST_LV_0100_20150317_003181	It will be fine
 QUEST_LV_0100_20150317_003182	
-QUEST_LV_0100_20150317_003183	It's too difficult
+QUEST_LV_0100_20150317_003183	It’s too difficult
 QUEST_LV_0100_20150317_003184	
-QUEST_LV_0100_20150317_003185	I'll get rid of the demons while resting
+QUEST_LV_0100_20150317_003185	I’ll get rid of the demons while resting
 QUEST_LV_0100_20150317_003186	Cheer up and hold on
 QUEST_LV_0100_20150317_003187	
-QUEST_LV_0100_20150317_003188	I'll go with you
+QUEST_LV_0100_20150317_003188	I’ll go with you
 QUEST_LV_0100_20150317_003189	I need to prepare myself
 QUEST_LV_0100_20150317_003190	About the followers
 QUEST_LV_0100_20150317_003191	
-QUEST_LV_0100_20150317_003192	I'll ask
-QUEST_LV_0100_20150317_003193	I'm not ready to hear yet
+QUEST_LV_0100_20150317_003192	I’ll ask
+QUEST_LV_0100_20150317_003193	I’m not ready to hear yet
 QUEST_LV_0100_20150317_003194	
 QUEST_LV_0100_20150317_003195	
-QUEST_LV_0100_20150317_003196	I'll help to concentrate
+QUEST_LV_0100_20150317_003196	I’ll help to concentrate
 QUEST_LV_0100_20150317_003197	
-QUEST_LV_0100_20150317_003198	Let's get rid of the contaminated guardian
+QUEST_LV_0100_20150317_003198	Let’s get rid of the contaminated guardian
 QUEST_LV_0100_20150317_003199	Notice /Get rid of the Royal guardians charging in
 QUEST_LV_0100_20150317_003200	Notice /Get rid of the Royal guardians charging in
 QUEST_LV_0100_20150317_003201	
 QUEST_LV_0100_20150317_003202	
 QUEST_LV_0100_20150317_003203	Ignore it
 QUEST_LV_0100_20150317_003204	
-QUEST_LV_0100_20150317_003205	I'll find the ma
+QUEST_LV_0100_20150317_003205	I’ll find the ma
 QUEST_LV_0100_20150317_003206	Notice /!/Is a trap. Get rid of the monsters flocking in! #7
 QUEST_LV_0100_20150317_003207	
 QUEST_LV_0100_20150317_003208	
 QUEST_LV_0100_20150317_003209	
 QUEST_LV_0100_20150317_003210	
 QUEST_LV_0100_20150317_003211	
-QUEST_LV_0100_20150317_003212	I'll borrow the Antidote
-QUEST_LV_0100_20150317_003213	It'll be okay soon
+QUEST_LV_0100_20150317_003212	I’ll borrow the Antidote
+QUEST_LV_0100_20150317_003213	It’ll be okay soon
 QUEST_LV_0100_20150317_003214	
 QUEST_LV_0100_20150317_003215	
 QUEST_LV_0100_20150317_003216	
@@ -3227,34 +3227,34 @@ QUEST_LV_0100_20150317_003226	Move to a where the last inscription is located
 QUEST_LV_0100_20150317_003227	Looking around/ # SITGROPESET2/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003228	
 QUEST_LV_0100_20150317_003229	I follow the whereabouts of Rexipher
-QUEST_LV_0100_20150317_003230	Don't chase
+QUEST_LV_0100_20150317_003230	Don’t chase
 QUEST_LV_0100_20150317_003231	Notice /! /Follow Rexipher and go to the Underground Mausoleum 3rd district! #7
 QUEST_LV_0100_20150317_003232	
-QUEST_LV_0100_20150317_003233	Seems like it'd be better to get rid of some guardians
+QUEST_LV_0100_20150317_003233	Seems like it’d be better to get rid of some guardians
 QUEST_LV_0100_20150317_003234	
 QUEST_LV_0100_20150317_003235	Defeat the Shnayim
 QUEST_LV_0100_20150317_003236	
 QUEST_LV_0100_20150317_003237	Historian Rexipher of research (6)
-QUEST_LV_0100_20150317_003238	I'll go find it
+QUEST_LV_0100_20150317_003238	I’ll go find it
 QUEST_LV_0100_20150317_003239	Notice /You brought the teeth of Hogma but Rexipher disappeared! #8
 QUEST_LV_0100_20150317_003240	Missing longer and historian Rexipher (1)
-QUEST_LV_0100_20150317_003241	I'll ask another historian
+QUEST_LV_0100_20150317_003241	I’ll ask another historian
 QUEST_LV_0100_20150317_003242	Stop looking for Rexipher
 QUEST_LV_0100_20150317_003243	The identity of the historian Rexipher
-QUEST_LV_0100_20150317_003244	I'm sure that is the name
+QUEST_LV_0100_20150317_003244	I’m sure that is the name
 QUEST_LV_0100_20150317_003245	Stop looking for Rexipher
-QUEST_LV_0100_20150317_003246	Rexipher's True Colors (1)
+QUEST_LV_0100_20150317_003246	Rexipher’s True Colors (1)
 QUEST_LV_0100_20150317_003247	He is right
-QUEST_LV_0100_20150317_003248	I don't think so
+QUEST_LV_0100_20150317_003248	I don’t think so
 QUEST_LV_0100_20150317_003249	Notice /You must go to Gedulah altar before Rexipher! #7
-QUEST_LV_0100_20150317_003250	Rexipher's True Colors (2)
-QUEST_LV_0100_20150317_003251	Rexipher's True Colors (3)
+QUEST_LV_0100_20150317_003250	Rexipher’s True Colors (2)
+QUEST_LV_0100_20150317_003251	Rexipher’s True Colors (3)
 QUEST_LV_0100_20150317_003252	Explain about the 5 clues and Rexipher
 QUEST_LV_0100_20150317_003253	
 QUEST_LV_0100_20150317_003254	About the seal of this place
-QUEST_LV_0100_20150317_003255	Rexipher's True Colors (4)
+QUEST_LV_0100_20150317_003255	Rexipher’s True Colors (4)
 QUEST_LV_0100_20150317_003256	I will go
-QUEST_LV_0100_20150317_003257	Rexipher's True Colors (5)
+QUEST_LV_0100_20150317_003257	Rexipher’s True Colors (5)
 QUEST_LV_0100_20150317_003258	
 QUEST_LV_0100_20150317_003259	About Ruklys
 QUEST_LV_0100_20150317_003260	
@@ -3263,9 +3263,9 @@ QUEST_LV_0100_20150317_003262	Find other things first
 QUEST_LV_0100_20150317_003263	About Ruklys memorial
 QUEST_LV_0100_20150317_003264	Checking/SITGROPE_LOOP/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003265	
-QUEST_LV_0100_20150317_003266	I'll find the piece of memorial
+QUEST_LV_0100_20150317_003266	I’ll find the piece of memorial
 QUEST_LV_0100_20150317_003267	
-QUEST_LV_0100_20150317_003268	It's too dangerous
+QUEST_LV_0100_20150317_003268	It’s too dangerous
 QUEST_LV_0100_20150317_003269	Learn Cleric Attributes
 QUEST_LV_0100_20150317_003270	Listen to the explanation about Attributes
 QUEST_LV_0100_20150317_003271	
@@ -3275,7 +3275,7 @@ QUEST_LV_0100_20150317_003274
 QUEST_LV_0100_20150317_003275	One to operate the device/MAKING/2/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003276	
 QUEST_LV_0100_20150317_003277	Swindler Rexipher
-QUEST_LV_0100_20150317_003278	I'll chase the Rexipher to the Royal tomb
+QUEST_LV_0100_20150317_003278	I’ll chase the Rexipher to the Royal tomb
 QUEST_LV_0100_20150317_003279	I still need more preparation
 QUEST_LV_0100_20150317_003280	
 QUEST_LV_0100_20150317_003281	Better not touch it unless necessary
@@ -3289,17 +3289,17 @@ QUEST_LV_0100_20150317_003288	I will repair the practice wooden seal
 QUEST_LV_0100_20150317_003289	
 QUEST_LV_0100_20150317_003290	I will accept that bet
 QUEST_LV_0100_20150317_003291	
-QUEST_LV_0100_20150317_003292	I'm not weak
+QUEST_LV_0100_20150317_003292	I’m not weak
 QUEST_LV_0100_20150317_003293	
 QUEST_LV_0100_20150317_003294	I will find and get rid of Chapparition
 QUEST_LV_0100_20150317_003295	
 QUEST_LV_0100_20150317_003296	I will find your sister and give her the necklace
 QUEST_LV_0100_20150317_003297	
-QUEST_LV_0100_20150317_003298	I'll complete the mission for you
+QUEST_LV_0100_20150317_003298	I’ll complete the mission for you
 QUEST_LV_0100_20150317_003299	
-QUEST_LV_0100_20150317_003300	I'll do the errand
+QUEST_LV_0100_20150317_003300	I’ll do the errand
 QUEST_LV_0100_20150317_003301	
-QUEST_LV_0100_20150317_003302	I'll share the food
+QUEST_LV_0100_20150317_003302	I’ll share the food
 QUEST_LV_0100_20150317_003303	
 QUEST_LV_0100_20150317_003304	
 QUEST_LV_0100_20150317_003305	I will burn the oration and comfort the souls
@@ -3311,30 +3311,30 @@ QUEST_LV_0100_20150317_003310	Learn Archer Attributes
 QUEST_LV_0100_20150317_003311	Young Magician Owyn (1)
 QUEST_LV_0100_20150317_003312	About the current situation of the tower
 QUEST_LV_0100_20150317_003313	Young Magician Owyn (2)
-QUEST_LV_0100_20150317_003314	I'll take care of Drake
+QUEST_LV_0100_20150317_003314	I’ll take care of Drake
 QUEST_LV_0100_20150317_003315	Well then, I shall get going. Goodbye.
 QUEST_LV_0100_20150317_003316	
-QUEST_LV_0100_20150317_003317	I'll go find the black coal powder
+QUEST_LV_0100_20150317_003317	I’ll go find the black coal powder
 QUEST_LV_0100_20150317_003318	
 QUEST_LV_0100_20150317_003319	I will bring the undying fire
 QUEST_LV_0100_20150317_003320	Go find it yourself
 QUEST_LV_0100_20150317_003321	
-QUEST_LV_0100_20150317_003322	I'll go and check on it
+QUEST_LV_0100_20150317_003322	I’ll go and check on it
 QUEST_LV_0100_20150317_003323	Checking bookcase/READ/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003324	
 QUEST_LV_0100_20150317_003325	Get rid of it
-QUEST_LV_0100_20150317_003326	It's strange so just ignore it
+QUEST_LV_0100_20150317_003326	It’s strange so just ignore it
 QUEST_LV_0100_20150317_003327	NPCChat/FTOWER42_SQ_01 /Now I can be free..
 QUEST_LV_0100_20150317_003328	
 QUEST_LV_0100_20150317_003329	Get rid of the observer
-QUEST_LV_0100_20150317_003330	It's annoying so just leave
+QUEST_LV_0100_20150317_003330	It’s annoying so just leave
 QUEST_LV_0100_20150317_003331	
 QUEST_LV_0100_20150317_003332	NPCChat/FTOWER42_SQ_02 /Finally free..
 QUEST_LV_0100_20150317_003333	
 QUEST_LV_0100_20150317_003334	Regain the holy ark
 QUEST_LV_0100_20150317_003335	NPCChat/FTOWER42_SQ_04 /Finally.
 QUEST_LV_0100_20150317_003336	
-QUEST_LV_0100_20150317_003337	I'll release you
+QUEST_LV_0100_20150317_003337	I’ll release you
 QUEST_LV_0100_20150317_003338	NPCChat/FTOWER42_SQ_05 /Freed from the restrains..
 QUEST_LV_0100_20150317_003339	
 QUEST_LV_0100_20150317_003340	
@@ -3344,35 +3344,35 @@ QUEST_LV_0100_20150317_003343
 QUEST_LV_0100_20150317_003344	Seems suspicious but grant his wish
 QUEST_LV_0100_20150317_003345	
 QUEST_LV_0100_20150317_003346	Release the seal
-QUEST_LV_0100_20150317_003347	You're busy so just ignore 
-QUEST_LV_0100_20150317_003348	NPCChat/FTOWER43_SQ_03 /Freedom. I'm finally free..
+QUEST_LV_0100_20150317_003347	You’re busy so just ignore 
+QUEST_LV_0100_20150317_003348	NPCChat/FTOWER43_SQ_03 /Freedom. I’m finally free..
 QUEST_LV_0100_20150317_003349	
-QUEST_LV_0100_20150317_003350	Seems strange but let's help
-QUEST_LV_0100_20150317_003351	Pretend you didn't hear it
+QUEST_LV_0100_20150317_003350	Seems strange but let’s help
+QUEST_LV_0100_20150317_003351	Pretend you didn’t hear it
 QUEST_LV_0100_20150317_003352	
-QUEST_LV_0100_20150317_003353	I'll find the mutated 매질
-QUEST_LV_0100_20150317_003354	That's tough
+QUEST_LV_0100_20150317_003353	I’ll find the mutated 매질
+QUEST_LV_0100_20150317_003354	That’s tough
 QUEST_LV_0100_20150317_003355	
-QUEST_LV_0100_20150317_003356	I'll collect it so go ahead
-QUEST_LV_0100_20150317_003357	I can't because I have other things to do
+QUEST_LV_0100_20150317_003356	I’ll collect it so go ahead
+QUEST_LV_0100_20150317_003357	I can’t because I have other things to do
 QUEST_LV_0100_20150317_003358	
-QUEST_LV_0100_20150317_003359	Let's just run away
+QUEST_LV_0100_20150317_003359	Let’s just run away
 QUEST_LV_0100_20150317_003360	
 QUEST_LV_0100_20150317_003361	Get rid of the surrounding monsters
 QUEST_LV_0100_20150317_003362	NPCChat/FTOWER44_SQ_04 /Thank you for releasing me
 QUEST_LV_0100_20150317_003363	
-QUEST_LV_0100_20150317_003364	I'll get rid of it
+QUEST_LV_0100_20150317_003364	I’ll get rid of it
 QUEST_LV_0100_20150317_003365	NPCChat/FTOWER44_SQ_05 /Thank you for letting me free
 QUEST_LV_0100_20150317_003366	
-QUEST_LV_0100_20150317_003367	I'm sorry but I don't think I can
+QUEST_LV_0100_20150317_003367	I’m sorry but I don’t think I can
 QUEST_LV_0100_20150317_003368	
-QUEST_LV_0100_20150317_003369	Don't worry
+QUEST_LV_0100_20150317_003369	Don’t worry
 QUEST_LV_0100_20150317_003370	
-QUEST_LV_0100_20150317_003371	I'll kill get rid of the Bearkaras for you 
+QUEST_LV_0100_20150317_003371	I’ll kill get rid of the Bearkaras for you 
 QUEST_LV_0100_20150317_003372	Better run away quickly
 QUEST_LV_0100_20150317_003373	
 QUEST_LV_0100_20150317_003374	Kill the monsters observing
-QUEST_LV_0100_20150317_003375	I'm busy now
+QUEST_LV_0100_20150317_003375	I’m busy now
 QUEST_LV_0100_20150317_003376	About the possessed soul
 QUEST_LV_0100_20150317_003377	
 QUEST_LV_0100_20150317_003378	I will release the soul by killing Stone Whale
@@ -3381,26 +3381,26 @@ QUEST_LV_0100_20150317_003380
 QUEST_LV_0100_20150317_003381	Notice /Go upstairs and find Goddess Gabija #5
 QUEST_LV_0100_20150317_003382	
 QUEST_LV_0100_20150317_003383	Fearless ones
-QUEST_LV_0100_20150317_003384	I'll teach him a lesson
+QUEST_LV_0100_20150317_003384	I’ll teach him a lesson
 QUEST_LV_0100_20150317_003385	Leave if for him to do it himself
 QUEST_LV_0100_20150317_003386	About the guards
 QUEST_LV_0100_20150317_003387	
-QUEST_LV_0100_20150317_003388	I'll get it to you
+QUEST_LV_0100_20150317_003388	I’ll get it to you
 QUEST_LV_0100_20150317_003389	About repairing the cable car
 QUEST_LV_0100_20150317_003390	
-QUEST_LV_0100_20150317_003391	I'll bring it 
+QUEST_LV_0100_20150317_003391	I’ll bring it 
 QUEST_LV_0100_20150317_003392	Lure the Baby Pantos
 QUEST_LV_0100_20150317_003393	About the Pantos
 QUEST_LV_0100_20150317_003394	Collect recycling materials
-QUEST_LV_0100_20150317_003395	That's too bad (leave)
+QUEST_LV_0100_20150317_003395	That’s too bad (leave)
 QUEST_LV_0100_20150317_003396	About the Holy Land
 QUEST_LV_0100_20150317_003397	Tyrant of Silver Gorge Stream
-QUEST_LV_0100_20150317_003398	I'll go and hunt the Poatas
-QUEST_LV_0100_20150317_003399	Don't worry. That will never happen
+QUEST_LV_0100_20150317_003398	I’ll go and hunt the Poatas
+QUEST_LV_0100_20150317_003399	Don’t worry. That will never happen
 QUEST_LV_0100_20150317_003400	About the cable car
 QUEST_LV_0100_20150317_003401	Making it dirty/ SITGROPE/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003402	
-QUEST_LV_0100_20150317_003403	I'm not sure but I'll give it a shot
+QUEST_LV_0100_20150317_003403	I’m not sure but I’ll give it a shot
 QUEST_LV_0100_20150317_003404	Seems like a dangerous plan
 QUEST_LV_0100_20150317_003405	About the Capris
 QUEST_LV_0100_20150317_003406	Petting/ PET/2/TRACK_BEFORE/None
@@ -3426,7 +3426,7 @@ QUEST_LV_0100_20150317_003425
 QUEST_LV_0100_20150317_003426	Release of Goddess Saulee (2)
 QUEST_LV_0100_20150317_003427	
 QUEST_LV_0100_20150317_003428	Release of Goddess Saule (3)
-QUEST_LV_0100_20150317_003429	I'll get rid of the monsters arround
+QUEST_LV_0100_20150317_003429	I’ll get rid of the monsters arround
 QUEST_LV_0100_20150317_003430	Release of Goddess Saule (4)
 QUEST_LV_0100_20150317_003431	Releasing the barrier/MAKING/3/TRACK_BEFORE/None/None/1/BOT/F_ground051/0.5/BOT
 QUEST_LV_0100_20150317_003432	Goddess Saule
@@ -3435,7 +3435,7 @@ QUEST_LV_0100_20150317_003434
 QUEST_LV_0100_20150317_003435	
 QUEST_LV_0100_20150317_003436	
 QUEST_LV_0100_20150317_003437	Looking for Goddess Saule
-QUEST_LV_0100_20150317_003438	I'll purify the pond
+QUEST_LV_0100_20150317_003438	I’ll purify the pond
 QUEST_LV_0100_20150317_003439	
 QUEST_LV_0100_20150317_003440	About Goddess Saule
 QUEST_LV_0100_20150317_003441	Notice/scroll /Use the cable car and go across to Zvelgian  #8
@@ -3443,7 +3443,7 @@ QUEST_LV_0100_20150317_003442	Notice/Go and purify the sacred pond #5
 QUEST_LV_0100_20150317_003443	
 QUEST_LV_0100_20150317_003444	Purifying/ MAKING/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003445	
-QUEST_LV_0100_20150317_003446	I'll look for the villagers
+QUEST_LV_0100_20150317_003446	I’ll look for the villagers
 QUEST_LV_0100_20150317_003447	
 QUEST_LV_0100_20150317_003448	
 QUEST_LV_0100_20150317_003449	
@@ -3459,30 +3459,30 @@ QUEST_LV_0100_20150317_003458	Merregina of the sacred pond
 QUEST_LV_0100_20150317_003459	Notice/Merregina appeared!
 QUEST_LV_0100_20150317_003460	
 QUEST_LV_0100_20150317_003461	
-QUEST_LV_0100_20150317_003462	I'll find what you want
+QUEST_LV_0100_20150317_003462	I’ll find what you want
 QUEST_LV_0100_20150317_003463	Close book
 QUEST_LV_0100_20150317_003464	
 QUEST_LV_0100_20150317_003465	I appreciate it
 QUEST_LV_0100_20150317_003466	Opening box with the key/# SITGROPESET2/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003467	
-QUEST_LV_0100_20150317_003468	I'll try making it
+QUEST_LV_0100_20150317_003468	I’ll try making it
 QUEST_LV_0100_20150317_003469	
-QUEST_LV_0100_20150317_003470	I'll make a bet
+QUEST_LV_0100_20150317_003470	I’ll make a bet
 QUEST_LV_0100_20150317_003471	
 QUEST_LV_0100_20150317_003472	I will do it
 QUEST_LV_0100_20150317_003473	
 QUEST_LV_0100_20150317_003474	
-QUEST_LV_0100_20150317_003475	I'll find the Clue so give me a hint
+QUEST_LV_0100_20150317_003475	I’ll find the Clue so give me a hint
 QUEST_LV_0100_20150317_003476	
-QUEST_LV_0100_20150317_003477	I'll solve the riddle
+QUEST_LV_0100_20150317_003477	I’ll solve the riddle
 QUEST_LV_0100_20150317_003478	
 QUEST_LV_0100_20150317_003479	Unealing/MAKING/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003480	Unealing// MAKING/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003481	
 QUEST_LV_0100_20150317_003482	
 QUEST_LV_0100_20150317_003483	
-QUEST_LV_0100_20150317_003484	I'll find the artifact
-QUEST_LV_0100_20150317_003485	I'll stop now. It's annoying.
+QUEST_LV_0100_20150317_003484	I’ll find the artifact
+QUEST_LV_0100_20150317_003485	I’ll stop now. It’s annoying.
 QUEST_LV_0100_20150317_003486	
 QUEST_LV_0100_20150317_003487	Looking at the inscription/LOOK/2/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003488	One look at the inscription/LOOK/2/TRACK_AFTER/None
@@ -3494,10 +3494,10 @@ QUEST_LV_0100_20150317_003493	Notice /You prayed for the soul of the dead soldie
 QUEST_LV_0100_20150317_003494	
 QUEST_LV_0100_20150317_003495	
 QUEST_LV_0100_20150317_003496	
-QUEST_LV_0100_20150317_003497	I'll find the box
+QUEST_LV_0100_20150317_003497	I’ll find the box
 QUEST_LV_0100_20150317_003498	Just ignore it and go your way
 QUEST_LV_0100_20150317_003499	
-QUEST_LV_0100_20150317_003500	Do not worry I'll collect them
+QUEST_LV_0100_20150317_003500	Do not worry I’ll collect them
 QUEST_LV_0100_20150317_003501	Take care of such things by yourself
 QUEST_LV_0100_20150317_003502	
 QUEST_LV_0100_20150317_003503	Notice/Piece of paper droped!#3
@@ -3515,64 +3515,64 @@ QUEST_LV_0100_20150317_003514	Mysterious slate (1)
 QUEST_LV_0100_20150317_003515	Of looking at/READ/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003516	Notice/Return to Klaipeda and talk to Knight Commander Uska
 QUEST_LV_0100_20150317_003517	Mysterious slate (2)
-QUEST_LV_0100_20150317_003518	I'll go visit Master Bokor
+QUEST_LV_0100_20150317_003518	I’ll go visit Master Bokor
 QUEST_LV_0100_20150317_003519	Mysterious slate (3)
-QUEST_LV_0100_20150317_003520	I'll go and meet Master Paladin
+QUEST_LV_0100_20150317_003520	I’ll go and meet Master Paladin
 QUEST_LV_0100_20150317_003521	
 QUEST_LV_0100_20150317_003522	
 QUEST_LV_0100_20150317_003523	
 QUEST_LV_0100_20150317_003524	
-QUEST_LV_0100_20150317_003525	I'll find the report and give it to offier Lutas
+QUEST_LV_0100_20150317_003525	I’ll find the report and give it to offier Lutas
 QUEST_LV_0100_20150317_003526	
-QUEST_LV_0100_20150317_003527	I'll steal the Saulem's trophy of war
+QUEST_LV_0100_20150317_003527	I’ll steal the Saulem’s trophy of war
 QUEST_LV_0100_20150317_003528	
-QUEST_LV_0100_20150317_003529	I'll take care of the Dumble balls
+QUEST_LV_0100_20150317_003529	I’ll take care of the Dumble balls
 QUEST_LV_0100_20150317_003530	
 QUEST_LV_0100_20150317_003531	
 QUEST_LV_0100_20150317_003532	Burning/MAKING/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003533	
-QUEST_LV_0100_20150317_003534	I'll get rid of the Dumble balls
+QUEST_LV_0100_20150317_003534	I’ll get rid of the Dumble balls
 QUEST_LV_0100_20150317_003535	Notice /! /Saulems are attacking to stop you! #5
 QUEST_LV_0100_20150317_003536	
-QUEST_LV_0100_20150317_003537	I'll go and check on it
+QUEST_LV_0100_20150317_003537	I’ll go and check on it
 QUEST_LV_0100_20150317_003538	
-QUEST_LV_0100_20150317_003539	I'll participate
+QUEST_LV_0100_20150317_003539	I’ll participate
 QUEST_LV_0100_20150317_003540	Using Status
 QUEST_LV_0100_20150317_003541	Try using status
 QUEST_LV_0100_20150317_003542	to check status #7
 QUEST_LV_0100_20150317_003543	The road back 
 QUEST_LV_0100_20150317_003544	Not as intended (2)
 QUEST_LV_0100_20150317_003545	
-QUEST_LV_0100_20150317_003546	I'll release the final seal
+QUEST_LV_0100_20150317_003546	I’ll release the final seal
 QUEST_LV_0100_20150317_003547	I need a minute prepare
 QUEST_LV_0100_20150317_003548	Operating/ MAKING/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003549	
 QUEST_LV_0100_20150317_003550	Touch the stone to look closely
 QUEST_LV_0100_20150317_003551	
-QUEST_LV_0100_20150317_003552	I'm curious
-QUEST_LV_0100_20150317_003553	I don't want to know
+QUEST_LV_0100_20150317_003552	I’m curious
+QUEST_LV_0100_20150317_003553	I don’t want to know
 QUEST_LV_0100_20150317_003554	
 QUEST_LV_0100_20150317_003555	
 QUEST_LV_0100_20150317_003556	
-QUEST_LV_0100_20150317_003557	It's the same reaction like the Nian stone. Run away!
-QUEST_LV_0100_20150317_003558	It's nothing serious
+QUEST_LV_0100_20150317_003557	It’s the same reaction like the Nian stone. Run away!
+QUEST_LV_0100_20150317_003558	It’s nothing serious
 QUEST_LV_0100_20150317_003559	Missing longer and historian Rexipher (2)
 QUEST_LV_0100_20150317_003560	Find aother historian
 QUEST_LV_0100_20150317_003561	
 QUEST_LV_0100_20150317_003562	
 QUEST_LV_0100_20150317_003563	
-QUEST_LV_0100_20150317_003564	I'll help you find the research data
+QUEST_LV_0100_20150317_003564	I’ll help you find the research data
 QUEST_LV_0100_20150317_003565	Find it and go back quickly
 QUEST_LV_0100_20150317_003566	About the loss of research data
 QUEST_LV_0100_20150317_003567	
-QUEST_LV_0100_20150317_003568	It's the famous genius of forgery
+QUEST_LV_0100_20150317_003568	It’s the famous genius of forgery
 QUEST_LV_0100_20150317_003569	You came to the wrong place
 QUEST_LV_0100_20150317_003570	
-QUEST_LV_0100_20150317_003571	I'll get the limestone 
-QUEST_LV_0100_20150317_003572	I can't do such dirty job
+QUEST_LV_0100_20150317_003571	I’ll get the limestone 
+QUEST_LV_0100_20150317_003572	I can’t do such dirty job
 QUEST_LV_0100_20150317_003573	
 QUEST_LV_0100_20150317_003574	
-QUEST_LV_0100_20150317_003575	I'll let you know when I see it
+QUEST_LV_0100_20150317_003575	I’ll let you know when I see it
 QUEST_LV_0100_20150317_003576	
 QUEST_LV_0100_20150317_003577	I can protect you
 QUEST_LV_0100_20150317_003578	
@@ -3582,18 +3582,18 @@ QUEST_LV_0100_20150317_003581	Retrieve the royal tombstone piece
 QUEST_LV_0100_20150317_003582	
 QUEST_LV_0100_20150317_003583	
 QUEST_LV_0100_20150317_003584	
-QUEST_LV_0100_20150317_003585	I'll get the sap
-QUEST_LV_0100_20150317_003586	I don't feel like it
+QUEST_LV_0100_20150317_003585	I’ll get the sap
+QUEST_LV_0100_20150317_003586	I don’t feel like it
 QUEST_LV_0100_20150317_003587	About getting the secret of the great king
 QUEST_LV_0100_20150317_003588	
 QUEST_LV_0100_20150317_003589	I will get the Amalas canyon
 QUEST_LV_0100_20150317_003590	
-QUEST_LV_0100_20150317_003591	Poor thing. Let's help
+QUEST_LV_0100_20150317_003591	Poor thing. Let’s help
 QUEST_LV_0100_20150317_003592	I suggest you train hard
 QUEST_LV_0100_20150317_003593	
-QUEST_LV_0100_20150317_003594	I'll check if Edang's words are correct
+QUEST_LV_0100_20150317_003594	I’ll check if Edang’s words are correct
 QUEST_LV_0100_20150317_003595	Prove it yourself
-QUEST_LV_0100_20150317_003596	Can't sell because I don't have it
+QUEST_LV_0100_20150317_003596	Can’t sell because I don’t have it
 QUEST_LV_0100_20150317_003597	Do it anyway
 QUEST_LV_0100_20150317_003598	Think more about it
 QUEST_LV_0100_20150317_003599	
@@ -3601,17 +3601,17 @@ QUEST_LV_0100_20150317_003600
 QUEST_LV_0100_20150317_003601	I am interested
 QUEST_LV_0100_20150317_003602	About Lydia Schaffen
 QUEST_LV_0100_20150317_003603	Working on the copy /MAKING/2/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_003604	Notice /You read the first tombstone of Lydia Schaffen. {nl} Let's read the rest of it too.
+QUEST_LV_0100_20150317_003604	Notice /You read the first tombstone of Lydia Schaffen. {nl} Let’s read the rest of it too.
 QUEST_LV_0100_20150317_003605	
 QUEST_LV_0100_20150317_003606	
 QUEST_LV_0100_20150317_003607	
 QUEST_LV_0100_20150317_003608	Good bye. (go to check on the tombstone)
 QUEST_LV_0100_20150317_003609	Stop it here
-QUEST_LV_0100_20150317_003610	Notice /You checked the fourth tombstone of Lydia Schaffen. {nl} Let's go check the last tombstone.
+QUEST_LV_0100_20150317_003610	Notice /You checked the fourth tombstone of Lydia Schaffen. {nl} Let’s go check the last tombstone.
 QUEST_LV_0100_20150317_003611	
-QUEST_LV_0100_20150317_003612	Notice /You've defeated the Chapparition that was blocking you to read the tombstone. {nl} Let's check the last tombstone of Lydia Schaffen.
+QUEST_LV_0100_20150317_003612	Notice /You’ve defeated the Chapparition that was blocking you to read the tombstone. {nl} Let’s check the last tombstone of Lydia Schaffen.
 QUEST_LV_0100_20150317_003613	
-QUEST_LV_0100_20150317_003614	Notice /You've read the tombstone of Agailla Flurry. {nl} Let's read the rest of the tombstone in order to obtain Flurry's legacy.
+QUEST_LV_0100_20150317_003614	Notice /You’ve read the tombstone of Agailla Flurry. {nl} Let’s read the rest of the tombstone in order to obtain Flurry’s legacy.
 QUEST_LV_0100_20150317_003615	
 QUEST_LV_0100_20150317_003616	Look for tombstone pieces from surrounding monsters. 
 QUEST_LV_0100_20150317_003617	
@@ -3638,9 +3638,9 @@ QUEST_LV_0100_20150317_003637
 QUEST_LV_0100_20150317_003638	
 QUEST_LV_0100_20150317_003639	
 QUEST_LV_0100_20150317_003640	
-QUEST_LV_0100_20150317_003641	Bishop's Dream of the Goddess (1)
-QUEST_LV_0100_20150317_003642	I'll go to the Eatern Woods
-QUEST_LV_0100_20150317_003643	I don't want to go
+QUEST_LV_0100_20150317_003641	Bishop’s Dream of the Goddess (1)
+QUEST_LV_0100_20150317_003642	I’ll go to the Eatern Woods
+QUEST_LV_0100_20150317_003643	I don’t want to go
 QUEST_LV_0100_20150317_003644	Statue of worship on/WORSHIP/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003645	
 QUEST_LV_0100_20150317_003646	
@@ -3674,7 +3674,7 @@ QUEST_LV_0100_20150317_003673
 QUEST_LV_0100_20150317_003674	
 QUEST_LV_0100_20150317_003675	
 QUEST_LV_0100_20150317_003676	
-QUEST_LV_0100_20150317_003677	I'll collect the sap
+QUEST_LV_0100_20150317_003677	I’ll collect the sap
 QUEST_LV_0100_20150317_003678	
 QUEST_LV_0100_20150317_003679	
 QUEST_LV_0100_20150317_003680	
@@ -3682,11 +3682,11 @@ QUEST_LV_0100_20150317_003681
 QUEST_LV_0100_20150317_003682	Visible gateway to pick up/FIRE/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003683	
 QUEST_LV_0100_20150317_003684	
-QUEST_LV_0100_20150317_003685	Doesn't sound so good
+QUEST_LV_0100_20150317_003685	Doesn’t sound so good
 QUEST_LV_0100_20150317_003686	
 QUEST_LV_0100_20150317_003687	
 QUEST_LV_0100_20150317_003688	
-QUEST_LV_0100_20150317_003689	It's probably digested by now
+QUEST_LV_0100_20150317_003689	It’s probably digested by now
 QUEST_LV_0100_20150317_003690	
 QUEST_LV_0100_20150317_003691	
 QUEST_LV_0100_20150317_003692	
@@ -3719,12 +3719,12 @@ QUEST_LV_0100_20150317_003718
 QUEST_LV_0100_20150317_003719	
 QUEST_LV_0100_20150317_003720	
 QUEST_LV_0100_20150317_003721	
-QUEST_LV_0100_20150317_003722	You'll be able to run away
+QUEST_LV_0100_20150317_003722	You’ll be able to run away
 QUEST_LV_0100_20150317_003723	
 QUEST_LV_0100_20150317_003724	
 QUEST_LV_0100_20150317_003725	
 QUEST_LV_0100_20150317_003726	
-QUEST_LV_0100_20150317_003727	I'll get rid of the Archon
+QUEST_LV_0100_20150317_003727	I’ll get rid of the Archon
 QUEST_LV_0100_20150317_003728	
 QUEST_LV_0100_20150317_003729	
 QUEST_LV_0100_20150317_003730	
@@ -3785,7 +3785,7 @@ QUEST_LV_0100_20150317_003784
 QUEST_LV_0100_20150317_003785	
 QUEST_LV_0100_20150317_003786	
 QUEST_LV_0100_20150317_003787	
-QUEST_LV_0100_20150317_003788	I'll go use the bomb
+QUEST_LV_0100_20150317_003788	I’ll go use the bomb
 QUEST_LV_0100_20150317_003789	
 QUEST_LV_0100_20150317_003790	
 QUEST_LV_0100_20150317_003791	
@@ -3801,24 +3801,24 @@ QUEST_LV_0100_20150317_003800
 QUEST_LV_0100_20150317_003801	
 QUEST_LV_0100_20150317_003802	
 QUEST_LV_0100_20150317_003803	
-QUEST_LV_0100_20150317_003804	Ok, I'll drop by
+QUEST_LV_0100_20150317_003804	Ok, I’ll drop by
 QUEST_LV_0100_20150317_003805	
 QUEST_LV_0100_20150317_003806	
 QUEST_LV_0100_20150317_003807	
-QUEST_LV_0100_20150317_003808	A Soldier's Favor
-QUEST_LV_0100_20150317_003809	I'll gather the keepstakes
+QUEST_LV_0100_20150317_003808	A Soldier’s Favor
+QUEST_LV_0100_20150317_003809	I’ll gather the keepstakes
 QUEST_LV_0100_20150317_003810	Stolen Food Supplies
-QUEST_LV_0100_20150317_003811	I'll get back the food supplies from the Vubbes
-QUEST_LV_0100_20150317_003812	Sorry, I'm busy
+QUEST_LV_0100_20150317_003811	I’ll get back the food supplies from the Vubbes
+QUEST_LV_0100_20150317_003812	Sorry, I’m busy
 QUEST_LV_0100_20150317_003813	To Leaf Veil Plateau
 QUEST_LV_0100_20150317_003814	
 QUEST_LV_0100_20150317_003815	
-QUEST_LV_0100_20150317_003816	Pharmacist's Favor (1)
-QUEST_LV_0100_20150317_003817	Ok, I'll give you some
-QUEST_LV_0100_20150317_003818	Pharmacist's Favor (2)
+QUEST_LV_0100_20150317_003816	Pharmacist’s Favor (1)
+QUEST_LV_0100_20150317_003817	Ok, I’ll give you some
+QUEST_LV_0100_20150317_003818	Pharmacist’s Favor (2)
 QUEST_LV_0100_20150317_003819	Kindness of the Mister
 QUEST_LV_0100_20150317_003820	Receive help
-QUEST_LV_0100_20150317_003821	Thank you but I'll pass.
+QUEST_LV_0100_20150317_003821	Thank you but I’ll pass.
 QUEST_LV_0100_20150317_003822	Crafting Armor (1)
 QUEST_LV_0100_20150317_003823	Crafting Armor (2)
 QUEST_LV_0100_20150317_003824	Crafting Armor (3)
@@ -3858,7 +3858,7 @@ QUEST_LV_0100_20150317_003857	Talk to search scout
 QUEST_LV_0100_20150317_003858	Tell the search scout about the order to assemble and find the location of the next soldier.
 QUEST_LV_0100_20150317_003859	Kill the Large Kepa
 QUEST_LV_0100_20150317_003860	Talk to Laimonas
-QUEST_LV_0100_20150317_003861	Let's listen to Laimonas' favor like Titas said.
+QUEST_LV_0100_20150317_003861	Let’s listen to Laimonas’ favor like Titas said.
 QUEST_LV_0100_20150317_003862	Offer worship to the statue
 QUEST_LV_0100_20150317_003863	Try offering worship to Goddess Zemyna Statue. The Statue is located at the end of the road on the right of Laimonas.
 QUEST_LV_0100_20150317_003864	You offered worship like Laimonas said. Tell Laimnoas about it.
@@ -3866,10 +3866,10 @@ QUEST_LV_0100_20150317_003865	Listen to the favor of Laimonas.
 QUEST_LV_0100_20150317_003866	Kill Infro Rocktors around the marked area
 QUEST_LV_0100_20150317_003867	Do Laimonas a favor and get rid of the Infro Rocktors on the road to Klaipeda.
 QUEST_LV_0100_20150317_003868	Talk to Klaipeda Guard Captain
-QUEST_LV_0100_20150317_003869	You seem to have taken care of Laimonas' favor. Tell the Guard leader that you got rid of the monsters on the road to Klaipeda.
+QUEST_LV_0100_20150317_003869	You seem to have taken care of Laimonas’ favor. Tell the Guard leader that you got rid of the monsters on the road to Klaipeda.
 QUEST_LV_0100_20150317_003870	Kill Infro Rocktors
 QUEST_LV_0100_20150317_003871	Go to Klaipeda
-QUEST_LV_0100_20150317_003872	Let's move on the way to the Klaipeda.
+QUEST_LV_0100_20150317_003872	Let’s move on the way to the Klaipeda.
 QUEST_LV_0100_20150317_003873	Get rid of the Rocktortuga that suddenly appeared
 QUEST_LV_0100_20150317_003874	Please be getting rid of lock torque Two moths that appeared suddenly before entering the Klaipeda.
 QUEST_LV_0100_20150317_003875	Report to Guard Captain the defeat of Rocktortuga.
@@ -3880,7 +3880,7 @@ QUEST_LV_0100_20150317_003879	Move to area with Hanamings to complete the duty g
 QUEST_LV_0100_20150317_003880	Chase the Hanamings
 QUEST_LV_0100_20150317_003881	Kill the Hanamings around
 QUEST_LV_0100_20150317_003882	Move to Hanaming habitat
-QUEST_LV_0100_20150317_003883	Go to Hanaming habitat to quickly complete the battle commander's assignment.
+QUEST_LV_0100_20150317_003883	Go to Hanaming habitat to quickly complete the battle commander’s assignment.
 QUEST_LV_0100_20150317_003884	Collect Hanaming Petals to investigate
 QUEST_LV_0100_20150317_003885	
 QUEST_LV_0100_20150317_003886	Give Hanaming Petals to Battle Commander
@@ -3902,20 +3902,20 @@ QUEST_LV_0100_20150317_003901
 QUEST_LV_0100_20150317_003902	
 QUEST_LV_0100_20150317_003903	
 QUEST_LV_0100_20150317_003904	Go to the Easter Woords base camp
-QUEST_LV_0100_20150317_003905	The Eastern Woods base camp seems to be in danger because of the monsters that suddenly flocked out of the Eastern Woods. Let's go and have a look.
+QUEST_LV_0100_20150317_003905	The Eastern Woods base camp seems to be in danger because of the monsters that suddenly flocked out of the Eastern Woods. Let’s go and have a look.
 QUEST_LV_0100_20150317_003906	Get rid of the Poatas in the Eastern Woods Base Camp
 QUEST_LV_0100_20150317_003907	Poatas appeared to save the Baby Poatas. Get rid of them.
 QUEST_LV_0100_20150317_003908	Talk to Knight Aras
 QUEST_LV_0100_20150317_003909	You got rid of the Poatas that were threatening Aras. Go and report him about it. 
 QUEST_LV_0100_20150317_003910	Get rid of the Poata that raid the outpost
-QUEST_LV_0100_20150317_003911	Get permission to enter Miner's Village from Knight Aras
-QUEST_LV_0100_20150317_003912	Ask Knight Aras for permission to enter the Miner's Vilalge.
+QUEST_LV_0100_20150317_003911	Get permission to enter Miner’s Village from Knight Aras
+QUEST_LV_0100_20150317_003912	Ask Knight Aras for permission to enter the Miner’s Vilalge.
 QUEST_LV_0100_20150317_003913	Kill the Pokubus in the farm
-QUEST_LV_0100_20150317_003914	You have to accept Aras's proposal to help his troops in order to go to the Miners' Village. First, let's get rid of Pokubus that occupy the farm.
+QUEST_LV_0100_20150317_003914	You have to accept Aras’s proposal to help his troops in order to go to the Miners’ Village. First, let’s get rid of Pokubus that occupy the farm.
 QUEST_LV_0100_20150317_003915	Report to Aras
-QUEST_LV_0100_20150317_003916	Report the killing of Pokubus, one of the assignements for going to Miner's Village, to Aras.
-QUEST_LV_0100_20150317_003917	Listen to the Sentinel's Chupacabra extermiantion plan.
-QUEST_LV_0100_20150317_003918	Let's help the Sentinel exterminate Chupacabras that threat the troops.
+QUEST_LV_0100_20150317_003916	Report the killing of Pokubus, one of the assignements for going to Miner’s Village, to Aras.
+QUEST_LV_0100_20150317_003917	Listen to the Sentinel’s Chupacabra extermiantion plan.
+QUEST_LV_0100_20150317_003918	Let’s help the Sentinel exterminate Chupacabras that threat the troops.
 QUEST_LV_0100_20150317_003919	Hunt Chupacabras
 QUEST_LV_0100_20150317_003920	Walk around the woods and get rid of chupacabras that endanger the soldiers.
 QUEST_LV_0100_20150317_003921	Go back and report to Sentinel
@@ -3925,7 +3925,7 @@ QUEST_LV_0100_20150317_003924	Listen to Sentinel about the monster that attacked
 QUEST_LV_0100_20150317_003925	Take back the supplies camp
 QUEST_LV_0100_20150317_003926	Get rid of the monsters occupying the supplies camp.
 QUEST_LV_0100_20150317_003927	Report back to the outpost sentinel
-QUEST_LV_0100_20150317_003928	Report to outpost sentinel that you've got back the supplies camp.
+QUEST_LV_0100_20150317_003928	Report to outpost sentinel that you’ve got back the supplies camp.
 QUEST_LV_0100_20150317_003929	Kill the Chupacabras in supply base
 QUEST_LV_0100_20150317_003930	Get information about Chupacabras from the supply officer
 QUEST_LV_0100_20150317_003931	Listen to the information about Chupacabras from the supply officer.
@@ -3944,7 +3944,7 @@ QUEST_LV_0100_20150317_003943	Talk to Aras
 QUEST_LV_0100_20150317_003944	
 QUEST_LV_0100_20150317_003945	Collect clues from Popolions
 QUEST_LV_0100_20150317_003946	
-QUEST_LV_0100_20150317_003947	Give piece of Vubbe's cloth to Operations Officer
+QUEST_LV_0100_20150317_003947	Give piece of Vubbe’s cloth to Operations Officer
 QUEST_LV_0100_20150317_003948	Found piece of Vubbe cloth. Can this be a clue? Give it to the operations officer
 QUEST_LV_0100_20150317_003949	Talk to Operations officer
 QUEST_LV_0100_20150317_003950	Operations officer seems to know something with the vubbe cloth. Try talking to him again.
@@ -3952,13 +3952,13 @@ QUEST_LV_0100_20150317_003951	Investigate the Northern Areas
 QUEST_LV_0100_20150317_003952	Operations officer says there are used to be no Vubbes in Eatern Woods. Check the northern area of Siauliai Easter Woods while Operations officer ask Aras for help.
 QUEST_LV_0100_20150317_003953	Report to the operations officer
 QUEST_LV_0100_20150317_003954	Is the Vubbe Fighter controlling the Vubbes? Tell the operations officer about what you saw.
-QUEST_LV_0100_20150317_003955	Get rid of Vubbe Fighter's subordinates
+QUEST_LV_0100_20150317_003955	Get rid of Vubbe Fighter’s subordinates
 QUEST_LV_0100_20150317_003956	Talk to Aras about the Vubbe Fighter.
 QUEST_LV_0100_20150317_003957	Search for Vubbe Fighter
 QUEST_LV_0100_20150317_003958	Is this one of the promises for Crytal Mines? Check how many Vubbe Fighters there are.
 QUEST_LV_0100_20150317_003959	
-QUEST_LV_0100_20150317_003960	Seems like that's the only Vubbe Fighter. Go back to Aras and tell him about the Vubbe Fighter.
-QUEST_LV_0100_20150317_003961	Get rid of Vubbe Fighter's subordinates
+QUEST_LV_0100_20150317_003960	Seems like that’s the only Vubbe Fighter. Go back to Aras and tell him about the Vubbe Fighter.
+QUEST_LV_0100_20150317_003961	Get rid of Vubbe Fighter’s subordinates
 QUEST_LV_0100_20150317_003962	Talk to supply solider in Eastern Woods
 QUEST_LV_0100_20150317_003963	There seems to a problme with the supplies. Talk to the supply solider.
 QUEST_LV_0100_20150317_003964	Collect Weaver claws
@@ -3975,13 +3975,13 @@ QUEST_LV_0100_20150317_003974	Kill the Pokubus
 QUEST_LV_0100_20150317_003975	
 QUEST_LV_0100_20150317_003976	Operations office says the search scout in lower area found the Vubbe Fighter. Go to the search scout near the bridge in the lower area of Bulvjes Farm.
 QUEST_LV_0100_20150317_003977	Search the Vubbe Fighter
-QUEST_LV_0100_20150317_003978	Search scout says the Vubbe Fighter is in the Nudegi Felled area but seems better to wait for additional troops. You need to get in the Crystal Mine ASAP so let's just go ahead and kill the Vubbe Fighter.
+QUEST_LV_0100_20150317_003978	Search scout says the Vubbe Fighter is in the Nudegi Felled area but seems better to wait for additional troops. You need to get in the Crystal Mine ASAP so let’s just go ahead and kill the Vubbe Fighter.
 QUEST_LV_0100_20150317_003979	Notify search scout that the Vubbe Fighter was killed
 QUEST_LV_0100_20150317_003980	Return to Vubbe Fighter and let him know that the Vubbe fighter is defeated.
 QUEST_LV_0100_20150317_003981	Kill the Vubbe Fighter
 QUEST_LV_0100_20150317_003982	
 QUEST_LV_0100_20150317_003983	Return to Aras and tell him the Vubbe Fighter was killed.
-QUEST_LV_0100_20150317_003984	Talk about Miner's Village with Aras
+QUEST_LV_0100_20150317_003984	Talk about Miner’s Village with Aras
 QUEST_LV_0100_20150317_003985	
 QUEST_LV_0100_20150317_003986	
 QUEST_LV_0100_20150317_003987	Defeated the Vubbes that barged in. Return to Aras and get permission to enter the Mines.
@@ -3998,7 +3998,7 @@ QUEST_LV_0100_20150317_003997	NetherBovine suddenly appeared and it looks very d
 QUEST_LV_0100_20150317_003998	Check the suspicious seal
 QUEST_LV_0100_20150317_003999	Something is sealed in the crystal pillars. Check out the pillars.
 QUEST_LV_0100_20150317_004000	Kill Demon Mirtis
-QUEST_LV_0100_20150317_004001	There were Demons in the Closed Area. Let's get rid of Mirtis.
+QUEST_LV_0100_20150317_004001	There were Demons in the Closed Area. Let’s get rid of Mirtis.
 QUEST_LV_0100_20150317_004002	Defeat Mirtis
 QUEST_LV_0100_20150317_004003	
 QUEST_LV_0100_20150317_004004	
@@ -4470,19 +4470,19 @@ QUEST_LV_0100_20150317_004469
 QUEST_LV_0100_20150317_004470	
 QUEST_LV_0100_20150317_004471	
 QUEST_LV_0100_20150317_004472	
-QUEST_LV_0100_20150317_004473	Investigate the Miners' Village(1)
-QUEST_LV_0100_20150317_004474	Go to Miners' Village
-QUEST_LV_0100_20150317_004475	You need to enter Crystal Mines for the revelation but Miners' Village was raided by Vubbes. Go to the MIners' Village quickly!
+QUEST_LV_0100_20150317_004473	Investigate the Miners’ Village(1)
+QUEST_LV_0100_20150317_004474	Go to Miners’ Village
+QUEST_LV_0100_20150317_004475	You need to enter Crystal Mines for the revelation but Miners’ Village was raided by Vubbes. Go to the MIners’ Village quickly!
 QUEST_LV_0100_20150317_004476	
 QUEST_LV_0100_20150317_004477	Talk to Village Mayor
 QUEST_LV_0100_20150317_004478	Talk to the Hunter
-QUEST_LV_0100_20150317_004479	You need to go to the Cyrstal Mines as told by the Goddess in bishop's dream but you can't just leave the refugees. Help the angry hunter.
-QUEST_LV_0100_20150317_004480	The hunter says that monsters stole all the relief goods meant for the village residents. Try to pick up at least what's left on the road.
+QUEST_LV_0100_20150317_004479	You need to go to the Cyrstal Mines as told by the Goddess in bishop’s dream but you can’t just leave the refugees. Help the angry hunter.
+QUEST_LV_0100_20150317_004480	The hunter says that monsters stole all the relief goods meant for the village residents. Try to pick up at least what’s left on the road.
 QUEST_LV_0100_20150317_004481	
 QUEST_LV_0100_20150317_004482	Talk to Mine Director Brinker
-QUEST_LV_0100_20150317_004483	You need to go to the Cyrstal Mines as told by the Goddess in bishop's dream but you can't just leave the refugees. Mine Director Brinker is standing by the wall with one hand on the wall. Ask what is happening.
+QUEST_LV_0100_20150317_004483	You need to go to the Cyrstal Mines as told by the Goddess in bishop’s dream but you can’t just leave the refugees. Mine Director Brinker is standing by the wall with one hand on the wall. Ask what is happening.
 QUEST_LV_0100_20150317_004484	Collect material for reinforcement from the rubble nearby
-QUEST_LV_0100_20150317_004485	The wall may collapse if Brinker releases his hands off the wall. Let's look for some rocks nearby to block the holes on the wall for Brinker.
+QUEST_LV_0100_20150317_004485	The wall may collapse if Brinker releases his hands off the wall. Let’s look for some rocks nearby to block the holes on the wall for Brinker.
 QUEST_LV_0100_20150317_004486	Give reinforcement materials to Brinker
 QUEST_LV_0100_20150317_004487	Give the stones you collected to Brinker.
 QUEST_LV_0100_20150317_004488	
@@ -4491,7 +4491,7 @@ QUEST_LV_0100_20150317_004490	Kill the monsters nearby so that Brinker can retur
 QUEST_LV_0100_20150317_004491	Tell Brinker that it is safe
 QUEST_LV_0100_20150317_004492	
 QUEST_LV_0100_20150317_004493	Talk to the Healer Lady
-QUEST_LV_0100_20150317_004494	You need to go to the Cyrstal Mines as told by the Goddess in bishop's dream but you can't just leave the refugees. Help the healer lady to treat injured people.
+QUEST_LV_0100_20150317_004494	You need to go to the Cyrstal Mines as told by the Goddess in bishop’s dream but you can’t just leave the refugees. Help the healer lady to treat injured people.
 QUEST_LV_0100_20150317_004495	Bringing the refugees
 QUEST_LV_0100_20150317_004496	Healer Lady is asking a favor for you to bring the other refugees. Bring the couple near the Statue of Goddess Zemyna to the Healer Lady.
 QUEST_LV_0100_20150317_004497	Turn over the refugees to the Healer Lady
@@ -4500,19 +4500,19 @@ QUEST_LV_0100_20150317_004499
 QUEST_LV_0100_20150317_004500	Kill the monsters
 QUEST_LV_0100_20150317_004501	
 QUEST_LV_0100_20150317_004502	
-QUEST_LV_0100_20150317_004503	Talk to Miner's Village Mayor
+QUEST_LV_0100_20150317_004503	Talk to Miner’s Village Mayor
 QUEST_LV_0100_20150317_004504	
 QUEST_LV_0100_20150317_004505	Rescue Vaidotas who is kidnapped by the Vubbes
-QUEST_LV_0100_20150317_004506	Revelation of Goddess is important but you can't leave the residents kidnapped. To save the residents trapped in the Mines, go to the Vubbe's base and save Vaidotas first.
-QUEST_LV_0100_20150317_004507	Block Vubbe's raid
+QUEST_LV_0100_20150317_004506	Revelation of Goddess is important but you can’t leave the residents kidnapped. To save the residents trapped in the Mines, go to the Vubbe’s base and save Vaidotas first.
+QUEST_LV_0100_20150317_004507	Block Vubbe’s raid
 QUEST_LV_0100_20150317_004508	
 QUEST_LV_0100_20150317_004509	Get rid of the Vubbes that are occupying the village
-QUEST_LV_0100_20150317_004510	Vubbes are taking over the village! Let's drive them out.
+QUEST_LV_0100_20150317_004510	Vubbes are taking over the village! Let’s drive them out.
 QUEST_LV_0100_20150317_004511	Seems like you drove out the Vubbes. Tell the Village Mayor about it.
 QUEST_LV_0100_20150317_004512	Get rid of the Vubbes
 QUEST_LV_0100_20150317_004513	You found Vaitodas. Discuss with him on how you can get into the Mines.
 QUEST_LV_0100_20150317_004514	Get rid of the Vubbes
-QUEST_LV_0100_20150317_004515	There's a suspicious treasure box. Go and open it.
+QUEST_LV_0100_20150317_004515	There’s a suspicious treasure box. Go and open it.
 QUEST_LV_0100_20150317_004516	Red Vubbe Fighter that abruptly appeared
 QUEST_LV_0100_20150317_004517	Red Vubbe Fighter appeared when you kicked the box! Get rid of it.
 QUEST_LV_0100_20150317_004518	There were no kidnapped people but only Vubbes. You better go back to Vaitodas.
@@ -4626,7 +4626,7 @@ QUEST_LV_0100_20150317_004625	Supply officer is appealing that he has too much w
 QUEST_LV_0100_20150317_004626	Give it to the supply officer
 QUEST_LV_0100_20150317_004627	Finished collecting the plantains needed. Give it to the supply officer.
 QUEST_LV_0100_20150317_004628	
-QUEST_LV_0100_20150317_004629	Supply officer's work does not end with this. Talk to the supply officer again.
+QUEST_LV_0100_20150317_004629	Supply officer’s work does not end with this. Talk to the supply officer again.
 QUEST_LV_0100_20150317_004630	
 QUEST_LV_0100_20150317_004631	
 QUEST_LV_0100_20150317_004632	
@@ -5445,7 +5445,7 @@ QUEST_LV_0100_20150317_005444
 QUEST_LV_0100_20150317_005445	
 QUEST_LV_0100_20150317_005446	
 QUEST_LV_0100_20150317_005447	Talk to Hames
-QUEST_LV_0100_20150317_005448	You've completed the amount you bet with Hames. Talk to him.
+QUEST_LV_0100_20150317_005448	You’ve completed the amount you bet with Hames. Talk to him.
 QUEST_LV_0100_20150317_005449	
 QUEST_LV_0100_20150317_005450	
 QUEST_LV_0100_20150317_005451	
@@ -6358,9 +6358,9 @@ QUEST_LV_0100_20150317_006357	Retrieve the stolen food supplies from the Vubbes
 QUEST_LV_0100_20150317_006358	Edgar says the Vubbes stole all the food supplies. Go and get it back from the Vubbes.
 QUEST_LV_0100_20150317_006359	This much food seems enouhg. Bring it back to Soldier Edgar.
 QUEST_LV_0100_20150317_006360	Kill the Vubbes and retrieve %s
-QUEST_LV_0100_20150317_006361	Talk to Miner's Village Mayor.
+QUEST_LV_0100_20150317_006361	Talk to Miner’s Village Mayor.
 QUEST_LV_0100_20150317_006362	Move to Leaf Veil Plateau
-QUEST_LV_0100_20150317_006363	Miners' Village
+QUEST_LV_0100_20150317_006363	Miners’ Village
 QUEST_LV_0100_20150317_006364	 is found at the further right of the 
 QUEST_LV_0100_20150317_006365	Silver Gorge Stream
 QUEST_LV_0100_20150317_006366	which is located below the twin bridge of 
@@ -6379,7 +6379,7 @@ QUEST_LV_0100_20150317_006378	Talk to the pharmacist
 QUEST_LV_0100_20150317_006379	
 QUEST_LV_0100_20150317_006380	Give medicinal herb
 QUEST_LV_0100_20150317_006381	The pharmacist needs Yukopus leaves and Kepa stem to use as treatment for injured people.
-QUEST_LV_0100_20150317_006382	Pharmacist's Favor
+QUEST_LV_0100_20150317_006382	Pharmacist’s Favor
 QUEST_LV_0100_20150317_006383	Give the Yukopus leaves and Kepa Stems that the Pharmacist requested. 
 QUEST_LV_0100_20150317_006384	Ask the pharmacist if she needs anything else.
 QUEST_LV_0100_20150317_006385	Get Medicine Materials
@@ -6387,7 +6387,7 @@ QUEST_LV_0100_20150317_006386	She needs more Yukopus leaves and Kepa Stem to mak
 QUEST_LV_0100_20150317_006387	Give Yukopus leaves and Kepa stem to the pharmacist.
 QUEST_LV_0100_20150317_006388	Talk to Mr. Juan in Mine Entrance
 QUEST_LV_0100_20150317_006389	Seems like Mr. Juan has something to say. Talk to him.
-QUEST_LV_0100_20150317_006390	Mr. Juan say he'll help you make armors. Gather the materials he asked for.
+QUEST_LV_0100_20150317_006390	Mr. Juan say he’ll help you make armors. Gather the materials he asked for.
 QUEST_LV_0100_20150317_006391	Receive gift from Mr. Juan
 QUEST_LV_0100_20150317_006392	Gathered the materials for Mr. Juna. Bring it to him.
 QUEST_LV_0100_20150317_006393	Get armor parts
@@ -6396,10 +6396,10 @@ QUEST_LV_0100_20150317_006395	Mr. Juan asked you to bring Tough Toots of Large R
 QUEST_LV_0100_20150317_006396	Bring the materials
 QUEST_LV_0100_20150317_006397	Acquired Tough Roots of Large Red Kepa. Bring it to Mr. Juan.
 QUEST_LV_0100_20150317_006398	 Get %s from Large Red Kepa
-QUEST_LV_0100_20150317_006399	Mr. Juan asked you to bring him Kepa's Teeth to make the armor.
-QUEST_LV_0100_20150317_006400	Acquired enough Kepa's Teeth! Bring it to Mr. Juan.
+QUEST_LV_0100_20150317_006399	Mr. Juan asked you to bring him Kepa’s Teeth to make the armor.
+QUEST_LV_0100_20150317_006400	Acquired enough Kepa’s Teeth! Bring it to Mr. Juan.
 QUEST_LV_0100_20150317_006401	 Get %s from Kepa
 QUEST_LV_0100_20150317_006402	Mr. Juan asked you to bring him Yukopus Leather to make the armor.
 QUEST_LV_0100_20150317_006403	Acquired Yukopus Leather! Bring it to Mr. Juan.
-QUEST_LV_0100_20150317_006404	Mr. Juan asked you to bring him Vubbe Theif's Leather to make the armor.
-QUEST_LV_0100_20150317_006405	Acquired Vubbe Thief's Leather! Bring it to Mr. Juan.
+QUEST_LV_0100_20150317_006404	Mr. Juan asked you to bring him Vubbe Theif’s Leather to make the armor.
+QUEST_LV_0100_20150317_006405	Acquired Vubbe Thief’s Leather! Bring it to Mr. Juan.


### PR DESCRIPTION
Changed all single quotes to ’ (typographically correct) quotes. Cleaned up grammar from line 1 to 364. Generally make the text that looks written look more like spoken.
