### PR TITLE
Update ITEM_en.tsv

### DIFF
--- a/ITEM_en.tsv
+++ b/ITEM_en.tsv
@@ -8,14 +8,14 @@ ITEM_20150317_000007	Long Armband
 ITEM_20150317_000008	Feathered Armband
 ITEM_20150317_000009	Tasseled Armband
 ITEM_20150317_000010	no_weapon
-ITEM_20150317_000011	Poorly Made Gladius
+ITEM_20150317_000011	Common Gladius ['로우'의 의미가 불분명-질이 낮은(Low Grade/Low Quality/Poorly-made)?조잡한(Crude/Rough)?보기 흔한(Common)?값싼(Cheap)?일반적인(Standard)? 기본적인/특징없는(Basic)?]
 ITEM_20150317_000012	One-Handed Sword [Slash]
-ITEM_20150317_000013	Gladius is a basic weapon carried by the kingdom's soldiers, and also commonly used by the people.
+ITEM_20150317_000013	A standard weapon carried by the soldiers but also commonly used by anyone.
 ITEM_20150317_000014	Gladius
-ITEM_20150317_000015	The Gladius is crafted with room for improvement over its military versions.
-ITEM_20150317_000016	Low Falchion
+ITEM_20150317_000015	This weapon is crafted with room for improvement over its military version.
+ITEM_20150317_000016	Low Falchion (ITEM_20150317_000011	Common Gladius 주석 참조)
 ITEM_20150317_000017	This sword is exceptional for slashing.
-ITEM_20150317_000018	Low Kaskara
+ITEM_20150317_000018	Low Kaskara (ITEM_20150317_000011	Common Gladius 주석 참조)
 ITEM_20150317_000019	Due to its easy manufacturing, Low Kaskara is frequently chosen by the adventurers as their first replacement for the training sword.
 ITEM_20150317_000020	Cinquedea
 ITEM_20150317_000021	Recommended for those who desire a heavier and stronger sword.
@@ -29,13 +29,13 @@ ITEM_20150317_000028	Kris
 ITEM_20150317_000029	Curved edge amplifies the damage. Kris is both practical and decorative.
 ITEM_20150317_000030	Snickersnee
 ITEM_20150317_000031	Its exceptional cutting prowess is favored by even the most experienced swordsmen.
-ITEM_20150317_000032	Poorly Made Shamshir
-ITEM_20150317_000033	Poorly Made Scimitar
-ITEM_20150317_000034	Soldier's Gladius
-ITEM_20150317_000035	Provided to all full-time soldiers. Its performance is better overall over the ones sold in the market.
+ITEM_20150317_000032	Poorly Made Shamshir (ITEM_20150317_000011	Common Gladius 주석 참조)
+ITEM_20150317_000033	Poorly Made Scimitar (ITEM_20150317_000011	Common Gladius 주석 참조)
+ITEM_20150317_000034	Soldier's Gladius / Army Gladius
+ITEM_20150317_000035	Basic armament provided to full-time soldiers. Its performance is better overall than the ones sold in the market.
 ITEM_20150317_000036	Mayor's Falchion
-ITEM_20150317_000037	This weapon makes you wonder the previous owner's past.
-ITEM_20150317_000038	Poorly Made Kaskara
+ITEM_20150317_000037	Looking at this weapon makes you wonder the previous owner's rather dubious past.
+ITEM_20150317_000038	Poorly Made Kaskara (ITEM_20150317_000011	Common Gladius 주석 참조)
 ITEM_20150317_000039	Mopla
 ITEM_20150317_000040	This sword combines both practicality and aesthetics.
 ITEM_20150317_000041	Heavy Gladius
@@ -63,11 +63,11 @@ ITEM_20150317_000062	Master Sword
 ITEM_20150317_000063	Panto Sword
 ITEM_20150317_000064	Sword used by the Panto. A better Panto Sword can be made if you craft it yourself.
 ITEM_20150317_000065	Flonas Sabre
-ITEM_20150317_000066	Some say this weapon unleashes the grudge of plants against animals.
+ITEM_20150317_000066	Some say this weapon unleashes the grudge that plants hold against animals.
 ITEM_20150317_000067	Golden Falchion
-ITEM_20150317_000068	Perhaps due to gold's correlation to luck, at times the Golden Falchion bestows luck during battle. Though of course, that would mean severe damage to foes.
+ITEM_20150317_000068	Perhaps due to gold's correlation to fortune, the Golden Falchion randomly bestows luck during battle. Though of course, that would mean severe damage/misfortune to foes.
 ITEM_20150317_000069	Steel Falchion
-ITEM_20150317_000070	Steel Falchion is a good choice if you pursue precision in your swordmanship.
+ITEM_20150317_000070	Steel Falchion is a good choice if you pursue precision in your sword tecniques.
 ITEM_20150317_000071	Silver Falchion
 ITEM_20150317_000072	Its lightweight and sturdiness allows you to unleash your potential during attack.
 ITEM_20150317_000073	Mandrapick
@@ -77,11 +77,11 @@ ITEM_20150317_000076	You should never underestimate a sword wielding wizard. Esp
 ITEM_20150317_000077	Cheminis Sword
 ITEM_20150317_000078	This sword is made after the recipe developed by an alchemist from Winterspoon family who claimed he can make a better sword than a blacksmith.
 ITEM_20150317_000079	Austas
-ITEM_20150317_000080	This sword is worth its price. However the merchants hopes you would return to buy more rather than using this sword for long.
+ITEM_20150317_000080	This sword is worthy of its price. However of course, the merchants would prefer you to return soon to buy other weapons rather than keep using this sword for longer.
 ITEM_20150317_000081	Miskas Sabre
-ITEM_20150317_000082	This weapon will make you swifter.
+ITEM_20150317_000082	This weapon will make your swordmanship swifter.
 ITEM_20150317_000083	Imperni Sword
-ITEM_20150317_000084	The swordmasters frequently tells
+ITEM_20150317_000084	It's not hard to sight a seasoned veteran emotionally recounting the moment when they first held this sword in their hands.
 ITEM_20150317_000085	Gritas
 ITEM_20150317_000086	
 ITEM_20150317_000087	Spatha


### PR DESCRIPTION
영어판 클라이언트 번역상 문제점:
1) 무기명 앞에 붙는 '로우'의 의미가 너무 광범위합니다. 
사용 예제로 봐서는 다음으로 추정됩니다만 정확한 번역을 위해서는 추가적인 설명이 필요합니다:
질이 낮은(Low Grade/Low Quality/Poorly-made)
조잡한(Crude/Rough)
보기 흔한(Common)
값싼(Cheap)
일반적인(Standard)
기본적인/특징없는(Basic)

'로우'가 붙은 무기 마다 개발자의 '로우'의 의도한 바가 틀리다면 영어 번역명 또한 그에 따라 제각각 달라져야 합니다.
예를들어 :
'로우 폴쳔' 의 개발자 의도는 '값싼, 흔한' 이라면  Cheap Falchion 으로 설정, 
'로우 글라디우스'의 개발자 의도는 '일반적이며, 별다른 특장점이 없는' 이라면 'Generic Gladius' 로 
제각각 달라져야 합니다.
'로우'를 영어로 하나의 아키타입(Archetype/카테고리)으로 통일하는것은 새로운 영문 형용사를 개발하지 않고 (던켈 같은 경우 Ok) 'Low'를 사용하는것은 어디까지나 조금 어색한감이 없지않아 있습니다. 제일 적당한 타입을 선택하시거나 새로운 영단어 아키타입을 개발하는것은 어떠신지요?

2) XX 소드/로드/보우/스태프 - 예를들어 '데미온 소드', '지존검', '디오 소드', '세스타스 소드' 등등
전설의 무기 위키 참조: http://en.wikipedia.org/wiki/List_of_mythological_objects

영문학 등 검색해보시면 느끼실테지만 자체 고유명이 없는 '누구누구의 검/활' (소유격 명칭, 예: Girdle of Hippolyta, Axe of Perun, Artemis' Bow) 등의 경우를 제외하고 XX Sword/Rod/Bow 페턴은 서구에서 흔하지 않습니다. 물론 한문의 영향을 받아 무협지에는 '지존검','보광검', '천무검' 등등의 '검'이 붙는 무기명이 많지만 서구권에서는 '검' (소드) 가 붙지 않고 순수 고유명이 통상적입니다. 
Tyrfing, Ogretooth, Claymore, Excalibur, Longinus 이런 흔한 예제만 보아도 '소드'가 붙는 이름은 흔하지 않고, 서구세계에서는 어색한 느낌을 줍니다. 
만약 소드를 필수적으로 넣을 필요가 있다면 (스토리/세계관상의 이유) 예로 Aesir Sword 대신
Sword of Aesir
Blade of Aesir
Aesir Blade / Aesirblade
Aesir Edge / Aesiredge
Grandsword of Aesir (전설무기)
Mastersword of Aesir (전설무기) 
The Aesir (전설무기, 고유명사) 
The Cursed Blood of Aesir (전설무기, 고유명사) 
The Light of Aesir (전설무기, 고유명사) 
기타 The ____(형용사+명사)_____ of Aesir  (전설무기, 고유명사) 패턴
등으로 설정하는것이 영미 문화상 어색하지 않고 자연스러운 방법이겠습니다. 영문 클라이언트용 무기명 선택/확정 시 고려해주시면 감사하겠습니다.
