### PR TITLE
Update QUEST_JOBSTEP.tsv

### DIFF
--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -339,64 +339,64 @@ QUEST_JOBSTEP_20150317_000338
 QUEST_JOBSTEP_20150317_000339	At least you weren't a bluffer. {nl}Good. I will approve your learning from Paladin.
 QUEST_JOBSTEP_20150317_000340	So you want to learn from the Highlanders. {nl}Alright. But there is a condition.
 QUEST_JOBSTEP_20150317_000341	You're the support from Highlander Master. {nl}It's urgent so I'll get to the point right away.
-QUEST_JOBSTEP_20150317_000342	There's a problem in Crystal Mines and Commander Uska asked us for support. {nl}But we, the Peltastas, also don't have time right now.{nl}
+QUEST_JOBSTEP_20150317_000342	There's a problem in the Crystal Mines and Commander Uska asked us for support. {nl}But we, the Peltastas, also don't have time right now.{nl}
 QUEST_JOBSTEP_20150317_000343	So I want you to help Commander Uska for us.
-QUEST_JOBSTEP_20150317_000344	Pledge is important. {nl}I cannot accept anything taht breaks the trust int he confusing current state.
-QUEST_JOBSTEP_20150317_000345	I thought it would be difficult even as we asked for support. {nl}But now we're relieve that you're the support.
-QUEST_JOBSTEP_20150317_000346	Highlander and Peltasta's Honor is on the line. {nl}Please help commander Uska well.
-QUEST_JOBSTEP_20150317_000347	There are rumors that a huge monster is roaming Crystal Mines 2nd Floor. {nl}But the mines is an important industry for Klaipeda so we can't just stay doing nothing. {nl}
-QUEST_JOBSTEP_20150317_000348	So please check Crystal Mines 2nd Floor and get rid of the source of rumors.
-QUEST_JOBSTEP_20150317_000349	Safety of the villagers is on the line. {nl}Please check it well.
-QUEST_JOBSTEP_20150317_000350	I can't believe there is still that kind of thing left.. {nl}It's a relief that no one was hurt. {nl}We should consider sending the elite troops until the Mines is stable.
-QUEST_JOBSTEP_20150317_000351	Anyway, thanks for the hard work and send my thanks to Highlander Masetr. {nl}I will thank Peltasta Master when I meet him soon.
-QUEST_JOBSTEP_20150317_000352	Good work. Now the Pelatastas owe me another one.{nl}I will lead you as Highlander Master as promised.
+QUEST_JOBSTEP_20150317_000344	Pledge is important. {nl}I cannot accept anything that breaks the trust in the current confusing state.
+QUEST_JOBSTEP_20150317_000345	I thought it would be difficult even as we asked for support. {nl}But now we're relieved that you're the support.
+QUEST_JOBSTEP_20150317_000346	Highlander and Peltasta's Honor is on the line. {nl}Please help Commander Uska.
+QUEST_JOBSTEP_20150317_000347	There are rumors that a huge monster is roaming Crystal Mines 2nd Floor. {nl}The mines is an important industry for Klaipeda so we can't just stand idly by. {nl}
+QUEST_JOBSTEP_20150317_000348	So please check Crystal Mines 2nd Floor and get rid of the source of the rumors.
+QUEST_JOBSTEP_20150317_000349	The safety of the villagers is on the line. {nl}Please check it thoroughly.
+QUEST_JOBSTEP_20150317_000350	I can't believe there is still that kind of thing left.. {nl}It's a relief that no one was hurt. {nl}We should consider sending the elite troops until the Crystal Mines is stable.
+QUEST_JOBSTEP_20150317_000351	Anyway, thank you for the hard work and send my thanks to Highlander Master. {nl}I will thank Peltasta Master when I meet him soon.
+QUEST_JOBSTEP_20150317_000352	Good work. Now the Pelatastas owe me another one.{nl}I will lead you as Highlander Master has promised.
 QUEST_JOBSTEP_20150317_000353	Seems like I get your help a lot. {nl}Please take care of Klaipeda in the future too.
-QUEST_JOBSTEP_20150317_000354	You want to learn from me? {nl}Alright, I'll accept the offer if you do me a favor.
+QUEST_JOBSTEP_20150317_000354	You want to learn from me? {nl}Alright, I'll accept your offer if you do me a favor.
 QUEST_JOBSTEP_20150317_000355	Did Peltasta Master send you? {nl}If it's about the shield, I already know it.
-QUEST_JOBSTEP_20150317_000356	If we don't get the supplies, then we don't have to keep the pledge with Highlanders. {nl}Also, our trust will be broken.
+QUEST_JOBSTEP_20150317_000356	If we don't get the supplies then we don't have to keep the pledge with Highlanders. {nl}Also, our trust will be broken.
 QUEST_JOBSTEP_20150317_000357	I should have sent a letter of apology but I wasn't able to. {nl}There will be word from a client soon so wait for a while.
 QUEST_JOBSTEP_20150317_000358	
 QUEST_JOBSTEP_20150317_000359	Fletcher Master
 QUEST_JOBSTEP_20150317_000360	Did you come from Klaipeda? {nl}You can't even if you rush it. Go back.
 QUEST_JOBSTEP_20150317_000361	Did you not hear me? {nl}Your turn is far behind.
-QUEST_JOBSTEP_20150317_000362	I've never been this mad since that tree took my workshop to the sky {nl}4 years ago on Divine Day.
+QUEST_JOBSTEP_20150317_000362	I haven't been this mad since that tree took my workshop to the sky {nl}4 years ago on Medis Diena.
 QUEST_JOBSTEP_20150317_000363	Did you get rid of it? That's great to hear. {nl}One less reason for the lazy Fedimian merchants.
-QUEST_JOBSTEP_20150317_000364	I will be able to send the rest of the stuff soon as promised. {nl}You can go back now. I need to concentrate.
-QUEST_JOBSTEP_20150317_000365	I can keep a good relationship with Highlander with your help. {nl}I will lead you as Peltasta Master as promised.
+QUEST_JOBSTEP_20150317_000364	I will be able to send the rest of the stuff soon, as promised. {nl}You can go back now. I need to concentrate.
+QUEST_JOBSTEP_20150317_000365	I can keep a good relationship with Highlander with your help. {nl}I will lead you as Peltasta Master has promised.
 QUEST_JOBSTEP_20150317_000366	I will send my disciple to Highlander Master so don't worry about that.
-QUEST_JOBSTEP_20150317_000367	It's emotional to see that there's someone willing to learn from a person like me. {nl}Alright, if you get me back my things, I will teach you the skills of Corsair.
+QUEST_JOBSTEP_20150317_000367	It's emotional to see that there's someone willing to learn from a person like me. {nl}Alright, if you get my things back, I will teach you the skills of Corsair.
 QUEST_JOBSTEP_20150317_000368	
-QUEST_JOBSTEP_20150317_000369	Now that's something! {nl}I will teach you the skill of Corsair as promised.
-QUEST_JOBSTEP_20150317_000370	Fight with all you've got. I will show you how to fight with sword and shield. {nl}Remember that it depends on your abilities that I could teach you or desert you.
+QUEST_JOBSTEP_20150317_000369	Now that's something! {nl}I will teach you the skill of Corsair, as promised.
+QUEST_JOBSTEP_20150317_000370	Fight with all that you've got. I will show you how to fight with sword and shield. {nl}Remember that it depends on your abilities that I could teach you or desert you.
 QUEST_JOBSTEP_20150317_000371	Are you thinking otherwise even when your best is not enough?
-QUEST_JOBSTEP_20150317_000372	You have a bad habit. But it could be changed. {nl}I teach strictly so better be prepared.
+QUEST_JOBSTEP_20150317_000372	You have a bad habit. But it could be changed. {nl}I teach strictly so you better be prepared.
 QUEST_JOBSTEP_20150317_000373	Teaching you skills is not difficult as long as you do me a favor. {nl}
-QUEST_JOBSTEP_20150317_000374	There's something I requested to Fletcher Master but there's no news yet. {nl}I want you to check it. I'm more worried about the person than the thing..
+QUEST_JOBSTEP_20150317_000374	There's something I requested to Fletcher Master but there's no news yet. {nl}I want you to check the status. I'm more worried about the person than the thing..
 QUEST_JOBSTEP_20150317_000375	Did Archer Master worry? I'm fine. {nl}If there's a problem, it's that the materials can't follow my crafting speed.
-QUEST_JOBSTEP_20150317_000376	Well he's hot tempered much so.. Please take care of it.
-QUEST_JOBSTEP_20150317_000377	I think it'll be over soon if you gather good stones from Penitence Route of Cathedral. {nl}Around 150 of it will do. I'll give you a bag for it.
+QUEST_JOBSTEP_20150317_000376	Well he's hot tempered so.. Please take care of it.
+QUEST_JOBSTEP_20150317_000377	I think it'll be over soon if you gather good stones from Penitence Route of Cathedral. {nl}Around 150 of it will do, I'll give you a bag for them.
 QUEST_JOBSTEP_20150317_000378	I wish there was a well flowing with the materials. {nl}It's my lifelong wish.
 QUEST_JOBSTEP_20150317_000379	The Golems? That's strange. {nl}Maybe the Goddess helped.{nl}
 QUEST_JOBSTEP_20150317_000380	Done. Take it. {nl}Send my regards to Archer Master.
-QUEST_JOBSTEP_20150317_000381	I was just going to send you an errand. Sorry for the Golems. {nl}Anyway, I'll pass you my skills as promised.
+QUEST_JOBSTEP_20150317_000381	I was just going to send you an errand. Sorry for the Golems. {nl}Anyway, I'll provide you my skills as promised.
 QUEST_JOBSTEP_20150317_000382	I have no business with you. {nl}I'm busy. Go back.
-QUEST_JOBSTEP_20150317_000383	You came to me to learn the skill of ranger right? {nl}I'll give it a positive consideration if you do me a favor.
-QUEST_JOBSTEP_20150317_000384	I can't get a grasp of what the eboniphons are doing.{nl}I'm sure it's not something good but I can't even tell its objectives and it's making me mad.
-QUEST_JOBSTEP_20150317_000385	So these must be the samples. This will be good enough for our trade. {nl}Alright, I'll make you become stronger.
+QUEST_JOBSTEP_20150317_000383	You came to me to learn the skill of rangers right? {nl}I'll consider it if you do me a favor.
+QUEST_JOBSTEP_20150317_000384	I can't get a grasp of what the Eboniphons are doing.{nl}I'm sure it's not something good but I can't even tell its objectives, it's making me mad.
+QUEST_JOBSTEP_20150317_000385	So these must be the samples. These will be good enough for our trade. {nl}Alright, I'll help you become stronger.
 QUEST_JOBSTEP_20150317_000386	You want to learn my skills? {nl}I'll think about it if you get me the tree I'm looking for.
 QUEST_JOBSTEP_20150317_000387	
-QUEST_JOBSTEP_20150317_000388	Ah, that' right. Just throw it there somewhere. {nl}It's nothing hard so i'll teach you, but if it disturbs my work, {nl}then it'll stop right away.
+QUEST_JOBSTEP_20150317_000388	Ah, that's right. Just throw it there somewhere. {nl}It's nothing hard so I'll teach you, but if it disturbs my work, {nl}then it'll stop right away.
 QUEST_JOBSTEP_20150317_000389	
 QUEST_JOBSTEP_20150317_000390	
 QUEST_JOBSTEP_20150317_000391	Since you've done the mission well, I'll teach you about the Hunter's way. {nl}Good work.
 QUEST_JOBSTEP_20150317_000392	
 QUEST_JOBSTEP_20150317_000393	
-QUEST_JOBSTEP_20150317_000394	It's ahrd to stray away from the charm of poison. I'm one of them. {nl}I'll let you know how appealing it is too. Let's start slowly from today.
+QUEST_JOBSTEP_20150317_000394	It's hard to stray away from the charm of poison. I'm one of them. {nl}I'll let you know how appealing it is too. Let's start slowly from today on.
 QUEST_JOBSTEP_20150317_000395	
 QUEST_JOBSTEP_20150317_000396	No one can hide perfectly from the scouts.
 QUEST_JOBSTEP_20150317_000397	You did it easier than I thought.{nl}Great. I think it'll be fun to teach you. {nl}Come to me anytime you want to learn from me.
-QUEST_JOBSTEP_20150317_000398	I think you're good enough to be accepted as my disciple but you still need to be tested. {nl}I will welcome you if you bring the rubbings fo Lydis Schaffen's gravestone in the courtyard of Goddess.
-QUEST_JOBSTEP_20150317_000399	It's the gravestone of the person all archers look up to. {nl}Do it well so that all the writings are readable.
+QUEST_JOBSTEP_20150317_000398	I think you're good enough to be accepted as my disciple but you still need to be tested. {nl}I will welcome you if you bring the rubbings of Lydis Schaffen's gravestone in the courtyard of the Goddess.
+QUEST_JOBSTEP_20150317_000399	It's the gravestone of the person that all archers look up to. {nl}Do it well so that all the writings are readable.
 QUEST_JOBSTEP_20150317_000400	I used to be a Schaffenstar back in the day.{nl}Anyway, I will teach you my skills as promised.
 QUEST_JOBSTEP_20150317_000401	Rogue Master
 QUEST_JOBSTEP_20150317_000402	
@@ -410,11 +410,11 @@ QUEST_JOBSTEP_20150317_000409	The spear is unbeatable and invincible. {nl}I want
 QUEST_JOBSTEP_20150317_000410	
 QUEST_JOBSTEP_20150317_000411	You want to learn from me? {nl}Then you have to pass a test. {nl}
 QUEST_JOBSTEP_20150317_000412	
-QUEST_JOBSTEP_20150317_000413	If you have the abilities to learn from me, then Yekub will be easy enough.
-QUEST_JOBSTEP_20150317_000414	I want to see their faces who would fight Yekub that doesn't even exist. {nl}Alright, you're good enough.
+QUEST_JOBSTEP_20150317_000413	If you have the ability to learn from me, then Yekub will be easy enough.
+QUEST_JOBSTEP_20150317_000414	I want to see their faces when they fight Yekub that doesn't even exist. {nl}Alright, you're good enough.
 QUEST_JOBSTEP_20150317_000415	
 QUEST_JOBSTEP_20150317_000416	
-QUEST_JOBSTEP_20150317_000417	Welcome to becoming a Centurion. {nl}You'll learn step by step about the formation from now.
+QUEST_JOBSTEP_20150317_000417	Welcome to becoming a Centurion. {nl}You'll learn step by step about the formation from now on.
 QUEST_JOBSTEP_20150317_000418	Squires are strong but we shine more when helping our partners. {nl}Using the rope to make connecting attacks with fellow colleagues {nl}is an attack that is especially stonger than any other attacks.
 QUEST_JOBSTEP_20150317_000419	
 QUEST_JOBSTEP_20150317_000420	Nobody should make any mistakes for connecting attacks to succeed. {nl}That is why you need to practice hard.
@@ -422,13 +422,13 @@ QUEST_JOBSTEP_20150317_000421	How much are you used to it? {nl}I will teach you 
 QUEST_JOBSTEP_20150317_000422	
 QUEST_JOBSTEP_20150317_000423	
 QUEST_JOBSTEP_20150317_000424	Going through these dangers can be a good experience.
-QUEST_JOBSTEP_20150317_000425	The Peltastas requested for help. {nl}We are tight with our troops but we also can't reject the Peltastas as we have a pledge with them.
+QUEST_JOBSTEP_20150317_000425	The Peltastas requested for help. {nl}We have limited troops but we also can't reject the Peltastas as we have a pledge with them.
 QUEST_JOBSTEP_20150317_000426	I want you to assist the Peltastas and carry out the mission.
-QUEST_JOBSTEP_20150317_000427	We, Peltatas, receive shield supplies as a condition for keeping our pledge with Highlanders. {nl}The shield always have been supplied on time but recently, the supplies have been cut. {nl}
+QUEST_JOBSTEP_20150317_000427	We, Peltatas, receive shield supplies as a condition for keeping our pledge with Highlanders. {nl}The shields have always been supplied on time but recently the supplies have been cut. {nl}
 QUEST_JOBSTEP_20150317_000428	Ask the Highlander what the problem is and if you can, please solve it.
 QUEST_JOBSTEP_20150317_000429	
 QUEST_JOBSTEP_20150317_000430	I'm following the traces of Eboniphons.{nl}Recent information says that they tested something in the Cathedral.{nl}
-QUEST_JOBSTEP_20150317_000431	You go to the Cathedral right away and get a sample of Moya's fluid. {nl}We'll be able to know something if we examine that.
+QUEST_JOBSTEP_20150317_000431	Go to the Cathedral right away and get a sample of Moya's fluid. {nl}We'll be able to know something if we examine that.
 QUEST_JOBSTEP_20150317_000432	I'll give you this flare since you're a novice. {nl}It will help you find the monsters easily.
 QUEST_JOBSTEP_20150317_000433	Poison is like a blade with two sides so you should be careful with it. {nl}Especially if you get a finger cut while using the poison..
 QUEST_JOBSTEP_20150317_000434	I assume you've come to learn something from me because you have the abilities. {nl}Something like winning a duel with me.


### PR DESCRIPTION
Proofread and edited lines 330 - 432

Still not sure whether to add "the" in front of most instances of a job master. Like "the Highlander Master" instead of "Highlander Master." Left it alone for now. 

344 - changed the wording a bit
347 - made sentence flow better
367 - changed the wording a bit
414 - not sure about this line, needs better translation
420 - need better translation
425 - changed it up a bit cant tell if this is accurate

A lot of these lines need better translation. I stopped for now before I try and retranslate or rearrange the sentences.
