### PR TITLE
QUEST_LV_0100

### DIFF
--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -2251,17 +2251,17 @@ QUEST_LV_0100_20150317_002250	Ordinary Man
 QUEST_LV_0100_20150317_002251	This is the back plate. {nl} I'll let you craft when we have all the other materials ready.
 QUEST_LV_0100_20150317_002252	Here you go. This is a Chest protector made of leather. {nl}It was fun to do this in a long time.
 QUEST_LV_0100_20150317_002253	Bone fragments are seen in the well.
-QUEST_LV_0100_20150317_002254	I'm furious and upset. {nl} Only if we arrived earlier, we could have saved ourselves from being totally wiped out .. {nl}
-QUEST_LV_0100_20150317_002255	Dear Revelator, I have a favor to ask of you. {nl}Can you get us back the keepstakes of my comrades?
-QUEST_LV_0100_20150317_002256	It's bad enough that they were killed by the Vubbes but even their keepstakes are being abused. What an awful thing.
-QUEST_LV_0100_20150317_002257	Thank you. {nl} My comrades who passed away will now be able to rest in peace.
-QUEST_LV_0100_20150317_002258	Oh my God. The Vubbes stole all the food supplies. {nl} They took even our immediate food... Please help us with your strength.
-QUEST_LV_0100_20150317_002259	They stole the food meant for both the army and residents. {nl} What do we do if we can't get back our food.. {nl}
-QUEST_LV_0100_20150317_002260	Thank you. {nl} This will at least get us to live for the few days.
-QUEST_LV_0100_20150317_002261	Thank you very much for your help previously but there are more keepstakes that need to be retrieved. {nl} Think of my comrades who can't rest in peace.. {nl}
-QUEST_LV_0100_20150317_002262	So please help us. {nl} If you get us back the rest of the keepstakes, we will compensate for it.
+xQUEST_LV_0100_20150317_002254	I'm furious and upset. {nl} If we got here earlier, we wouldn't have been totally wiped out ... {nl}
+xQUEST_LV_0100_20150317_002255	Dear Revelator, I have a favor to ask of you. {nl}Can you return the keepstakes of my comrades?
+xQUEST_LV_0100_20150317_002256	It's bad enough that they were killed by the Vubbes, but even their keepstakes are being abused. How awful...
+xQUEST_LV_0100_20150317_002257	Thank you. {nl} My comrades will now be able to rest in peace.
+xQUEST_LV_0100_20150317_002258	Oh my God. The Vubbes stole all the food supplies. {nl} They took even our immediate food... Please use your strength to help us.
+xQUEST_LV_0100_20150317_002259	They stole the food meant for both the army and the residents. {nl} What do we do if we can't get back our food.. {nl}
+xQUEST_LV_0100_20150317_002260	Thank you. {nl} This will at least get us through the next few days.
+xQUEST_LV_0100_20150317_002261	Thank you for your help earlier, but there are more keepsakes that need to be retrieved. {nl} Think of my comrades who can't rest in peace.. {nl}
+xQUEST_LV_0100_20150317_002262	So please help us. {nl} If you get us back the rest of the keepsakes, we will provide compensation.
 QUEST_LV_0100_20150317_002263	Thank you, but we still need more... {nl} Sorry.. {nl}
-QUEST_LV_0100_20150317_002264	We collected almost all the keepsakes.. {nl} Please help us til the end.
+QUEST_LV_0100_20150317_002264	We collected almost all the keepsakes... {nl} Please help us til the end.
 QUEST_LV_0100_20150317_002265	It hurts to think about giving these keepstakes to my dead comrades' families.
 QUEST_LV_0100_20150317_002266	Thank you very much. {nl} My comrades can now rest in peace with the Goddesses.
 QUEST_LV_0100_20150317_002267	We survived immediate danger with your help last time but we still need more. {nl} Could you help us out a bit more?
@@ -2271,9 +2271,9 @@ QUEST_LV_0100_20150317_002270	Fedimian Resident
 QUEST_LV_0100_20150317_002271	I heard the wise man Maven who built the great cathedral left five necklaces.{nl}I also heard that the one who collects those five necklaces will possess the great power.
 QUEST_LV_0100_20150317_002272	Hey, if you are planning to keep on your journey, don't get close to the cursed city.{nl}It didn't even receive the blessing on the divine day. You will turn into a stone if you get close to the city.
 QUEST_LV_0100_20150317_002273	It's true that I am looking for the revelator, but I need someone skillful.{nl}I am sorry, but you don't look like the revelator I am looking for.
-QUEST_LV_0100_20150317_002274	There is the great cathedral which was built by Maven beyond Pilgrim's Way.{nl}Ruklys, Lydia Schaffen, Agailla Flurry are all his disciples.
-QUEST_LV_0100_20150317_002275	The great cathedral was destroyed a lot on the divine day so I wonder if there are still people going there, but..{nl}There were many people going there to do various rituals before.
-QUEST_LV_0100_20150317_002276	They call the way to the great cathedral, Pilgrim's Way.
+xQUEST_LV_0100_20150317_002274	There is The Great Cathedral, which was built by Maven, beyond Pilgrim's Way.{nl}Ruklys, Lydia Schaffen, and Agailla Flurry are all his disciples.
+xQUEST_LV_0100_20150317_002275	The Great Cathedral was significantly damaged on The Divine Day, so I wonder if there are people still going there, but...{nl}There once was a great many of people going there to do various rituals.
+xQUEST_LV_0100_20150317_002276	They call the trail to The Great Cathedral, Pilgrim's Way.
 QUEST_LV_0100_20150317_002277	Welcome. {nl} These items were hard to get.
 QUEST_LV_0100_20150317_002278	Hawkers of Klaipeda
 QUEST_LV_0100_20150317_002279	I came to pray in the distance Klaipeda. {nl} again as disaster does not occur, I like son between the army returns Moruchonhi.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -2252,21 +2252,21 @@ QUEST_LV_0100_20150317_002251	This is the back plate. {nl} I'll let you craft wh
 QUEST_LV_0100_20150317_002252	Here you go. This is a Chest protector made of leather. {nl}It was fun to do this in a long time.
 QUEST_LV_0100_20150317_002253	Bone fragments are seen in the well.
 xQUEST_LV_0100_20150317_002254	I'm furious and upset. {nl} If we got here earlier, we wouldn't have been totally wiped out ... {nl}
-xQUEST_LV_0100_20150317_002255	Dear Revelator, I have a favor to ask of you. {nl}Can you return the keepstakes of my comrades?
-xQUEST_LV_0100_20150317_002256	It's bad enough that they were killed by the Vubbes, but even their keepstakes are being abused. How awful...
+xQUEST_LV_0100_20150317_002255	Dear Revelator, I have a favor to ask of you. {nl}Can you return the keepsakes of my comrades?
+xQUEST_LV_0100_20150317_002256	It's bad enough that they were killed by the Vubbes, but even their keepsakes are being abused. How awful...
 xQUEST_LV_0100_20150317_002257	Thank you. {nl} My comrades will now be able to rest in peace.
 xQUEST_LV_0100_20150317_002258	Oh my God. The Vubbes stole all the food supplies. {nl} They took even our immediate food... Please use your strength to help us.
 xQUEST_LV_0100_20150317_002259	They stole the food meant for both the army and the residents. {nl} What do we do if we can't get back our food.. {nl}
 xQUEST_LV_0100_20150317_002260	Thank you. {nl} This will at least get us through the next few days.
 xQUEST_LV_0100_20150317_002261	Thank you for your help earlier, but there are more keepsakes that need to be retrieved. {nl} Think of my comrades who can't rest in peace.. {nl}
 xQUEST_LV_0100_20150317_002262	So please help us. {nl} If you get us back the rest of the keepsakes, we will provide compensation.
-QUEST_LV_0100_20150317_002263	Thank you, but we still need more... {nl} Sorry.. {nl}
-QUEST_LV_0100_20150317_002264	We collected almost all the keepsakes... {nl} Please help us til the end.
-QUEST_LV_0100_20150317_002265	It hurts to think about giving these keepstakes to my dead comrades' families.
-QUEST_LV_0100_20150317_002266	Thank you very much. {nl} My comrades can now rest in peace with the Goddesses.
-QUEST_LV_0100_20150317_002267	We survived immediate danger with your help last time but we still need more. {nl} Could you help us out a bit more?
-QUEST_LV_0100_20150317_002268	I'm enraged thinking about the Vubbes who will be hearily satisfied with our food. {nl}Especially at such difficult times nowadays.
-QUEST_LV_0100_20150317_002269	Thank you. {nl} We still lack some but at least we got back this much.
+xQUEST_LV_0100_20150317_002263	Thank you, but we still need more... {nl} Sorry... {nl}
+xQUEST_LV_0100_20150317_002264	We've almost collected all the keepsakes... {nl} Please help us til the end.
+xQUEST_LV_0100_20150317_002265	It hurts to think about giving these keepsakes to my dead comrades' families.
+xQUEST_LV_0100_20150317_002266	Thank you very much. {nl} My comrades can now rest in peace with the Goddesses.
+xQUEST_LV_0100_20150317_002267	We survived immediate danger with your help earlier, but we still need some assistance. {nl} Could you help us out a bit more?
+xQUEST_LV_0100_20150317_002268	I'm enraged thinking about the Vubbes who will be heartily satisfied with our food. {nl}Especially with such difficult times nowadays.
+xQUEST_LV_0100_20150317_002269	Thank you. {nl} We're still lacking some goods, but at least we got back this much.
 QUEST_LV_0100_20150317_002270	Fedimian Resident
 QUEST_LV_0100_20150317_002271	I heard the wise man Maven who built the great cathedral left five necklaces.{nl}I also heard that the one who collects those five necklaces will possess the great power.
 QUEST_LV_0100_20150317_002272	Hey, if you are planning to keep on your journey, don't get close to the cursed city.{nl}It didn't even receive the blessing on the divine day. You will turn into a stone if you get close to the city.
@@ -3806,7 +3806,7 @@ QUEST_LV_0100_20150317_003805	To the Overlong Bridge Valley
 QUEST_LV_0100_20150317_003806	
 QUEST_LV_0100_20150317_003807	Notice/Arrived at the Fallen Worry Forest where the Brambles are hiding.#3
 QUEST_LV_0100_20150317_003808	A Soldier's Favor
-QUEST_LV_0100_20150317_003809	I'll gather the keepstakes
+QUEST_LV_0100_20150317_003809	I'll gather the keepsakes
 QUEST_LV_0100_20150317_003810	Stolen Food Supplies
 QUEST_LV_0100_20150317_003811	I'll get back the food supplies from the Vubbes
 QUEST_LV_0100_20150317_003812	Sorry, I'm busy
@@ -4028,7 +4028,7 @@ QUEST_LV_0100_20150317_004027	Rescue Varkis who is under attack
 QUEST_LV_0100_20150317_004028	Varkis is under attack! Defeat the monsters and rescue him.
 QUEST_LV_0100_20150317_004029	You defeated the monster but Varkis is seriously injured. Talk to Varkis.
 QUEST_LV_0100_20150317_004030	Get rid of Rajatoad
-QUEST_LV_0100_20150317_004031	Burn the keepstakes of Varkis in his camp and comfort his soul.
+QUEST_LV_0100_20150317_004031	Burn the keepsakes of Varkis in his camp and comfort his soul.
 QUEST_LV_0100_20150317_004032	Varkis did not make it. Comfort Varkis' soul by burning his journal in the bonfire in his camp.
 QUEST_LV_0100_20150317_004033	Collect data of Explorer Varkis
 QUEST_LV_0100_20150317_004034	Seems like Varkis is still attached to his research work. Collect his data around the Dykyne Crossroads.
@@ -6348,8 +6348,8 @@ QUEST_LV_0100_20150317_006347
 QUEST_LV_0100_20150317_006348	Talk to Soldier Jace
 QUEST_LV_0100_20150317_006349	Talk to Soldier Jace.
 QUEST_LV_0100_20150317_006350	Retrieving memento of soldiers
-QUEST_LV_0100_20150317_006351	Vubbes stole keepstakes of the dead troops. Get it back from Vubbes so that the troops can rest in peace.
-QUEST_LV_0100_20150317_006352	Colleted all the keepstakes. Bring it to Soldier Jays.
+QUEST_LV_0100_20150317_006351	Vubbes stole keepsakes of the dead troops. Get it back from Vubbes so that the troops can rest in peace.
+QUEST_LV_0100_20150317_006352	Colleted all the keepsakes. Bring it to Soldier Jays.
 QUEST_LV_0100_20150317_006353	Defeat Vubbe and get %s
 QUEST_LV_0100_20150317_006354	Get rid of the Vubbe Thief
 QUEST_LV_0100_20150317_006355	Talk to Soldier Edgar


### PR DESCRIPTION
Corrected all instances of "keepsakes" being spelled "keepstakes."  I didn't x off some lines, as I didn't completely proof the random ones not near the quest (only corrected the known typo).
