### PR TITLE
Update ETC_en.tsv

### DIFF
--- a/ETC_en.tsv
+++ b/ETC_en.tsv
@@ -1,7 +1,7 @@
 ﻿ETC_20150317_000001	Kepa
 ETC_20150317_000002	It is not that strong monster but you will be crying if you attack it rashly.
 ETC_20150317_000003	Large Kepa
-ETC_20150317_000004	Sometimes some people are trying to eat the Large Kepa, please stop them if you can.
+ETC_20150317_000004	Sometimes there are people who are trying to eat the Large Kepa, please stop them if you can.
 ETC_20150317_000005	Red Kepa
 ETC_20150317_000006	It is different with most people know, Red Kepa is more similar to the original Kepa.
 ETC_20150317_000007	Poisoned Kepa.
@@ -1540,8 +1540,8 @@ ETC_20150317_001539	Inventory is full. You cannot receive basic items.
 ETC_20150317_001540	Account ID can not contain spaces
 ETC_20150317_001541	Because there is no proper equipment, you will not be able to use the skills
 ETC_20150317_001542	Out of the range distance of herbivorous subject
-ETC_20150317_001543	Cannot use it yet
-ETC_20150317_001544	Cannot create anymore.
+ETC_20150317_001543	You cannot use it yet
+ETC_20150317_001544	Cannot create anymore
 ETC_20150317_001545	Enchantment error (error code: {Auto_1})
 ETC_20150317_001546	Duel status activated. {nl}The squad will be withdrawn automatically.
 ETC_20150317_001547	The duel status has been cancelled.
@@ -1551,7 +1551,7 @@ ETC_20150317_001550	New patch available. {nl} Please restart game to download th
 ETC_20150317_001551	Cannot be equip by your class.
 ETC_20150317_001552	Cannot be used while moving
 ETC_20150317_001553	Outside of the field of view
-ETC_20150317_001554	HP is low
+ETC_20150317_001554	You don't have sufficient HP
 ETC_20150317_001555	{Auto_1} Buff needed
 ETC_20150317_001556	Can be used only during non-combat status
 ETC_20150317_001557	Cannot be used in current status
@@ -1775,7 +1775,7 @@ ETC_20150317_001774	Helmet
 ETC_20150317_001775	Cooldown : {Sec} seconds
 ETC_20150317_001776	Effect when equipped with a weapon
 ETC_20150317_001777	Effect when equipped with a secondary weapon
-ETC_20150317_001778	Effect when equipped with a Top, Pants
+ETC_20150317_001778	Effect when equipped with a top, pants
 ETC_20150317_001779	Effect when equipped with boots
 ETC_20150317_001780	Effect when equipped with gloves
 ETC_20150317_001781	Maximum Attack
@@ -1786,7 +1786,7 @@ ETC_20150317_001785	Fire Attack Rate
 ETC_20150317_001786	Skill Ability
 ETC_20150317_001787	Weight : {All} / {Max}
 ETC_20150317_001788	Weight ({Rate}%)
-ETC_20150317_001789	Can't add sockets
+ETC_20150317_001789	Unable to add a socket
 ETC_20150317_001790	Tournament Champion
 ETC_20150317_001791	Tournament Second Winner
 ETC_20150317_001792	Ranker of Tournament {Auto_1} Round
@@ -1797,7 +1797,7 @@ ETC_20150317_001796	Get on
 ETC_20150317_001797	Demotion
 ETC_20150317_001798	Pet
 ETC_20150317_001799	Info
-ETC_20150317_001800	You are far from the companion.
+ETC_20150317_001800	You are too far from the companion.
 ETC_20150317_001801	Please select the PC to take the companion.
 ETC_20150317_001802	You are with [{Name}] companion.
 ETC_20150317_001803	Successfully adopted companion.
@@ -1849,11 +1849,11 @@ ETC_20150317_001848	Hunting Count
 ETC_20150317_001849	Emerged Area
 ETC_20150317_001850	Times
 ETC_20150317_001851	Damage
-ETC_20150317_001852	{Ul} Max Attack! {/}
-ETC_20150317_001853	{Ul}Max Damage! {/}
+ETC_20150317_001852	{Ul}Maximum Attack! {/}
+ETC_20150317_001853	{Ul}Maximum Damage! {/}
 ETC_20150317_001854	Lv
-ETC_20150317_001855	Acquired Quantity
-ETC_20150317_001856	Acquired Monsters
+ETC_20150317_001855	Obtained Quantity
+ETC_20150317_001856	Obtained Monsters
 ETC_20150317_001857	Buy from shop
 ETC_20150317_001858	Sell to shop
 ETC_20150317_001859	Cheat key
@@ -1862,19 +1862,19 @@ ETC_20150317_001861	Change Equipment
 ETC_20150317_001862	Crafting
 ETC_20150317_001863	Pocket
 ETC_20150317_001864	Package
-ETC_20150317_001865	Guild request
+ETC_20150317_001865	Guild Request
 ETC_20150317_001866	Innkeeper
 ETC_20150317_001867	Roulette
 ETC_20150317_001868	Place
 ETC_20150317_001869	End Time
 ETC_20150317_001870	%v person
 ETC_20150317_001871	Area
-ETC_20150317_001872	Acquire
+ETC_20150317_001872	Obtain
 ETC_20150317_001873	Inheritance
 ETC_20150317_001874	Start
 ETC_20150317_001875	Join
-ETC_20150317_001876	Acquired items
-ETC_20150317_001877	Accessories
+ETC_20150317_001876	Obtained item
+ETC_20150317_001877	Accessory
 ETC_20150317_001878	Set
 ETC_20150317_001879	Recipe
 ETC_20150317_001880	Active Skill
@@ -1910,8 +1910,8 @@ ETC_20150317_001909	Adventure journals registration is required. Press A key to 
 ETC_20150317_001910	[{Auto_1}] You can use the title.
 ETC_20150317_001911	Attributes
 ETC_20150317_001912	{@st59} Click for more information {/}
-ETC_20150317_001913	Same class Advancement is required for the next level up.
-ETC_20150317_001914	Skill levels increase by using skill points.
+ETC_20150317_001913	The next level requires the same class advancement.
+ETC_20150317_001914	Use Skill Points to increase the skill level.
 ETC_20150317_001915	Equip Information
 ETC_20150317_001916	Disable
 ETC_20150317_001917	Enable
@@ -1921,13 +1921,13 @@ ETC_20150317_001920	Random
 ETC_20150317_001921	Equal
 ETC_20150317_001922	Level difference
 ETC_20150317_001923	View All
-ETC_20150317_001924	Fighter
+ETC_20150317_001924	Warrior
 ETC_20150317_001925	Wizard
 ETC_20150317_001926	Archer
 ETC_20150317_001927	Cleric
 ETC_20150317_001928	View information
 ETC_20150317_001929	Channel
-ETC_20150317_001930	{Channel} Do you want to move to channel?
+ETC_20150317_001930	Do you want to move to channel {Channel}?
 ETC_20150317_001931	Price
 ETC_20150317_001932	s Lodge
 ETC_20150317_001933	Channel is closed.
@@ -2165,7 +2165,7 @@ ETC_20150317_002164	Unsealed!
 ETC_20150317_002165	Failed to protect the seal {nl} Try again!
 ETC_20150317_002166	You opened the treasure chest and the Hogmas are charging in!
 ETC_20150317_002167	There is no Hogma Battle Boss to use the scroll.
-ETC_20150317_002168	You cannot use it while another event quest is in progess
+ETC_20150317_002168	You cannot use it while another event quest is in progress
 ETC_20150317_002169	Seems like it's nothing
 ETC_20150317_002170	No response
 ETC_20150317_002171	I wonder why these are here
@@ -2261,8 +2261,8 @@ ETC_20150317_002260	You've successfully collected the dewdrops!
 ETC_20150317_002261	Detected the monster which swallowed the flag to tear around here.{nl}Use V key for faith's mark!
 ETC_20150317_002262	A lighting fighter curses the sanctum
 ETC_20150317_002263	The lighting fighter appeared as the power of faith's mark!
-ETC_20150317_002264	Blessed from Sanctum, It is able to make a power attack during 10 sec!
-ETC_20150317_002265	Blessed from Sanctum, You will be received the spirit of divine during 10 sec!
+ETC_20150317_002264	Blessed from Sanctum, it is able to make a power attack during 10 sec!
+ETC_20150317_002265	Blessed from Sanctum, you will be received the spirit of divine during 10 sec!
 ETC_20150317_002266	Worship the Goddess Statue
 ETC_20150317_002267	Use warp
 ETC_20150317_002268	Worshipping
@@ -2705,7 +2705,7 @@ ETC_20150317_002704	Successfully purchased market items. Please check the cabine
 ETC_20150317_002705	There are too many search results. Please use more detailed search words to narrow your results.
 ETC_20150317_002706	Do you want to cancel item registration?
 ETC_20150317_002707	Successfully canceled market items. Please check the cabinet.
-ETC_20150317_002708	Items equipped cannot be registered.
+ETC_20150317_002708	The equipped item cannot be registered.
 ETC_20150317_002709	Private
 ETC_20150317_002710	Confirm Purchase
 ETC_20150317_002711	Price : Low to High
@@ -2713,11 +2713,11 @@ ETC_20150317_002712	Price : High to Low
 ETC_20150317_002713	Latest Enrolled
 ETC_20150317_002714	Price entered must be at least 1.
 ETC_20150317_002715	Only skills with consume items is possible.
-ETC_20150317_002716	Keep out! The stones should be delivered ASAP.
-ETC_20150317_002717	Arrow of bleeding
-ETC_20150317_002718	Arrow
+ETC_20150317_002716	Keep out! The stones should be delivered as soon as possible.
+ETC_20150317_002717	Bleeding Arrow
+ETC_20150317_002718	Penetrating Arrow
 ETC_20150317_002719	Explosive Arrow
-ETC_20150317_002720	[Crafting available]
+ETC_20150317_002720	[Available to craft]
 ETC_20150317_002721	Stamina
 ETC_20150317_002722	Attack
 ETC_20150317_002723	Attacking speed
@@ -2729,15 +2729,15 @@ ETC_20150317_002728	Critical Resistance
 ETC_20150317_002729	Splash Defense
 ETC_20150317_002730	INT
 ETC_20150317_002731	SPR
-ETC_20150317_002732	Skill attack power
-ETC_20150317_002733	Magic Resistances
+ETC_20150317_002732	Skill Attack
+ETC_20150317_002733	Magic Resistance
 ETC_20150317_002734	Dugout Attack
 ETC_20150317_002735	Rim Attack
 ETC_20150317_002736	Magic Attack
 ETC_20150317_002737	Magic Defense
-ETC_20150317_002738	Create additional slot when equipped
+ETC_20150317_002738	Create an additional slot when equipped
 ETC_20150317_002739	Gender
-ETC_20150317_002740	Maximum socket
+ETC_20150317_002740	Maximum Sockets
 ETC_20150317_002741	Sell to shop
 ETC_20150317_002742	Trade with player
 ETC_20150317_002743	Enhance Potential
@@ -2750,15 +2750,15 @@ ETC_20150317_002749	Blows
 ETC_20150317_002750	Increase Area
 ETC_20150317_002751	Increase area of slash
 ETC_20150317_002752	Attack Range
-ETC_20150317_002753	Attack angl
-ETC_20150317_002754	Bururokuyuru
+ETC_20150317_002753	Attack Angle
+ETC_20150317_002754	Block Rate
 ETC_20150317_002755	Repeated hit
 ETC_20150317_002756	Rear attack range
 ETC_20150317_002757	Use specific skill
 ETC_20150317_002758	Possible
 ETC_20150317_002759	Not Available
 ETC_20150317_002760	Critical Attack
-ETC_20150317_002761	Critical defense force
+ETC_20150317_002761	Critical Defense
 ETC_20150317_002762	Tradable
 ETC_20150317_002763	Untradable
 ETC_20150317_002764	Potion recovery amount
@@ -3770,20 +3770,20 @@ ETC_20150317_003769	wearing at least {/} armor will be of help
 ETC_20150317_003770	Use key to open inventory and wear using right mouse click
 ETC_20150317_003771	Wear the {@st54}Thick clothes{/} that you have.
 ETC_20150317_003772	There is {@st54} Think clothes {/}in the inventory so wear that
-ETC_20150317_003773	Character level increased
+ETC_20150317_003773	Your character level has increased
 ETC_20150317_003774	Level up tx failure. request levelup tx until successful
 ETC_20150317_003775	Keyboard
 ETC_20150317_003776	to increase stats
 ETC_20150317_003777	to learn Attributes
-ETC_20150317_003778	Class level up
+ETC_20150317_003778	Your class level has increased
 ETC_20150317_003779	to learn skills
 ETC_20150317_003780	Monster regen success:
 ETC_20150317_003781	No monster regens nearby
 ETC_20150317_003782	Zone does not have special regen and set regen
 ETC_20150317_003783	Class
 ETC_20150317_003784	by level
-ETC_20150317_003785	None Skills
-ETC_20150317_003786	No skill lock
+ETC_20150317_003785	No Skills
+ETC_20150317_003786	No Skill lock
 ETC_20150317_003787	Level settings is not a number.
 ETC_20150317_003788	No results within the current zone.
 ETC_20150317_003789	no value selected
@@ -3793,8 +3793,8 @@ ETC_20150317_003792	Enter recommended quest level in numbers
 ETC_20150317_003793	There is no quest to this level stand.
 ETC_20150317_003794	CANCEL selection or nil value
 ETC_20150317_003795	{/} Begin Quest
-ETC_20150317_003796	Quest NPC dialog
-ETC_20150317_003797	Quest complete
+ETC_20150317_003796	Quest in progress NPC Talk
+ETC_20150317_003797	Quest Completed
 ETC_20150317_003798	show quest info in C: \
 ETC_20150317_003799	Give up Quest
 ETC_20150317_003800	Go to start NPC
@@ -3929,7 +3929,7 @@ ETC_20150317_003928	Key of the Puzzle Box
 ETC_20150317_003929	It is available to have in the inventory!
 ETC_20150317_003930	Enter the three-digit number that is different in the chat window
 ETC_20150317_003931	During operation, enter the three-digit number that is different in the chat window
-ETC_20150317_003932	Acquisition
+ETC_20150317_003932	Obtain
 ETC_20150317_003933	Failure, Can restart when item drop
 ETC_20150317_003934	Each three-digit number must be different
 ETC_20150317_003935	There is no three-digit number
@@ -3940,7 +3940,7 @@ ETC_20150317_003939	In Operation, Enter a number in the range 0 ~ 10000 in the c
 ETC_20150317_003940	More Low
 ETC_20150317_003941	More Higher
 ETC_20150317_003942	Not a number in the range 0 ~ 10000
-ETC_20150317_003943	2. Kill the crowd monsters
+ETC_20150317_003943	2. Defeat the crowd monsters
 ETC_20150317_003944	Chalk for Scribbles
 ETC_20150317_003945	In this inventory, Available!
 ETC_20150317_003946	Write the scribble information in a chat window
@@ -4294,9 +4294,9 @@ ETC_20150317_004293	Start is possible{/}
 ETC_20150317_004294	Progress {/}
 ETC_20150317_004295	Get rewarded {/}
 ETC_20150317_004296	{@st43} Perform missions
-ETC_20150317_004297	{@st41} Rewards
+ETC_20150317_004297	{@st41} Reward(s)
 ETC_20150317_004298	{@st41b} Experience :
-ETC_20150317_004299	{@st41} Items required
+ETC_20150317_004299	{@st41} Required item
 ETC_20150317_004300	{@st45tw} Give up
 ETC_20150317_004301	Do you want to move {nl} the area?
 ETC_20150317_004302	{Auto_1} buff (completed)
@@ -4692,8 +4692,8 @@ ETC_20150317_004691	Sorcerer
 ETC_20150317_004692	Number of selected items
 ETC_20150317_004693	Default
 ETC_20150317_004694	{nl}{#ff0000} The code is not supported. Please check the Datatree_tooltipset {nl}
-ETC_20150317_004695	{#050505}{s18}{b} socket for mounting
-ETC_20150317_004696	{#050505}{s22}{b} When item changed
+ETC_20150317_004695	{#050505}{s18}{b} When socketed:
+ETC_20150317_004696	{#050505}{s22}{b} When equipped:
 ETC_20150317_004697	{@st42} Use
 ETC_20150317_004698	Shop available for sale
 ETC_20150317_004699	Store sales is impossible
@@ -6104,12 +6104,12 @@ ETC_20150317_006103	You can't use an item with zero durability.
 ETC_20150317_006104	You can repair an item with decreased durability through a repair menu.{nl}Select an item you want to repair
 ETC_20150317_006105	Click it, and the selected items' durability will be fully restored.
 ETC_20150317_006106	Repair fee will be charged, normally items with higher rank will cost more to repair.
-ETC_20150317_006107	If you add gems to an equipment you can add a useful effect to it.
-ETC_20150317_006108	A gem can be inserted to an equipment you own has a socket.
+ETC_20150317_006107	If you add a gem to an equipment, you can add a useful effect to it.
+ETC_20150317_006108	A gem can be inserted to a socket of an equipment.
 ETC_20150317_006109	Some items will not have any socket.
 ETC_20150317_006110	You can ask a blacksmith NPC to add gem sockets to your equipment.
 ETC_20150317_006111	Silver is required to add a socket.
-ETC_20150317_006112	Right-click on the gem in your inventroy to highlight items that you can add the gem into.
+ETC_20150317_006112	Right-click on the gem in your inventory to highlight the item that you can add the gem into.
 ETC_20150317_006113	When you select an item, the gem will be inserted into the item socket.
 ETC_20150317_006114	Inserted gems can be viewed in the item tooltip.
 ETC_20150317_006115	A gem that has already been inserted into an item
@@ -8826,19 +8826,19 @@ ETC_20150317_008825	Press F12 to record a gameplay video.
 ETC_20150317_008826	Screenshot Tip
 ETC_20150317_008827	Press Print Screen to take screenshots.
 ETC_20150317_008828	Character Info Tip
-ETC_20150317_008829	Press F1 to view your character information.
+ETC_20150317_008829	Press F1 to view info about your character.
 ETC_20150317_008830	Inventory Tip
 ETC_20150317_008831	Press F2 to open your inventory to see the items and silver you own.
 ETC_20150317_008832	Classes, Skills and Attributes Tip
-ETC_20150317_008833	Press F1 to view info on your class, skills, and attributes.
+ETC_20150317_008833	Press F1 to view info about your class, skills, and attributes.
 ETC_20150317_008834	Adventure Journal Tip
-ETC_20150317_008835	Press F4 to view your cumulative record of gameplay.
+ETC_20150317_008835	Press F4 to view your cumulative record and progress of gameplay.
 ETC_20150317_008836	Quest Tip
 ETC_20150317_008837	Press F5 to view information on quests in progress.
 ETC_20150317_008838	Party Tip
 ETC_20150317_008839	Press F6 to view your party.
 ETC_20150317_008840	Party Request Tip
-ETC_20150317_008841	Right click on another player's character to send a party request. When the request is accepted, you can play together in a party.
+ETC_20150317_008841	Right-click on another player's character to send a party request. When the request is accepted, you can play together in a party.
 ETC_20150317_008842	Public Party List Tip
 ETC_20150317_008843	It shows the list of current parties in the game. Click on the list to join the party.
 ETC_20150317_008844	Buddy List Tip
@@ -8864,29 +8864,29 @@ ETC_20150317_008863	When you reach max class level, you can Advance to the same 
 ETC_20150317_008864	Mission Tip
 ETC_20150317_008865	Use the mission item purchased from the mercenary commision to open the portal and enter mission.
 ETC_20150317_008866	Field Boss Tip
-ETC_20150317_008867	A field boss can sometimes appear in some areas.
+ETC_20150317_008867	A field boss can sometimes appear in certain areas.
 ETC_20150317_008868	Elemental Attributes Tip
-ETC_20150317_008869	Monsters have 1 of the 6 elemental attributes : Fire, Ice, Earth, Darkness, Poison or Electric.
+ETC_20150317_008869	Monsters have 1 of the 6 elemental attributes: Fire, Ice, Earth, Darkness, Poison or Electric.
 ETC_20150317_008870	Resistance Tip
 ETC_20150317_008871	Attacking with countering properties of each monster can cause more damage.
 ETC_20150317_008872	Archer Tip
 ETC_20150317_008873	Press and hold the attack button to continuously attack the enemy in target. You can also move while attacking using the arrow keys.
 ETC_20150317_008874	Archer's arrow attacks have maximum range. Higher damage is made when shot from a distance.
-ETC_20150317_008875	When Archer type class levels up, accuracy and evasion increases.
-ETC_20150317_008876	Basic range attack of Archers cause more damage to flying monsters.
+ETC_20150317_008875	The accuracy and evasion increases when an Archer type class levels up.
+ETC_20150317_008876	The basic range attack of Archers cause more damage to flying monsters.
 ETC_20150317_008877	Wizard Tip
 ETC_20150317_008878	When Wizard type classes are attacked during skill casting, the skill can be cancelled.
-ETC_20150317_008879	When Wizard type classes level up, Magic defense increases.
+ETC_20150317_008879	The magic defense increases when a Wizard type class levels up.
 ETC_20150317_008880	Warrior Tip
-ETC_20150317_008881	When Warrior type classes level up, Physical defense increases.
+ETC_20150317_008881	The physical defense increases when a Warrior type class levels up.
 ETC_20150317_008882	Cleric Tip
 ETC_20150317_008883	Cleric's magic circles installed on the ground may not be effective on flying monsters.
-ETC_20150317_008884	When Cleric type classes level up, SP and SP recovery increases.
+ETC_20150317_008884	The SP and SP recovery increases when a Cleric type class levels up.
 ETC_20150317_008885	Hold down the Ctrl key to lock target.
 ETC_20150317_008886	Use Alt key to stop movement immediately.
-ETC_20150317_008887	Press the space bar key during battle to face the current target.
+ETC_20150317_008887	Press the Space bar key during battle to face the current target.
 ETC_20150317_008888	When boarding the companion, character's stats will increase in proportion to the ability of companion.ETC_20150312_005342
-ETC_20150317_008889	Card Synthesis
+ETC_20150317_008889	Card Synthesis (Coming Soon)
 ETC_20150317_008890	Arrow crafting skill is required.
 ETC_20150317_008891	Set the current equipment level.
 ETC_20150317_008892	Adds 2 item quality levels
@@ -8909,7 +8909,7 @@ ETC_20150317_008908	Base level up
 ETC_20150317_008909	Target Level
 ETC_20150317_008910	Go to test_zonemove.xml coordinates
 ETC_20150317_008911	ClassName Xml
-ETC_20150317_008912	Fullscreen
+ETC_20150317_008912	Open All UI
 ETC_20150317_008913	Press Enter to Close Dialog
 ETC_20150317_008914	Check Main Session properties
 ETC_20150317_008915	Property Name
@@ -8923,12 +8923,12 @@ ETC_20150317_008922	Propagation direction between the coordinates
 ETC_20150317_008923	Remove Group Buff
 ETC_20150317_008924	Show FPS
 ETC_20150317_008925	PvP Mode
-ETC_20150317_008926	Delete Inventory items
+ETC_20150317_008926	Delete inventory items
 ETC_20150317_008927	Field Events
 ETC_20150317_008928	Event Type
 ETC_20150317_008929	Start Field Events
 ETC_20150317_008930	Reset Field Event conditions
-ETC_20150317_008931	Skill Points Up
+ETC_20150317_008931	Skill Point Up
 ETC_20150317_008932	Learn Skills
 ETC_20150317_008933	Reset Raid Party time
 ETC_20150317_008934	Remove monsters
@@ -9195,7 +9195,7 @@ ETC_20150317_009194	Practice Post (Earth)
 ETC_20150317_009195	[Tools Merchant]{nl} Mirina
 ETC_20150317_009196	[Equipment Merchant]{nl} Dunkel
 ETC_20150317_009197	[Accessory Merchant]{nl} Ronesa
-ETC_20150317_009198	Goddess Statue of Klaipeda
+ETC_20150317_009198	Klaipeda Goddess Statue
 ETC_20150317_009199	[Blacksmith]{nl} Zaras
 ETC_20150317_009200	[Peltasta Master]{nl} Maria Leed
 ETC_20150317_009201	[Cryomancer Master]{nl} Aleister Crowley
@@ -9206,7 +9206,7 @@ ETC_20150317_009205	[Wizard Master]{nl} Lucia
 ETC_20150317_009206	[Archer Master]{nl} Edmundas Tiller
 ETC_20150317_009207	[Cleric Master]{nl} Rozaliia
 ETC_20150317_009208	[Priest Master]{nl} Boruble
-ETC_20150317_009209	[Krivi Master]{nl} Herkus
+ETC_20150317_009209	[Krivis Master]{nl} Herkus
 ETC_20150317_009210	[Auctioneer]{nl} Demares
 ETC_20150317_009211	[Market Manager]{nl} Rosie
 ETC_20150317_009212	[Companion Trader]{nl} Christina
@@ -10649,7 +10649,7 @@ ETC_20150401_010648	Putting down on the floor
 ETC_20150401_010649	Attacks are useless because of the protection screen
 ETC_20150401_010650	Glackuman was drawn to the spell and is going to appear. {nl} Get ready
 ETC_20150401_010651	The Spell Summon Crystal is transgering strong energy to the monsters
-ETC_20150401_010652	Cannot use it now.
+ETC_20150401_010652	You cannot use this now.
 ETC_20150401_010653	This skill cannot be used while in combat.
 ETC_20150401_010654	Shout
 ETC_20150401_010655	Warehouse Keeper


### PR DESCRIPTION
After watching video of CBT user playing in ENG modified game client, I made some minor edits to reflect a better and logical translation.

ETC_20150317_004696 {#050505}{s22}{b}장비 교체시 
↓
ETC_20150317_004696 {#050505}{s22}{b} When item changed
↓
ETC_20150317_004696 {#050505}{s22}{b} When equipped: 

"When equipped" makes more sense than the previous translation. Because the bubble of the text is pointing to the non-equipped item. 
http://i.imgur.com/n064bJC.jpg <--- helpful to see
