### PR TITLE
Update QUEST_LV_0100.tsv

### DIFF
--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -5263,11 +5263,11 @@ QUEST_LV_0100_20150317_005262	Defeat the monster that followed Toby
 QUEST_LV_0100_20150317_005263	Todou is being chased by Yonazolem! Defeat the Yonazolem.
 QUEST_LV_0100_20150317_005264	Defeat Yonazolem that Todou brought along
 xQUEST_LV_0100_20150317_005265	Rexipher is thinking deeply, looking at the clues. Talk to him.
-xQUEST_LV_0100_20150317_005266	Get Hogma's Teeth
+xQUEST_LV_0100_20150317_005266	Get Hogma Teeth
 xQUEST_LV_0100_20150317_005267	Rexipher says the clues are covered with something and needs Hogma's teeth to use as an abrasive. Get him Hogma's teeth.
-xQUEST_LV_0100_20150317_005268	Got Hogma's teeth. Talk to Rexipher. 
+xQUEST_LV_0100_20150317_005268	Got Hogma teeth. Talk to Rexipher. 
 QUEST_LV_0100_20150317_005269	Get %s
-xQUEST_LV_0100_20150317_005270	Get Hogma's Teeth
+xQUEST_LV_0100_20150317_005270	Get Hogma Teeth
 xQUEST_LV_0100_20150317_005271	Find out Rexipher's Whereabouts
 xQUEST_LV_0100_20150317_005272	Rexipher disappeared with Zachariel's clues. Go to Liason Official Veil and ask about Rexipher's whereabouts.
 xQUEST_LV_0100_20150317_005273	Veil says he doesn't know Rexipher. Ask other historians for Rexipher's whereabouts.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -5262,62 +5262,62 @@ QUEST_LV_0100_20150317_005261	Vincent seems to have found out. Talk to Vincent a
 QUEST_LV_0100_20150317_005262	Defeat the monster that followed Toby
 QUEST_LV_0100_20150317_005263	Todou is being chased by Yonazolem! Defeat the Yonazolem.
 QUEST_LV_0100_20150317_005264	Defeat Yonazolem that Todou brought along
-QUEST_LV_0100_20150317_005265	Rexipher is thinking deeply looking at the clues. Talk to him.
-QUEST_LV_0100_20150317_005266	Get the Teeth of Hogma
-QUEST_LV_0100_20150317_005267	Rexipher says the clues is covered with something and needs Hogma's teeth to use as abrasive. Get him Hogma's teeth.
-QUEST_LV_0100_20150317_005268	Got Hogma's teeth. Talk to Rexipher. 
+xQUEST_LV_0100_20150317_005265	Rexipher is thinking deeply, looking at the clues. Talk to him.
+xQUEST_LV_0100_20150317_005266	Get Hogma's Teeth
+xQUEST_LV_0100_20150317_005267	Rexipher says the clues are covered with something and needs Hogma's teeth to use as an abrasive. Get him Hogma's teeth.
+xQUEST_LV_0100_20150317_005268	Got Hogma's teeth. Talk to Rexipher. 
 QUEST_LV_0100_20150317_005269	Get %s
-QUEST_LV_0100_20150317_005270	Get Hogma's Teeth
-QUEST_LV_0100_20150317_005271	Find out Rexipher's whereabouts
-QUEST_LV_0100_20150317_005272	Rexipher disappeared with Zachariel's clues. Go to liason official Veil and ask about Rexipher's whereabouts.
-QUEST_LV_0100_20150317_005273	Veil says he doesn't know Rexipher. Ask other historians for Rexipher's whereabouts.
-QUEST_LV_0100_20150317_005274	Historian Colin says he doesn't know Rexipher. Ask other historians for Rexipher's whereabouts.
-QUEST_LV_0100_20150317_005275	Ask Cyrenia Odelle for Rexipher's whereabouts
-QUEST_LV_0100_20150317_005276	Rexipher took all the clues of Zachariel so you must find him no matter what. Ask about him again. 
-QUEST_LV_0100_20150317_005277	Trace Rexipher's whereabouts
-QUEST_LV_0100_20150317_005278	You were not able to find Rexipher's wherabouts but you found out that Rexipher is a demon's name. Continue investigating about Rexipher. 
-QUEST_LV_0100_20150317_005279	Go to Chesed Altar where Rexepher stayed
-QUEST_LV_0100_20150317_005280	A man looking like Rexipher is attacking historians in Chesed Altar and Gedula Altar to control the altar. First, go the the Chesed altar.
-QUEST_LV_0100_20150317_005281	Defeat the Hogmas
+xQUEST_LV_0100_20150317_005270	Get Hogma's Teeth
+xQUEST_LV_0100_20150317_005271	Find out Rexipher's Whereabouts
+xQUEST_LV_0100_20150317_005272	Rexipher disappeared with Zachariel's clues. Go to Liason Official Veil and ask about Rexipher's whereabouts.
+xQUEST_LV_0100_20150317_005273	Veil says he doesn't know Rexipher. Ask other historians for Rexipher's whereabouts.
+xQUEST_LV_0100_20150317_005274	Historian Colin says he doesn't know Rexipher, either. Ask other historians for Rexipher's whereabouts.
+xQUEST_LV_0100_20150317_005275	Ask Cyrenia Odelle for Rexipher's Whereabouts
+xQUEST_LV_0100_20150317_005276	Rexipher took all of Zachariel's clues; you must find him, no matter what. Ask about him again. 
+xQUEST_LV_0100_20150317_005277	Trace Rexipher's Whereabouts
+xQUEST_LV_0100_20150317_005278	You were not able to find Rexipher's whereabouts, but you found out that Rexipher is a demon's name. Continue investigating Rexipher. 
+QUEST_LV_0100_20150317_005279	Go to Chesed Altar where Rexipher Stayed
+xQUEST_LV_0100_20150317_005280	A man looking like Rexipher is attacking historians at the Chesed and Gedula Altars to take control of the area. First, go the the Chesed Altar.
+xQUEST_LV_0100_20150317_005281	Defeat the Hogmas
 QUEST_LV_0100_20150317_005282	
 QUEST_LV_0100_20150317_005283	
-QUEST_LV_0100_20150317_005284	Talk to historian Cyrenia Odelle
-QUEST_LV_0100_20150317_005285	Cyrenia Odelle came near the altar. Talk to her.
-QUEST_LV_0100_20150317_005286	Talk to historian Cyrenia Odelle
+xQUEST_LV_0100_20150317_005284	Talk to Historian Cyrenia Odelle
+xQUEST_LV_0100_20150317_005285	Cyrenia Odelle came to the altar. Talk to her.
+xQUEST_LV_0100_20150317_005286	Talk to Historian Cyrenia Odelle
 QUEST_LV_0100_20150317_005287	
 QUEST_LV_0100_20150317_005288	
 QUEST_LV_0100_20150317_005289	
-QUEST_LV_0100_20150317_005290	Talk to Cyrenia Odelle
+xQUEST_LV_0100_20150317_005290	Talk to Cyrenia Odelle
 QUEST_LV_0100_20150317_005291	
 QUEST_LV_0100_20150317_005292	
 QUEST_LV_0100_20150317_005293	
 QUEST_LV_0100_20150317_005294	
 QUEST_LV_0100_20150317_005295	
 QUEST_LV_0100_20150317_005296	
-QUEST_LV_0100_20150317_005297	Go to Cyrenia Odelle
-QUEST_LV_0100_20150317_005298	Cetek Altar was destroyed but you managed to release the seal of Sviesa Altar. Talk to Cyrenia Odelle.
-QUEST_LV_0100_20150317_005299	Defeat Rexipher's subordinates
-QUEST_LV_0100_20150317_005300	Rexipher kidnapped Cyrenia Odelle! Vetter kill his subordinates and follow him.
+xQUEST_LV_0100_20150317_005297	Go to Cyrenia Odelle
+QUEST_LV_0100_20150317_005298	The Chesed Altar was destroyed but you managed to release the seal of Sviesa Altar. Talk to Cyrenia Odelle.
+xQUEST_LV_0100_20150317_005299	Defeat Rexipher's Subordinates
+xQUEST_LV_0100_20150317_005300	Rexipher kidnapped Cyrenia Odelle! Better kill his subordinates and follow him.
 QUEST_LV_0100_20150317_005301	
-QUEST_LV_0100_20150317_005302	Create Crude Explorer Stick
-QUEST_LV_0100_20150317_005303	Epigraphis Raymond wants to use the branches of small tree to make an explorer stick and find the piece of memorial stone. 
-QUEST_LV_0100_20150317_005304	Find the first piece of Memorial stone
-QUEST_LV_0100_20150317_005305	Raymond asked you to gather small tree branches from small tree and make an explorer stick. 
-QUEST_LV_0100_20150317_005306	Small tree branch
-QUEST_LV_0100_20150317_005307	Find the first piece of Gravestone
-QUEST_LV_0100_20150317_005308	Made the Crude Explorer stick using the samll tree. Use it to find the firest piece of gravestone.
-QUEST_LV_0100_20150317_005309	Fond the first piece of gravestone. Go back to Raymond. 
-QUEST_LV_0100_20150317_005310	Find the second piece of gravestone under Sekrus Bridge
-QUEST_LV_0100_20150317_005311	Raymond told you where the seconds piece of gravestone might be. First, check if this unique slate is the the second piece of gravestone.
-QUEST_LV_0100_20150317_005312	Could not find it in the unique slate but you defeated Echat and got the second piece of gravestone. Go back to Raymond. 
-QUEST_LV_0100_20150317_005313	Defeat Echat
-QUEST_LV_0100_20150317_005314	Collect the dusty ruins
-QUEST_LV_0100_20150317_005315	Raymond asked you to collect pieces of dusty ruins from Gaisra Battlefield. He tols you to kill the Treeambulo and get it back if it steals the ruins from you. 
-QUEST_LV_0100_20150317_005316	Gathered enough pieces of dusty ruins. Give it to Raymond. 
-QUEST_LV_0100_20150317_005317	Burn Treeambulo and get carbonized pieces
-QUEST_LV_0100_20150317_005318	Raymond told you to light the firewood in Gaisra Battlefield and kill the Treeambulos to burn it to get carbonized pieces. 
-QUEST_LV_0100_20150317_005319	Collected enough carbonized pieces. Take it to Ryamond. 
-QUEST_LV_0100_20150317_005320	Collect carbonized pieces of ruins
+xQUEST_LV_0100_20150317_005302	Create Crude Explorer Stick
+xQUEST_LV_0100_20150317_005303	Epigraphis Raymond wants to use Small Tree Branches to make a Crude Explorer Stick, useful for finding the Gravestone Pieces. 
+xQUEST_LV_0100_20150317_005304	Find the First Piece of Gravestone
+xQUEST_LV_0100_20150317_005305	Raymond asked you to gather Small Tree Branches and make a Crude Explorer Stick. 
+xQUEST_LV_0100_20150317_005306	Small Tree Branch
+xQUEST_LV_0100_20150317_005307	Find the First Piece of Gravestone
+xQUEST_LV_0100_20150317_005308	Made the Crude Explorer stick using the Small Tree Branches. Use it to find the First Piece of Gravestone.
+xQUEST_LV_0100_20150317_005309	Found the First Piece of Gravestone. Go back to Raymond. 
+xQUEST_LV_0100_20150317_005310	Find the Second Piece of Gravestone under Sekrus Bridge
+xQUEST_LV_0100_20150317_005311	Raymond told you where the Second Piece of Gravestone might be. First, make sure this unique slate is actually the Second Piece of Gravestone.
+xQUEST_LV_0100_20150317_005312	The unique slate wasn't the real thing, but you defeated Echat and got the Second Piece of Gravestone. Go back to Raymond. 
+xQUEST_LV_0100_20150317_005313	Defeat Echat
+xQUEST_LV_0100_20150317_005314	Collect the Dusty Ruins
+xQUEST_LV_0100_20150317_005315	Raymond asked you to collect pieces of the Dusty Ruins from Gaisra Battlefield. He told you to kill the Treeambuloes and get the Dusty Ruins back if they happen to steal any from you. 
+xQUEST_LV_0100_20150317_005316	Gathered enough Dusty Ruins. Give them to Raymond. 
+xQUEST_LV_0100_20150317_005317	Burn Treeambuloes and get Carbonized Pieces
+xQUEST_LV_0100_20150317_005318	Raymond told you to light the firewood in Gaisra Battlefield and kill the Treeambuloes, then burn them to get carbonized pieces. 
+xQUEST_LV_0100_20150317_005319	Collected enough Carbonized Pieces. Take them to Ryamond. 
+QUEST_LV_0100_20150317_005320	Collect Carbonized Pieces
 QUEST_LV_0100_20150317_005321	Go and talk to the Cleric Master in Klaipeda
 QUEST_LV_0100_20150317_005322	Learn about the Attributes
 QUEST_LV_0100_20150317_005323	Learn attributes and talk to the Cleric Master


### PR DESCRIPTION
The wording on line 5279 is kinda awkward.  Not sure if it's talking about the true demon (in the past) or the demon in human form. I left the "x" off for further editing.

Line 5298 refers to the previously mentioned "Chesed Altar" as "Cetek Altar."  I kept it as Chesed for uniformity.  Correct me if I'm wrong here.  Also, not sure if Sviesa Altar is a third, previously unmentioned altar, or a different translation for the previously mentioned Gedula altar. Finally, I'm not sure if a seal is on the altars, or the altars contain a beneficial seal.  I just left it as is ("seal of Sviesa Altar," versus "seal on Sviesa Altar").  I kept the "x" off for now, and left it as Sviesa.

From line 5303 on till the end of the quest, the description of the object being gathered keeps changing from "gravestone" to "memorial stone."  I made it gravestone, only.

Line 5311 mentions "unique slate," of which is implied to be under the bridge.  However, I'm not sure if it's referring to a patch of slate in the ground / in the bridge, or a chunk of slate laying around on its own??  I'm going with the idea that it's a piece that fell off underside of the bridge.

Line 5317 brings up Treeambulo, which I changed to be plural with an -es ending (like Buffalo -> Buffaloes).

Line 5320: Based on the previous formatting of the quest, the quest tracker lines were sometimes listed after the objective was completed / listed them twice (quest tracker and then some other context).  That being said, I feel it's referring the Treeambulo pieces again, but I'm not 100% that it isn't referring to a new "Carbonized Piece of Ruin."  But I don't think that's correct - please provide some input.  Left the "x" off for now.
