### PR TITLE
Update ITEM_en.tsv

### DIFF
--- a/ITEM_en.tsv
+++ b/ITEM_en.tsv
@@ -83,63 +83,63 @@ ITEM_20150317_000082	This weapon will make your swordmanship swifter.
 ITEM_20150317_000083	Imperni Sword
 ITEM_20150317_000084	It's not hard to sight a seasoned veteran emotionally recounting the moment when they first held this sword in their hands.
 ITEM_20150317_000085	Gritas
-ITEM_20150317_000086	
+ITEM_20150317_000086	A sword used by valiant adventurers. For this ironic reason, it is often found within strong monsters. A person who obtains this sword is unknowingly exacting revenge for its previous owner.
 ITEM_20150317_000087	Spatha
-ITEM_20150317_000088	A sword for upgraded the gladius to expand the blade.
+ITEM_20150317_000088	An improved version of Gladius by extending its blade length.
 ITEM_20150317_000089	Arras's Falchion
-ITEM_20150317_000090	You have the opportunity to experience the performance of Falcion.
+ITEM_20150317_000090	This weapon gives you the opportunity to experience the falchion.
 ITEM_20150317_000091	Smith Sword
-ITEM_20150317_000092	When you attack, there is a 2% chance it'll add +600% damage.
-ITEM_20150317_000093	Sometimes It can show you the grand soul of the blacksmith.
+ITEM_20150317_000092	2% chance to cause an additional +600% damage.
+ITEM_20150317_000093	At times this sword gleams with the master craftsmanship of the blacksmith.
 ITEM_20150317_000094	Klavis Sword
-ITEM_20150317_000095	A good deal, even if it has poor performance.
+ITEM_20150317_000095	Despite its performance, it sells relatively well.
 ITEM_20150317_000096	Dio Sword
-ITEM_20150317_000097	Thresh Sword
+ITEM_20150317_000097	Thresh Sword [주석참조]
 ITEM_20150317_000098	Sestas Sword
 ITEM_20150317_000099	Drat Sword
 ITEM_20150317_000100	Aston Sword
 ITEM_20150317_000101	Debby Sword
 ITEM_20150317_000102	Prima Sword
-ITEM_20150317_000103	Trinity Sword
-ITEM_20150317_000104	
+ITEM_20150317_000103	Trinity Sword / Trinity Blade
+ITEM_20150317_000104	If you're unsatisfied with one type of Falchion, this is the choice. However, you'll have to bear the extra cost for its crafting.
 ITEM_20150317_000105	Durandal
-ITEM_20150317_000106	
+ITEM_20150317_000106	Many adventurers name their best sword after this weapon. This was the name of the sword yielded by [의미상 택일: A)an ancient warrior chosen by a Goddess (여신이 선택한 용사) / B)an ancient warrior of a chosen Goddess ('선택받은 여신')
 ITEM_20150317_000107	Velniup
-ITEM_20150317_000108	
+ITEM_20150317_000108	People even go as far to say that this weapon is overly too cruel.
 ITEM_20150317_000109	Fortis
-ITEM_20150317_000110	
+ITEM_20150317_000110	Unpopular during the Great Plant Cataclysm, the resurgence of strong defense monsters is proving its value.
 ITEM_20150317_000111	Chapparition Cutter
-ITEM_20150317_000112	According to one theory, This sword is used in battles between Demons.
-ITEM_20150317_000113	Deathweaver cutter
-ITEM_20150317_000114	
+ITEM_20150317_000112	According to a theory, this sword is also used in battles amongst the Demons.
+ITEM_20150317_000113	Deathweaver Cutter / Deathweaver Edge
+ITEM_20150317_000114	Thou, wielder of this blade, shalt become the deathbringer. / Now that you wield this blade, you must become the deathbringer.
 ITEM_20150317_000115	Chapparition Sword
 ITEM_20150317_000116	It is also the indirect evidence that there were disputes between Demons.
-ITEM_20150317_000117	Bendras Sword
-ITEM_20150317_000118	
+ITEM_20150317_000117	Bendras Sword / Vendrass Blade
+ITEM_20150317_000118	A sword carrying some of the might and blessings of the Goddess which have undone many evils in the past.
 ITEM_20150317_000119	Illizia
-ITEM_20150317_000120	
-ITEM_20150317_000121	Delete schedule
+ITEM_20150317_000120	This blade severely threatens both the life of the foe and the owner's finance. Of course, most swordmen ignore the latter effect.
+ITEM_20150317_000121	Scheduled for deletion
 ITEM_20150317_000122	Two-Handed Sword [Slash]
 ITEM_20150317_000123	Dunkel Bastard Sword
-ITEM_20150317_000124	Master craftsman and sword soldier called it is a basic sword of mixed style. Self comfort is important.
+ITEM_20150317_000124	Some master craftsman and soldiers call this a 'mixed style but a two-handed sword'. You know, because you always have to justify yourself.
 ITEM_20150317_000125	Flamberge
-ITEM_20150317_000126	
+ITEM_20150317_000126	If you're expert in two-handed weapons, the wave shaped edge can cause massive damage.
 ITEM_20150317_000127	Nodachi
-ITEM_20150317_000128	Nodachi with the right length increases slashing power and dominates the distance between the enemy.
+ITEM_20150317_000128	A Nodachi with the 'just-right' length can amplify its slashing and dominate the space between the wielder and their foe.
 ITEM_20150317_000129	Claymore
-ITEM_20150317_000130	Claymores of our kingdom are created with an emphasis on weight and power.
+ITEM_20150317_000130	All Claymores from our kingdom are made with an emphasis on weight and power.
 ITEM_20150317_000131	Colossus
-ITEM_20150317_000132	The fan shape increases the power, It likely applies to a variety of skills.
+ITEM_20150317_000132	The particular fan shape of the blade offers potential to amplify its power and versatility to be adapted in many tecniques.
 ITEM_20150317_000133	Caliburn
-ITEM_20150317_000134	This sword is used by many high ranking swordsmen.
+ITEM_20150317_000134	Frequently carried by high ranking soldiers.
 ITEM_20150317_000135	Quaddara
-ITEM_20150317_000136	Unseemingly, this sword is wielded in two hands. It is used by many swordsmen pursing practicality.
+ITEM_20150317_000136	Contrary to the appearance, this sword is double-edged and often used by swordsmen pursuing practicality.
 ITEM_20150317_000137	Light Claymore
-ITEM_20150317_000138	It is possible to attack the enemy by utilizing the structure of the blade.
-ITEM_20150317_000139	Rough Colossus
-ITEM_20150317_000140	Ilwoon
-ITEM_20150317_000141	Initially, Great Ruklys also used this sword.
-ITEM_20150317_000142	Practice Bastard Sword
+ITEM_20150317_000138	The shape of the blade enables you to perform a strikedown attack.
+ITEM_20150317_000139	Mediocre Colossus
+ITEM_20150317_000140	Ylloon / Eilloon / Illunn
+ITEM_20150317_000141	Initially even the Great Ruklys carried this sword.
+ITEM_20150317_000142	Practice Bastard Sword / Training Bastard Sword
 ITEM_20150317_000143	Bastard Sword
 ITEM_20150317_000144	Heavy Flamberge
 ITEM_20150317_000145	Heavy Nodachi
@@ -148,49 +148,49 @@ ITEM_20150317_000147	Dunkel Nodachi
 ITEM_20150317_000148	Dunkel Quaddara
 ITEM_20150317_000149	Dunkel Flamberge
 ITEM_20150317_000150	Dunkel Claymore
-ITEM_20150317_000151	Great Sword
+ITEM_20150317_000151	Greatsword
 ITEM_20150317_000152	Katzbalger
 ITEM_20150317_000153	Dress Sword
 ITEM_20150317_000154	Zweihander
 ITEM_20150317_000155	Executioner's Sword
 ITEM_20150317_000156	Lumai Two-Handed Sword
-ITEM_20150317_000157	Over Knife
+ITEM_20150317_000157	Overknife
 ITEM_20150317_000158	Potentia
-ITEM_20150317_000159	If you are not satisfied with mediocre Flamberge, this will be a good choice.
+ITEM_20150317_000159	A great alternative if you seek more from regular Flamberges.
 ITEM_20150317_000160	Temsus Flamberge
-ITEM_20150317_000161	In addition to your potential, it is a weapon that there is a chance for significant improvement. Please try the possibility.
+ITEM_20150317_000161	A sword with great capacity for improvement that compliments your innate power. Try its potential yourself!
 ITEM_20150317_000162	Didel Colossus
-ITEM_20150317_000163	If you want to attack heavier, stronger, and wider, then this sword will help.
+ITEM_20150317_000163	This sword is for you if you seek more weight, more power and more reach in your slashes.
 ITEM_20150317_000164	Collecture
-ITEM_20150317_000165	It is often used after the plant disasters, but before that it was common in collections and as decoration
+ITEM_20150317_000165	This widely used weapon was mostly sought after as a decoration or collectible item prior to the Great Plant Cataclysm.
 ITEM_20150317_000166	Hogma Great Sword
-ITEM_20150317_000167	
+ITEM_20150317_000167	How the Hogmas obtain or craft this weapon is a trivial fact. The only fact we are concerned with is that we can craft and use it for ourselves.
 ITEM_20150317_000168	Cheminis Bastard Sword
-ITEM_20150317_000169	Winter spoon family has released the recipe of this sword to all Alchemists to use against the plant disaster.
+ITEM_20150317_000169	In the wake of the Great Plant Cataclysm, the Winterspoon family disclosed the crafting recipe for this weapon to all alchemists.
 ITEM_20150317_000170	Primaluce
-ITEM_20150317_000171	
+ITEM_20150317_000171	Swordsmen who seeks raw power in their weapon frequently chooses this sword as their first magic sword.
 ITEM_20150317_000172	Kindzal
-ITEM_20150317_000173	
+ITEM_20150317_000173	Those who likes to temper their weapons craft this sword for their use.
 ITEM_20150317_000174	Imperni Two-Handed Sword
 ITEM_20150317_000175	If you got this sword using the black market, then It is an evidence that was obtained certain trust.
-ITEM_20150317_000176	Freebeulranda 
-ITEM_20150317_000177	Craftsman who devised the recipe of this sword are the same manufacturers of Primaluce.
+ITEM_20150317_000176	Frieblandea [주석참조]
+ITEM_20150317_000177	This sword shares the same inventor with the 'Primaluce' sword.
 ITEM_20150317_000178	Lapis Katzbalger
-ITEM_20150317_000179	The way to strengthen the Katzbalger is not yet 100 years old. So the recipe of this sword is not irrelevant with Rukliss
+ITEM_20150317_000179	The enhancement of Katzbalger has been developed less than 100 years ago. Thus the crafting recipe for this weapon is unrelated to Ruklyss.
 ITEM_20150317_000180	Smith Two-Handeded Sword
-ITEM_20150317_000181	The climate not considering the stability of the weapons has increased after Goddess day.
+ITEM_20150317_000181	Since the Day of Descent [주석참조], less and less people are concerned about the instability of magic weapons.
 ITEM_20150317_000182	Klavis Two-Handed Sword
-ITEM_20150317_000183	It can be a reliable extension of both your bands.
-ITEM_20150317_000184	Thresh Two-Handed Sword
+ITEM_20150317_000183	This sword can be a trustworthy extension of both your bands.
+ITEM_20150317_000184	Thresh Two-Handed Sword [주석참조]
 ITEM_20150317_000185	Sestas Two-Handed Sword
-ITEM_20150317_000186	Drat Two-Handed Sword
+ITEM_20150317_000186	Drat Two-Handed Sword [주석참조]
 ITEM_20150317_000187	Aston Two-Handed Sword
 ITEM_20150317_000188	Debby Two-Handed Sword
 ITEM_20150317_000189	Prima Two-Handed Sword
 ITEM_20150317_000190	Flamini
-ITEM_20150317_000191	It is a good sword that seemed to soldiers of the necessities to stand against the Demons since a long time ago.
+ITEM_20150317_000191	A good sword that has long been regarded as essential item when facing Demons.
 ITEM_20150317_000192	Wizard Slayer
-ITEM_20150317_000193	Wizards tend to ignore this sword. However, very experienced wizards will surely pay attention.
+ITEM_20150317_000193	Wizards often pays no attention to this weapon. However, seasoned wizards clearly will.
 ITEM_20150317_000194	Two-Handed Sword [Strike]
 ITEM_20150317_000195	
 ITEM_20150317_000196	Lucyduce

--- a/ITEM_en.tsv
+++ b/ITEM_en.tsv
@@ -13,26 +13,26 @@ ITEM_20150317_000012	One-Handed Sword [Slash]
 ITEM_20150317_000013	A standard weapon carried by the soldiers but also commonly used by anyone.
 ITEM_20150317_000014	Gladius
 ITEM_20150317_000015	This weapon is crafted with room for improvement over its military version.
-ITEM_20150317_000016	Low Falchion (질이 낮은)
+ITEM_20150317_000016	Mediocre Falchion (질이 낮은)
 ITEM_20150317_000017	This sword is exceptional for slashing.
-ITEM_20150317_000018	Low Kaskara (질이 낮은)
-ITEM_20150317_000019	Due to its easy manufacturing, Low Kaskara is frequently chosen by the adventurers as their first replacement for the training sword.
+ITEM_20150317_000018	Mediocre Kaskara (질이 낮은)
+ITEM_20150317_000019	Due to easy manufacturing, it is frequently chosen by the adventurers as their first replacement for the training sword.
 ITEM_20150317_000020	Cinquedea
 ITEM_20150317_000021	Recommended for those who desire a heavier and stronger sword.
 ITEM_20150317_000022	Sabre
-ITEM_20150317_000023	Primary weapon of the cavalry, the Sabre is optimally designed for  slashing. The Hilt also protects your hands.
+ITEM_20150317_000023	Primary weapon of the cavalry optimized for slashing. The Hilt also protects your hands.
 ITEM_20150317_000024	Shamshir
 ITEM_20150317_000025	The large curved crescent edge allows for a powerful slash.
 ITEM_20150317_000026	Scimitar
 ITEM_20150317_000027	Its heavy weight is compensated by a very powerful slash.
 ITEM_20150317_000028	Kris
-ITEM_20150317_000029	Curved edge amplifies the damage. Kris is both practical and decorative.
+ITEM_20150317_000029	Both practical and decorative, its curved edge amplifies the damage.
 ITEM_20150317_000030	Snickersnee
 ITEM_20150317_000031	Its exceptional cutting prowess is favored by even the most experienced swordsmen.
-ITEM_20150317_000032	Poorly Made Shamshir (질이 낮은)
-ITEM_20150317_000033	Poorly Made Scimitar (질이 낮은)
+ITEM_20150317_000032	Mediocre Shamshir (질이 낮은)
+ITEM_20150317_000033	Mediocre Scimitar (질이 낮은)
 ITEM_20150317_000034	Soldier's Gladius
-ITEM_20150317_000035	Basic armament provided to full-time soldiers. Its performance is better overall than the ones sold in the market.
+ITEM_20150317_000035	Basic armament provided to full-time soldiers. Its overall performance is better than the ones sold in the market.
 ITEM_20150317_000036	Mayor's Falchion
 ITEM_20150317_000037	Looking at this weapon makes you wonder the previous owner's rather dubious past.
 ITEM_20150317_000038	Crude Kaskara (조잡한)
@@ -137,8 +137,8 @@ ITEM_20150317_000136	Contrary to the appearance, this sword is double-edged and 
 ITEM_20150317_000137	Light Claymore
 ITEM_20150317_000138	The shape of the blade enables you to perform a strikedown attack.
 ITEM_20150317_000139	Mediocre Colossus
-ITEM_20150317_000140	Ylloon / Eilloon / Illunn
-ITEM_20150317_000141	Initially even the Great Ruklys carried this sword.
+ITEM_20150317_000140	Yllun / Eillun / Illunn
+ITEM_20150317_000141	Initially even the Great Ruklyss carried this sword.
 ITEM_20150317_000142	Practice Bastard Sword / Training Bastard Sword
 ITEM_20150317_000143	Bastard Sword
 ITEM_20150317_000144	Heavy Flamberge
@@ -218,7 +218,7 @@ ITEM_20150317_000217	Cane
 ITEM_20150317_000218	There are ways to customize the rod for yourself even if you did not carve the rod yourself.
 ITEM_20150317_000219	Crook
 ITEM_20150317_000220	According to legend, in the beginning this weapon was only used by evil wizards.
-ITEM_20150317_000221	Peuter Rod
+ITEM_20150317_000221	Pewter Rod
 ITEM_20150317_000222	It was once a popular weapon among ambitious young wizards.
 ITEM_20150317_000223	Owl Rod
 ITEM_20150317_000224	The decoration is liked by experienced wizards.
@@ -241,13 +241,13 @@ ITEM_20150317_000240	Heavy Long Rod
 ITEM_20150317_000241	Cane Rover
 ITEM_20150317_000242	Heavy Cane
 ITEM_20150317_000243	Heavy Crook
-ITEM_20150317_000244	Heavy Peuter Rod
+ITEM_20150317_000244	Heavy Pewter Rod
 ITEM_20150317_000245	Dunkel Crook
 ITEM_20150317_000246	Dunkel Crystal Rod
 ITEM_20150317_000247	Dunkel Long Rod
 ITEM_20150317_000248	Dunkel Cane Rover
 ITEM_20150317_000249	Dunkel Cane
-ITEM_20150317_000250	Dunkel Peuter Rod
+ITEM_20150317_000250	Dunkel Pewter Rod
 ITEM_20150317_000251	Serpentine Rod
 ITEM_20150317_000252	Alter Rod
 ITEM_20150317_000253	Nald Rod

--- a/ITEM_en.tsv
+++ b/ITEM_en.tsv
@@ -83,7 +83,7 @@ ITEM_20150317_000082	This weapon will make your swordmanship swifter.
 ITEM_20150317_000083	Imperni Sword
 ITEM_20150317_000084	It's not hard to sight a seasoned veteran emotionally recounting the moment when they first held this sword in their hands.
 ITEM_20150317_000085	Gritas
-ITEM_20150317_000086	A sword used by valiant adventurers. For this ironic reason, it is often found within strong monsters. A person who obtains this sword is unknowingly exacting revenge for its previous owner.
+ITEM_20150317_000086	A sword used by valiant adventurers. Ironically for the same reason, it is often found within strong monsters. A person who obtains this sword is unknowingly exacting revenge for its previous owner.
 ITEM_20150317_000087	Spatha
 ITEM_20150317_000088	An improved version of Gladius by extending its blade length.
 ITEM_20150317_000089	Arras's Falchion


### PR DESCRIPTION
번역상 이슈
1. 영문명 개명 제안

소드, 등등 기타 무기종류 이름:
-트레시 : 철자에 관계없이 발음상 영어로 '쓰레기' 가 되어버립니다. 유저들이 훗날 무기명을 거론할때(사고팔때 등등) 그다지 좋지 않아 보입니다. 예제: B>trash rod 20k/삼>트레시 로드 2만골드, 예제에서 보시듯, 유저중에 철자를 하나하나 정확히 기입하는 플레이어는... 많지 않습니다.
-드라트 Drat : 영어로 '제기랄'이 되어버립니다만, Draagth 라든가로 바꾸심이...http://dictionary.reference.com/browse/drat
-아스턴 Aston : 영국의 지역 이름/대학명/Aston Martin 고급차 브랜드 입니다. http://en.wikipedia.org/wiki/Aston_(disambiguation)
-데비 Debby : Deborah의 줄임말, 여성 이름입니다. 혹시 의도하신 무기명인지...

제안) 무기명이 조금 더 길었으면 하는 바람이 있습니다. 
한글 특성상 이름 끝에 '스' 등은 영어로 s로 끝나버리기에 최소 3-4자정도는 되어야 이름다운 이름이 됩니다. 
'디오'같은경우 단순 Dio 가 되어버리는데 여기에 훗날 '소드' 가 어색한 이유로 삭제되면 정말 말그대로 아이템명이 'Dio' 가 되어버립니다.
1. 프리마루체 & 프리에블란다

이 두자루의 검의 이름이 '프리' 로 시작하는 이유가 '동일인물이 개발한 검' 이라면 영문명상 Prima까지 가야합니다. 정확히는 모르겠으나 Primaluce의 경우 '원초적인 빛' 또는 '태초의 빛'이라는 뜻의 멋진 이름으로 그 구성이 아마도 라틴어/이탈리아어의 Prima (첫, 태초의, 원천적) + luce (빛) 인것같아보입니다.
그러므로 장인이 같은 인물이라면 Prima 를 두번째 검에 붙일 가능성이 크므로, '프리에블란다' 에서 Pri 까지만 유사한것이 영어로는 Prima 단어가 깨지므로 이름을 다시 고려하시길 부탁합니다. 만약 의도하신거면 Frieblandea 정도가 적당할듯 하네요.

제안) 첫자루가 Prima + luce 라면, 두번째 자루도 Prima + _____ 형태가 되는것이 영어로는 자연스럽게 느껴집니다만.. (개인적으로는 하나는 빛, 하나는 어둠/밤이라는 noctis / tenebrae 를 추천합니다. 프리마녹티스Primanoctis/ 프리마테네브라 Primatenebrae )
1. 세계관 이벤트 고유명사 통일

게임속 세계관에서 일어난 대사건들의 영어 고유명사 개발이 필요합니다. 
'식물재앙' 
저는 개인적으로 the Great Plant Cataclysm 라고 현재 쓰고있습니다만, 사건에 대한 상세한 정보를 주신다면 그에 해당하는 추천을 해드리겠습니다.

'신수의 날'
현제 저로써는 아무런 정보가 없어 무엇을 지칭하는건지 모르겠습니다. 번역할때 그냥 한글로 뒀습니다. 위와 동일하게 사건에 대한 상세한 정보를 주신다면 그에 해당하는 추천을 해드리겠습니다.
어림짐작으로는 'The Day of Goddess Descent' 이라든가 'The Great Blessing' 등등일것같은 느낌이 듭니다.

'루클리스'
영문철자 통일이 필요합니다. Ruklys, Ruklyss, Ruclis, Ruclyss 등등.  일단 지금은 Ruclyss로 번역을 추진하겠습니다.
