### PR TITLE
Update QUEST_LV_0100.tsv

### DIFF
--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -1,117 +1,117 @@
 ﻿QUEST_LV_0100_20150317_000001	Sentinel
-QUEST_LV_0100_20150317_000002	You better go straight to Shadow Forest Road if you want to go to Klaipeda. {nl} It is dangerous in the deep woods so try to stay away if you can.
+QUEST_LV_0100_20150317_000002	You better go directly via Shadow Forest Road if you want to go to Klaipeda.{nl}The deep woods are dangerous, so try to stay away if you can.
 QUEST_LV_0100_20150317_000003	Man in hiding
-QUEST_LV_0100_20150317_000004	Fi... Finally! Has help arrived? {nl} What! It's just a kid? Hey, are there still Vubbes outside?
-QUEST_LV_0100_20150317_000005	Ughh... Go away! Do not talk to me! We're going to get caught by the Vubbes! {nl} This is my place so get out of here!
-QUEST_LV_0100_20150317_000006	What? Do not lie to me! The Vubbes' odor is stinging my nose. What!! {nl} Hey, you don't fool adults! Go away! Do not come near this barrel!
-QUEST_LV_0100_20150317_000007	Fi... Finally! Has the rescue arrived? {nl} What! It's just a kid? What are you looking at? Close the lid and just go on your way! {nl}
-QUEST_LV_0100_20150317_000008	But the paper you're holding... It looks familiar? {nl} Let me see that! What are you doing? There's an adult speaking to you!
-QUEST_LV_0100_20150317_000009	This!! It's mine?! I will never give it away again!! {nl} It's not something you need - I'm gonna rip it apart!
+QUEST_LV_0100_20150317_000004	Fi... Finally! Has help arrived?{nl}What, it's just a kid? Hey... Are there still Vubbes outside?
+QUEST_LV_0100_20150317_000005	Ugh. Go away! Do not talk to me! We'll get caught by the Vubbes!{nl}This is my place so get out of here!
+QUEST_LV_0100_20150317_000006	What? Do not lie to me! I can smell the Vubbes from here.{nl}You can't fool an adult! Go away! Do not come near this barrel!
+QUEST_LV_0100_20150317_000007	Fi... Finally! Has help arrived?{nl}What, it's just a kid? What are you looking at? Close the lid and just go away!{nl}
+QUEST_LV_0100_20150317_000008	What's that paper you're holding? It looks familiar...{nl}Let me see that! What are you doing? Hey, there's an adult speaking to you!
+QUEST_LV_0100_20150317_000009	This paper, it's mine! I'm never giving it away again!!{nl}It's.. not something you need - I'll just rip it apart. There.
 QUEST_LV_0100_20150317_000010	Sheesh, that's lame...
-QUEST_LV_0100_20150317_000011	This is the first sign after all the goddesses disappeared.{nl}Maybe, out of all those people, one person may bring the goddesses back.
+QUEST_LV_0100_20150317_000011	This is the first sign after all the goddesses disappeared.{nl}Maybe one of these people will be the one to bring the goddesses back.
 QUEST_LV_0100_20150317_000012	Soldier Blag
-QUEST_LV_0100_20150317_000013	I warn you! {nl}Monsters are attacking, so all citizens must run way! {nl}By the way, how come those citizens are in the military zone?{nl}
-QUEST_LV_0100_20150317_000014	Ah, so you are the Revelator! I am sorry that I didn't recognize you.{nl}Monsters are attacking the supply base at the moment.{nl}I need to take some important rations out from the base... Please help me!
-QUEST_LV_0100_20150317_000015	It was silent not too long ago, but now they are coming in a group.{nl}What is happening?
-QUEST_LV_0100_20150317_000016	I felt unsafe...{nl}But, I didn't expect they would come en masse.
-QUEST_LV_0100_20150317_000017	You'll see the 1st supply warehouse when you go straight up the road.{nl}Please take out some remaining supplies...damn...
-QUEST_LV_0100_20150317_000018	In case you may need it in the future, I wrote down who Sparnas is.{nl}You may not know, but I was a biologist 4 years ago.
-QUEST_LV_0100_20150317_000019	Please pass this report to Luders. {nl}He is probably at the central supply base.
+QUEST_LV_0100_20150317_000013	Be warned!{nl}Monsters are attacking, so all citizens must evacuate!{nl}By the way, how come those citizens are in the military zone?{nl}
+QUEST_LV_0100_20150317_000014	Ah, so you are the Revelator! I'm sorry, I didn't recognize you.{nl}Monsters are attacking the supply base at the moment.{nl}I need to take some important rations out from the base. Please help me!
+QUEST_LV_0100_20150317_000015	It was quiet not too long ago, but now they are coming in groups.{nl}What is happening?
+QUEST_LV_0100_20150317_000016	I felt unsafe...{nl}But, I didn't expect they would be coming en masse.
+QUEST_LV_0100_20150317_000017	You'll see the 1st supply warehouse as you head up the road.{nl}Please bring some of the remaining supplies.
+QUEST_LV_0100_20150317_000018	I wrote down who Sparnas is, in case you need it in the future.{nl}You may not know, but I was a biologist four years ago.
+QUEST_LV_0100_20150317_000019	Please pass this report to Luders.{nl}He is probably at the central supply base.
 QUEST_LV_0100_20150317_000020	Officer Luders
-QUEST_LV_0100_20150317_000021	Ah, you must be the rumored Revelator. Nice to meet you.{nl}Is this Blag's report?{nl}
-QUEST_LV_0100_20150317_000022	Hmm... Is that so?{nl}They just destroyed the supplies and ran away. Even if Chupacabras have wings, I am sure that they can't do something like this.{nl}
-QUEST_LV_0100_20150317_000023	It is little less.{nl}I am sorry, but please bring us Moody's report at the crooked roat in Amzina.
+QUEST_LV_0100_20150317_000021	Ah, you must be the so called Revelator. Nice to meet you.{nl}Is this Blag's report?{nl}
+QUEST_LV_0100_20150317_000022	Hmm... Is that so?{nl}They just destroyed the supplies and ran away. Even if Chupacabras have wings, I am sure they can't do something like this.{nl}
+QUEST_LV_0100_20150317_000023	It is little less.{nl}I am sorry, but please bring us Moody's report from the crooked roat in Amzina.
 QUEST_LV_0100_20150317_000024	I feel safe since Luders is here.
 QUEST_LV_0100_20150317_000025	Soldier York
-QUEST_LV_0100_20150317_000026	Siaulambs are breaking the norms.{nl}I am in panic myself, so I don't know what to do.{nl}Luders will not stand this... What should we do?
+QUEST_LV_0100_20150317_000026	Siaulambs are breaking the norms.{nl}I am in a panic myself, so I don't know what to do.{nl}Luders will not stand for this... What should we do?
 QUEST_LV_0100_20150317_000027	Do you think the problem would be resolved by just defeating Sparnas?
 QUEST_LV_0100_20150317_000028	Thanks to your help, I think I can get myself together.{nl}But... this kind of thing will happen again right? Then what should I do...?
-QUEST_LV_0100_20150317_000029	Sparnas? We don't have an answer for that.{nl}It just appears from the sky without any signs, destroys all supplies and just dissappears.{nl}I get a headache by just hearing its cries.
-QUEST_LV_0100_20150317_000030	The place I just talked about is the 2nd supply warehouse. {nl}It is depressing to think about how these kind of things will be recurring in the fututre
-QUEST_LV_0100_20150317_000031	Take it. I made a bait from the old grains in the supplies.{nl}I will lure him up there, so you stay here.{nl}Sparnas will definitely appear at one of these two places. Do not miss it, and destroy it for sure.{nl}
+QUEST_LV_0100_20150317_000029	Sparnas? We don't have an answer for that.{nl}It just appears from the sky without any signs, destroys all supplies and then dissappears.{nl}I get a headache just hearing its cries.
+QUEST_LV_0100_20150317_000030	The place I just talked about is the 2nd supply warehouse.{nl}It is depressing to think how these kinds of things will be recurring in the future.
+QUEST_LV_0100_20150317_000031	Take it. I made some bait from old grains in the supplies.{nl}I will lure him up there, so you stay here.{nl}Sparnas will definitely appear at one of these two places. Do not miss it, and destroy it for sure.{nl}
 QUEST_LV_0100_20150317_000032	We may not get a second chance if we don't defeat it this time.{nl}They're not idiots.
-QUEST_LV_0100_20150317_000033	I heard the sound of fighting so I came in a hurry...Have you defeated it?{nl}I only spotted Siaulambs.{nl}Well done. You have performed a meritorious deed.
+QUEST_LV_0100_20150317_000033	I heard the sound of fighting so I came in a hurry. Have you defeated it?{nl}I only spotted Siaulambs.{nl}Well done. You have performed a meritorious deed.
 QUEST_LV_0100_20150317_000034	Adjutant Paulina
-QUEST_LV_0100_20150317_000035	We should retrieve the stolen objects. {nl}They can't say they are the soldiers of the kingdom if they just get attacked.
-QUEST_LV_0100_20150317_000036	We should get back the stolen stuffs.{nl}We shouldn't call ourself soldiers if we just do nothing.{nl}
-QUEST_LV_0100_20150317_000037	I feel so upset enduring this all the time.{nl}Reinforcement should come soon. What can we expect from such an imcompetent kingdom?
+QUEST_LV_0100_20150317_000035	We should recover the stolen items.{nl}They can't say they are the soldiers of the kingdom if they just get attacked.
+QUEST_LV_0100_20150317_000036	We should recover the stolen items.{nl}We can't call ourselves soldiers if we just do nothing.{nl}
+QUEST_LV_0100_20150317_000037	I feel so upset having to endure this all the time.{nl}Reinforcements should be coming soon, but what can we expect from such an imcompetent kingdom?
 QUEST_LV_0100_20150317_000038	Adjutant Volda
-QUEST_LV_0100_20150317_000039	You must be late for other things, so thank you so much.{nl}We can't just sit here and wait. We plan to keep attacking.
+QUEST_LV_0100_20150317_000039	Thank you very much, but you must be late for other things.{nl}Besides we can't just sit here and wait. We plan to keep attacking.
 QUEST_LV_0100_20150317_000040	Secret Guardian
-QUEST_LV_0100_20150317_000041	The goddess already forecasted this.{nl}No beings can escape from her vision.
+QUEST_LV_0100_20150317_000041	The goddess already foretold this.{nl}No beings can escape from her vision.
 QUEST_LV_0100_20150317_000042	Liaison Officer Niels
 QUEST_LV_0100_20150317_000043	Hello.{nl}Have you seen an old man who lost his way?{nl}His name is Jonas.{nl}
-QUEST_LV_0100_20150317_000044	You haven't seen him.{nl}Where is he now then. He is in his dotage.
+QUEST_LV_0100_20150317_000044	You haven't seen him?{nl}Where is he now then..? He is old and weak.
 QUEST_LV_0100_20150317_000045	Jonas is a descendant of the family that has been protecting this royal tomb.{nl}He is a very important person to our lab team so please take good care of him.
 QUEST_LV_0100_20150317_000046	Archivist Jonas
 QUEST_LV_0100_20150317_000047	Our family has been waiting for you for a long time.{nl}Now is the time to give you the thing that we have been protecting for a long time.
-QUEST_LV_0100_20150317_000048	It is good to hear that Jonas has regained his conciousness. {nl}You are the person who lifted the light signal, right? {nl}
+QUEST_LV_0100_20150317_000048	It is good to hear that Jonas has regained his conciousness.{nl}You are the person who lifted the light signal, right?{nl}
 QUEST_LV_0100_20150317_000049	Ahylas came after seeing the light.{nl}Meet him downstairs.
-QUEST_LV_0100_20150317_000050	We haven't heard news from Kepeck for a long time after we sent him supplies.{nl}We don't have enough to form a search team, so please help us.
+QUEST_LV_0100_20150317_000050	We haven't heard any news from Kepeck for a long time after we sent him supplies.{nl}We don't have enough people to form a search team, so please help us find him.
 QUEST_LV_0100_20150317_000051	Historian Beard
-QUEST_LV_0100_20150317_000052	Always prepare for monsters' attacks.{nl}Especially, outside places like here.
+QUEST_LV_0100_20150317_000052	Always be prepared for monster attacks.{nl}Especially in places like here.
 QUEST_LV_0100_20150317_000053	Mercenary Mirta
 QUEST_LV_0100_20150317_000054	Didn't I already warn you?{nl}Please be careful next time.
 QUEST_LV_0100_20150317_000055	Historian Kepeck
-QUEST_LV_0100_20150317_000056	Niels must have sent you.{nl}Well, if you are in a hurry, record it yourself and take it to Niels.
-QUEST_LV_0100_20150317_000057	When you go straight on the right road and cross the bridge, you will see the artifacts of the great king, Zachariel. {nl}Record them and take that to Niels. He will understand.
+QUEST_LV_0100_20150317_000056	Niels must have sent you.{nl}Well, if you are in a hurry, record it yourself and take it back to Niels.
+QUEST_LV_0100_20150317_000057	When you go straight on the right road and cross the bridge, you will see the artifacts of the great King Zachariel.{nl}Record them and take the recordings to Niels. He will understand.
 QUEST_LV_0100_20150317_000058	So this is Kepeck's record... Mercenary Mirta was looking for this.{nl}I am okay as long as I can confirm their safety. Thank you for your efforts.
 QUEST_LV_0100_20150317_000059	Ahylas Jonas
 QUEST_LV_0100_20150317_000060	
 QUEST_LV_0100_20150317_000061	
 QUEST_LV_0100_20150317_000062	Disciple of Gustas
-QUEST_LV_0100_20150317_000063	Have you unlocked the seal of Pagasa cliff?{nl}It will start now.
-QUEST_LV_0100_20150317_000064	Words carved into a rock
+QUEST_LV_0100_20150317_000063	Have you unlocked the seal of Pagasa Cliff?{nl}It will start now.
+QUEST_LV_0100_20150317_000064	Words carved into a rock.
 QUEST_LV_0100_20150317_000065	Do not touch or push it.
 QUEST_LV_0100_20150317_000066	I was waiting for you.{nl}The next seal is located on the way to Broken Sanctum.
 QUEST_LV_0100_20150317_000067	You won't know how eagerly we have waited for this moment.{nl}We really wanted to meet you.
 QUEST_LV_0100_20150317_000068	Gustas Jonas
-QUEST_LV_0100_20150317_000069	So it's you. {nl}You are much more of a man compared to what I had imagined.
+QUEST_LV_0100_20150317_000069	So it's you.{nl}You are much more of a man compared to what I had imagined.
 QUEST_LV_0100_20150317_000070	Soldier Alan
-QUEST_LV_0100_20150317_000071	You are a new soldier right?{nl}I received a patrolling order, but I guess you can go on behalf of me.
-QUEST_LV_0100_20150317_000072	You are good.{nl}I don't want to go there due to a horrible memory.
-QUEST_LV_0100_20150317_000073	I am about to remember something...
+QUEST_LV_0100_20150317_000071	You are a new soldier right?{nl}I received a patrolling order, but I guess you can go my behalf.
+QUEST_LV_0100_20150317_000072	You're good.{nl}I don't want to go there. I had a horrible experience once.
+QUEST_LV_0100_20150317_000073	I'm remembering something...
 QUEST_LV_0100_20150317_000074	You know that we are dispatched here to destroy Gaigalas right?{nl}Hey newcomer. Can you take this report to Commander Wallis?
 QUEST_LV_0100_20150317_000075	Commander Wallis
 QUEST_LV_0100_20150317_000076	How come you brought this report instead of Alan?{nl}Are you a newcomer?
-QUEST_LV_0100_20150317_000077	I can return home after we defeat Gaigalas.{nl}Ah, I want to just go home.
+QUEST_LV_0100_20150317_000077	I can return home after we defeat Gaigalas.{nl}Ah, I just want to go home.
 QUEST_LV_0100_20150317_000078	Wallis is at Three Footsteps.
 QUEST_LV_0100_20150317_000079	I don't care how good you are. You are new here.{nl}It is an order. Bring some juice from Kepa Raiders.
-QUEST_LV_0100_20150317_000080	Guys these days, they don't have guts. {nl}I hope you're a good influence to them.
+QUEST_LV_0100_20150317_000080	Guys these days, they don't have any guts.{nl}I hope you're a good influence to them.
 QUEST_LV_0100_20150317_000081	I am sure we will win this battle.{nl}Why? Owls told us that they will help us.
-QUEST_LV_0100_20150317_000082	Kepa Raiders are near Lanutis Falls.{nl}To defeat Gaigalas, we really need that.
+QUEST_LV_0100_20150317_000082	The Kepa Raiders are near Lanutis Falls.{nl}To defeat Gaigalas, we really need that.
 QUEST_LV_0100_20150317_000083	Soldier Weisz
-QUEST_LV_0100_20150317_000084	Hey you are taking a rest?{nl}Get some oil from Duckeys at Lanvas Garden.
+QUEST_LV_0100_20150317_000084	Hey, are you taking a break?{nl}Get some oil from Duckeys at Lanvas Garden.
 QUEST_LV_0100_20150317_000085	We will lure Gaigalas using Duckey Oil.{nl}Hey newcomer, don't loaf around.
-QUEST_LV_0100_20150317_000086	Today will be the last day for Gaigalas.{nl}Newcomer, are you ready?
-QUEST_LV_0100_20150317_000087	Next, we will get leather from Cronewt that lives in Lanvas Garden.{nl}Move fast, soldier.
-QUEST_LV_0100_20150317_000088	We will win for sure this time.{nl}Since the goddesses are on our side.
-QUEST_LV_0100_20150317_000089	You are good for a newcomer.{nl}It's disordered here at the moment, so you keep those ingredients for now.{nl}
-QUEST_LV_0100_20150317_000090	While I make preparations for the battle, get to know our soldiers.{nl}I will call you before we confront Gaigalas.
+QUEST_LV_0100_20150317_000086	Today will be the last day for Gaigalas.{nl}Are you ready, newcomer?
+QUEST_LV_0100_20150317_000087	Next, we will get leather from the Cronewt that lives in Lanvas Garden.{nl}Move fast, soldier.
+QUEST_LV_0100_20150317_000088	We will win for sure this time.{nl}The goddesses are on our side.
+QUEST_LV_0100_20150317_000089	You are pretty good for a newcomer.{nl}It's disorganized here at the moment, so you can keep those ingredients for now.{nl}
+QUEST_LV_0100_20150317_000090	Get to know our soldiers while I make preparations for the battle.{nl}I will call you before we confront Gaigalas.
 QUEST_LV_0100_20150317_000091	When we burn the Duckey Oil, Gaigalas will appear after smelling the odor.{nl}Lanvas Garden will be a good place to burn it.
 QUEST_LV_0100_20150317_000092	My heart is pounding.{nl}I feel like my spirit is about to leave my body.
 QUEST_LV_0100_20150317_000093	Statue of Old Owl
 QUEST_LV_0100_20150317_000094	There's no one in this forest. Why are you here?{nl}
-QUEST_LV_0100_20150317_000095	Gaigalas?{nl}It will be difficult to defeat it without anything.
-QUEST_LV_0100_20150317_000096	I have seen many deaths here.{nl}I don't want to see anymore sacrifices.
-QUEST_LV_0100_20150317_000097	I need the juice from Kepa Raiders and the leather from Cronewt.
-QUEST_LV_0100_20150317_000098	Why do you have that?{nl}Please hand it to me. I will make a Fragment of Memory.
-QUEST_LV_0100_20150317_000099	I will revive the memories of our sleeping colleagues with this Fragment of Memory.
+QUEST_LV_0100_20150317_000095	Who? Gaigalas?{nl}Defeating it without any assitance will be difficult.
+QUEST_LV_0100_20150317_000096	I have seen many deaths here.{nl}I don't want to see any more sacrifices.
+QUEST_LV_0100_20150317_000097	I need Kepa Raider juice, and Cronewt leather.
+QUEST_LV_0100_20150317_000098	Why do you have that?{nl}Hand it to me and I will make a Fragment of Memory.
+QUEST_LV_0100_20150317_000099	With this Fragment of Memory I will revive the memories of our sleeping colleagues.
 QUEST_LV_0100_20150317_000100	It will be difficult to defeat it without the Fragment of Memory.{nl}Please bring the horn of Infroholder.
-QUEST_LV_0100_20150317_000101	How come you have all those ingredients?
+QUEST_LV_0100_20150317_000101	How come you have all these ingredients?
 QUEST_LV_0100_20150317_000102	
-QUEST_LV_0100_20150317_000103	We can calm them if we defeat Gaigalas.{nl}Please go see Worrying Owl.
+QUEST_LV_0100_20150317_000103	We can calm them if we defeat Gaigalas.{nl}Please go see the Worrying Owl.
 QUEST_LV_0100_20150317_000104	The Statue of Worrying Owl
 QUEST_LV_0100_20150317_000105	Please wake the sleeping colleagues and help us complete the magic on this day.{nl}With the Fragment of Memory.
 QUEST_LV_0100_20150317_000106	They will be satisfied.{nl}I will stand here while remembering our colleagues.
-QUEST_LV_0100_20150317_000107	You will find Gaigalas when you go to the entrance of Ishimtini.{nl}Please avenge our soldiers.
+QUEST_LV_0100_20150317_000107	You will find Gaigalas when you go to the entrance of Ishimtini.{nl}Please avenge our fallen soldiers.
 QUEST_LV_0100_20150317_000108	I was in an isolated place so I didn't fall asleep.{nl}But, watching it all was painful for me.
-QUEST_LV_0100_20150317_000109	My colleagues were attacked while they were trying to help soldiers.
+QUEST_LV_0100_20150317_000109	My colleagues were attacked while they were trying to help the soldiers.
 QUEST_LV_0100_20150317_000110	Some symbols started to show on the body of Jonas after he drank the medicine.
 QUEST_LV_0100_20150317_000111	Archaeologist Dezic
-QUEST_LV_0100_20150317_000112	I am looking for my assistant named Irene. {nl}Can you defeat all the monsters nearby so I can go look for her?
-QUEST_LV_0100_20150317_000113	I told him not to get excited even if he finds something.{nl}He did it again.
-QUEST_LV_0100_20150317_000114	Thanks.{nl}I will go first to look for Irene.
+QUEST_LV_0100_20150317_000112	I am looking for my assistant named Irene.{nl}Can you defeat the monsters nearby so I can go look for her?
+QUEST_LV_0100_20150317_000113	I told her not to get excited even if she finds something.{nl}She did it again.
+QUEST_LV_0100_20150317_000114	Thanks.{nl}I will go look for Irene.
 QUEST_LV_0100_20150317_000115	Technician Heinen
 QUEST_LV_0100_20150317_000116	
 QUEST_LV_0100_20150317_000117	
@@ -119,26 +119,26 @@ QUEST_LV_0100_20150317_000118
 QUEST_LV_0100_20150317_000119	Much better than I expected.{nl}I want to propose a deal to you.
 QUEST_LV_0100_20150317_000120	
 QUEST_LV_0100_20150317_000121	
-QUEST_LV_0100_20150317_000122	That barrier..when was it made?{nl}It has been there for quite some time, but I can't exactly remember when.{nl}
-QUEST_LV_0100_20150317_000123	I am sure that barrier is responsible for the increasing number of monsters lately.{nl}
+QUEST_LV_0100_20150317_000122	That barrier... When was it made?{nl}It has been there for quite some time, but I can't remember exactly how long.{nl}
+QUEST_LV_0100_20150317_000123	I'm sure that barrier is responsible for the increasing number of monsters lately.{nl}
 QUEST_LV_0100_20150317_000124	We don't have many soldiers here.{nl}No one in their right mind would come here in this day and age.{nl}
 QUEST_LV_0100_20150317_000125	Rolandas Jonas
-QUEST_LV_0100_20150317_000126	No one knows what the great king, Zachariel, tried to protect.{nl}But, I am sure that we are not the only ones who want to solve that mystery.
+QUEST_LV_0100_20150317_000126	No one knows what the great King Zachariel tried to protect.{nl}And I'm sure that we're not the only ones who want to solve that mystery.
 QUEST_LV_0100_20150317_000127	Please unleash the seals with this Key of the Great King at the Awaiting Stone Bridge.{nl}You will know what to do next.
 QUEST_LV_0100_20150317_000128	I found Irene, but I don't know how to rescue her.{nl}She is tied at the 2nd Architects' Site in Rodoma, but I can't rescue her myself...
 QUEST_LV_0100_20150317_000129	Assistant Irene
-QUEST_LV_0100_20150317_000130	I can't move due to the barrier.{nl}Please break the three barriers at Rodoma Architects' Site.
+QUEST_LV_0100_20150317_000130	I can't move because of the barrier.{nl}Please break the three barriers at the Rodoma Architects' Site.
 QUEST_LV_0100_20150317_000131	Not done yet? Damn...
 QUEST_LV_0100_20150317_000132	I didn't expect that I would fall into this kind of thing.{nl}Damn, I should not have followed him.
 QUEST_LV_0100_20150317_000133	Mercenary Glen
-QUEST_LV_0100_20150317_000134	So many researchers are disappearing these days.{nl}I am trying to get some clues by defeating Saugas, can you help us?
-QUEST_LV_0100_20150317_000135	Saugas distribute reward equally among themselves.{nl}Maybe we can find some clues there.
-QUEST_LV_0100_20150317_000136	Fortunately, they are very old.{nl}That means it's not due to monsters.
-QUEST_LV_0100_20150317_000137	This is a very dangerous place since many people have gone missing here.{nl}But, that is not the main problem here.{nl}
-QUEST_LV_0100_20150317_000138	Sometimes when certain people disappear, no one else notices.{nl}It's as if their memories have been erased. Isn't it strange?{nl}
-QUEST_LV_0100_20150317_000139	Please defeat all monsters nearby to prevent anything from happening.{nl}There were reports that the monsters at the 1st Architects' Place had turned violent.
+QUEST_LV_0100_20150317_000134	So many researchers are disappearing these days.{nl}I'm trying to find some clues by defeating Saugas. Can you help us?
+QUEST_LV_0100_20150317_000135	Saugas distribute rewards equally among themselves.{nl}Maybe we can find some clues there.
+QUEST_LV_0100_20150317_000136	Fortunately they are very old.{nl}That means it's not due to monsters.
+QUEST_LV_0100_20150317_000137	This is a very dangerous place and many people have gone missing here.{nl}But that is not the main problem here.{nl}
+QUEST_LV_0100_20150317_000138	Sometimes when certain people disappear no one else notices.{nl}It's as if all memories of those who disappear are erased. Isn't it strange?{nl}
+QUEST_LV_0100_20150317_000139	Please defeat all monsters nearby to prevent anything from happening.{nl}There were reports that the monsters at the 1st Architects' Site had turned violent.
 QUEST_LV_0100_20150317_000140	Very good indeed.{nl}We don't have to worry for a while.
-QUEST_LV_0100_20150317_000141	Monsters are coming.{nl}They probably found out I got released.
+QUEST_LV_0100_20150317_000141	Monsters are coming!{nl}They probably found out I was released.
 QUEST_LV_0100_20150317_000142	The goddesses sent you?{nl}I never thought that you would protect me.{nl}
 QUEST_LV_0100_20150317_000143	Where is that huge scorpion? We are in trouble!
 QUEST_LV_0100_20150317_000144	I should go see Dezik.{nl}I hope to see you again in the future.
@@ -146,323 +146,323 @@ QUEST_LV_0100_20150317_000145	Someone must have done something strange to the mo
 QUEST_LV_0100_20150317_000146	Sir, recover your consciousness. Sir!
 QUEST_LV_0100_20150317_000147	New Royal Tomb Researcher
 QUEST_LV_0100_20150317_000148	I lost my important research materials at the Abondoned Old Workplace.{nl}The monsters must have taken them... Should I just give up?
-QUEST_LV_0100_20150317_000149	I am so glad to see the Royal Tomb myself, but the monsters are scary.
-QUEST_LV_0100_20150317_000150	Thank you so much.{nl}But, please also check the Records Repository.
+QUEST_LV_0100_20150317_000149	I am so glad I get to see the Royal Tomb myself, but the monsters... They are scary.
+QUEST_LV_0100_20150317_000150	Thank you so much.{nl}But you should also check the Records Repository.
 QUEST_LV_0100_20150317_000151	The entrace to the Royal Tomb is hidden somewhere in this gigantic canyon.{nl}And this place is the start of the canyon.
-QUEST_LV_0100_20150317_000152	Many experts came here to conduct research on the Royal Tomb.{nl}Maybe, we can find some clues about Divine Day here.
+QUEST_LV_0100_20150317_000152	Many experts have come here to conduct research on the Royal Tomb.{nl}Maybe we can find some clues about the Divine Day here.
 QUEST_LV_0100_20150317_000153	Why are there so many monsters at the Canyon when there is such little plant life?
 QUEST_LV_0100_20150317_000154	What happened to my request? Is it not done yet?
-QUEST_LV_0100_20150317_000155	Look at the ground closely. {nl}It may have fallen down on the ground.
-QUEST_LV_0100_20150317_000156	Only these?{nl}Well, thank you for finding this much though.{nl}I can just copy again from the beginning.
-QUEST_LV_0100_20150317_000157	So Niels has also sent you?{nl}I am not going. I have to research about wild flowers.{nl}
-QUEST_LV_0100_20150317_000158	I guess I saw a delusion.{nl}I will compensate you for protecting me.{nl}
-QUEST_LV_0100_20150317_000159	Yes. {nl}Bring my record from Niels.
-QUEST_LV_0100_20150317_000160	Jonas told you to give you his record?{nl}Okay. Please also give him this medicine.{nl}
-QUEST_LV_0100_20150317_000161	This medicine will help recover conciousness.{nl}Davio at the right side of research camp has the medicine.
-QUEST_LV_0100_20150317_000162	Jonas is the head of the family that protects the Royal Tomb of Zachariel.{nl}He was very healthy before, but he is in his dotage.{nl}
+QUEST_LV_0100_20150317_000155	Look closely at the ground.{nl}It may have fallen down.
+QUEST_LV_0100_20150317_000156	Only these?{nl}Well, thank you for finding this much at least.{nl}I can just copy again from the beginning.
+QUEST_LV_0100_20150317_000157	So Niels has also sent you?{nl}I am not going. I have to research the wild flowers.{nl}
+QUEST_LV_0100_20150317_000158	I guess what I saw was a delusion.{nl}I will compensate you for protecting me.{nl}
+QUEST_LV_0100_20150317_000159	Yes.{nl}Bring my record from Niels.
+QUEST_LV_0100_20150317_000160	Jonas told you to bring his record?{nl}Okay. Would you please also bring him this medicine.{nl}
+QUEST_LV_0100_20150317_000161	The medicine will help recover conciousness.{nl}Davio at the right side of the research camp has the medicine.
+QUEST_LV_0100_20150317_000162	Jonas is the head of the family that protects the Royal Tomb of Zachariel.{nl}He was very healthy before, but these days he is old and weak.{nl}
 QUEST_LV_0100_20150317_000163	If Jonas was walking with his maid, then that's after you went outside.{nl}Jonas was found when he was in his dotage and the maid is still missing.
-QUEST_LV_0100_20150317_000164	Please take good care of Jonas.{nl}It would be a big trouble if he got hurt.
+QUEST_LV_0100_20150317_000164	Please take good care of Jonas.{nl}It would be a big problem if he got hurt.
 QUEST_LV_0100_20150317_000165	Davio is at the right side of the camp.{nl}I hope the medicine works well.
-QUEST_LV_0100_20150317_000166	Finally, I remember everything.{nl}I am the head of the family that protects the royal tomb..Who are you?{nl}
-QUEST_LV_0100_20150317_000167	Revelator. If this is the decision of the goddess, then it must be also your right.{nl}You have a job to do so follow me to the light signal place.
+QUEST_LV_0100_20150317_000166	Finally, I remember everything.{nl}I am the head of the family that protects the royal tomb... Who are you?{nl}
+QUEST_LV_0100_20150317_000167	Revelator. If this is the decision of the goddess, then you must be right.{nl}You have a job to do, so follow me to the light signal place.
 QUEST_LV_0100_20150317_000168	I have made Niels and you worry...
-QUEST_LV_0100_20150317_000169	I will lead the way and you will handle any approaching monsters.{nl}I am counting on you.
+QUEST_LV_0100_20150317_000169	I will lead the way and you will handle any monsters we encounter.{nl}I am counting on you.
 QUEST_LV_0100_20150317_000170	Now is our chance. Follow me!
 QUEST_LV_0100_20150317_000171	I am sure that you are qualified for this.{nl}Goddess Laima has led all these.
-QUEST_LV_0100_20150317_000172	I finally found someone to share this sad news.{nl}I regret not recognizing you sooner due to my dotage.
-QUEST_LV_0100_20150317_000173	Zachariel told me to share this sad news with the qualified person.{nl}See if you are qualifed for this at the Greak King's Eyes.
+QUEST_LV_0100_20150317_000172	I finally found someone to share this sad news with.{nl}I regret not recognizing you sooner due to my senility.
+QUEST_LV_0100_20150317_000173	Zachariel told me to share this sad news with the qualified person.{nl}See if you are qualifed for this at the Great King's Eyes.
 QUEST_LV_0100_20150317_000174	We have one more responsiblity besides protecting this Royal Tomb.{nl}To protect the sad news until the qualified person comes.{nl}
 QUEST_LV_0100_20150317_000175	I don't know what that sad news is.{nl}The king has told us to protect it so we are just following his order.
 QUEST_LV_0100_20150317_000176	Medicine Dealer
 QUEST_LV_0100_20150317_000177	Hmm... Well, there's a mint that only grows at Metos Canyon.{nl}Please bring me that.
-QUEST_LV_0100_20150317_000178	Metos Canyon is the best place to wake up your consciousness.{nl}Especially for an old man who is in his dotage.
+QUEST_LV_0100_20150317_000178	Metos Canyon is the best place to wake up your consciousness. Especially for an old man.
 QUEST_LV_0100_20150317_000179	That's right. You have some sense.{nl}
 QUEST_LV_0100_20150317_000180	Alright, it's done.{nl}Take this to Davio.
 QUEST_LV_0100_20150317_000181	Merchant Davio
-QUEST_LV_0100_20150317_000182	We brought that oldman's medicine. {nl}But we spent a long time getting it. I should charge you more.{nl}
-QUEST_LV_0100_20150317_000183	The golds that Lichenclops have in this town will be enough.{nl}Bring those to the pharmacist at Kapas.
-QUEST_LV_0100_20150317_000184	This will be enough. Davio sent you right?{nl}But to make the medicine effective, I need one more ingredient.
-QUEST_LV_0100_20150317_000185	To make the medicine, I needed find the cause and it drove me crazy.{nl}The funny thing about it is that it was the same thing as the magic that was used long ago.{nl}
-QUEST_LV_0100_20150317_000186	I heard a rumor that Zachariel erased the memories of all workers after building the royal tomb.{nl}That's the magic casted on Jonas. But he is also in his dotage because of his age.
-QUEST_LV_0100_20150317_000187	It was so hard to get that oldman's medicine.{nl}But, there's nothing that I cannot get.
+QUEST_LV_0100_20150317_000182	We brought that old man's medicine. {nl}But we spent a long time getting it. I should charge you more.{nl}
+QUEST_LV_0100_20150317_000183	The gold that Lichenclops have in this town will be enough.{nl}Bring those to the pharmacist at Kapas.
+QUEST_LV_0100_20150317_000184	This will be enough. Davio sent you right?{nl}To make the medicine effective I need one more ingredient.
+QUEST_LV_0100_20150317_000185	To make the medicine, I needed find the cause and it drove me crazy.{nl}The funny thing is that it was the same thing as the magic that was used long ago.{nl}
+QUEST_LV_0100_20150317_000186	I heard a rumor that Zachariel erased the memories of all workers after building the royal tomb.{nl}That's the magic cast on Jonas, though he is also a bit senile.
+QUEST_LV_0100_20150317_000187	It was so hard to get that old man's medicine.{nl}But, there's nothing that I cannot get.
 QUEST_LV_0100_20150317_000188	It will be completed when you melt it in the honey that you brought. Take it.
 QUEST_LV_0100_20150317_000189	That medicine works well. Make him swallow it somehow.
-QUEST_LV_0100_20150317_000190	It's late. {nl}Did you bring my records?
-QUEST_LV_0100_20150317_000191	Go to the Abondoned Workplace.{nl}Some oldman is wandering around, and I think that's Jonas.
+QUEST_LV_0100_20150317_000190	It's late.{nl}Did you bring my records?
+QUEST_LV_0100_20150317_000191	Go to the Abondoned Workplace.{nl}Some old man is wandering around there. I think it's Jonas.
 QUEST_LV_0100_20150317_000192	What is that? It smells like honey alcohol.
-QUEST_LV_0100_20150317_000193	I feel dizzy.{nl}What am I doing here anyways?
-QUEST_LV_0100_20150317_000194	It's good to hear that they are searching for it.{nl}I left all the supplies and my belogings since monsters were chasing after me.{nl}Can you first find the scattered supplies?
+QUEST_LV_0100_20150317_000193	I feel dizzy.{nl}What am I doing here anyway?
+QUEST_LV_0100_20150317_000194	It's good to hear that they are searching for it.{nl}I left all the supplies and my belogings since monsters were chasing after me.{nl}Can you go find the scattered supplies first?
 QUEST_LV_0100_20150317_000195	I don't have anything to tell you as a humble mercenary.{nl}I was okay even on the Divine Day, I am sure this place is cursed.{nl}
 QUEST_LV_0100_20150317_000196	Why do you come here now after such a long time?{nl}Where is Mirta and who are you?
-QUEST_LV_0100_20150317_000197	I am about to remember something.{nl}It keeps fading whenever I try to recollect.
+QUEST_LV_0100_20150317_000197	I'm trying to remember something but it keeps fading whenever I get close.
 QUEST_LV_0100_20150317_000198	Vaidotas
-QUEST_LV_0100_20150317_000199	The smell.. I think the purifying device in the mine is broken. {nl}We better repair it quickly. The people taken away might suffocate.
-QUEST_LV_0100_20150317_000200	Do you know the legend Cunningham? {nl} It's a legend about the great demon sealed here in the Crystal Mine. {nl} For more details, there is a book about it in the miners lounge of 2nd Gallery so try reading it. {nl}
-QUEST_LV_0100_20150317_000201	Anyway, my guess is that the demon is re-awakening and controlling the Vubbes. {nl} The dream the bishop had and the legends of Cunningham ... I feel that it might be a sign that something huge is about to happen. {nl}
-QUEST_LV_0100_20150317_000202	Only the Goddess would know if it's hope or despair. {nl}
-QUEST_LV_0100_20150317_000203	The purifier can be easily fixed by anyone but it may be hard to find the parts. {nl} In that case, use the compass that I gave you. {nl}
-QUEST_LV_0100_20150317_000204	Well then, I have some other things to do so I will meet you in the 3rd Gallery. {nl} I wish for your fortune of war in the name of the Goddess.
-QUEST_LV_0100_20150317_000205	If you can't repair the purifier, use the compass I gave you. {nl}You'll be able to find a way.
+QUEST_LV_0100_20150317_000199	The smell.. I think the purifying device in the mine is broken.{nl}We better repair it quickly. The people taken away might suffocate.
+QUEST_LV_0100_20150317_000200	Do you know the legend of Cunningham?{nl}It's a legend about the great demon sealed here in the Crystal Mine.{nl}For more details, there is a book about it in the miners lounge of 2nd Gallery.{nl}
+QUEST_LV_0100_20150317_000201	Anyway, my guess is that the demon is re-awakening and is controlling the Vubbes.{nl}The dream the bishop had and the legend of Cunningham... I feel it might be a sign that something huge is about to happen.{nl}
+QUEST_LV_0100_20150317_000202	Only the goddess would know if it is hope or despair.{nl}
+QUEST_LV_0100_20150317_000203	The purifier can be easily fixed by anyone but it may be hard to find the parts.{nl}In that case, use the compass that I gave you.{nl}
+QUEST_LV_0100_20150317_000204	Well then, I have some things to do so I will meet you in the 3rd Gallery.{nl}I wish for your fortune of war in the name of the goddess.
+QUEST_LV_0100_20150317_000205	If you can't repair the purifier, use the compass I gave you.{nl}You'll be able to find a way.
 QUEST_LV_0100_20150317_000206	Village Aunt
 QUEST_LV_0100_20150317_000207	Did you come to save us? Did you?
-QUEST_LV_0100_20150317_000208	Okay, We are going to be okay now!
+QUEST_LV_0100_20150317_000208	Okay! We are going to be okay now!
 QUEST_LV_0100_20150317_000209	Village Girl
 QUEST_LV_0100_20150317_000210	Please save us. Please..
 QUEST_LV_0100_20150317_000211	Please release me. Please..
 QUEST_LV_0100_20150317_000212	Mr. Juan
-QUEST_LV_0100_20150317_000213	I feel mad whenever I see those Vubbes that ruined my hometown. {nl} That's why I want to help people like you who fight againt the Vubbes.
-QUEST_LV_0100_20150317_000214	I would have left already if this wasn't my hometown. {nl} Where on earth have all the Vubbes been hiding before they crawled out.
+QUEST_LV_0100_20150317_000213	I feel mad whenever I see those Vubbes that ruined my hometown.{nl}That's why I want to help people like you who fight againt the Vubbes.
+QUEST_LV_0100_20150317_000214	I would have left already if this wasn't my hometown.{nl}Where on earth have all the Vubbes been hiding before they crawled out?
 QUEST_LV_0100_20150317_000215	Pharmacist lady
-QUEST_LV_0100_20150317_000216	Thanks for the last time.{nl}Without you, I would have never gotten those ingredients..
+QUEST_LV_0100_20150317_000216	Thanks for the last time.{nl}Without you, I would have never gotten those ingredients.
 QUEST_LV_0100_20150317_000217	Maybe the person that the goddess sent was you.{nl}You are the most merciful person I have ever seen among the revelators.
 QUEST_LV_0100_20150317_000218	Soldier Jays
 QUEST_LV_0100_20150317_000219	I will protect this village for my dead colleagues.
 QUEST_LV_0100_20150317_000220	Even if the world changes, I will never forgive the Vubbes.
 QUEST_LV_0100_20150317_000221	Soldier Edgar
 QUEST_LV_0100_20150317_000222	These are the rations that we gathered from the east forest.{nl}I will never, ever lose them again. Never.
-QUEST_LV_0100_20150317_000223	Because of you, I found this much.{nl}I am happy.
+QUEST_LV_0100_20150317_000223	Thanks to you, I found this much.{nl}I'm so happy.
 QUEST_LV_0100_20150317_000224	Knight Commander Uska
-QUEST_LV_0100_20150317_000225	Is this slate the evidence of salvation? {nl} It just looks like an old slate to me.
+QUEST_LV_0100_20150317_000225	Is this slate the evidence of salvation?{nl}It just looks like an old rock to me.
 QUEST_LV_0100_20150317_000226	
-QUEST_LV_0100_20150317_000227	You better ask the Bokor Master about this slate. {nl} She lives at the end of Klaipeda Residential Area so go pay her a visit.
-QUEST_LV_0100_20150317_000228	Use your time wisely. {nl} No one can know everything about one's own future.
+QUEST_LV_0100_20150317_000227	You better ask the Bokor Master about this slate.{nl}She lives at the end of Klaipedas Residential Area so go pay her a visit.
+QUEST_LV_0100_20150317_000228	Use your time wisely.{nl}No one can know everything about one's own future.
 QUEST_LV_0100_20150317_000229	So you finally came.{nl}What did the Bokor Master tell you?
-QUEST_LV_0100_20150317_000230	I'm also curious about the girl who cracked the seal. {nl} This is not a seal that can easily be broken.
-QUEST_LV_0100_20150317_000231	If the Bokor Master told you that I would know it..{nl}I can think of a place. {nl}
+QUEST_LV_0100_20150317_000230	I'm also curious about the girl who cracked the seal.{nl}This is not a seal that can easily be broken.
+QUEST_LV_0100_20150317_000231	If the Bokor Master told you that I would know it..{nl}I can think of a place.{nl}
 QUEST_LV_0100_20150317_000232	
-QUEST_LV_0100_20150317_000233	Miner's Village Mayor
-QUEST_LV_0100_20150317_000234	Welcome. Aren't you our town's savior? {nl}
+QUEST_LV_0100_20150317_000233	Miners' Village Mayor
+QUEST_LV_0100_20150317_000234	Welcome. Aren't you our town's savior?{nl}
 QUEST_LV_0100_20150317_000235	
-QUEST_LV_0100_20150317_000236	So this revelation is Goddess Laima and we have to collect all these for the Goddess to regain her powers? {nl} That is amazing.
-QUEST_LV_0100_20150317_000237	Oh, please do not reveal the fact that the Revelator has been found unless absolutely necessary. {nl} It may only create confusion if the rumors spread.
-QUEST_LV_0100_20150317_000238	Ah! You mean the report..{nl}At first, those Siaulagos did something strange to the supplies.{nl}After some period of time, they ran away when Sparnas came.{nl}
-QUEST_LV_0100_20150317_000239	I got spotted by those Siaulagos when they were running away, so I engaged in a battle..{nl}Yes..As you can see, I lost it. I mean the report.{nl}Aren't they bastards?
+QUEST_LV_0100_20150317_000236	So this revelation is Goddess Laima and we have to collect all these for the Goddess to regain her powers?{nl}That is amazing.
+QUEST_LV_0100_20150317_000237	Oh, please do not reveal the fact that the Revelator has been found unless absolutely necessary.{nl}It may only create confusion if the rumors spread.
+QUEST_LV_0100_20150317_000238	Ah, you mean the report.{nl}At first, those Siaulagos did something strange to the supplies, but they ran away after a while when Sparnas came.{nl}
+QUEST_LV_0100_20150317_000239	I was spotted by those Siaulagos when they were running away, so I engaged in a battle..{nl}Yes.. And as you can see, I lost it. The report, I mean.{nl}Aren't they bastards?
 QUEST_LV_0100_20150317_000240	When you find the report, please hand it over to Luders right away.{nl}I feel terrified to think what those bastards did to our supplies.
-QUEST_LV_0100_20150317_000241	Yes. After seeing the Moody's report, I am confident now.{nl}They probably put something in our supplies to lure Sparnas.{nl}Such as Old Grains that birds go crazy on.
-QUEST_LV_0100_20150317_000242	The soldiers on patrol found the place where Siaulambs' stolen goods are packed.{nl}How about we steal them for ourselves?{nl}Let's make it known that we're not weak as they think.{nl}
+QUEST_LV_0100_20150317_000241	Yes. After seeing Moody's report, I am confident that they put something in our supplies to lure Sparnas.{nl}Such as Old Grains that birds go crazy on.
+QUEST_LV_0100_20150317_000242	The soldiers on patrol found the place where Siaulambs' stolen goods are packed.{nl}How about we steal them for ourselves?{nl}Let's make it known that we're not as weak as they think.{nl}
 QUEST_LV_0100_20150317_000243	You should fight fire with fire.{nl}We will keep attacking until they fully realize that they've made a mistake.
 QUEST_LV_0100_20150317_000244	We're not going to suffer anymore.{nl}Thanks for your efforts.
 QUEST_LV_0100_20150317_000245	It will be Ziedo Pond.{nl}I heard there are many Siaulambs, so be careful.
-QUEST_LV_0100_20150317_000246	I have not heard of anything else about the bishop's dream. {nl} Sorry, I can't be of much help.
+QUEST_LV_0100_20150317_000246	I have not heard anything else about the bishop's dream.{nl}Sorry, I can't be of much help.
 QUEST_LV_0100_20150317_000247	Klaipeda Guard Captain
-QUEST_LV_0100_20150317_000248	Go ahead to Klaipeda. {nl} Commander Uska is waiting for you in Klaipeda Central Plaza. {nl} I heard the bishop also had a dream about the Goddess... And I think it has to do with it.
+QUEST_LV_0100_20150317_000248	Go ahead to Klaipeda.{nl}Commander Uska is waiting for you in Klaipeda Central Plaza.{nl}I heard the bishop also had a dream about the Goddess... And I think it has to do with that.
 QUEST_LV_0100_20150317_000249	Klaipeda Guard
-QUEST_LV_0100_20150317_000250	Thank you for making your way here. {nl} If there is this much still left even after sir Titas handled it himself, can you imagine how it was before?
+QUEST_LV_0100_20150317_000250	Thank you for making your way here.{nl}If there is this much still left even after Sir Titas handled it himself, can you imagine how it was before?
 QUEST_LV_0100_20150317_000251	Mercenary Tobi
-QUEST_LV_0100_20150317_000252	Do you want to do a small task?{nl}I am already known so it's hard for me to do.
-QUEST_LV_0100_20150317_000253	If you don't want, you don't have to do it.{nl}There are plenty of people who can do this.
+QUEST_LV_0100_20150317_000252	Do you want to do a small task for me?{nl}I'm a known face so it will be hard for me to do it myself.
+QUEST_LV_0100_20150317_000253	If you don't want to, then you don't have to.{nl}There are plenty of people around who can do this.
 QUEST_LV_0100_20150317_000254	Good.{nl}You possess tremendous abilities.
 QUEST_LV_0100_20150317_000255	It's definitely worth to be deserved.{nl}Even if we consider the fact that the great king spent all his assets on builidng the royal tomb, the amount of inputs were still a lot.
-QUEST_LV_0100_20150317_000256	Hey you. That equipment is not permitted.{nl}It must be near here yet.{nl}
-QUEST_LV_0100_20150317_000257	Okay. Bring me some kind of evidences from those people who make counterfeits.{nl}Just do anything to get them.
-QUEST_LV_0100_20150317_000258	I am looking for the evidences of artifacts forgery.{nl}The first thing that you will do is to gather necessary equipments for digging.
-QUEST_LV_0100_20150317_000259	Of course you should show us your skills.{nl}Defeating Desert Chupacabras or Zinutes will be enough to prove your skills.
+QUEST_LV_0100_20150317_000256	Hey you. That equipment is not permitted.{nl}Do not leave it lying around.{nl}
+QUEST_LV_0100_20150317_000257	Okay. Bring me some kind of evidence that those people are making counterfeits.{nl}Do whatever it takes.
+QUEST_LV_0100_20150317_000258	I am looking for the evidence of artifact forgery.{nl}The first thing you must do is gather the equipment necessary for digging.
+QUEST_LV_0100_20150317_000259	Of course you should show us your skills.{nl}Defeating Desert Chupacabras or Zinutes will be enough to prove yourself.
 QUEST_LV_0100_20150317_000260	Supply Officer
-QUEST_LV_0100_20150317_000261	Thank you for your help. {nl} I think this is enough. {nl}
-QUEST_LV_0100_20150317_000262	)} {nl} If you have time, please tell our troops to assemble.{nl} If you don't want to, you may just go ahead to Klaipeda.
+QUEST_LV_0100_20150317_000261	Thank you for your help.{nl}I think this is enough.{nl}
+QUEST_LV_0100_20150317_000262	)}{nl}If you have time, please tell our troops to assemble.{nl} If you don't want to, you may just go ahead to Klaipeda.
 QUEST_LV_0100_20150317_000263	Scout
-QUEST_LV_0100_20150317_000264	Go back, it's dangerous. {nl} Kepas will soon be marching in.
-QUEST_LV_0100_20150317_000265	Oh, you're the Revelator. {nl} Since it's some fate that we fought together, let me give you a scoop of good information.
-QUEST_LV_0100_20150317_000266	Oh, you mentioned that we need to assemble right? {nl}Help me find the missing luggage and I'll go as soon as I can.
-QUEST_LV_0100_20150317_000267	Isn't the luggage ready yet? {nl} I can't go back without it.
-QUEST_LV_0100_20150317_000268	Thank you. You found it sooner than I expected. {nl}
-QUEST_LV_0100_20150317_000269	If you follow the road to the north, you will find the search scout. {nl} Well then, good luck.
+QUEST_LV_0100_20150317_000264	Go back, it's dangerous!{nl}Kepas will soon be marching in.
+QUEST_LV_0100_20150317_000265	Oh, you're the Revelator.{nl}It must be fate that we are to fight together. Let me give you the inside scoop.
+QUEST_LV_0100_20150317_000266	You mentioned that we need to assemble, right?{nl}Help me find the missing luggage and I'll go as soon as I can.
+QUEST_LV_0100_20150317_000267	You haven't found the luggage yet? I can't go back without it.
+QUEST_LV_0100_20150317_000268	Thank you. You found it sooner than I expected.{nl}
+QUEST_LV_0100_20150317_000269	If you follow the road to the north, you will find the Search Scout.{nl}Good luck.
 QUEST_LV_0100_20150317_000270	Raimonas
-QUEST_LV_0100_20150317_000271	Have you ever offered worship to the Statue? {nl} If not, I'd really recommend you to.
-QUEST_LV_0100_20150317_000272	That depends on which Goddess it is. {nl} Go straight along way on the right.{nl} That's where Statue of Goddess Zemyna is so feel her blessings yourself.
+QUEST_LV_0100_20150317_000271	Have you ever offered worship to the Statue?{nl}If not, I'd really recommend it.
+QUEST_LV_0100_20150317_000272	That depends on which Goddess it is.{nl}If you follow the road to the right you will find the Statue of Goddess Zemyna. 
 QUEST_LV_0100_20150317_000273	I do worry that the monsters might harm the Statue of the Goddess.
-QUEST_LV_0100_20150317_000274	Good thing to hear that the Statue is fine. {nl} The monsters should know that they should be afraid of the Goddess. {nl}
-QUEST_LV_0100_20150317_000275	Go down the Shadow Forest Road and you should arrive at Klaipeda shortly. {nl} Well then, may be blessings of Goddess be with you
-QUEST_LV_0100_20150317_000276	Plese do me a favor if you are headed to Klaipeda. {nl} It's not easy to go back and forth Klaipeda because of the Infro Rocktors nowadays.
+QUEST_LV_0100_20150317_000274	Good thing to hear that the Statue is fine.{nl}The monsters know to fear the Goddess.{nl}
+QUEST_LV_0100_20150317_000275	Go down the Shadow Forest Road and you should arrive at Klaipeda shortly.{nl}Well then, may be blessings of Goddess be with you
+QUEST_LV_0100_20150317_000276	Please do me a favor if you are headed to Klaipeda.{nl}It's not easy to go back and forth from Klaipeda because of the Infro Rocktors nowadays.
 QUEST_LV_0100_20150317_000277	Maybe taking care of the Statues will make the Goddesses return sooner...
-QUEST_LV_0100_20150317_000278	Follow the road on the left of the camp crossroads. {nl}{-scp SCR_DIALOG_NPC_ANIM(
-QUEST_LV_0100_20150317_000279	)}You'll meet the troops right away.
-QUEST_LV_0100_20150317_000280	)}Alright, good job.{nl}You'll arrive at Klaipeda shortly when you follow the Shadow Forest Road.{nl}Don't forget to drop by Sir Uska.
+QUEST_LV_0100_20150317_000278	Follow the road on the left at the camp crossroads.{nl}{-scp SCR_DIALOG_NPC_ANIM(
+QUEST_LV_0100_20150317_000279	)} You'll meet the troops right away.
+QUEST_LV_0100_20150317_000280	)} Alright, good job.{nl}You'll arrive at Klaipeda shortly if you follow the Shadow Forest Road.{nl}Don't forget to drop by Sir Uska.
 QUEST_LV_0100_20150317_000281	Battle Commander
-QUEST_LV_0100_20150317_000282	I will have my men notify the troops to assemble. {nl} You may return to sir Titas and let him know.
-QUEST_LV_0100_20150317_000283	It's nothing difficult. {nl} If you don't want, I'll let you go to Klaipeda right away.
+QUEST_LV_0100_20150317_000282	I will have my men notify the troops to assemble.{nl}You may return to Sir Titas and let him know.
+QUEST_LV_0100_20150317_000283	It's nothing difficult.{nl}If you don't want to, I'll let you go to Klaipeda right away.
 QUEST_LV_0100_20150317_000284	Search Scout
-QUEST_LV_0100_20150317_000285	It sure is a problem. {nl} I didn't know Kepas could grow that big.
+QUEST_LV_0100_20150317_000285	It sure is a problem.{nl}I didn't know Kepas could grow that big.
 QUEST_LV_0100_20150317_000286	Shouldn't Revelators go to Klaipeda instead of here?
-QUEST_LV_0100_20150317_000287	I feel so relieved to be positioned in the Western Woods. {nl} There are some places where you'd rather die than be positioned there.
-QUEST_LV_0100_20150317_000288	When you see a Statue of Goddess, try offering a worship. {nl} Surely, something nice will happen.
+QUEST_LV_0100_20150317_000287	I feel so relieved to be stationed in the Western Woods.{nl}There are some places where you'd rather die than to be stationed.
+QUEST_LV_0100_20150317_000288	When you see a Statue of Goddess, try offering your worship.{nl}Surely something nice will happen.
 QUEST_LV_0100_20150317_000289	This is a dangerous area. What are you doing here?
-QUEST_LV_0100_20150317_000290	Thank you for your help. {nl} The Large Kepa appearing here.. Must report to Titas about it.
-QUEST_LV_0100_20150317_000291	Weird.. That is not a type of monster you'd face in a place like this. {nl} It must be hard to just walk around
-QUEST_LV_0100_20150317_000292	Assemble already? {nl} That's tough. There's still a pile of missions.
+QUEST_LV_0100_20150317_000290	Thank you for your help.{nl}The Large Kepa appearing here... I must report to Sir Titas about it.
+QUEST_LV_0100_20150317_000291	Weird... That is not a type of monster you'd face in a place like this.{nl}It must be hard to just walk around.
+QUEST_LV_0100_20150317_000292	Assemble already?{nl}That's tough. There's still a pile of missions.
 QUEST_LV_0100_20150317_000293	
 QUEST_LV_0100_20150317_000294	Even if the Goddess arrived, I will not go until the mission is completed.
-QUEST_LV_0100_20150317_000295	Yes. This should be enough. {nl} This is a pill that will restore your stamina instantly... I have enough of it so I will give you this as a gift. {nl}
-QUEST_LV_0100_20150317_000296	Stamina is consumed when you move. {nl}You can recover stamina by destroying Tree Root Crystal or when you are in rest mode. {nl} But you don't have time for that when you are chased by monsters isn't it? {nl} And that's when this pill comes in handy.
-QUEST_LV_0100_20150317_000297	I heard the news from my men and was starting to become worried. {nl} All is well if it ended up good.
+QUEST_LV_0100_20150317_000295	Yes. This should be enough.{nl}This is a pill that will restore your stamina instantly. I have enough of it so I will give you this as a gift.{nl}
+QUEST_LV_0100_20150317_000296	Stamina is consumed when you move.{nl}You can recover stamina by destroying a Tree Root Crystal or by resting.{nl}But you don't have time for that when you are being chased by monsters.{nl}That's when this pill comes in handy.
+QUEST_LV_0100_20150317_000297	I heard the news from my men and was starting to become worried.{nl}All is well if it ended up good.
 QUEST_LV_0100_20150317_000298	Klaipeda Resident
-QUEST_LV_0100_20150317_000299	)} {nl} When do you think the Goddess is coming back? {nl} Even if I ask the Revelators, all they say is that they must go to Klaipeda..
-QUEST_LV_0100_20150317_000300	Are you the Revelator? {nl} You said the Goddess appeared in your dream. {nl}It's what the soldiers were saying.
+QUEST_LV_0100_20150317_000299	)} {nl}When do you think the Goddess is coming back?{nl}Even if I ask the Revelators, all they say is that they must go to Klaipeda...
+QUEST_LV_0100_20150317_000300	Are you the Revelator?{nl}You said the Goddess appeared in your dream.{nl}It's what the soldiers were saying.
 QUEST_LV_0100_20150317_000301	Trooper
-QUEST_LV_0100_20150317_000302	I wonder where and what the Goddess is doing...
-QUEST_LV_0100_20150317_000303	Thank you for making your way until here. {nl}I am Uska, the Knight-Commander in charge of Siaulai and Klaipeda.
-QUEST_LV_0100_20150317_000304	The bishop also dreamed of revelation. {nl} He said send the revelator to the Crystal Mine. {nl}
-QUEST_LV_0100_20150317_000305	Let me know when you are ready to go to the Crystal Mine. {nl} I'll tell you the location and how to get into the Crystal Mine.
-QUEST_LV_0100_20150317_000306	The Bishop told us to send the Revelator to Crystal Mine. {nl} He said the Goddess told him to do so. {nl}
-QUEST_LV_0100_20150317_000307	But the Miner's Village is at war with the Vubbes {nl}and entrance is limited to authorized people only. {nl} Aras is the one in charge of Eastern Woods so try talking to him
-QUEST_LV_0100_20150317_000308	Monsters have been around for long but they started becoming violent four years ago. {nl} The one that was affected the most would be plant types.{nl} They did not exist before. {nl}
-QUEST_LV_0100_20150317_000309	Of course, beasts were no exception. {nl} When the monster that seemed like a fusion of the demon appeared, I thought it was all over.
+QUEST_LV_0100_20150317_000302	I wonder what the Goddess is doing...
+QUEST_LV_0100_20150317_000303	Thank you for making your way here.{nl}I am Uska, the Knight-Commander in charge of Siaulai and Klaipeda.
+QUEST_LV_0100_20150317_000304	The bishop also dreamed of revelation.{nl}He said to send the Revelator to the Crystal Mine.{nl}
+QUEST_LV_0100_20150317_000305	Let me know when you are ready to go to the Crystal Mine.{nl}I'll tell you the location and how to get in.
+QUEST_LV_0100_20150317_000306	The Bishop told us to send the Revelator to Crystal Mine.{nl}He said the Goddess told him to do so.{nl}
+QUEST_LV_0100_20150317_000307	But the Miners' Village is at war with the Vubbes and entrance is limited to authorized people only.{nl}Aras is the one in charge of Eastern Woods so try talking to him.
+QUEST_LV_0100_20150317_000308	Monsters have been around for a long time, but they only started becoming violent four years ago.{nl}The ones that were affected the most would be the plant types. They did not exist before.{nl}
+QUEST_LV_0100_20150317_000309	Of course, beasts were no exception.{nl}When the monster that seemed like it was fused with a demon appeared, I thought it was all over.
 QUEST_LV_0100_20150317_000310	Knight Aras
-QUEST_LV_0100_20150317_000311	Aren't you hurt? {nl} Thank you for getting rid of the Poatas but you're so reckless.
-QUEST_LV_0100_20150317_000312	You want to get into the Crystal Mine? {nl} The Miner's Village is currently at war with the Vubbes and it's very dangerous {nl}so I cannot permit that.
-QUEST_LV_0100_20150317_000313	And our troops are in no condition to guard you. {nl} I'm sorry but you have to go back.
-QUEST_LV_0100_20150317_000314	If you can't get rid of the Pokubus, you'll have to give up going into the Miner's Village.
-QUEST_LV_0100_20150317_000315	Thank you. {nl} Do not worry, I'll keep my promise.
+QUEST_LV_0100_20150317_000311	Aren't you hurt?{nl}Thank you for getting rid of the Poatas but you're too reckless.
+QUEST_LV_0100_20150317_000312	You want to get into the Crystal Mine?{nl}The Miners' Village is currently at war with the Vubbes and it's very dangerous,{nl}so I cannot permit that.
+QUEST_LV_0100_20150317_000313	And our troops are in no condition to guard you.{nl}I'm sorry but you have to go back.
+QUEST_LV_0100_20150317_000314	If you can't get rid of the Pokubus, you'll have to give up going into the Miners' Village.
+QUEST_LV_0100_20150317_000315	Thank you.{nl}Do not worry, I'll keep my promise.
 QUEST_LV_0100_20150317_000316	Outpost Sentinel
 QUEST_LV_0100_20150317_000317	
-QUEST_LV_0100_20150317_000318	Other monsters also show up when there are Chupacabras. {nl} Miner's Village is a problem on its own but there are just too many things to pay attention to.
-QUEST_LV_0100_20150317_000319	Thank you. {nl} It really helps lifting our spirits.
-QUEST_LV_0100_20150317_000320	With your abilities, I have one more favor to ask. {nl} Can you help us drive out the Chupacabras in the supplies camp too?
-QUEST_LV_0100_20150317_000321	The Miners' Village is a problem but out situation here is not so good either. {nl}We have to prepare some measures before the number of monsters increase even more..
-QUEST_LV_0100_20150317_000322	Are you done already? {nl} No one has completed as fast before.
-QUEST_LV_0100_20150317_000323	I'm in the mission to find out why the monsters in the East woords suddenly increased. {nl}Also, I act as the intermediate in supplying the Miner's Village. {nl}
-QUEST_LV_0100_20150317_000324	Other knight is out in the Miner's Village but.. {nl} To be honest, It would have ended sooner if it was Sir Aras but the battle is taking longer than expected.
-QUEST_LV_0100_20150317_000325	Since you're going to help, please get rid of the Giant Gray Chupacabras too. {nl}They are the culprits stealing our supplies.
-QUEST_LV_0100_20150317_000326	Giant Gray Chupacabras appear when you kill normal chupacabras. {nl} Well then, thanks for your help.
-QUEST_LV_0100_20150317_000327	Thank you. {nl} Now we can finally get to work easily.
-QUEST_LV_0100_20150317_000328	Finding the cause of the monsters is important, {nl} but I'm more worried supplies not making it to the Miners' Village.
-QUEST_LV_0100_20150317_000329	The movement of weavers in the lower area of the stream seems suspicious . {nl} Just like they're trying to interfere with supplying the Miners' Village.
-QUEST_LV_0100_20150317_000330	It's not a usual situation. {nl} But we might have to give up our current supplies and support ourselves until the next batch of supplies arrive.
-QUEST_LV_0100_20150317_000331	Thank you. {nl} With you Helping us out like this, we will not be defeated.
-QUEST_LV_0100_20150317_000332	The next mission is to find the cause of the monsters increasing. {nl} Popolions have a big appetitle so we may be able to find crucial clue.
-QUEST_LV_0100_20150317_000333	Miners' Village is already in trouble and if the East Woods is in this situation, we can't assure the safety of Klaipeda . {nl}We can just hope that Klaipeda is doing well.
+QUEST_LV_0100_20150317_000318	Other monsters also show up when there are Chupacabras.{nl}Miners' Village is a problem on its own but there are just too many things to pay attention to.
+QUEST_LV_0100_20150317_000319	Thank you.{nl}It really helps lift our spirits.
+QUEST_LV_0100_20150317_000320	With your abilities, I have one more favor to ask.{nl}Can you help us drive out the Chupacabras in the supply camp too?
+QUEST_LV_0100_20150317_000321	The Miners' Village is a problem but out situation here is not so good either. {nl}We have to prepare some measures before the number of monsters increase even more.
+QUEST_LV_0100_20150317_000322	Are you done already?{nl}Never seen anyone as fast as you before.
+QUEST_LV_0100_20150317_000323	I'm on a mission to find out why the number of monsters in the East woods suddenly increased.{nl}Also, I act as the intermediary in supplying the Miners' Village.{nl}
+QUEST_LV_0100_20150317_000324	There are other knights out in Miners' Village but...{nl}To be honest, the battle is taking longer than expected. It would have ended sooner if Sir Aras was there.
+QUEST_LV_0100_20150317_000325	Since you're going to help, please get rid of the Giant Gray Chupacabras too.{nl}They are the culprits stealing our supplies.
+QUEST_LV_0100_20150317_000326	Giant Gray Chupacabras appear when you kill normal chupacabras.{nl}Well then, thanks for your help.
+QUEST_LV_0100_20150317_000327	Thank you.{nl}Now we can finally get to work easily.
+QUEST_LV_0100_20150317_000328	Finding the cause of the monsters is important,{nl}but I'm more worried about supplies not making it to the Miners' Village.
+QUEST_LV_0100_20150317_000329	The movement of weavers in the lower area of the stream seems suspicious.{nl}Seems like they're trying to interfere with supplying the Miners' Village.
+QUEST_LV_0100_20150317_000330	We might have to give up our current supplies and support ourselves until the next batch of supplies arrive.
+QUEST_LV_0100_20150317_000331	Thank you.{nl}With you helping us out like this, we will not be defeated.
+QUEST_LV_0100_20150317_000332	The next mission is to find the cause of the increasing number of monsters.{nl}Popolions have a big appetite so I hope we can find a clue.
+QUEST_LV_0100_20150317_000333	Miners' Village is already in trouble and if the East Woods is in this situation, we can't assure the safety of Klaipeda.{nl}We can just hope that Klaipeda is doing well.
 QUEST_LV_0100_20150317_000334	Operations officer
-QUEST_LV_0100_20150317_000335	Were you sent by Aras? {nl} It's a piece of Vubbe clothing. Hmm... Is that so...
-QUEST_LV_0100_20150317_000336	I think the Vubbes of the Miner's Village have made their way into the woods. {nl} Maybe that's the reason behind the sudden increase in monsters too. {nl}
-QUEST_LV_0100_20150317_000337	I better ask Sir Aras to search for Vubbes in other areas too. {nl} In the meantime, please take a look at the upper side.
-QUEST_LV_0100_20150317_000338	We haven't searched the upper side yet. {nl} Of course, we should be sending troops but I ask for your help as this is an urgent matter.
-QUEST_LV_0100_20150317_000339	You saw the Vubbe fighter but missed it? {nl} We also got a report that the Vubbe fighter appeared in the area below. {nl}
-QUEST_LV_0100_20150317_000340	First, talk to the search scout in the lower bridge of Bulvjes. {nl} This will become a tedious long term war if we miss the Vubbe fighter.
-QUEST_LV_0100_20150317_000341	So Vubbe Fighter was the reason behind the increase of monsters. {nl} Please find out how many Vubbe Fighters there are. {nl}
-QUEST_LV_0100_20150317_000342	Under the circumstances, it makes sense that the monsters are controlled by Vubbe Fighter. {nl} But deep down, you just don't want to believe it.
-QUEST_LV_0100_20150317_000343	Following your report, there is no more Vubbe Fighter in this woods. {nl}
+QUEST_LV_0100_20150317_000335	Were you sent by Aras?{nl}It's a piece of Vubbe clothing. Hmm... Is that so...
+QUEST_LV_0100_20150317_000336	I think the Vubbes of the Miners' Village have made their way into the woods.{nl}Maybe that's the reason behind the sudden increase in monsters too.{nl}
+QUEST_LV_0100_20150317_000337	I better ask Sir Aras to search for Vubbes in other areas too.{nl}In the meantime, please take a look at the upper side.
+QUEST_LV_0100_20150317_000338	We haven't searched the upper side yet.{nl}Of course, we should be sending troops but I ask for your help as this is an urgent matter.
+QUEST_LV_0100_20150317_000339	You saw the Vubbe fighter but missed it?{nl}We also got a report that the Vubbe fighter appeared in the area below.{nl}
+QUEST_LV_0100_20150317_000340	First, talk to the search scout in the lower bridge of Bulvjes.{nl}This will become a tedious long term war if we miss the Vubbe fighter.
+QUEST_LV_0100_20150317_000341	So the Vubbe Fighter was the reason behind the increase of monsters.{nl}Please find out how many Vubbe Fighters there are.{nl}
+QUEST_LV_0100_20150317_000342	Under the circumstances, it makes sense that the monsters are controlled by Vubbe Fighters.{nl}But deep down, you just don't want to believe it.
+QUEST_LV_0100_20150317_000343	Following your report, there are no more Vubbe Fighters in these woods.{nl}
 QUEST_LV_0100_20150317_000344	
 QUEST_LV_0100_20150317_000345	Supply Soldier
-QUEST_LV_0100_20150317_000346	We need Weaver Claws as a part of supplies to be sent to Miners' Village {nl}but we just don't have time to look for those. {nl} What do we do?
-QUEST_LV_0100_20150317_000347	Actually, it doesn't make sense for the supply soldier to get the supplies. {nl}It should have come from Klaipeda.
-QUEST_LV_0100_20150317_000348	Thank you. {nl} Unexpected help always feels good.
-QUEST_LV_0100_20150317_000349	In fact, everything would have been fine if Pokubus weren't around. {nl} The Pokubus were running wild and that's why were weren't able to retrieve all the supplies.
-QUEST_LV_0100_20150317_000350	I don't know why they suddenly prey on the supplies. {nl} Could something be commanding them?
-QUEST_LV_0100_20150317_000351	Thank you. {nl} I envy your ability.
+QUEST_LV_0100_20150317_000346	We need Weaver Claws as a part of supplies to be sent to Miners' Village {nl}but we just don't have time to look for them.{nl}What do we do?
+QUEST_LV_0100_20150317_000347	Actually, it doesn't make sense for the supply soldier to get the supplies.{nl}It should have come from Klaipeda.
+QUEST_LV_0100_20150317_000348	Thank you.{nl}Unexpected help always feels good.
+QUEST_LV_0100_20150317_000349	In fact, everything would have been fine if the Pokubus weren't around.{nl}The Pokubus were running wild and that's why were weren't able to retrieve all the supplies.
+QUEST_LV_0100_20150317_000350	I don't know why they suddenly started to prey on the supplies.{nl}Could something be commanding them?
+QUEST_LV_0100_20150317_000351	Thank you.{nl}I envy your ability.
 QUEST_LV_0100_20150317_000352	Eastern Woods Search Scout
-QUEST_LV_0100_20150317_000353	Oh, it's you. {nl} I have heard from the operations officer. {nl}
-QUEST_LV_0100_20150317_000354	Vubbe Fighter is hiding deep in the Nudegi Felled Area. {nl} We got the orders to kill but it may be safer to wait for additional troops.
-QUEST_LV_0100_20150317_000355	I'm just a search scout but it was my first time to see the Vubbe Fighter so near.
-QUEST_LV_0100_20150317_000356	Awesome. You got rid of it by yourself. {nl} Go ahead and report to sir Aras. He'll be very pleased.
-QUEST_LV_0100_20150317_000357	You mean you really killed the Vubbe Fighter? {nl}Well then, now we can be relieved since the number of monsters will no longer grow.
-QUEST_LV_0100_20150317_000358	Of course. As promised, I will grant your access to the Miners' Village. {nl} Please wait.
+QUEST_LV_0100_20150317_000353	Oh, it's you.{nl}I have heard from the operations officer.{nl}
+QUEST_LV_0100_20150317_000354	A Vubbe Fighter is hiding deep in the Nudegi Felled Area.{nl}We got the orders to kill it, but it may be safer to wait for additional troops.
+QUEST_LV_0100_20150317_000355	I'm just a search scout but it was my first time to see a Vubbe Fighter up close.
+QUEST_LV_0100_20150317_000356	Awesome. You got rid of it by yourself.{nl}Go ahead and report to Sir Aras. He'll be very pleased.
+QUEST_LV_0100_20150317_000357	You mean you really killed the Vubbe Fighter?{nl}Well then, now we can be relieved since the number of monsters will no longer grow.
+QUEST_LV_0100_20150317_000358	Of course. As promised, I will grant your access to the Miners' Village.{nl}Please wait.
 QUEST_LV_0100_20150317_000359	If you find any clues, let the Operations Officer in the northern area know about it.
-QUEST_LV_0100_20150317_000360	I think the Miners' Village is not in a good situation. {nl}It's too late to move the troops so you go first to support the Miners' Village.
-QUEST_LV_0100_20150317_000361	They have low IQ but these monsters build groups and live as a community. {nl} They used to appear only occasionally in the deeper areas of the mines... Could they be expanding their forces? {nl}
-QUEST_LV_0100_20150317_000362	Whatever the reason is, Vubbes expanding their territory is a big problem. {nl} The monster that lose territory to Vubbes will be forced to make their way into our base.
-QUEST_LV_0100_20150317_000363	It's a single road from here on so you'll be able to find the people easily. {nl}
-QUEST_LV_0100_20150317_000364	Oh, let me give you some helpful information in return to your kind act for our village. {nl} The evidence of salvation that the Revelators are looking for can be found in the Closed Area.
-QUEST_LV_0100_20150317_000365	One thing, there's something that keeps bothering me. {nl} A vague feeling of something alien.
+QUEST_LV_0100_20150317_000360	I think the Miners' Village is not in a good situation.{nl}It's too late to move the troops so you go first to support the Miners' Village.
+QUEST_LV_0100_20150317_000361	They have low IQ but these monsters build groups and live as a community.{nl}They used to appear only occasionally in the deeper areas of the mines... Could they be expanding their forces?{nl}
+QUEST_LV_0100_20150317_000362	Whatever the reason is, Vubbes expanding their territory is a big problem.{nl}Monsters that lose their territory to Vubbes will be forced to make their way into our base.
+QUEST_LV_0100_20150317_000363	It's a single road from here on so you'll be able to find the people easily.{nl}
+QUEST_LV_0100_20150317_000364	Oh, let me give you some helpful information in return for your your help.{nl}The evidence of salvation that the Revelators are looking for can be found in the Closed Area.
+QUEST_LV_0100_20150317_000365	One thing, there's something that keeps bothering me.{nl}A vague feeling of something alien.
 QUEST_LV_0100_20150317_000366	Miner
-QUEST_LV_0100_20150317_000367	Thank you for saving me. {nl} The revelator has come to save us. It's like a dream. {nl}
-QUEST_LV_0100_20150317_000368	The Closed Area? {nl} If you insist to get in.. Gather the mysterious stones the Vubbes have. {nl} The walls just open when you touch the crystal clogged wall with it.
-QUEST_LV_0100_20150317_000369	I'm collecting the supplies to be sent to the Miners Village. {nl} The monsters stole it all. {nl}
-QUEST_LV_0100_20150317_000370	But supply box also contains dangerous explosives and collecting them is not an easy task.
-QUEST_LV_0100_20150317_000371	They couldn't have gone far. {nl}It would have been better it exploded on their way.
+QUEST_LV_0100_20150317_000367	Thank you for saving me.{nl}The revelator has come to save us. It's like a dream.{nl}
+QUEST_LV_0100_20150317_000368	The Closed Area?{nl}If you insist on getting in, gather the mysterious stones the Vubbes have.{nl}The walls just open when you touch the crystal clogged wall with it.
+QUEST_LV_0100_20150317_000369	I was collecting the supplies to be sent to the Miners' Village, but the monsters stole it all.{nl}
+QUEST_LV_0100_20150317_000370	The supply boxes contain dangerous explosives and collecting them is not an easy task.
+QUEST_LV_0100_20150317_000371	They couldn't have gone far.{nl}It would have been better if it just exploded on the way.
 QUEST_LV_0100_20150317_000372	Mercenary Lint
-QUEST_LV_0100_20150317_000373	Thank you for the last time.{nl}I should return to my commander soon..I think I can return to him after I get some more rest.
-QUEST_LV_0100_20150317_000374	I knew you would. {nl} One more thing, the ground of the Closed Area is weak so the entrance have been blocked for a long time. {nl}
-QUEST_LV_0100_20150317_000375	The kidnapped people are veteran miners so they may know how to get in. {nl} Well then, may be blessings of Goddess be with you.
-QUEST_LV_0100_20150317_000376	It wasn't long ago. {nl} I felt a strange power while performing various experiments in the Closed Area. {nl}It was different from the mana that we know but it was very warm. {nl}
-QUEST_LV_0100_20150317_000377	But the force that did not allow me to approach it as if it had an owner already. {nl} A few days after the incident, the bishop dreamed about the evidence of salvation. {nl}
-QUEST_LV_0100_20150317_000378	Perhaps the evidence of salvation is the force I felt .. {nl} That's what I think.
-QUEST_LV_0100_20150317_000379	All I see are monsters and we're out of supplies. {nl}I'm also curious how the battle situation is in Miners' Village.
-QUEST_LV_0100_20150317_000380	Until I'm assigned a new task, I'm thinking of going back to my duties as a search scout. {nl} Observing the monsters, you know.
-QUEST_LV_0100_20150317_000381	The Miners' Village is under battle and entrance is prohibited for civilians. {nl}Remember that we can't guarantee your safety if you do not get my permission.
-QUEST_LV_0100_20150317_000382	You have to cheer up.{nl} Even sir Aras is holding on.
-QUEST_LV_0100_20150317_000383	Goddess Zemyna overlooks the earth. {nl}There are rumors that the Goddess has abandoned us but that's nonsense. {nl}Her statue still shines beautifully when you pray to it.
-QUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods. {nl} That's why the Mining Village located in the middle of it turned to a battlefield. {nl}
-QUEST_LV_0100_20150317_000385	That's why I can't permit entrance to the Miners Village for safety reasons. {nl} Of course it will be a different story if your skill are good enough to ensure your safety even without the protection of guards.
-QUEST_LV_0100_20150317_000386	Gosh, it could have been really dangerous. {nl} That huge thing was hiding so well.
-QUEST_LV_0100_20150317_000387	It's very important to study monsters at times like this. {nl}It's like weather forecasts where you try to find out the cause and see what would happen.
-QUEST_LV_0100_20150317_000388	I'm sure the leaf bugs in Uoros farm stole it. {nl}They did steal from us once before.
+QUEST_LV_0100_20150317_000373	Thank you again.{nl}I should return to my commander soon. I think I can return to him after I get some more rest.
+QUEST_LV_0100_20150317_000374	I knew you would.{nl}One more thing, the ground near the Closed Area is weak so the entrance has been blocked for a long time.{nl}
+QUEST_LV_0100_20150317_000375	The kidnapped people are veteran miners so they may know how to get in.{nl}Well then, may the blessings of the Goddess be with you.
+QUEST_LV_0100_20150317_000376	It wasn't long ago.{nl}I felt a strange power while performing experiments in the Closed Area.{nl}It was different from the mana that we know but it was very warm.{nl}
+QUEST_LV_0100_20150317_000377	But some force did not allow me to approach, as if it had an owner already.{nl}A few days after the incident, the bishop dreamed about the evidence of salvation.{nl}
+QUEST_LV_0100_20150317_000378	Perhaps the evidence of salvation is the force I felt...{nl}That's what I think.
+QUEST_LV_0100_20150317_000379	All I see are monsters and we're out of supplies.{nl}I'm also curious how the battle situation is in Miners' Village.
+QUEST_LV_0100_20150317_000380	Until I'm assigned a new task, I'm thinking of going back to my duties as a search scout.{nl}Observing the monsters, you know.
+QUEST_LV_0100_20150317_000381	The Miners' Village is under siege and entrance is prohibited for civilians.{nl}Remember that we can't guarantee your safety if you do not get my permission.
+QUEST_LV_0100_20150317_000382	You have to cheer up.{nl} Even Sir Aras is holding on.
+QUEST_LV_0100_20150317_000383	Goddess Zemyna overlooks the earth.{nl}There are rumors that the Goddess has abandoned us but that's nonsense.{nl}Her statue still shines beautifully when you pray to it.
+QUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods.{nl}That's why the Mining Village located in the middle of it turned to a battlefield.{nl}
+QUEST_LV_0100_20150317_000385	And that's why I can't permit entrance to the Miners Village. For safety reasons.{nl}Of course it will be a different story if your skill are good enough to ensure your safety even without the protection of guards.
+QUEST_LV_0100_20150317_000386	Gosh, it could have been really dangerous.{nl}That huge thing was hiding so well.
+QUEST_LV_0100_20150317_000387	It's very important to study monsters at times like this.{nl}It's like weather forecasts where you try to find out the cause and see what would happen.
+QUEST_LV_0100_20150317_000388	I'm sure the leaf bugs in Uoros farm stole it.{nl}They did steal from us once before.
 QUEST_LV_0100_20150317_000389	Send my regards to the Guard Captain when you meet him.
-QUEST_LV_0100_20150317_000390	Then, in order to test if your skills are good enough to enter the Miners Village.. {nl} I need you to help us solve a problem we have. {nl}
-QUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus. {nl} I believe this would be a fairly easy task
+QUEST_LV_0100_20150317_000390	In order to test if your skills are good enough to enter the Miners Village,{nl}I need you to help us solve a problem we have.{nl}
+QUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus.{nl}I believe this would be a fairly easy task
 QUEST_LV_0100_20150317_000392	There seems to be a gap in the rock where you can insert something.
-QUEST_LV_0100_20150317_000393	Let's search the Bulvjes farm first. {nl}But don't chase them or something as it can be dangerous.
-QUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess. {nl} Anyway, supplies camp is located further below the farm.
+QUEST_LV_0100_20150317_000393	Let's search the Bulvjes farm first.{nl}But don't chase them or something as it can be dangerous.
+QUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess.{nl}Anyway, the supply camp is located further below the farm.
 QUEST_LV_0100_20150317_000395	
-QUEST_LV_0100_20150317_000396	Vubbes are emerging inside the Mine Gallery so be sure to stay together in groups of 5.
+QUEST_LV_0100_20150317_000396	Vubbes are emerging inside the Mine Gallery so be sure to stay together in groups of five.
 QUEST_LV_0100_20150317_000397	Equipment Merchant
 QUEST_LV_0100_20150317_000398	Even at times like this, I struggle to find the best items I can. You can't go easy in terms of dealing with your customers.
-QUEST_LV_0100_20150317_000399	Monsters attack and steal from people who buy items from me. I think they know can tell which items are good. I feel sorry for those who were attacked but it also proves that the items are worth it.
-QUEST_LV_0100_20150317_000400	The monsters never raided into Klaipeda but with sir Uska gone, it's hard to be at ease. You have you watch out for yourself at times like this.
-QUEST_LV_0100_20150317_000401	I want to travel with a single weapon in hand like an adventurer.. But I guess that's hard..
-QUEST_LV_0100_20150317_000402	If you listen to the soldiers, they use terms only they can understand and make it sound difficult. And when I ask a friend soldier, it's not like they are talking about anything important.
-QUEST_LV_0100_20150317_000403	Be cautious of people who sell weapons from monsters without permit. They scam you to buy useless things or sell at ridiculously high prices.
+QUEST_LV_0100_20150317_000399	Monsters attack and steal from people who buy items from me. I think they know I can tell which items are good.{nl}I feel sorry for those who were attacked but it also proves that the items are worth it.
+QUEST_LV_0100_20150317_000400	The monsters never raided into Klaipeda but with Sir Uska gone, it's hard to be at ease.{nl}You have you watch out for yourself at times like this.
+QUEST_LV_0100_20150317_000401	I want to travel with a single weapon in hand like an adventurer... But it's not that easy.
+QUEST_LV_0100_20150317_000402	If you listen to the soldiers, they'll use terms only they can understand and make it sound difficult.{nl}But when I ask a friend who's a soldier, he says it's not like they are talking about anything important.
+QUEST_LV_0100_20150317_000403	Be cautious of people who sell weapons from monsters without permit.{nl}They'll try and scam you into to buying useless things or sell you things at ridiculously high prices.
 QUEST_LV_0100_20150317_000404	Item Merchant
-QUEST_LV_0100_20150317_000405	It's the little things you miss out that makes you regret when you travel. Better to buy enough of it when you can.
-QUEST_LV_0100_20150317_000406	I feel sorry for those who were injured. Can't we get along with the monsters?
-QUEST_LV_0100_20150317_000407	I'd rather want to stay safe and at peace even if the sales would be lower rather than sales going up because of people worrying when the monsters would attack.
-QUEST_LV_0100_20150317_000408	I sell things that people need but I sometimes think it would have been better if i was a healer because you can be closer to the explorers to help them.
-QUEST_LV_0100_20150317_000409	I hear strange howling from a distance. Could it be the sound of the monstesr?
-QUEST_LV_0100_20150317_000410	People say I'm weird and I talk too much but i don't mind. Even if I'm really weird like they say, that doesn't mean even the items I sell are also weird.
+QUEST_LV_0100_20150317_000405	It's the little things you forget to buy that makes you regret when you travel.{nl}Better buy enough of them when you can.
+QUEST_LV_0100_20150317_000406	I feel sorry for those who were injured. Can't we just get along with the monsters?
+QUEST_LV_0100_20150317_000407	I'd rather stay safe and at peace with lower sales than have sales go up because of people worrying when the monsters might attack.
+QUEST_LV_0100_20150317_000408	I sell things that people need, but I sometimes think it would've been better if I was a healer,{nl}because that way I could be closer to the explorers to help them.
+QUEST_LV_0100_20150317_000409	I hear strange howling from the distance. Could it be the sound of the monsters?
+QUEST_LV_0100_20150317_000410	People say I'm weird and I talk too much but I don't mind. Even if I'm really weird like they say, that doesn't mean the items I sell are weird.
 QUEST_LV_0100_20150317_000411	Blacksmith
-QUEST_LV_0100_20150317_000412	Hello. {nl} I can help you repair items but I can't craft new ones because I don't have the materials. {nl} Go on and choose from whatever is available.
+QUEST_LV_0100_20150317_000412	Hello.{nl}I can help you repair items but I can't craft new ones because I don't have the materials.{nl}Go on and choose from whatever is available.
 QUEST_LV_0100_20150317_000413	Klaipeda resident
-QUEST_LV_0100_20150317_000414	It's true we're in tough times but everyone looking after the soldiers only.
-QUEST_LV_0100_20150317_000415	Aside from anything else, I want to eat till i'm full. {nl} You need to eat to have strength.
-QUEST_LV_0100_20150317_000416	Why have the Goddess disappeared? {nl} Everyone is looking for where they've gone but no one is asking why they disappeared.
-QUEST_LV_0100_20150317_000417	I can't eat, wear, or rest freely because of those monsters. {nl} In the old days, we used gather herbs or pick fruits in Siaulai Forest you know.
-QUEST_LV_0100_20150317_000418	Everyone is talking about the war wherever you go. {nl} Like who and how much people are hurt or who's assigned to where. {nl} All the stories about the war makes me sick!
-QUEST_LV_0100_20150317_000419	I heard they will send soldiers who aren't even trained into the nest of monsters. {nl} It might be better to gather the old people and make them soldiers.
-QUEST_LV_0100_20150317_000420	My life is just a repetition of worries and anger. {nl} The Goddess should return soon.
-QUEST_LV_0100_20150317_000421	There are suddenly many people who dreamed about the revelation. {nl} Could it be a sign of something about to happen again? {nl}
-QUEST_LV_0100_20150317_000422	Bishop of Klaipeda also dreamed about the Goddess. {nl} Could it be the same dream with the Revelators?
+QUEST_LV_0100_20150317_000414	It's true these are tough times but everyone is looking out for the soldiers.
+QUEST_LV_0100_20150317_000415	Aside from everything else, I want to eat till I'm full.{nl}You need to eat to have strength.
+QUEST_LV_0100_20150317_000416	Why have the goddesses disappeared?{nl}Everyone is looking for where they've gone but no one is asking why they've disappeared.
+QUEST_LV_0100_20150317_000417	I can't eat, sleep, or move about freely because of those monsters.{nl}In the old days, we used gather herbs or pick fruits in Siaulai Forest you know.
+QUEST_LV_0100_20150317_000418	Everyone is talking about the war wherever you go.{nl}Like who and how much people are hurt or who's assigned to where.{nl}All the stories about the war makes me sick!
+QUEST_LV_0100_20150317_000419	I heard they will send soldiers who aren't even trained into the nest of monsters.{nl}It might be better to gather the old people and make them soldiers.
+QUEST_LV_0100_20150317_000420	My life is just a repetition of worries and anger.{nl}The Goddess should return soon.
+QUEST_LV_0100_20150317_000421	There are suddenly many people who dreamed about the revelation.{nl}Could it be a sign that something is about to happen again?{nl}
+QUEST_LV_0100_20150317_000422	Bishop of Klaipeda also dreamed about the Goddess.{nl}Could it be the same dream as with the Revelators?
 QUEST_LV_0100_20150317_000423	Mother of Soldier
-QUEST_LV_0100_20150317_000424	)} My son had enlisted to the Army. {nl} He said who would if not him at such difficult times like this.
-QUEST_LV_0100_20150317_000425	)} Monster are growing and the forest is too chaotic for people to live in. {nl} At least, Klaipeda is safe.
-QUEST_LV_0100_20150317_000426	)} At least Klaipeda is safe but other cities are in chaos? {nl} Well, putting aside the capital, Fedimian has totally collapsed except for the Sacred Area.
-QUEST_LV_0100_20150317_000427	)} It's a good thing that my son accomplished his dream of becoming a solder.. {nl} But the monsters are rising and I'm worried he might get hurt.
-QUEST_LV_0100_20150317_000428	)} Maybe Klaipeda is where the Goddess has bestowed her blessings. {nl} I hope the blessings would also reach my son who enlisted in the army.
-QUEST_LV_0100_20150317_000429	)} My husband used to be a miner and how relieved I am that he isn't anymore. {nl} It would be too dangerous if the monsters raid at times like this isn't it?
-QUEST_LV_0100_20150317_000430	)} Many refugees came from the fallen town. {nl} Our food supplies are also running short but we still have to help each other.
-QUEST_LV_0100_20150317_000431	I may not bring in the items with best quality but isn't having all the items necessary a skill of its own? Gotta work hard to get through tough times.
-QUEST_LV_0100_20150317_000432	I think the best weapons and armors are the ones that you get used to over a long period time. In order to do so, you must start first by buying good items.
-QUEST_LV_0100_20150317_000433	I used to pack my things and go around on travel in the past but I guess that would be difficult now.
+QUEST_LV_0100_20150317_000424	)} My son has enlisted in the Army.{nl}He said who would, if not him, at such difficult times like this.
+QUEST_LV_0100_20150317_000425	)} Monster are growing and the forest is too chaotic for people to live in.{nl}At least, Klaipeda is safe.
+QUEST_LV_0100_20150317_000426	)} At least Klaipeda is safe but other cities are in chaos?{nl}Well, putting aside the capital, Fedimian has totally collapsed except for the Sacred Area.
+QUEST_LV_0100_20150317_000427	)} It's a good thing that my son accomplished his dream of becoming a solder...{nl}But the monsters are rising and I'm worried he might get hurt.
+QUEST_LV_0100_20150317_000428	)} Maybe Klaipeda is where the Goddess has bestowed her blessings.{nl}I hope the blessings will also reach my son who enlisted in the army.
+QUEST_LV_0100_20150317_000429	)} My husband used to be a miner and how relieved I am that he isn't anymore.{nl}It would be too dangerous if the monsters raid at times like this wouldn't it?
+QUEST_LV_0100_20150317_000430	)} Many refugees came from the fallen town.{nl}Our food supplies are running short but we still have to help each other.
+QUEST_LV_0100_20150317_000431	I may not bring in the items with best quality, but isn't having all the items necessary a skill of its own?{nl}I've got to work hard to get through tough times.
+QUEST_LV_0100_20150317_000432	I think the best weapons and armor are the ones that you get used to over a long period time.{nl}In order to do so, you must start first by buying good items.
+QUEST_LV_0100_20150317_000433	I used to pack my things and go around travelling in the past but I guess that would be difficult now.
 QUEST_LV_0100_20150317_000434	Try using a variety of weapons. Eventually, you'll find one that a fits you.
 QUEST_LV_0100_20150317_000435	The armors that suit you guarantees your safety.
-QUEST_LV_0100_20150317_000436	Difference in a single armor can result in life and death. Look around if you have anything you need.
+QUEST_LV_0100_20150317_000436	A single armor piece can mean the difference between life and death. Look around if you have everything you need.
 QUEST_LV_0100_20150317_000437	It's free to look around.
 QUEST_LV_0100_20150317_000438	Look around and see if you need anything.
 QUEST_LV_0100_20150317_000439	Look around carefully. You might find something that can help you.
-QUEST_LV_0100_20150317_000440	Sometimes, things that you just look at without any thoughts can actually fit you very well so take a look and think about it.
+QUEST_LV_0100_20150317_000440	Sometimes, things that you just look at without any thoughts can actually fit you very well, so take a look and think about it.
 QUEST_LV_0100_20150317_000441	You can just look around. Find me anytime you need.
 QUEST_LV_0100_20150317_000442	We have enough items so take a look.
-QUEST_LV_0100_20150317_000443	You need good weapons and armors to prepare for the monsters. That is what I'm selling.
+QUEST_LV_0100_20150317_000443	You need good weapons and armor to prepare for the monsters. That is what I'm selling.
 QUEST_LV_0100_20150317_000444	Items I have for sale are flawless. These are all new.
-QUEST_LV_0100_20150317_000445	If you don't prepare the equipments now, you might regret it later when you're surrounded by the monsters. Look around when you can.
+QUEST_LV_0100_20150317_000445	If you don't prepare the equipment now, you might regret it later, when you're surrounded by monsters. Have a look around when you can.
 QUEST_LV_0100_20150317_000446	I've prepared the best items I can find. The prices aren't bad either so look around.
 QUEST_LV_0100_20150317_000447	The things I sell are good both in price and quality.
-QUEST_LV_0100_20150317_000448	Care to look at the items I'm selling if you have time?
+QUEST_LV_0100_20150317_000448	If you have the time, take a look at the items I have for sale.
 QUEST_LV_0100_20150317_000449	I hope good items will find good owners.
-QUEST_LV_0100_20150317_000450	Yes this was originally a bustling shopping area. But everyone left as it became difficult to live..
+QUEST_LV_0100_20150317_000450	Yes this was originally a bustling shopping area. But everyone left as it became difficult to live...
 QUEST_LV_0100_20150317_000451	I was too busy to afford to talk to the people when they gathered.
-QUEST_LV_0100_20150317_000452	A lot of people seem to be coming thanks to sir Uska's recruitment notice.
-QUEST_LV_0100_20150317_000453	There's a lot to prepare when you go to battle with the monsters.
+QUEST_LV_0100_20150317_000452	A lot of people seem to be coming thanks to Sir Uska's recruitment notice.
+QUEST_LV_0100_20150317_000453	There's a lot of preparation for when you go to battle with the monsters.
 QUEST_LV_0100_20150317_000454	Times are difficult but I decided not to raise the prices. Have a look.
-QUEST_LV_0100_20150317_000455	Monsters mistake things for food and swallow just swallow it. They must be really hungry.
-QUEST_LV_0100_20150317_000456	I once encountered a monster in Siauliai Woods. I just stood still and the monster went away... I guess there are monsters that do not make the first attack on people.
+QUEST_LV_0100_20150317_000455	Monsters mistake things for food and just swallow it. They must be really hungry.
+QUEST_LV_0100_20150317_000456	I once encountered a monster in Siauliai Woods. I just stood still and the monster went away...{nl}I guess there are monsters that do not make the first attack on people.
 QUEST_LV_0100_20150317_000457	I've heard that some people sell things that are dropped from those who were running away from the monsters. Things I sell are not like that so no need to worry about that.
-QUEST_LV_0100_20150317_000458	Everything aside, I do not lie about my items being cheap. The stuff I sell are priced just right.
+QUEST_LV_0100_20150317_000458	Everything aside, I do not lie about my items being cheap. The stuff I sell is priced just right.
 QUEST_LV_0100_20150317_000459	Feel free to look around anytime.
 QUEST_LV_0100_20150317_000460	It can be hard if you don't prepare enough potions.
 QUEST_LV_0100_20150317_000461	It's free to look around the things I sell.
-QUEST_LV_0100_20150317_000462	How do continue business if you don't make profits?
+QUEST_LV_0100_20150317_000462	How do you continue running a business if you don't make profits?
 QUEST_LV_0100_20150317_000463	I thought about moving my business to somewhere else but I had to stay for the people who come to me.
-QUEST_LV_0100_20150317_000464	I don't think of making a lot of money. You just need what's enough to get live by.
-QUEST_LV_0100_20150317_000465	I think we have to help each other at difficult times like this. I hope could be of help.
+QUEST_LV_0100_20150317_000464	I don't think of making a lot of money. I just need enough to live by.
+QUEST_LV_0100_20150317_000465	I think we have to help each other at difficult times like these. I hope I can be of help.
 QUEST_LV_0100_20150317_000466	Can I help you? I'll show you what we have prepared.
 QUEST_LV_0100_20150317_000467	Please feel free to come back if you need anything.
 QUEST_LV_0100_20150317_000468	You don't necessarily have to buy things so feel free to look around
@@ -470,47 +470,47 @@ QUEST_LV_0100_20150317_000469	I sold items even before the monsters appeared.
 QUEST_LV_0100_20150317_000470	Don't you feel good just looking at the items even if you don't buy them?
 QUEST_LV_0100_20150317_000471	You can find me anytime if you want a look at the items I'm selling.
 QUEST_LV_0100_20150317_000472	What would it be like to go on an adventure fighting monsters? I was born and raised here so I sometimes wonder how it would be in other areas.
-QUEST_LV_0100_20150317_000473	When I see the soldiers who protect from the monsters, I want to give them for free sometimes. Although it's really not easy to do so..
+QUEST_LV_0100_20150317_000473	Sometimes when I see the soldiers who protect us from the monsters, I want to give them things for free.{nl}Although it's really not easy for me to do so...
 QUEST_LV_0100_20150317_000474	Better were the days when Commander Uska took care of Klaipeda himself.
 QUEST_LV_0100_20150317_000475	Isn't there a way to get rid of all the monsters running wild in Siauliai Forest?
 QUEST_LV_0100_20150317_000476	I hope some skilled person could drive out all the monsters.
-QUEST_LV_0100_20150317_000477	Living in a place where monsters are running wild outside is driving me nuts. {nl} And I can't think of going anywhere else because of the monsters..
-QUEST_LV_0100_20150317_000478	I'd wipe out all the monsters if I had the skills. {nl} Why are soldiers leaving the monsters alone?
+QUEST_LV_0100_20150317_000477	Living in a place where monsters are running wild outside is driving me nuts.{nl}And I can't think of going anywhere else because of the monsters...
+QUEST_LV_0100_20150317_000478	I'd wipe out all the monsters if I had the skills.{nl}Why are soldiers leaving the monsters alone?
 QUEST_LV_0100_20150317_000479	I am tired of living a life running away from the monsters.
-QUEST_LV_0100_20150317_000480	Thinking of the peaceful days in the past make me feel like I'm dreaming . {nl} Like a very long nightmare.
-QUEST_LV_0100_20150317_000481	I want to run away to another place if I can. {nl} Is there a future for the kingdom.
-QUEST_LV_0100_20150317_000482	I can't sleep well nowadays. {nl} It's all because of those monsters.
-QUEST_LV_0100_20150317_000483	To live at peace in a world where monsters are running wild ... Impossible.
-QUEST_LV_0100_20150317_000484	Does salvation even exist? {nl} Hanging on each day in hopes of the Goddess is really miserable.
-QUEST_LV_0100_20150317_000485	We can't go out nor just stay. Is this really ok? {nl}I can't seem to find an answer no matter how much I think about it.
+QUEST_LV_0100_20150317_000480	Thinking of the peaceful days in the past makes me feel like I'm dreaming.{nl}Being awake is like a very long nightmare.
+QUEST_LV_0100_20150317_000481	I want to run away to another place if I can.{nl}Is there a future for the kingdom?
+QUEST_LV_0100_20150317_000482	I can't sleep well nowadays.{nl}It's all because of those monsters.
+QUEST_LV_0100_20150317_000483	To live at peace in a world where monsters are running wild... Impossible.
+QUEST_LV_0100_20150317_000484	Does salvation even exist?{nl}Hanging on each day in hopes of the Goddess is really miserable.
+QUEST_LV_0100_20150317_000485	We can't go out nor can we just stay. Is this really ok?{nl}I can't seem to find an answer no matter how much I think about it.
 QUEST_LV_0100_20150317_000486	Getting used to a world living together with monsters, what a terrible and scary thing is that?
-QUEST_LV_0100_20150317_000487	I heard that there are people who study monsters. {nl} What is wrong with them. {nl} Those monsters are bad creatures that could attack us any moment.
-QUEST_LV_0100_20150317_000488	I'm afraid that Klaipeda might become like the capital. {nl}It's now being called the fallen city, right?
-QUEST_LV_0100_20150317_000489	Many people are afraid of Bokors for summoning the zombies. {nl} But we curse of the enemy of the Goddess.
-QUEST_LV_0100_20150317_000490	Intelligence. calm judgment and cold rationality. {nl} These are the qualities required for our Cryomnacer.
-QUEST_LV_0100_20150317_000491	Fire is grace sent to us by the Goddess Gabija. {nl} You cannot become a great Pyromancer if you overlook that. 
-QUEST_LV_0100_20150317_000492	It is vain death that lies at the end of those who only seek dauntlessness. {nl} If you wish to achieve true justice, lift the shield of Peltasta.
-QUEST_LV_0100_20150317_000493	After the Goddesses disappeared, the capital was destroyed on the Day of Divine. {nl} I hope more people will become Paltastas to protect the world.
+QUEST_LV_0100_20150317_000487	I heard that there are people who study monsters.{nl}What is wrong with them?{nl}Those monsters are bad creatures that could attack us at any moment.
+QUEST_LV_0100_20150317_000488	I'm afraid that Klaipeda might become like the capital.{nl}It's now being called the fallen city, right?
+QUEST_LV_0100_20150317_000489	Many people are afraid of Bokors for summoning the zombies.{nl}But we curse the enemy of the Goddess.
+QUEST_LV_0100_20150317_000490	Intelligence, calm judgment and cold rationality.{nl}These are the qualities required for our Cryomancers.
+QUEST_LV_0100_20150317_000491	Fire is grace sent to us by the Goddess Gabija.{nl}You cannot become a great Pyromancer if you overlook that.
+QUEST_LV_0100_20150317_000492	It is vain death that lies at the end for those who only seek dauntlessness.{nl}If you wish to achieve true justice, lift the shield of Peltasta.
+QUEST_LV_0100_20150317_000493	After the Goddesses disappeared, the capital was destroyed on the Day of Divine.{nl}I hope more people will become Paltastas to protect the world.
 QUEST_LV_0100_20150317_000494	Rodelero Master
 QUEST_LV_0100_20150317_000495	
-QUEST_LV_0100_20150317_000496	Master Squire 
-QUEST_LV_0100_20150317_000497	We are in chaos nowadays, but we used to live in honorable times before.{nl}Well.. they are all past now.
+QUEST_LV_0100_20150317_000496	Master Squire
+QUEST_LV_0100_20150317_000497	We are in chaos nowadays, but we used to live in honorable times before.{nl}Well.. they are all in the past now.
 QUEST_LV_0100_20150317_000498	Master Wizard
 QUEST_LV_0100_20150317_000499	No matter how much magic talent you have, it is useless unless you train hard.
-QUEST_LV_0100_20150317_000500	You must be brave in order to protect the kingdom. {nl} But for that bravery to be different from recklessness, your skills should be good enough.
-QUEST_LV_0100_20150317_000501	The Goddesses may be all gone but my powers are still doing fine, right? {nl} I'm sure it must be proof that Goddess Gabija is at least safe somewhere.
+QUEST_LV_0100_20150317_000500	You must be brave in order to protect the kingdom.{nl}But for that bravery to be different from recklessness, your skills should be good enough.
+QUEST_LV_0100_20150317_000501	The Goddesses may be all gone but my powers are still doing fine, right?{nl}I'm sure it must be proof that Goddess Gabija is at least safe somewhere.
 QUEST_LV_0100_20150317_000502	
 QUEST_LV_0100_20150317_000503	
 QUEST_LV_0100_20150317_000504	Master Quarrelshooter
-QUEST_LV_0100_20150317_000505	It's painful to see people who come to Klaipeda seeking refuge from the monsters. {nl} That wouldn't have been necessary if you were a Quarrel Shooter.
+QUEST_LV_0100_20150317_000505	It's painful to see people who come to Klaipeda seeking refuge from the monsters.{nl}That wouldn't have been necessary if you were a Quarrel Shooter.
 QUEST_LV_0100_20150317_000506	Ranger Master
 QUEST_LV_0100_20150317_000507	I heard monsters swarm in flocks outside of Klaipeda.{nl} It would be better to learn/train my skill rather than foolishly attack them one by one.
 QUEST_LV_0100_20150317_000508	Sapper Master
-QUEST_LV_0100_20150317_000509	People shouldn't do things they'll regret. {nl} I lost even the ones whom I want to ask for forgiveness on the Divine Day four years ago. {nl}
+QUEST_LV_0100_20150317_000509	People shouldn't do things they'll regret.{nl}I lost even the ones whom I want to ask for forgiveness on the Divine Day four years ago.{nl}
 QUEST_LV_0100_20150317_000510	Archer Master
-QUEST_LV_0100_20150317_000511	Killing enemies one by one from a distance is the beauty of the bow and arrow. {nl} No matter how many shots you make, it's the actual shots that count, isn't it?
+QUEST_LV_0100_20150317_000511	Killing enemies one by one from a distance is the beauty of the bow and arrow.{nl}No matter how many shots you make, it's the actual shots that count, isn't it?
 QUEST_LV_0100_20150317_000512	Priest Master
-QUEST_LV_0100_20150317_000513	Priest does not suspect the Goddess. {nl} Only faith can support the priest.
+QUEST_LV_0100_20150317_000513	Priest does not suspect the Goddess.{nl}Only faith can support the priest.
 QUEST_LV_0100_20150317_000514	Sadhu Master
 QUEST_LV_0100_20150317_000515	The inner side of every properties have truthful and divine entities in them.{nl}They are called Spirits.
 QUEST_LV_0100_20150317_000516	Rexipher
@@ -530,17 +530,17 @@ QUEST_LV_0100_20150317_000529	According to soldiers, other monsters are appearin
 QUEST_LV_0100_20150317_000530	Those silly things are keep coming to us.{nl}I will go get Sparnas from now on.{nl}It will be the first and the last chance. Tell me when you are ready.
 QUEST_LV_0100_20150317_000531	They are just creating so many problems.{nl}They even got their hands on the supplies, I will not feel enough even if I hit him with a bat in the middle of the market.
 QUEST_LV_0100_20150317_000532	What? Tutu? {nl}I don't have to time to think about those negligible beings.
-QUEST_LV_0100_20150317_000533	When you level up, you can increase a status of your choice and become stronger. {nl} Would you like to check it now?
-QUEST_LV_0100_20150317_000534	It's important to think ahead about what you would want to be. {nl} It's never an easy thing.
-QUEST_LV_0100_20150317_000535	Yes. That's how you do it. {nl} Pretty simple, huh?
-QUEST_LV_0100_20150317_000536	Sir Aras is in the center area of the Woods. {nl} But there has been a tremendous increase in monsters around here so I suggest you don't go in.
-QUEST_LV_0100_20150317_000537	The monster that somehow coming into the Klaipeda but has received. {nl} If you do not want to delete monster increases were due to Locate and it will be a difficult. {nl}
-QUEST_LV_0100_20150317_000538	The strange feeling I had in the Crystal Mine 3rd Gallery, {nl} it keeps occurring to me that it might be related to the girl that town people are talking about. {nl}
+QUEST_LV_0100_20150317_000533	When you level up, you can increase a status of your choice and become stronger.{nl}Would you like to check it now?
+QUEST_LV_0100_20150317_000534	It's important to think ahead about what you would want to be.{nl}It's never an easy thing.
+QUEST_LV_0100_20150317_000535	Yes. That's how you do it.{nl}Pretty simple, huh?
+QUEST_LV_0100_20150317_000536	Sir Aras is in the center area of the Woods.{nl}But there has been a tremendous increase in monsters around here so I suggest you don't go in.
+QUEST_LV_0100_20150317_000537	The monster that somehow coming into the Klaipeda but has received.{nl}If you do not want to delete monster increases were due to Locate and it will be a difficult.{nl}
+QUEST_LV_0100_20150317_000538	The strange feeling I had in the Crystal Mine 3rd Gallery,{nl}it keeps occurring to me that it might be related to the girl that town people are talking about.{nl}
 QUEST_LV_0100_20150317_000539	I just feel bad that I wasn't able to meet
-QUEST_LV_0100_20150317_000540	Thank you for saving the villagers but, {nl} you're not going to the Closed Area, are you?
+QUEST_LV_0100_20150317_000540	Thank you for saving the villagers but,{nl}you're not going to the Closed Area, are you?
 QUEST_LV_0100_20150317_000541	Let's unleash the last seal at the left side of here.{nl}The odor in the air is changing. I am sure it's a demon.
 QUEST_LV_0100_20150317_000542	Demons are approaching. It's not good.{nl}It is sealed tightly, but I don't feel safe.
-QUEST_LV_0100_20150317_000543	I smell was BiteRegina I underwriting. and {nl} It was good because as not hurt.
+QUEST_LV_0100_20150317_000543	I smell was BiteRegina I underwriting. and{nl}It was good because as not hurt.
 QUEST_LV_0100_20150317_000544	Okay. So the hidden door to the Divine Place is open now so please enter.{nl}You will see one of the two seals that protect the architects of Zachariel, the great king.
 QUEST_LV_0100_20150317_000545	Now, we just have to see Zachariel's eternal sleep.{nl}It was a real honor for me to meet you.
 QUEST_LV_0100_20150317_000546	Well done.{nl}Morcus is wating for you at the Long Bridge Canyon. Hurry.
@@ -573,20 +573,20 @@ QUEST_LV_0100_20150317_000572	I will move out from here.{nl}For more research, w
 QUEST_LV_0100_20150317_000573	By the way, why are these stones acting like this?
 QUEST_LV_0100_20150317_000574	I can't trust you yet since I haven't worked with you before.{nl}Come back after you are more experienced.
 QUEST_LV_0100_20150317_000575	I can not accept myself. I just saw those village people being taken away.
-QUEST_LV_0100_20150317_000576	Belief in yourself. Endless confidence. {nl} These are the most important things when projecting yourself in reality. {nl} That is the nature of Psychokino and the power that moves the world.
-QUEST_LV_0100_20150317_000577	Linker is someone who connects people with the rope of Mana. {nl} How strong the connection is depends on the quality of Mana.
+QUEST_LV_0100_20150317_000576	Belief in yourself. Endless confidence.{nl}These are the most important things when projecting yourself in reality.{nl}That is the nature of Psychokino and the power that moves the world.
+QUEST_LV_0100_20150317_000577	Linker is someone who connects people with the rope of Mana.{nl}How strong the connection is depends on the quality of Mana.
 QUEST_LV_0100_20150317_000578	Cataphract Master
-QUEST_LV_0100_20150317_000579	Cataphract program, has the power to proceed through all the enemies that confront before. {nl} and brave warriors to fight on the front lines.
+QUEST_LV_0100_20150317_000579	Cataphract program, has the power to proceed through all the enemies that confront before.{nl}and brave warriors to fight on the front lines.
 QUEST_LV_0100_20150317_000580	May I help you? {nl}Fortunately, we have some potions left in stock.
-QUEST_LV_0100_20150317_000581	Looking for some good equipment? {nl} I have prepared the best ones available. {nl} Look around, the prices aren't bad either.
-QUEST_LV_0100_20150317_000582	Oh, this anvil is my small gift to you for saving me. {nl} It's a useful item that can upgrade your equipment. {nl}
+QUEST_LV_0100_20150317_000581	Looking for some good equipment?{nl}I have prepared the best ones available.{nl}Look around, the prices aren't bad either.
+QUEST_LV_0100_20150317_000582	Oh, this anvil is my small gift to you for saving me.{nl}It's a useful item that can upgrade your equipment.{nl}
 QUEST_LV_0100_20150317_000583	Well then, see you in the mines.
-QUEST_LV_0100_20150317_000584	Miner's village Mayor
+QUEST_LV_0100_20150317_000584	Miners' Village Mayor
 QUEST_LV_0100_20150317_000585	
 QUEST_LV_0100_20150317_000586	Goddess Saule
 QUEST_LV_0100_20150317_000587	To retrieve the revelation, please go to Fallen Worry Forest.{nl}Now is the chance when the Demons' Lord, Bramble recovers his power.
 QUEST_LV_0100_20150317_000588	Royal Tomb Foundation Stone
-QUEST_LV_0100_20150317_000589	I pass my words to the revelotor who comes here.{nl}I, Zachariel, sleep here to protect the goal of the goddess. 
+QUEST_LV_0100_20150317_000589	I pass my words to the revelotor who comes here.{nl}I, Zachariel, sleep here to protect the goal of the goddess.
 QUEST_LV_0100_20150317_000590	If something vicious comes here, protect here from it by waking the sleeping protector.{nl}{nl}
 QUEST_LV_0100_20150317_000591	The manual to use Royal Tomb Cube
 QUEST_LV_0100_20150317_000592	The protector who is polluted with the vicious atmosphere will forget his responsibility to protect the royal tomb.{nl}We can defeat the protector near the cube.
@@ -619,7 +619,7 @@ QUEST_LV_0100_20150317_000618	To have guardians perform their mission, you need 
 QUEST_LV_0100_20150317_000619	If the origins of royal tomb's power be contaminated, guardians will lose their mission.{nl}You can purify the origins of royal tomb's power by lighting up the stone lanterns with burning stone inside of a guardian.
 QUEST_LV_0100_20150317_000620	Instruction of royal tomb's power suppressor
 QUEST_LV_0100_20150317_000621	
-QUEST_LV_0100_20150317_000622	Due to devil's tric, magical stream has been lost.{nl}You need to gather and charge magical sources of guardians. 
+QUEST_LV_0100_20150317_000622	Due to devil's tric, magical stream has been lost.{nl}You need to gather and charge magical sources of guardians.
 QUEST_LV_0100_20150317_000623	It is good enough.{nl}Now, charge for lack of magical power.
 QUEST_LV_0100_20150317_000624	I will open the way.{nl}Charge lack of magical power by reigniting the stone lantern of royal tomb.
 QUEST_LV_0100_20150317_000625	When suppressed power flows again, guardians will regain their reason.{nl}But it would take a long time.
@@ -668,7 +668,7 @@ QUEST_LV_0100_20150317_000667	Are you going to Fedimian as well?{nl}We are stone
 QUEST_LV_0100_20150317_000668	
 QUEST_LV_0100_20150317_000669	There is no reason for those monsters walking around. {nl}They are just there.
 QUEST_LV_0100_20150317_000670	Hey, Why are you so late?{nl}While you were gone, monsters stole everything from us!
-QUEST_LV_0100_20150317_000671	We can reimburse for the expenses for others, but what about the tool box? {nl}We lost Sprit of Stonemason to Moa.. 
+QUEST_LV_0100_20150317_000671	We can reimburse for the expenses for others, but what about the tool box? {nl}We lost Sprit of Stonemason to Moa..
 QUEST_LV_0100_20150317_000672	The ones with wings like sparkling things.
 QUEST_LV_0100_20150317_000673	There was no tool box?{nl}Well. We can't do anything about it. I will think that I just got revenge on it.{nl}
 QUEST_LV_0100_20150317_000674	Tara Milds
@@ -701,59 +701,59 @@ QUEST_LV_0100_20150317_000700	It's called Moa. {nl}It ran away to the abondoned 
 QUEST_LV_0100_20150317_000701	
 QUEST_LV_0100_20150317_000702	Did Laima know that the world would turn out like this?{nl}She is the goddess of destiny and forecasts.
 QUEST_LV_0100_20150317_000703	It's not a strange, Even the world will over tomorrow.{nl}But I want to know. Why Goddess disappeared..
-QUEST_LV_0100_20150317_000704	Press the {Img F1 40 40} key to use your remaining status points on the ability you want to enhance. {nl}
+QUEST_LV_0100_20150317_000704	Press the {Img F1 40 40} key to use your remaining status points on the ability you want to enhance.{nl}
 QUEST_LV_0100_20150317_000705	Press the {Img F10 40 40} key to open the Help menu.
-QUEST_LV_0100_20150317_000706	Press the {Img F3 40 40} key to open the Skill window. Use available skill points on the skills you want to enhance, then click Apply. {nl}
-QUEST_LV_0100_20150317_000707	Finding and offering a worship to all the Statues of Goddess scattered around the world while you travel,  will surely have you compensated. {nl}
+QUEST_LV_0100_20150317_000706	Press the {Img F3 40 40} key to open the Skill window. Use available skill points on the skills you want to enhance, then click Apply.{nl}
+QUEST_LV_0100_20150317_000707	Finding and offering a worship to all the Statues of Goddess scattered around the world while you travel,  will surely have you compensated.{nl}
 QUEST_LV_0100_20150317_000708	Press the {Img F10 40 40} key to open the Help window for more information.
 QUEST_LV_0100_20150317_000709	Other troops are fighting in the Miners' Village and we are blocking the monsters from here. {nl}I don't think the Vubbes are smart enough to make use of tactics... I am concerned about that.
-QUEST_LV_0100_20150317_000710	We have problems here, but I'm also worried about the other troops fighting in the Miners' Village. {nl} Normally, it should have been cleared up pretty fast.
+QUEST_LV_0100_20150317_000710	We have problems here, but I'm also worried about the other troops fighting in the Miners' Village.{nl}Normally, it should have been cleared up pretty fast.
 QUEST_LV_0100_20150317_000711	Guard Gilbert
-QUEST_LV_0100_20150317_000712	It's the Pantos again. {nl} They even stole the working parts. {nl} Well then, we've got to take them back, right?
-QUEST_LV_0100_20150317_000713	I could handle it myself. {nl}Those weaklings would come trembling on their knees to return the parts. {nl} But what if more thieves come while I'm at it?
-QUEST_LV_0100_20150317_000714	Well done. {nl} Now put this on and grease it then it will work as it should. 
-QUEST_LV_0100_20150317_000715	The Pantos hid some parts in the grasslands of Mieguista Hills. {nl} Try to get me those for the time being since it's urgent.
-QUEST_LV_0100_20150317_000716	The Pantos think the grassland hides everything. {nl} I used to find that cute about them.
+QUEST_LV_0100_20150317_000712	It's the Pantos again.{nl}They even stole the working parts.{nl}Well then, we've got to take them back, right?
+QUEST_LV_0100_20150317_000713	I could handle it myself. {nl}Those weaklings would come trembling on their knees to return the parts.{nl}But what if more thieves come while I'm at it?
+QUEST_LV_0100_20150317_000714	Well done.{nl}Now put this on and grease it then it will work as it should.
+QUEST_LV_0100_20150317_000715	The Pantos hid some parts in the grasslands of Mieguista Hills.{nl}Try to get me those for the time being since it's urgent.
+QUEST_LV_0100_20150317_000716	The Pantos think the grassland hides everything.{nl}I used to find that cute about them.
 QUEST_LV_0100_20150317_000717	Guard Matthew
-QUEST_LV_0100_20150317_000718	I am looking for cable car parts but nothings seems to be in sight. {nl} Maybe the Zignuts of Nepavy sun swallowed it. {nl}
+QUEST_LV_0100_20150317_000718	I am looking for cable car parts but nothings seems to be in sight.{nl}Maybe the Zignuts of Nepavy sun swallowed it.{nl}
 QUEST_LV_0100_20150317_000719	
 QUEST_LV_0100_20150317_000720	I want to go destroy those demons, but..{nl}Cable car is not working well so I should go after fixing it.
-QUEST_LV_0100_20150317_000721	If it wasn't for me, uncle Gilbert would have been going around looking through this huge area. {nl} I'm truly worried.
-QUEST_LV_0100_20150317_000722	This is a sacred place we have enshrined for generations. {nl} We used to hold prayer and important meetings whenever there was a disaster {nl}
-QUEST_LV_0100_20150317_000723	But it's been like this since it fell to evil forces four years ago. {nl} I guess the elders couldn't have helped it either.
-QUEST_LV_0100_20150317_000724	In the past, it was just a rope on a lax basket. {nl} You had to put your life on the line whenever you crossed it. {nl}
-QUEST_LV_0100_20150317_000725	So I went to Klaipeda and learned the skills myself. {nl} I have to start looking for a successor, but Matthew doesn't seem interested.
+QUEST_LV_0100_20150317_000721	If it wasn't for me, uncle Gilbert would have been going around looking through this huge area.{nl}I'm truly worried.
+QUEST_LV_0100_20150317_000722	This is a sacred place we have enshrined for generations.{nl}We used to hold prayer and important meetings whenever there was a disaster{nl}
+QUEST_LV_0100_20150317_000723	But it's been like this since it fell to evil forces four years ago.{nl}I guess the elders couldn't have helped it either.
+QUEST_LV_0100_20150317_000724	In the past, it was just a rope on a lax basket.{nl}You had to put your life on the line whenever you crossed it.{nl}
+QUEST_LV_0100_20150317_000725	So I went to Klaipeda and learned the skills myself.{nl}I have to start looking for a successor, but Matthew doesn't seem interested.
 QUEST_LV_0100_20150317_000726	Guard Basil
-QUEST_LV_0100_20150317_000727	The curse doll will be filled with the mine of Mushcaria. {nl} It is in the Tustanti Plateu, can you get it for me?
-QUEST_LV_0100_20150317_000728	They used to be considered mysterious creatures, worthy of respect. {nl} But nowadays you just go a few steps outside town and they are everywhere, preying on people.
-QUEST_LV_0100_20150317_000729	I forgot that Mushcaria is still alive. {nl} Anyway, good job.
+QUEST_LV_0100_20150317_000727	The curse doll will be filled with the mine of Mushcaria.{nl}It is in the Tustanti Plateu, can you get it for me?
+QUEST_LV_0100_20150317_000728	They used to be considered mysterious creatures, worthy of respect.{nl}But nowadays you just go a few steps outside town and they are everywhere, preying on people.
+QUEST_LV_0100_20150317_000729	I forgot that Mushcaria is still alive.{nl}Anyway, good job.
 QUEST_LV_0100_20150317_000730	There is enough time, so visit Algis first.
-QUEST_LV_0100_20150317_000731	Now I will head this way to the church. {nl} Our Paladin friend likes the word 'if' a lot. {nl}
-QUEST_LV_0100_20150317_000732	If our mission goes as planned, then we will have no need to meet again. {nl} Well, it sounds like it would be unpleasant to meet you again, haha.
+QUEST_LV_0100_20150317_000731	Now I will head this way to the church.{nl}Our Paladin friend likes the word 'if' a lot.{nl}
+QUEST_LV_0100_20150317_000732	If our mission goes as planned, then we will have no need to meet again.{nl}Well, it sounds like it would be unpleasant to meet you again, haha.
 QUEST_LV_0100_20150317_000733	Guard Allen
-QUEST_LV_0100_20150317_000734	The Mazas barrier which should the Demons have been destroyed. {nl} Would you help me repair it?
-QUEST_LV_0100_20150317_000735	The barriers were made a long time ago. {nl} And now that I wasn't able to protect it well, what do I tell our ancestors?
+QUEST_LV_0100_20150317_000734	The Mazas barrier which should the Demons have been destroyed.{nl}Would you help me repair it?
+QUEST_LV_0100_20150317_000735	The barriers were made a long time ago.{nl}And now that I wasn't able to protect it well, what do I tell our ancestors?
 QUEST_LV_0100_20150317_000736	I'm not smart enough to know anything about restoring the barrier so tell that to sir Kayetonas.
 QUEST_LV_0100_20150317_000737	Follwer Kayetonas
-QUEST_LV_0100_20150317_000738	No wonder. I was bewildered when the Demons suddenly appeared out of nowhere. {nl} I better let the Brothers know about this. Thank you.
+QUEST_LV_0100_20150317_000738	No wonder. I was bewildered when the Demons suddenly appeared out of nowhere.{nl}I better let the Brothers know about this. Thank you.
 QUEST_LV_0100_20150317_000739	Guard Kenneth
-QUEST_LV_0100_20150317_000740	You can't let your guard down just because the Demon summoners are gone. {nl} We don't even know when this appeared in the first place. {nl}
+QUEST_LV_0100_20150317_000740	You can't let your guard down just because the Demon summoners are gone.{nl}We don't even know when this appeared in the first place.{nl}
 QUEST_LV_0100_20150317_000741	Anyway, please tell Sir Kayetonas in Flower Hill about this.
 QUEST_LV_0100_20150317_000742	It might be a bit extreme, but I'm thinking about getting rid of all the Demon souls.{nl}
 QUEST_LV_0100_20150317_000743	
-QUEST_LV_0100_20150317_000744	You'd better get rid of the extracted souls quickly. {nl} Wouldn't it be scary to see them come back to life?
-QUEST_LV_0100_20150317_000745	Actually, I had some doubts, but it seems to work? {nl} Please let Sir Kayetonas know about this. {nl} I think he will be pleased, he is in Flower Hill.
-QUEST_LV_0100_20150317_000746	Now, I think I can live. {nl} We have to keep and stop the Demons. {nl} Please tell Sir Kayetonas that protecting this place isn't easy.
+QUEST_LV_0100_20150317_000744	You'd better get rid of the extracted souls quickly.{nl}Wouldn't it be scary to see them come back to life?
+QUEST_LV_0100_20150317_000745	Actually, I had some doubts, but it seems to work?{nl}Please let Sir Kayetonas know about this.{nl}I think he will be pleased, he is in Flower Hill.
+QUEST_LV_0100_20150317_000746	Now, I think I can live.{nl}We have to keep and stop the Demons.{nl}Please tell Sir Kayetonas that protecting this place isn't easy.
 QUEST_LV_0100_20150317_000747	The demons are very strong.{nl}I will protect this place to block those demons.
-QUEST_LV_0100_20150317_000748	Welcome, I'm glad to see that you've had a safe journey here. {nl}Before anything else, there are things about this place that the Revelator should know. {nl}
+QUEST_LV_0100_20150317_000748	Welcome, I'm glad to see that you've had a safe journey here. {nl}Before anything else, there are things about this place that the Revelator should know.{nl}
 QUEST_LV_0100_20150317_000749	My old friend, Algis, will explain. Please listen to him.
 QUEST_LV_0100_20150317_000750	I can see the monsters cleary from up here.{nl}He may get surrounded by them soon.
-QUEST_LV_0100_20150317_000751	The broken barrier pieces are scattered in the Mazas shelter. {nl} Collect it and give it to sir Kayetonas in flower hill. {nl}
+QUEST_LV_0100_20150317_000751	The broken barrier pieces are scattered in the Mazas shelter.{nl}Collect it and give it to sir Kayetonas in flower hill.{nl}
 QUEST_LV_0100_20150317_000752	My poor father must be happy if he know I became a guard.{nl}But, I already made a mistake.
 QUEST_LV_0100_20150317_000753	We can say it's peaceful for now.{nl}For now.
 QUEST_LV_0100_20150317_000754	
 QUEST_LV_0100_20150317_000755	That's why if there are guards struggling with the barrier, I want you to help.
-QUEST_LV_0100_20150317_000756	Heard the plan failed. {nl} I guess we have to do something before the Gesti recovers.
+QUEST_LV_0100_20150317_000756	Heard the plan failed.{nl}I guess we have to do something before the Gesti recovers.
 QUEST_LV_0100_20150317_000757	Guard Ella
 QUEST_LV_0100_20150317_000758	Think about those flowers bite my leg someday.{nl}They may look beautiful to you, but I don't just see them as beautiful.
 QUEST_LV_0100_20150317_000759	I need the fluids of Nepenthes, but it doesn't wake up.{nl}If it doesn't wake up, there is no way to extract them.{nl}
@@ -776,10 +776,10 @@ QUEST_LV_0100_20150317_000775	At least, the demons won't cross here.{nl}We may e
 QUEST_LV_0100_20150317_000776	It's getting swallowed up side down.{nl}Very effective indeed.
 QUEST_LV_0100_20150317_000777	Follower Vaidas
 QUEST_LV_0100_20150317_000778	It is reassuring to hear that Brother Thomas will be in charge of the altar.{nl}
-QUEST_LV_0100_20150317_000779	Brother Baidutis is waiting on the 1st Floor. {nl} Barrier of Gesti is blocking the way but it can simply be put off by the power of altar so not to worry.
+QUEST_LV_0100_20150317_000779	Brother Baidutis is waiting on the 1st Floor.{nl}Barrier of Gesti is blocking the way but it can simply be put off by the power of altar so not to worry.
 QUEST_LV_0100_20150317_000780	Follower Buydas
 QUEST_LV_0100_20150317_000781	I regret myself that I didn't bring enough Divine Stones.{nl}I should have put them in all my pockets.
-QUEST_LV_0100_20150317_000782	The altars in the church are made to stop Demons. {nl} Of course, only we, the Paladins, know how to use them.
+QUEST_LV_0100_20150317_000782	The altars in the church are made to stop Demons.{nl}Of course, only we, the Paladins, know how to use them.
 QUEST_LV_0100_20150317_000783	Is Brother Baidutis alright?{nl} I would have been in serious trouble if not for your help.
 QUEST_LV_0100_20150317_000784	Follower Thomas
 QUEST_LV_0100_20150317_000785	Yognome is trying to eat the altar.{nl}I want you to defeat Yognome.
@@ -795,11 +795,11 @@ QUEST_LV_0100_20150317_000794	We can sustain for a while if these stones can be 
 QUEST_LV_0100_20150317_000795	It is a strategy to attack the boss first when there are multiple enemies.{nl}This time, it will be Glizardon.
 QUEST_LV_0100_20150317_000796	I never thought you would defeat it this quickly.{nl}Thank you for your help.
 QUEST_LV_0100_20150317_000797	Follower Donatas
-QUEST_LV_0100_20150317_000798	Thank you. {nl} This is sufficient to make a transformation scroll.
-QUEST_LV_0100_20150317_000799	You can transform into a Demon by using this scroll. {nl} Persuade the Demons to go to the altar on their own.
-QUEST_LV_0100_20150317_000800	I get caught every time, maybe the Demons know my scent. {nl} I'm sure it'll be easier for you since you haven't been around for long.
-QUEST_LV_0100_20150317_000801	Alright. {nl} I think that would be enough for you to take a grasp of it.
-QUEST_LV_0100_20150317_000802	The power of the altar makes conversion simple. {nl} First, you activate the power of Globejas altar. {nl} Then, stay within the influence of the altar and fight the Demons.
+QUEST_LV_0100_20150317_000798	Thank you.{nl}This is sufficient to make a transformation scroll.
+QUEST_LV_0100_20150317_000799	You can transform into a Demon by using this scroll.{nl}Persuade the Demons to go to the altar on their own.
+QUEST_LV_0100_20150317_000800	I get caught every time, maybe the Demons know my scent.{nl}I'm sure it'll be easier for you since you haven't been around for long.
+QUEST_LV_0100_20150317_000801	Alright.{nl}I think that would be enough for you to take a grasp of it.
+QUEST_LV_0100_20150317_000802	The power of the altar makes conversion simple.{nl}First, you activate the power of Globejas altar.{nl}Then, stay within the influence of the altar and fight the Demons.
 QUEST_LV_0100_20150317_000803	The Demons have stronger minds than you might think. {nl}It will take a lot of effort to make them forget Gesti.
 QUEST_LV_0100_20150317_000804	Don't trust the waste too much since Glizardon may find out about it.
 QUEST_LV_0100_20150317_000805	I am thinking about an effective way to defeat the demons.{nl}I feel so reliable since you came.
@@ -819,7 +819,7 @@ QUEST_LV_0100_20150317_000818	Don't you think we would be able to find the fragm
 QUEST_LV_0100_20150317_000819	Be careful.{nl}It will be dangerous if Treeambulo in flame runs into the camp.
 QUEST_LV_0100_20150317_000820	Treasure Hunter Ethan
 QUEST_LV_0100_20150317_000821	I am a treasure hunter and not a monster hunter.{nl}I don't want to add my gravestone here by touching it.
-QUEST_LV_0100_20150317_000822	ve Collected all the debris out of the deal is over Raymond. {nl} brought back the parcel to Raymond.
+QUEST_LV_0100_20150317_000822	ve Collected all the debris out of the deal is over Raymond.{nl}brought back the parcel to Raymond.
 QUEST_LV_0100_20150317_000823	Ethan told you to give it to me?{nl}Hmm. It will take sometime to restore it.{nl}
 QUEST_LV_0100_20150317_000824	Can you take the restored gravestone fragments to my assistant at Irody Square?{nl}I think something good will happen when we finish restoring it.
 QUEST_LV_0100_20150317_000825	Epigraphist Smid
@@ -850,93 +850,93 @@ QUEST_LV_0100_20150317_000849	This operation had failed several years ago.{nl}Wh
 QUEST_LV_0100_20150317_000850	I understand. Please take this Unicorn's horn to that girl.{nl}Her brother went missing after that.
 QUEST_LV_0100_20150317_000851	Girl
 QUEST_LV_0100_20150317_000852	I told him not to go..
-QUEST_LV_0100_20150317_000853	So it was terrible. {nl} I was lucky I almost get dispatches.
+QUEST_LV_0100_20150317_000853	So it was terrible.{nl}I was lucky I almost get dispatches.
 QUEST_LV_0100_20150317_000854	If you have trouble pulling it over to the burning firewoods, then kick just kick it hard.
 QUEST_LV_0100_20150317_000855	I need the flame of Infroburk at Shiluma altar.{nl}Getting close to the back of that monster and heats the arrows.
 QUEST_LV_0100_20150317_000856	I was trying to get something myself when I signed contract with Raymond.{nl}But, I have nothing besides stone fragments.
 QUEST_LV_0100_20150317_000857	You will know what's on Rukly's monument after restoring it.
-QUEST_LV_0100_20150317_000858	Great. {nl} Leave activating the altar to me and go to Vidas in Himnas chapel.
+QUEST_LV_0100_20150317_000858	Great.{nl}Leave activating the altar to me and go to Vidas in Himnas chapel.
 QUEST_LV_0100_20150317_000859	Even if a person is in danger, if he knows that someone will come to help him, he will have the extra energy to endure longer.
 QUEST_LV_0100_20150317_000860	Good. This will be enough.
 QUEST_LV_0100_20150317_000861	It feels so good to see them flying.{nl}But, they are too noisy so I need to study more.
 QUEST_LV_0100_20150317_000862	I've never seen a stone with full of divine energy as this.{nl}Thanks for trying your best.
 QUEST_LV_0100_20150317_000863	The demons' attacks are stronger than we expected.{nl}If we are able to defeat Glizardon, then it will be easier to defeat them.
 QUEST_LV_0100_20150317_000864	Follower Baidutis
-QUEST_LV_0100_20150317_000865	I came to say that the Gesti went up to the 2nd floor and let my guard down. {nl} I would have been in a big trouble if not for you.
-QUEST_LV_0100_20150317_000866	I studied the barrier of the gate but power of the basement altar will not be enough. {nl} Unless you add the power of crytal held by Corylus.
-QUEST_LV_0100_20150317_000867	Maybe the Goddess knew it'd fail and that's why she said wait for the Revelator. {nl} At least, we got the Gesti hurt so it can also be good.
-QUEST_LV_0100_20150317_000868	Well done. {nl} Making the crystal of light with this will enough power to break the barrier.
+QUEST_LV_0100_20150317_000865	I came to say that the Gesti went up to the 2nd floor and let my guard down.{nl}I would have been in a big trouble if not for you.
+QUEST_LV_0100_20150317_000866	I studied the barrier of the gate but power of the basement altar will not be enough.{nl}Unless you add the power of crytal held by Corylus.
+QUEST_LV_0100_20150317_000867	Maybe the Goddess knew it'd fail and that's why she said wait for the Revelator.{nl}At least, we got the Gesti hurt so it can also be good.
+QUEST_LV_0100_20150317_000868	Well done.{nl}Making the crystal of light with this will enough power to break the barrier.
 QUEST_LV_0100_20150317_000869	Prepare yourself before bringing the crystal of light to the gate. {nl}It can attract powerful monsters.
 QUEST_LV_0100_20150317_000870	I think I'll stay here to stop the Demons from entering the basement.
-QUEST_LV_0100_20150317_000871	It is an honor to fight with you, Revelator. {nl} Could you drive the Demons from this area while Sir Algis investigates?
+QUEST_LV_0100_20150317_000871	It is an honor to fight with you, Revelator.{nl}Could you drive the Demons from this area while Sir Algis investigates?
 QUEST_LV_0100_20150317_000872	If you are okay, can you take Eyes of Madness to Rodelin?{nl}They are handy when you want to hide yourself from demons.
 QUEST_LV_0100_20150317_000873	I don't want those filthy things to be near me either.{nl}But, it's worse to face against those demons alone.
 QUEST_LV_0100_20150317_000874	Thanks.{nl}I should share them with other brothers before the demons find out.
 QUEST_LV_0100_20150317_000875	You are indeed the revelator.{nl}Now, we can concentrate on protecting the altar.
-QUEST_LV_0100_20150317_000876	The barrier of main entrance in 1st floor can be offset by the power of the church so don't worry. {nl}That's what the altars are for. {nl}
-QUEST_LV_0100_20150317_000877	Let's take care of the Unknocker first. {nl} I'll lead the Unknocker so you try to find a chance.
+QUEST_LV_0100_20150317_000876	The barrier of main entrance in 1st floor can be offset by the power of the church so don't worry. {nl}That's what the altars are for.{nl}
+QUEST_LV_0100_20150317_000877	Let's take care of the Unknocker first.{nl}I'll lead the Unknocker so you try to find a chance.
 QUEST_LV_0100_20150317_000878	I want to request to you to defeat Pawndel and Pawnd.{nl}They are demon sisters and they give us headaches.
 QUEST_LV_0100_20150317_000879	Be careful since I got almost attacked as well.{nl}They are really violent.
 QUEST_LV_0100_20150317_000880	Good job. {nl}The babbling laughter seems to have stopped.
 QUEST_LV_0100_20150317_000881	
 QUEST_LV_0100_20150317_000882	It's a bit blasphemous, but we don't have much choice.
-QUEST_LV_0100_20150317_000883	Well done. {nl} It will probably be difficult to trust each other from now on. {nl}
-QUEST_LV_0100_20150317_000884	I'm thinking of converting the Demons using the power of the altar. {nl} The converted Demons will absorb the divine power and slowly start to die. {nl}
-QUEST_LV_0100_20150317_000885	But before that, it's important to understand the Demons. {nl} Collect the souls of the Demons
-QUEST_LV_0100_20150317_000886	I remember the first time I converted the Demons. {nl} I pray for their poor souls.
-QUEST_LV_0100_20150317_000887	Great job. {nl} If there are any good Demons, the Goddess will look after them.
-QUEST_LV_0100_20150317_000888	The Central Altar suppressing the power of the Demons suddenly stopped. {nl} Could you take a look at what's going on?
+QUEST_LV_0100_20150317_000883	Well done.{nl}It will probably be difficult to trust each other from now on.{nl}
+QUEST_LV_0100_20150317_000884	I'm thinking of converting the Demons using the power of the altar.{nl}The converted Demons will absorb the divine power and slowly start to die.{nl}
+QUEST_LV_0100_20150317_000885	But before that, it's important to understand the Demons.{nl}Collect the souls of the Demons
+QUEST_LV_0100_20150317_000886	I remember the first time I converted the Demons.{nl}I pray for their poor souls.
+QUEST_LV_0100_20150317_000887	Great job.{nl}If there are any good Demons, the Goddess will look after them.
+QUEST_LV_0100_20150317_000888	The Central Altar suppressing the power of the Demons suddenly stopped.{nl}Could you take a look at what's going on?
 QUEST_LV_0100_20150317_000889	Strange, it was definitely working.
-QUEST_LV_0100_20150317_000890	It was an ambush. {nl} We would have been in big trouble without your help.
-QUEST_LV_0100_20150317_000891	You need the seal of space to enter the hidden sanctuary. {nl} It's hidden in Sventove Central Altar but i hope it's not too late.
-QUEST_LV_0100_20150317_000892	Structures in the Tenet Cathedral are placed to ward against the Demons. {nl} Each one in itself is a small barrier that contributes to a huge barrier. {nl}
-QUEST_LV_0100_20150317_000893	The most powerful barrier is in the 2nd floor. {nl} I heard that it can exert the greatest force when the divine sphere is there.
-QUEST_LV_0100_20150317_000894	Gesti made the first move. {nl} It will be difficult to approach secretly.
-QUEST_LV_0100_20150317_000895	I must change the plan. {nl} First you need to go watch the movement of the Gesti. {nl}
+QUEST_LV_0100_20150317_000890	It was an ambush.{nl}We would have been in big trouble without your help.
+QUEST_LV_0100_20150317_000891	You need the seal of space to enter the hidden sanctuary.{nl}It's hidden in Sventove Central Altar but i hope it's not too late.
+QUEST_LV_0100_20150317_000892	Structures in the Tenet Cathedral are placed to ward against the Demons.{nl}Each one in itself is a small barrier that contributes to a huge barrier.{nl}
+QUEST_LV_0100_20150317_000893	The most powerful barrier is in the 2nd floor.{nl}I heard that it can exert the greatest force when the divine sphere is there.
+QUEST_LV_0100_20150317_000894	Gesti made the first move.{nl}It will be difficult to approach secretly.
+QUEST_LV_0100_20150317_000895	I must change the plan.{nl}First you need to go watch the movement of the Gesti.{nl}
 QUEST_LV_0100_20150317_000896	Let's start by occupying the bell tower.
 QUEST_LV_0100_20150317_000897	From here, we can see what Gesti is going to do.
-QUEST_LV_0100_20150317_000898	Alright, bring the seal of space from Sventove Central Altar. {nl} You can do it, right?
-QUEST_LV_0100_20150317_000899	You must know that the revelation is hidden in the sanctuary. {nl} The seal of the space is the only key that get you to the sanctuary. {nl}
-QUEST_LV_0100_20150317_000900	It's not just the Tenet Cathedral. {nl} You can enter all the places that the Goddess hid.
-QUEST_LV_0100_20150317_000901	The seal of space can only be used by the Revelator so you won't be able to find the revelation right away. {nl}
+QUEST_LV_0100_20150317_000898	Alright, bring the seal of space from Sventove Central Altar.{nl}You can do it, right?
+QUEST_LV_0100_20150317_000899	You must know that the revelation is hidden in the sanctuary.{nl}The seal of the space is the only key that get you to the sanctuary.{nl}
+QUEST_LV_0100_20150317_000900	It's not just the Tenet Cathedral.{nl}You can enter all the places that the Goddess hid.
+QUEST_LV_0100_20150317_000901	The seal of space can only be used by the Revelator so you won't be able to find the revelation right away.{nl}
 QUEST_LV_0100_20150317_000902	But the enemy is the Demon King. Even the Paladin Master couldn't defeat him.{nl}I should use the power of Broken Altar.
-QUEST_LV_0100_20150317_000903	We can't do anything about the destroyed altar but the fragments still have power. {nl} Gather the pieces and insert it in the 8 pillars of the Sventove Central Hall.
-QUEST_LV_0100_20150317_000904	When you are done, I will be able to tie up Gesti through the power of the divine crystal and the church. {nl} It may be for a short while but that's the best option we have.
-QUEST_LV_0100_20150317_000905	So you activated the Malda altar? {nl} Now it will be safe to stay here for the time being. Good work.
-QUEST_LV_0100_20150317_000906	Demon are going around the second floor searching every corner. {nl} Activating the Auka altar will be able to turn their attention.
-QUEST_LV_0100_20150317_000907	I'm relieved you're beside me. {nl} I think it was a good thing that Laima chose you.
-QUEST_LV_0100_20150317_000908	Good job. {nl} When this is over, I should gather all brothers and drive them away at once.
+QUEST_LV_0100_20150317_000903	We can't do anything about the destroyed altar but the fragments still have power.{nl}Gather the pieces and insert it in the 8 pillars of the Sventove Central Hall.
+QUEST_LV_0100_20150317_000904	When you are done, I will be able to tie up Gesti through the power of the divine crystal and the church.{nl}It may be for a short while but that's the best option we have.
+QUEST_LV_0100_20150317_000905	So you activated the Malda altar?{nl}Now it will be safe to stay here for the time being. Good work.
+QUEST_LV_0100_20150317_000906	Demon are going around the second floor searching every corner.{nl}Activating the Auka altar will be able to turn their attention.
+QUEST_LV_0100_20150317_000907	I'm relieved you're beside me.{nl}I think it was a good thing that Laima chose you.
+QUEST_LV_0100_20150317_000908	Good job.{nl}When this is over, I should gather all brothers and drive them away at once.
 QUEST_LV_0100_20150317_000909	I'll ring the bell and let you know when the Gesti show up so have a safe trip on your way.
-QUEST_LV_0100_20150317_000910	So you found the seal of space. {nl}Use the seal on the pillar beside me to go to the sanctuary. {nl} It is prepared for the Revelator only.
+QUEST_LV_0100_20150317_000910	So you found the seal of space. {nl}Use the seal on the pillar beside me to go to the sanctuary.{nl}It is prepared for the Revelator only.
 QUEST_LV_0100_20150317_000911	May the blessings of the Goddess be with you.
-QUEST_LV_0100_20150317_000912	So Gesti just ran away. {nl} Fine. Since you got the revelation, we've completed the mission. {nl}
+QUEST_LV_0100_20150317_000912	So Gesti just ran away.{nl}Fine. Since you got the revelation, we've completed the mission.{nl}
 QUEST_LV_0100_20150317_000913	
-QUEST_LV_0100_20150317_000914	When you find the revelation, tell Mater Paladin of the story you've been through so far. {nl} May the blessings of the Goddess be with you.
+QUEST_LV_0100_20150317_000914	When you find the revelation, tell Mater Paladin of the story you've been through so far.{nl}May the blessings of the Goddess be with you.
 QUEST_LV_0100_20150317_000915	Seems like Gesti did not notice yet. {nl}Better prepare the divine crystal.
-QUEST_LV_0100_20150317_000916	All the preparations made. {nl} Barriers of the church will soon weaken the Gesti. {nl}
-QUEST_LV_0100_20150317_000917	The weakened Gesti will be enough for you to handle. {nl} When the Gesti is cornered, I will make the final strike with the divine sphere.
-QUEST_LV_0100_20150317_000918	This is a piece of Mazas shelter barrier. {nl} Do not worry. {nl} There are ways to recover the barrier so I'm sure it will be alright.
-QUEST_LV_0100_20150317_000919	I didn't know the Demons will use the summoner to come across here. {nl} Better get rid of them all before they seige us.
-QUEST_LV_0100_20150317_000920	Even with so many Demons, you still managed to make it through. {nl} You may be the Revelator, but that's still impressive. {nl}
-QUEST_LV_0100_20150317_000921	It's the revelation. {nl} Cherish it and do not show it to anyone else. {nl}
-QUEST_LV_0100_20150317_000922	Come on. Go to the Paladin Master. {nl} He will tell you the way you must go.
-QUEST_LV_0100_20150317_000923	I asked my precious friend Algis for Tenet Church. {nl} I won't lose to Gesti but it is important to have some back up plan just in case.
+QUEST_LV_0100_20150317_000916	All the preparations made.{nl}Barriers of the church will soon weaken the Gesti.{nl}
+QUEST_LV_0100_20150317_000917	The weakened Gesti will be enough for you to handle.{nl}When the Gesti is cornered, I will make the final strike with the divine sphere.
+QUEST_LV_0100_20150317_000918	This is a piece of Mazas shelter barrier.{nl}Do not worry.{nl}There are ways to recover the barrier so I'm sure it will be alright.
+QUEST_LV_0100_20150317_000919	I didn't know the Demons will use the summoner to come across here.{nl}Better get rid of them all before they seige us.
+QUEST_LV_0100_20150317_000920	Even with so many Demons, you still managed to make it through.{nl}You may be the Revelator, but that's still impressive.{nl}
+QUEST_LV_0100_20150317_000921	It's the revelation.{nl}Cherish it and do not show it to anyone else.{nl}
+QUEST_LV_0100_20150317_000922	Come on. Go to the Paladin Master.{nl}He will tell you the way you must go.
+QUEST_LV_0100_20150317_000923	I asked my precious friend Algis for Tenet Church.{nl}I won't lose to Gesti but it is important to have some back up plan just in case.
 QUEST_LV_0100_20150317_000924	
-QUEST_LV_0100_20150317_000925	In the kingdom, there are several valuable weapons aside from this divine sphere. {nl} Those weapons saved many lives on the Divine Day four years ago.
-QUEST_LV_0100_20150317_000926	From now on, I will focus on the divine crystal. {nl} In the meanwhile, please use your skills so that I won't be disturbed.
-QUEST_LV_0100_20150317_000927	I'm sorry. It's all my fault. {nl}The Gesti found out the divine heal is not the revelation so it will head straight to the church. {nl}
-QUEST_LV_0100_20150317_000928	But his old body of mine does not follow my will anymore. {nl} Now I can only trust my old friend Algis and you. {nl}
+QUEST_LV_0100_20150317_000925	In the kingdom, there are several valuable weapons aside from this divine sphere.{nl}Those weapons saved many lives on the Divine Day four years ago.
+QUEST_LV_0100_20150317_000926	From now on, I will focus on the divine crystal.{nl}In the meanwhile, please use your skills so that I won't be disturbed.
+QUEST_LV_0100_20150317_000927	I'm sorry. It's all my fault. {nl}The Gesti found out the divine heal is not the revelation so it will head straight to the church.{nl}
+QUEST_LV_0100_20150317_000928	But his old body of mine does not follow my will anymore.{nl}Now I can only trust my old friend Algis and you.{nl}
 QUEST_LV_0100_20150317_000929	
-QUEST_LV_0100_20150317_000930	It is too much for me to handle alone without any help from other brothers. {nl} I'd better run the Malda Altar. {nl}
+QUEST_LV_0100_20150317_000930	It is too much for me to handle alone without any help from other brothers.{nl}I'd better run the Malda Altar.{nl}
 QUEST_LV_0100_20150317_000931	
 QUEST_LV_0100_20150317_000932	We still have a lot to do here.{nl}The goddess told us to never give up.
-QUEST_LV_0100_20150317_000933	The world still needs more experience. {nl} We probably wouldn't have made it this far without the help of the Goddess.
-QUEST_LV_0100_20150317_000934	The activation of tree guard post is taking longer than I thought. {nl} We have no time, let's use a Demon's soul instead.
-QUEST_LV_0100_20150317_000935	All souls are pure. {nl} So even if it's a Demon's soul, it can still provide some divine power.
-QUEST_LV_0100_20150317_000936	Oh the Tree guard post was filled with soul of the Demon. {nl} It still needs some final touches to complete but I'll take care of it. {nl}Great job.
-QUEST_LV_0100_20150317_000937	It's amazing you can use the barrier like that. {nl} Even the Paladins did not know about that. {nl}
+QUEST_LV_0100_20150317_000933	The world still needs more experience.{nl}We probably wouldn't have made it this far without the help of the Goddess.
+QUEST_LV_0100_20150317_000934	The activation of tree guard post is taking longer than I thought.{nl}We have no time, let's use a Demon's soul instead.
+QUEST_LV_0100_20150317_000935	All souls are pure.{nl}So even if it's a Demon's soul, it can still provide some divine power.
+QUEST_LV_0100_20150317_000936	Oh the Tree guard post was filled with soul of the Demon.{nl}It still needs some final touches to complete but I'll take care of it. {nl}Great job.
+QUEST_LV_0100_20150317_000937	It's amazing you can use the barrier like that.{nl}Even the Paladins did not know about that.{nl}
 QUEST_LV_0100_20150317_000938	
-QUEST_LV_0100_20150317_000939	Standing against this much enemies itself is a great deal. {nl} It's all thanks to the Paladin Master.
+QUEST_LV_0100_20150317_000939	Standing against this much enemies itself is a great deal.{nl}It's all thanks to the Paladin Master.
 QUEST_LV_0100_20150317_000940	Even though he's still young, Kenneth is amazing. {nl}I think we can entrust him a little more.
 QUEST_LV_0100_20150317_000941	This is the message from the guards.{nl}A gigantic demon monster is coming this way.{nl}Follow me quickly.{nl}
 QUEST_LV_0100_20150317_000942	Biteregina that used to live in the deep forest came here.{nl}It even built the hive at the upper side of Rojus Plateau. Can you get rid of it since it's dangerous?
@@ -945,27 +945,27 @@ QUEST_LV_0100_20150317_000944	I can't do anything since Sidmias are attacking us
 QUEST_LV_0100_20150317_000945	Those Sidmias want me to put my head on that flower bud.{nl}It's not good at all.
 QUEST_LV_0100_20150317_000946	We received the charm from the elders that will brainwash Pantos to stand on our side.{nl}Do you want to take up the challenge?{nl}
 QUEST_LV_0100_20150317_000947	According to the elders, we are done with those Pantos.{nl}We can't continue the relationship anymore.
-QUEST_LV_0100_20150317_000948	This barrier is impossible to open from the inside. {nl} Fortunately, the entrance to the basement looks safe. {nl}
-QUEST_LV_0100_20150317_000949	However, it's too dangerous to in the basement with the divine sphere. {nl} I'll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
+QUEST_LV_0100_20150317_000948	This barrier is impossible to open from the inside.{nl}Fortunately, the entrance to the basement looks safe.{nl}
+QUEST_LV_0100_20150317_000949	However, it's too dangerous to in the basement with the divine sphere.{nl}I'll wait here so you go to the 1st floor through the basement and open the barrier.{nl}
 QUEST_LV_0100_20150317_000950	You have done what other can't easily do.{nl}The goddess must be proud of you.
 QUEST_LV_0100_20150317_000951	My faith in religion is strong enough to destroy those demons, but the reality isn't that simple.{nl}I hope you help us a bit.
 QUEST_LV_0100_20150317_000952	
-QUEST_LV_0100_20150317_000953	Get rid of the Demons around the tree guard barrier. {nl} The souls of the Demons will be able to fill the divine powers a little. Thanks!
+QUEST_LV_0100_20150317_000953	Get rid of the Demons around the tree guard barrier.{nl}The souls of the Demons will be able to fill the divine powers a little. Thanks!
 QUEST_LV_0100_20150317_000954	Very good. Those flowers on the ground will be enough.{nl}Don't you think so?
 QUEST_LV_0100_20150317_000955	We are the people following the Paladin Master.{nl}We will defeat the people who disobey the goddess.{nl}
 QUEST_LV_0100_20150317_000956	Everyone has their reasons for following him.{nl}Some of them received benefits from him and some of them were already Paladins like Algis.
 QUEST_LV_0100_20150317_000957	Maybe the goddess knew it would happen and that's why she waited for the savior.{nl}I feel like I put a big burden on your shoulders.{nl}
 QUEST_LV_0100_20150317_000958	
 QUEST_LV_0100_20150317_000959	This is the plan that was carried on for hundreds of years since the first Paladin.{nl}We should never fail this plan.
-QUEST_LV_0100_20150317_000960	Please put the pieces to the Ruklys memorial in front of preparing me rubbings. {nl} because had been working with us and listening together, you'll be able to simplify. {nl}
+QUEST_LV_0100_20150317_000960	Please put the pieces to the Ruklys memorial in front of preparing me rubbings.{nl}because had been working with us and listening together, you'll be able to simplify.{nl}
 QUEST_LV_0100_20150317_000961	I will follow you soon. Just a moment.
 QUEST_LV_0100_20150317_000962	After we finish the rubber copying, we can say farewell to this place.{nl}Can you help me a bit more?
 QUEST_LV_0100_20150317_000963	The capital may already be in ruins, but I will protect Klaipeda.
-QUEST_LV_0100_20150317_000964	Using all your power to crush any enemy that would threaten the Kingdom. {nl} That's how Highlanders fight in battle. {nl}
-QUEST_LV_0100_20150317_000965	Good work, guys. {nl} Actually, I was also an adventure but the results seem to be fine. {nl} You just need to tell it like that to sir Kayetos in Flower hill.
-QUEST_LV_0100_20150317_000966	Seems like even Auka altar lost its powers. {nl} There were stories about its powers wiping out dozens of Demons in the past.
+QUEST_LV_0100_20150317_000964	Using all your power to crush any enemy that would threaten the Kingdom.{nl}That's how Highlanders fight in battle.{nl}
+QUEST_LV_0100_20150317_000965	Good work, guys.{nl}Actually, I was also an adventure but the results seem to be fine.{nl}You just need to tell it like that to sir Kayetos in Flower hill.
+QUEST_LV_0100_20150317_000966	Seems like even Auka altar lost its powers.{nl}There were stories about its powers wiping out dozens of Demons in the past.
 QUEST_LV_0100_20150317_000967	It's hard to watch the Egnomes running around the Atgaila chapel.{nl} Please clean up the Egnomes.
-QUEST_LV_0100_20150317_000968	Many Treasures of the Paladin which should not go into the hands of the Demons are also here. {nl} You should not fall into it.
+QUEST_LV_0100_20150317_000968	Many Treasures of the Paladin which should not go into the hands of the Demons are also here.{nl}You should not fall into it.
 QUEST_LV_0100_20150317_000969	After using this amulet on those Pantos, hit them several times.{nl}Try those Pantos at Levanda military camp.
 QUEST_LV_0100_20150317_000970	Isn't this city amazing? I want to stay here if I can.{nl}But, I prefer going to other places with my horse.
 QUEST_LV_0100_20150317_000971	The space movement magic field will take you to your preferred floor in the tower.{nl}I don't know if we can use the field anymore. Let's go and find out.
@@ -1013,8 +1013,8 @@ QUEST_LV_0100_20150317_001012	This is the entrance to the tower.{nl}I became unc
 QUEST_LV_0100_20150317_001013	I will take care of you and take you to Gabiya.{nl}Are you ready?
 QUEST_LV_0100_20150317_001014	All other magicians either died or ran away.{nl}You are our last hope. Let's go in.
 QUEST_LV_0100_20150317_001015	Gabija did not hide herself.{nl}She just coudnl't come forward because she had to protect the tower from demons.{nl}
-QUEST_LV_0100_20150317_001016	I heard Agailla Flurry went because she coun't find a successor. {nl}I heard it was for something important.. But I don't know what it is. 
-QUEST_LV_0100_20150317_001017	The Divine Day can strike anytime again whether it is in your hometown or my kingdom. {nl} The culprit of the plague would be something worthy of my sword.
+QUEST_LV_0100_20150317_001016	I heard Agailla Flurry went because she coun't find a successor. {nl}I heard it was for something important.. But I don't know what it is.
+QUEST_LV_0100_20150317_001017	The Divine Day can strike anytime again whether it is in your hometown or my kingdom.{nl}The culprit of the plague would be something worthy of my sword.
 QUEST_LV_0100_20150317_001018	Owyn
 QUEST_LV_0100_20150317_001019	Support? It really cheers us up!{nl}Please get rid of the monsters nearby.
 QUEST_LV_0100_20150317_001020	All other magicians either died or ran away.{nl}Only Gabiya is protecting the tower herself.
@@ -1100,63 +1100,63 @@ QUEST_LV_0100_20150317_001099	Don't ever think of blocking axe from in front.{nl
 QUEST_LV_0100_20150317_001100	You should go to the great cathedral to follow the revelation,{nl}But, unfortunately, you are not skillful enough.
 QUEST_LV_0100_20150317_001101	Train more at the entrace of Katin Forest. {nl}Believe that you will get your victory at the end.
 QUEST_LV_0100_20150317_001102	Let's meet at Technical Room 1. {nl}Ah, it will be better if you could get the Blackened Essence from monsters.
-QUEST_LV_0100_20150317_001103	Look at this busted cable car.{nl} The damage is pretty serious. {nl}
+QUEST_LV_0100_20150317_001103	Look at this busted cable car.{nl} The damage is pretty serious.{nl}
 QUEST_LV_0100_20150317_001104	It's obviously the work of Grummer and Zignuts from the Cholras road. {nl}Give them a taste of your skills while I fix this.
-QUEST_LV_0100_20150317_001105	This would not have happened if the old people had lent their ears on what the young men said. {nl} But what's done is already done. What can we do about it?
-QUEST_LV_0100_20150317_001106	Good work. {nl} It's the parts the Pantos stole before. {nl} I never imagine I'd be seeing it again like this.
+QUEST_LV_0100_20150317_001105	This would not have happened if the old people had lent their ears on what the young men said.{nl}But what's done is already done. What can we do about it?
+QUEST_LV_0100_20150317_001106	Good work.{nl}It's the parts the Pantos stole before.{nl}I never imagine I'd be seeing it again like this.
 QUEST_LV_0100_20150317_001107	Guard Molly
-QUEST_LV_0100_20150317_001108	The Pantos were not always such violent monsters. {nl}There must be a way to change them back. {nl}
+QUEST_LV_0100_20150317_001108	The Pantos were not always such violent monsters. {nl}There must be a way to change them back.{nl}
 QUEST_LV_0100_20150317_001109	I want you to give young Pantos the highland beets in Nyosalrus Street.{nl}Then they would come to remind me of something?
-QUEST_LV_0100_20150317_001110	It's a bitter thing indeed. {nl} No matter how troubled the world is, they weren't like that before.
-QUEST_LV_0100_20150317_001111	That's right. Thank you very much! {nl} Have you seen a broken cable car there? I used to ride that when I was a kid.
-QUEST_LV_0100_20150317_001112	Thank you! {nl} You've saved me and my friends from spending more than half of our lives just protecting the cable car. {nl}
-QUEST_LV_0100_20150317_001113	Since I'm the only one who can fix the cable car, I'll consider it clear. {nl} Oh, of course, thanks for your help.
-QUEST_LV_0100_20150317_001114	Please bring me the Mally seeds in the way to Labure roads. {nl} They would be a good source of magic for the shaman doll. {nl} {nl}
-QUEST_LV_0100_20150317_001115	So exciting. {nl} Some straws, seeds, and a bit of rope and those kinds of things can go around alive.
+QUEST_LV_0100_20150317_001110	It's a bitter thing indeed.{nl}No matter how troubled the world is, they weren't like that before.
+QUEST_LV_0100_20150317_001111	That's right. Thank you very much!{nl}Have you seen a broken cable car there? I used to ride that when I was a kid.
+QUEST_LV_0100_20150317_001112	Thank you!{nl}You've saved me and my friends from spending more than half of our lives just protecting the cable car.{nl}
+QUEST_LV_0100_20150317_001113	Since I'm the only one who can fix the cable car, I'll consider it clear.{nl}Oh, of course, thanks for your help.
+QUEST_LV_0100_20150317_001114	Please bring me the Mally seeds in the way to Labure roads.{nl}They would be a good source of magic for the shaman doll. {nl}{nl}
+QUEST_LV_0100_20150317_001115	So exciting.{nl}Some straws, seeds, and a bit of rope and those kinds of things can go around alive.
 QUEST_LV_0100_20150317_001116	Guard Mory
-QUEST_LV_0100_20150317_001117	The Simorph popping out is a bit frightening. {nl} So the Pantos can fall this bad.
-QUEST_LV_0100_20150317_001118	Won't you help me purify Labure road? {nl} The shaman doll finds the evil force but we have to purify it ourselves.
-QUEST_LV_0100_20150317_001119	Contamination is everywhere, but I think Labure Road is the worst. {nl} Maybe it's spreading through the roots?
-QUEST_LV_0100_20150317_001120	Look at these gentle pantos. {nl} It's insane that we have to make the pantos our enemies when the evils are charging in.
-QUEST_LV_0100_20150317_001121	We need the rope for ceremony to make the shaman doll. {nl} It's on the waist of the Panto Shaman in the Cottage. {nl} Bring it to me.
-QUEST_LV_0100_20150317_001122	If you persuade the Capria, the Pantos will be tamed. {nl}Capri is the leader of pantos. {nl}
+QUEST_LV_0100_20150317_001117	The Simorph popping out is a bit frightening.{nl}So the Pantos can fall this bad.
+QUEST_LV_0100_20150317_001118	Won't you help me purify Labure road?{nl}The shaman doll finds the evil force but we have to purify it ourselves.
+QUEST_LV_0100_20150317_001119	Contamination is everywhere, but I think Labure Road is the worst.{nl}Maybe it's spreading through the roots?
+QUEST_LV_0100_20150317_001120	Look at these gentle pantos.{nl}It's insane that we have to make the pantos our enemies when the evils are charging in.
+QUEST_LV_0100_20150317_001121	We need the rope for ceremony to make the shaman doll.{nl}It's on the waist of the Panto Shaman in the Cottage.{nl}Bring it to me.
+QUEST_LV_0100_20150317_001122	If you persuade the Capria, the Pantos will be tamed. {nl}Capri is the leader of pantos.{nl}
 QUEST_LV_0100_20150317_001123	Let's follow the baby pantos. {nl}It will definitely lead the way to Capri.
-QUEST_LV_0100_20150317_001124	I hope the Capria would understand us. {nl} We should do whatever we can.
-QUEST_LV_0100_20150317_001125	Got angry right away when seeing the baby Pantos? {nl} Would it really not work.
-QUEST_LV_0100_20150317_001126	I worked so hard to fix it but I'm worried for the Poatas. {nl} Monsters of that size can destroy the cable car.
+QUEST_LV_0100_20150317_001124	I hope the Capria would understand us.{nl}We should do whatever we can.
+QUEST_LV_0100_20150317_001125	Got angry right away when seeing the baby Pantos?{nl}Would it really not work.
+QUEST_LV_0100_20150317_001126	I worked so hard to fix it but I'm worried for the Poatas.{nl}Monsters of that size can destroy the cable car.
 QUEST_LV_0100_20150317_001127	Our guards love to fight {nl}Pantos were not this reckless before. {nl}I wonder if we should be like this when the Demons waiting to march in.
-QUEST_LV_0100_20150317_001128	The Poatas also destroyed the cable car in Nepavy. {nl}But it's not like we can guard it all the time. {nl}
-QUEST_LV_0100_20150317_001129	Even if we stay on guards, a fight with the Poatas? {nl} That's not easy.
+QUEST_LV_0100_20150317_001128	The Poatas also destroyed the cable car in Nepavy. {nl}But it's not like we can guard it all the time.{nl}
+QUEST_LV_0100_20150317_001129	Even if we stay on guards, a fight with the Poatas?{nl}That's not easy.
 QUEST_LV_0100_20150317_001130	
 QUEST_LV_0100_20150317_001131	
 QUEST_LV_0100_20150317_001132	
-QUEST_LV_0100_20150317_001133	This place has a very sacred meaning for us. {nl} And we have called ourselves the watchmen for protecting this place. {nl}
-QUEST_LV_0100_20150317_001134	It has been protected since the day the promised by the first Paladin. {nl} And now that the Demons have invaded, it is time to keep that promise.
-QUEST_LV_0100_20150317_001135	Pantos changed and became wild after the Divine Day four years ago. {nl} Before that, we didn't really mind each other and even joked around together. {nl}
+QUEST_LV_0100_20150317_001133	This place has a very sacred meaning for us.{nl}And we have called ourselves the watchmen for protecting this place.{nl}
+QUEST_LV_0100_20150317_001134	It has been protected since the day the promised by the first Paladin.{nl}And now that the Demons have invaded, it is time to keep that promise.
+QUEST_LV_0100_20150317_001135	Pantos changed and became wild after the Divine Day four years ago.{nl}Before that, we didn't really mind each other and even joked around together.{nl}
 QUEST_LV_0100_20150317_001136	I really wonder what has become of the sacred land?
-QUEST_LV_0100_20150317_001137	The Caprias were the first to change after the incident four years ago. {nl} And then the Pantos.. now only the babies are left.
+QUEST_LV_0100_20150317_001137	The Caprias were the first to change after the incident four years ago.{nl}And then the Pantos.. now only the babies are left.
 QUEST_LV_0100_20150317_001138	Our family has been protecting this land for a long time.{nl}Please cooperate with us to keep the reverent atmosphere here.{nl}-Guard
-QUEST_LV_0100_20150317_001139	Thank you for helping out. {nl} My workload has reduced a lot.
+QUEST_LV_0100_20150317_001139	Thank you for helping out.{nl}My workload has reduced a lot.
 QUEST_LV_0100_20150317_001140	
-QUEST_LV_0100_20150317_001141	We used to be on good terms with the Pantos. {nl} These days, we're constantly at each other's throats.
+QUEST_LV_0100_20150317_001141	We used to be on good terms with the Pantos.{nl}These days, we're constantly at each other's throats.
 QUEST_LV_0100_20150317_001142	I came back because the elders told me to restore the dolls used for spells.{nl}The dolls for spells. Isn't it exciting?
-QUEST_LV_0100_20150317_001143	Thank you. {nl} We might be able to go get more when more young men come.
-QUEST_LV_0100_20150317_001144	I can't stand seeing the Panto totems pressed with evil forces. {nl} I'm going to break it through the shaman doll. Want to give it a try?
-QUEST_LV_0100_20150317_001145	We can't do anything until Basil restores the shaman doll perfectly. {nl} Unless for special situations like this, we can use, uhm, nothing.
-QUEST_LV_0100_20150317_001146	It would have been a disaster if the Carnivore had had legs. {nl} I'm glad it was killed beforehand.
-QUEST_LV_0100_20150317_001147	I heard we promised the first Paladin three things in return for saving our family. {nl}
-QUEST_LV_0100_20150317_001148	To help build the Tenet Cathedral, {nl} to protect the divine relics by having watchmen guard the sacred land, {nl} and lastly, to protect each other together when great danger arises. {nl}
-QUEST_LV_0100_20150317_001149	I do not know what curse it was. {nl} There's got to be a record in the Tenet Cathedral.
-QUEST_LV_0100_20150317_001150	Our Shaman dolls are different from Bokor's Shaman dolls. {nl}
-QUEST_LV_0100_20150317_001151	It does not curse like the Bokor's. {nl} It moves by itself to attack, or something like that.
-QUEST_LV_0100_20150317_001152	The Demons could have used their hands to make it easier for them to attack. {nl} Or maybe they were eyeing on the divine heal. {nl}
-QUEST_LV_0100_20150317_001153	Since the divine heal was hidden deep below the ground. {nl} Who could have known that the reason for the world's overturn was because of the plants?
+QUEST_LV_0100_20150317_001143	Thank you.{nl}We might be able to go get more when more young men come.
+QUEST_LV_0100_20150317_001144	I can't stand seeing the Panto totems pressed with evil forces.{nl}I'm going to break it through the shaman doll. Want to give it a try?
+QUEST_LV_0100_20150317_001145	We can't do anything until Basil restores the shaman doll perfectly.{nl}Unless for special situations like this, we can use, uhm, nothing.
+QUEST_LV_0100_20150317_001146	It would have been a disaster if the Carnivore had had legs.{nl}I'm glad it was killed beforehand.
+QUEST_LV_0100_20150317_001147	I heard we promised the first Paladin three things in return for saving our family.{nl}
+QUEST_LV_0100_20150317_001148	To help build the Tenet Cathedral,{nl}to protect the divine relics by having watchmen guard the sacred land,{nl}and lastly, to protect each other together when great danger arises.{nl}
+QUEST_LV_0100_20150317_001149	I do not know what curse it was.{nl}There's got to be a record in the Tenet Cathedral.
+QUEST_LV_0100_20150317_001150	Our Shaman dolls are different from Bokor's Shaman dolls.{nl}
+QUEST_LV_0100_20150317_001151	It does not curse like the Bokor's.{nl}It moves by itself to attack, or something like that.
+QUEST_LV_0100_20150317_001152	The Demons could have used their hands to make it easier for them to attack.{nl}Or maybe they were eyeing on the divine heal.{nl}
+QUEST_LV_0100_20150317_001153	Since the divine heal was hidden deep below the ground.{nl}Who could have known that the reason for the world's overturn was because of the plants?
 QUEST_LV_0100_20150317_001154	You may use a bit of force if words aren't enough. {nl}We can't grow any further from each other anymore.
-QUEST_LV_0100_20150317_001155	You can summon the shaman doll with this summon scroll. {nl}
-QUEST_LV_0100_20150317_001156	If possible, get rid of the Carnivore too. {nl} It was contaminated by the Magi and I can't stand watching it anymore.
-QUEST_LV_0100_20150317_001157	Make a mess in the nest of Poatas in Margas Hill and it will appear. {nl}
+QUEST_LV_0100_20150317_001155	You can summon the shaman doll with this summon scroll.{nl}
+QUEST_LV_0100_20150317_001156	If possible, get rid of the Carnivore too.{nl}It was contaminated by the Magi and I can't stand watching it anymore.
+QUEST_LV_0100_20150317_001157	Make a mess in the nest of Poatas in Margas Hill and it will appear.{nl}
 QUEST_LV_0100_20150317_001158	Liaison Official Colin
-QUEST_LV_0100_20150317_001159	Rexipher? {nl} Although it is the first time I've heard the name. {nl}
+QUEST_LV_0100_20150317_001159	Rexipher?{nl}Although it is the first time I've heard the name.{nl}
 QUEST_LV_0100_20150317_001160	
 QUEST_LV_0100_20150317_001161	The Desk of Royal Tomb
 QUEST_LV_0100_20150317_001162	You can't obtain the secret and precious wisdom of the royal tomb even if you wish.{nl}When the time comes and you are ready, you will be able to fetch it.{nl}
@@ -1186,15 +1186,15 @@ QUEST_LV_0100_20150317_001185	Thank you. This is an amazing jewel.{nl}It is rare
 QUEST_LV_0100_20150317_001186	That proves that it is an important object.
 QUEST_LV_0100_20150317_001187	Unknown being.
 QUEST_LV_0100_20150317_001188	How dare someone wants to confront me.{nl}Tell me the secret number. I can't tell you unless you tell me the number.
-QUEST_LV_0100_20150317_001189	You're a brave guy. {nl} There are five clues in 1st Mine Lot . {nl} No need to hurry. It will take a long time.
-QUEST_LV_0100_20150317_001190	Found it. {nl} Then I'll start from now.
-QUEST_LV_0100_20150317_001191	I'll give you a riddle. {nl} It is something you must do, have done most, and will have to do. {nl} Show your answer in action.
-QUEST_LV_0100_20150317_001192	Good work. {nl} You will be rewarded with proper compensation.
+QUEST_LV_0100_20150317_001189	You're a brave guy.{nl}There are five clues in 1st Mine Lot .{nl}No need to hurry. It will take a long time.
+QUEST_LV_0100_20150317_001190	Found it.{nl}Then I'll start from now.
+QUEST_LV_0100_20150317_001191	I'll give you a riddle.{nl}It is something you must do, have done most, and will have to do.{nl}Show your answer in action.
+QUEST_LV_0100_20150317_001192	Good work.{nl}You will be rewarded with proper compensation.
 QUEST_LV_0100_20150317_001193	What do you think are the factors that affect outcomes?{nl}If you just focus on attacking, then you may receive more damages.
 QUEST_LV_0100_20150317_001194	If you ask me what is the strongest weapon, I will answer that is is faith.{nl}A colleague that you can truly rely on.
 QUEST_LV_0100_20150317_001195	Thaumaturge does not get stronger by learning.{nl}You should learn it yourself.
 QUEST_LV_0100_20150317_001196	
-QUEST_LV_0100_20150317_001197	Stealth, detection, trap installation. {nl} Scouts are masters of searching and monitoring.
+QUEST_LV_0100_20150317_001197	Stealth, detection, trap installation.{nl}Scouts are masters of searching and monitoring.
 QUEST_LV_0100_20150317_001198	We Sadhu are always on an eternal journey. {nl}When our journeys in this world come to an end, we'll still continue in the afterlife.
 QUEST_LV_0100_20150317_001199	Nothing is unfair in real battles.{nl}You've gotta do anything to win. Don't you think so?
 QUEST_LV_0100_20150317_001200	We should find it quickly..{nl}It may be an end to Macians' Tower.
@@ -1208,27 +1208,27 @@ QUEST_LV_0100_20150317_001207	There's an interesting stroy behind that gigantic 
 QUEST_LV_0100_20150317_001208	Silver of Fedimian
 QUEST_LV_0100_20150317_001209	Read a book called
 QUEST_LV_0100_20150317_001210	The spear in itself is a weapon of pure  destruction.{nl} It is the best weapon anyone can easily learn and master.
-QUEST_LV_0100_20150317_001211	Golem, that's awesome. {nl} And you remember what I taught you?
-QUEST_LV_0100_20150317_001212	I guess the Revelator really is different. {nl} You you seem to be different from the other Revelators too...
-QUEST_LV_0100_20150317_001213	You looked so cool when you defeated the Golem. {nl} Where did you learn to do that?
-QUEST_LV_0100_20150317_001214	I'm grateful for your help. {nl} Commander Uska is waiting for you in Klaipeda, so go find him.
-QUEST_LV_0100_20150317_001215	I firmly believe that the Goddess will return someday. No doubt about it. {nl} We have to believe it. If we do not believe in the Goddess then who will?
-QUEST_LV_0100_20150317_001216	Please hurry and support the Miners' Village. {nl} Someone like you will be of great help.
-QUEST_LV_0100_20150317_001217	I heard the stories. So you defeated the Vubbe Fighter, huh? {nl} That's incredible.
+QUEST_LV_0100_20150317_001211	Golem, that's awesome.{nl}And you remember what I taught you?
+QUEST_LV_0100_20150317_001212	I guess the Revelator really is different.{nl}You you seem to be different from the other Revelators too...
+QUEST_LV_0100_20150317_001213	You looked so cool when you defeated the Golem.{nl}Where did you learn to do that?
+QUEST_LV_0100_20150317_001214	I'm grateful for your help.{nl}Commander Uska is waiting for you in Klaipeda, so go find him.
+QUEST_LV_0100_20150317_001215	I firmly believe that the Goddess will return someday. No doubt about it.{nl}We have to believe it. If we do not believe in the Goddess then who will?
+QUEST_LV_0100_20150317_001216	Please hurry and support the Miners' Village.{nl}Someone like you will be of great help.
+QUEST_LV_0100_20150317_001217	I heard the stories. So you defeated the Vubbe Fighter, huh?{nl}That's incredible.
 QUEST_LV_0100_20150317_001218	I was anxious watching from a distance but it was really awesome.
 QUEST_LV_0100_20150317_001219	Frankly, I'm scared. {nl}Miners' Village, and then the East Woods... Even Klaipeda is becoming dangerous.
 QUEST_LV_0100_20150317_001220	Although I am very concerned about Miners' Village, {nl}at least it has calmed down this much thanks to you.
 QUEST_LV_0100_20150317_001221	Healer Lady
 QUEST_LV_0100_20150317_001222	We pray that the blessings of the Goddess will always be with the Revelator who saved us.
-QUEST_LV_0100_20150317_001223	I'm helping the refugees. {nl} The monsters attacked the village.
+QUEST_LV_0100_20150317_001223	I'm helping the refugees.{nl}The monsters attacked the village.
 QUEST_LV_0100_20150317_001224	Miner's manager Bringker
-QUEST_LV_0100_20150317_001225	Still anxious. {nl} But thanks to you things are better than before.
+QUEST_LV_0100_20150317_001225	Still anxious.{nl}But thanks to you things are better than before.
 QUEST_LV_0100_20150317_001226	I can't believe the Cunningham's story is true... I think it needs more research.
-QUEST_LV_0100_20150317_001227	Everything has a source called Mana. {nl} And everyone can connect to each other's Mana if they want. {nl} Just like digging a canal.
-QUEST_LV_0100_20150317_001228	Have you ever seen Vubbes using pickaxes? {nl} What are they trying to find...
+QUEST_LV_0100_20150317_001227	Everything has a source called Mana.{nl}And everyone can connect to each other's Mana if they want.{nl}Just like digging a canal.
+QUEST_LV_0100_20150317_001228	Have you ever seen Vubbes using pickaxes?{nl}What are they trying to find...
 QUEST_LV_0100_20150317_001229	Thank you very much for saved us.{nl}
-QUEST_LV_0100_20150317_001230	If you still want to enter the Closed Area, collect the strange stone from the Vubbes. {nl} Stic it to the wall and the crystal wals open.
-QUEST_LV_0100_20150317_001231	What are you doing here? {nl} Go into the mines quickly. {nl} Weren't we supposed to meet in 1st Gallery?
+QUEST_LV_0100_20150317_001230	If you still want to enter the Closed Area, collect the strange stone from the Vubbes.{nl}Stic it to the wall and the crystal wals open.
+QUEST_LV_0100_20150317_001231	What are you doing here?{nl}Go into the mines quickly.{nl}Weren't we supposed to meet in 1st Gallery?
 QUEST_LV_0100_20150317_001232	No demons would be able to cross here.{nl}I will do my best to protect here so they can't interrupt the Paladin Master.
 QUEST_LV_0100_20150317_001233	Firm faith in us is the greatest shield.{nl}We always fought with our justice and faith.
 QUEST_LV_0100_20150317_001234	Well done.{nl}As the Paladin Master, I salute to your accomplishment.
@@ -1291,7 +1291,7 @@ QUEST_LV_0100_20150317_001290	An unknown event that is being plotted by an unkno
 QUEST_LV_0100_20150317_001291	Now is the time to concentrate on the research, but I can't concentrate at all.{nl}Also where is my assistant..
 QUEST_LV_0100_20150317_001292	Without Irene, I would have died.{nl}Of course, I really appreciate for your help.
 QUEST_LV_0100_20150317_001293	Irene saved my life.{nl}And you also saved my life.
-QUEST_LV_0100_20150317_001294	I heard the story but I can't really believe it. {nl} Getting rid of the Vubbe Fighter.
+QUEST_LV_0100_20150317_001294	I heard the story but I can't really believe it.{nl}Getting rid of the Vubbe Fighter.
 QUEST_LV_0100_20150317_001295	Where is the scholar. I am really worried.
 QUEST_LV_0100_20150317_001296	Without Dezik, I would have probably gone crazy within those monsters.{nl}Of course, thank you so much for your help as well.
 QUEST_LV_0100_20150317_001297	We are about to leave here, what's the matter?{nl}I haven't heard that we would receive reinforcements.
@@ -1304,7 +1304,7 @@ QUEST_LV_0100_20150317_001303	Do you think I am crazy to stay here longer?{nl}I 
 QUEST_LV_0100_20150317_001304	Historian Cyrenia Odell
 QUEST_LV_0100_20150317_001305	This feeling..{nl}Is it the feeling of an historian, or the fear that comes from human instinct..
 QUEST_LV_0100_20150317_001306	Adventurer Vakis
-QUEST_LV_0100_20150317_001307	Explorer? Of course it is not dangerous. {nl} However, Guchi~ari~tsu when you discover something is guided in a row this day.
+QUEST_LV_0100_20150317_001307	Explorer? Of course it is not dangerous.{nl}However, Guchi~ari~tsu when you discover something is guided in a row this day.
 QUEST_LV_0100_20150317_001308	Historian Rexipher
 QUEST_LV_0100_20150317_001309	There's an old saying.{nl}A person who fights against beasts should be careful not to be a beast himself.{nl}When you look at the abyss for a long time, the abyss will also look at you..{nl}
 QUEST_LV_0100_20150317_001310	I have a feeling that I would meet you again.{nl}Farewell until then..
@@ -1349,30 +1349,30 @@ QUEST_LV_0100_20150317_001348	I want to take a look at it more closely, but ther
 QUEST_LV_0100_20150317_001349	I never knew that I would be able to see these beautiful patterns.{nl}When you go to Garden of Pillar, there may be more beautiful patterns. Follow me.
 QUEST_LV_0100_20150317_001350	It seems that wandering spirits want to give the rewards to someone in Fedimian.
 QUEST_LV_0100_20150317_001351	After I finish the work, Unicorn appeared.
-QUEST_LV_0100_20150317_001352	Thank you for the regards from sir Laimonas. {nl} Come on in to Klaipeda. Sir Uska is waiting.
+QUEST_LV_0100_20150317_001352	Thank you for the regards from sir Laimonas.{nl}Come on in to Klaipeda. Sir Uska is waiting.
 QUEST_LV_0100_20150317_001353	Don't forget to send my regards to the Klaipeda Chief Commander.
 QUEST_LV_0100_20150317_001354	When you are ready, please go to Aras in the Eastern Woods.
-QUEST_LV_0100_20150317_001355	Welcome! {nl} Oh, you're the Revelator. I really wanted to meet you. {nl}
-QUEST_LV_0100_20150317_001356	This is a warp scroll. {nl} You can go to any Goddess Statue or return to previous location by using it. {nl}
+QUEST_LV_0100_20150317_001355	Welcome!{nl}Oh, you're the Revelator. I really wanted to meet you.{nl}
+QUEST_LV_0100_20150317_001356	This is a warp scroll.{nl}You can go to any Goddess Statue or return to previous location by using it.{nl}
 QUEST_LV_0100_20150317_001357	We'll give you more than what the Knights asked for so please help us find the Goddesses.
-QUEST_LV_0100_20150317_001358	I think Large Kepa is still out there. {nl} Would you take a look?
-QUEST_LV_0100_20150317_001359	It was there right? {nl} My senses are never wrong. 
-QUEST_LV_0100_20150317_001360	Even though Klaipeda is just around the corner, the supply situation is not good enough. {nl} Think how worse it would be in other areas. 
-QUEST_LV_0100_20150317_001361	My men should have returned by now but there is no sign of them. {nl} They know well that I'm too busy to check on them myself. 
-QUEST_LV_0100_20150317_001362	My men said they are going to the Delon shelter . {nl} The Golem may appear anytime and yet they are so carefree. 
-QUEST_LV_0100_20150317_001363	Rocktortuga will ambush this area soon. {nl} We must stop it from crossing the barrier. 
-QUEST_LV_0100_20150317_001364	Have you seen baby Poatas? {nl} We better drive them out quickly so that the mother Poatas won't keep showing up. 
-QUEST_LV_0100_20150317_001365	Vubbes have built their base outside the village. {nl} Now that we don't even have troops, {nl}something serious might happen if we don't drive them out of their base. 
-QUEST_LV_0100_20150317_001366	Thank you so much for your bravery. 
+QUEST_LV_0100_20150317_001358	I think Large Kepa is still out there.{nl}Would you take a look?
+QUEST_LV_0100_20150317_001359	It was there right?{nl}My senses are never wrong.
+QUEST_LV_0100_20150317_001360	Even though Klaipeda is just around the corner, the supply situation is not good enough.{nl}Think how worse it would be in other areas.
+QUEST_LV_0100_20150317_001361	My men should have returned by now but there is no sign of them.{nl}They know well that I'm too busy to check on them myself.
+QUEST_LV_0100_20150317_001362	My men said they are going to the Delon shelter .{nl}The Golem may appear anytime and yet they are so carefree.
+QUEST_LV_0100_20150317_001363	Rocktortuga will ambush this area soon.{nl}We must stop it from crossing the barrier.
+QUEST_LV_0100_20150317_001364	Have you seen baby Poatas?{nl}We better drive them out quickly so that the mother Poatas won't keep showing up.
+QUEST_LV_0100_20150317_001365	Vubbes have built their base outside the village.{nl}Now that we don't even have troops, {nl}something serious might happen if we don't drive them out of their base.
+QUEST_LV_0100_20150317_001366	Thank you so much for your bravery.
 QUEST_LV_0100_20150317_001367	How could I express my gratitude. {nl}I'm sure the Goddess sent you to us.
-QUEST_LV_0100_20150317_001368	This patient told us the Chafer must have appeared. {nl} Can you help us and check on it?
+QUEST_LV_0100_20150317_001368	This patient told us the Chafer must have appeared.{nl}Can you help us and check on it?
 QUEST_LV_0100_20150317_001369	Now, I have to treat this patient... So thank you.
 QUEST_LV_0100_20150317_001370	Those refugees are probably having a hard time getting here because of the monsters.
 QUEST_LV_0100_20150317_001371	I can't help but think about it since he's worked here for so long.
-QUEST_LV_0100_20150317_001372	Thank you. Now I can feel at ease and return to the village. {nl} May the blessing of the Goddess be with you always.
-QUEST_LV_0100_20150317_001373	Being attacked by the Golems will get them back to their senses. 
-QUEST_LV_0100_20150317_001374	Usually, you can't find them no matter how hard you try. {nl} Strange huh?
-QUEST_LV_0100_20150317_001375	I am pleased that the friends went back home safely. Was Mashi anxiety to hear the story of {nl} is the Molich close on the prowl.
+QUEST_LV_0100_20150317_001372	Thank you. Now I can feel at ease and return to the village.{nl}May the blessing of the Goddess be with you always.
+QUEST_LV_0100_20150317_001373	Being attacked by the Golems will get them back to their senses.
+QUEST_LV_0100_20150317_001374	Usually, you can't find them no matter how hard you try.{nl}Strange huh?
+QUEST_LV_0100_20150317_001375	I am pleased that the friends went back home safely. Was Mashi anxiety to hear the story of{nl}is the Molich close on the prowl.
 QUEST_LV_0100_20150317_001376	After unleashing the seal, listen to the next steps for the next seal from the brothers there.
 QUEST_LV_0100_20150317_001377	You have the Essence Stone to unleash the seal.{nl}You are the person who Jonas sent right?{nl}
 QUEST_LV_0100_20150317_001378	From now on, we will unleash the very important seal.{nl}The first seal is at the Pasaga Cliff.
@@ -1405,7 +1405,7 @@ QUEST_LV_0100_20150317_001404
 QUEST_LV_0100_20150317_001405	
 QUEST_LV_0100_20150317_001406	
 QUEST_LV_0100_20150317_001407	
-QUEST_LV_0100_20150317_001408	It won't take long. {nl} Excuse me.
+QUEST_LV_0100_20150317_001408	It won't take long.{nl}Excuse me.
 QUEST_LV_0100_20150317_001409	
 QUEST_LV_0100_20150317_001410	Let's give up on this and move to the big transportation magic field instead.
 QUEST_LV_0100_20150317_001411	The Asmodian attacked the tower is not the first time, but did Mase long earthquake up here. Thanks to {nl}, and whether they are by but Gabija disappeared in the world?
@@ -1414,31 +1414,31 @@ QUEST_LV_0100_20150317_001413	There's nothing we can do about it.{nl}Even it it 
 QUEST_LV_0100_20150317_001414	The barrier device is on the left end of his hallway.{nl}Let's go upstairs right after we activate the device.
 QUEST_LV_0100_20150317_001415	The device is at the left end of this hallway.{nl}It seems okay yet.
 QUEST_LV_0100_20150317_001416	Good!{nl}There wouldn't be more monsters now.{nl}
-QUEST_LV_0100_20150317_001417	Soon Let's go to the next floor. {nl} Gabija budget is awaiting us. {nl}
+QUEST_LV_0100_20150317_001417	Soon Let's go to the next floor.{nl}Gabija budget is awaiting us.{nl}
 QUEST_LV_0100_20150317_001418	Refugee
-QUEST_LV_0100_20150317_001419	I lost everything. {nl} I don't know how I can go on anymore. {nl} Would my life have become this miserable if not for the Divine Day?
-QUEST_LV_0100_20150317_001420	Four years ago, it was on the eve of the so called 'Divine Day'. {nl} Suddenly, a huge tree emerged in the middle of the capital and the earth and sky reversed. {nl}
-QUEST_LV_0100_20150317_001421	I never knew a tree could grow that big. {nl} And the destruction of the capital began. {nl}
-QUEST_LV_0100_20150317_001422	Everything happened so fast, and nobody knew what to do. {nl} We didn't know whether to run away or try to stop it... Our minds just became blank.
-QUEST_LV_0100_20150317_001423	The destruction of the capital was just the beginning. {nl} Divine Day was simply a prelude to the catastrophes coming ahead. {nl}
+QUEST_LV_0100_20150317_001419	I lost everything.{nl}I don't know how I can go on anymore.{nl}Would my life have become this miserable if not for the Divine Day?
+QUEST_LV_0100_20150317_001420	Four years ago, it was on the eve of the so called 'Divine Day'.{nl}Suddenly, a huge tree emerged in the middle of the capital and the earth and sky reversed.{nl}
+QUEST_LV_0100_20150317_001421	I never knew a tree could grow that big.{nl}And the destruction of the capital began.{nl}
+QUEST_LV_0100_20150317_001422	Everything happened so fast, and nobody knew what to do.{nl}We didn't know whether to run away or try to stop it... Our minds just became blank.
+QUEST_LV_0100_20150317_001423	The destruction of the capital was just the beginning.{nl}Divine Day was simply a prelude to the catastrophes coming ahead.{nl}
 QUEST_LV_0100_20150317_001424	Monstrous plants sprouted up all over and began devouring people.{nl} Everyone started running, but before I knew it I was the only person left.{nl}
-QUEST_LV_0100_20150317_001425	Enough... Don't ask any more questions. {nl} I don't want to think about it anymore.
+QUEST_LV_0100_20150317_001425	Enough... Don't ask any more questions.{nl}I don't want to think about it anymore.
 QUEST_LV_0100_20150317_001426	From here, it's Zachariel's royal tomb excavation site.{nl}You can freely enter, but please be careful not to disturb the research.
 QUEST_LV_0100_20150317_001427	Niels is the one who is in charge of this place.{nl}If you need to ask something, go find Niles at the researchers' camp.
 QUEST_LV_0100_20150317_001428	We don't block anyone's entrance here, but we can't guarantee one's safety.
 QUEST_LV_0100_20150317_001429	The researchers here receive support from the kingdom.{nl}The person in charge is Niels so if you need to ask something, go talk to Niels at the researchers' camp.
 QUEST_LV_0100_20150317_001430	The royal tomb should be protected.{nl}If it can't be protected, it will be destroyed itself.
-QUEST_LV_0100_20150317_001431	There is Fedimian, but there are interesting ruins around If you look it's too old city. {nl} I will have city Toka .. Cathedral cursed Toka tower of the wizard.
+QUEST_LV_0100_20150317_001431	There is Fedimian, but there are interesting ruins around If you look it's too old city.{nl}I will have city Toka .. Cathedral cursed Toka tower of the wizard.
 QUEST_LV_0100_20150317_001432	Hundreds of years skip a name to the large witch before it is Agailla Flurry vertical tower. Most of the magic to existing {nl}, either came out from the tower, but it is there is no difference.
 QUEST_LV_0100_20150317_001433	The city is abondoned after it is cursed with a magic that turns things into stones. {nl}It is beyond Pilgrim's Road.
-QUEST_LV_0100_20150317_001434	It was the place where people lived and supported the previous rebel Ruklys. {nl} the curse would be hard while you went so still valid.
-QUEST_LV_0100_20150317_001435	The Goddess Zemynas Quezon and Irasshai me always Jofuiru protect. {nl} brother also I believe that is the Mina has received a care.
+QUEST_LV_0100_20150317_001434	It was the place where people lived and supported the previous rebel Ruklys.{nl}the curse would be hard while you went so still valid.
+QUEST_LV_0100_20150317_001435	The Goddess Zemynas Quezon and Irasshai me always Jofuiru protect.{nl}brother also I believe that is the Mina has received a care.
 QUEST_LV_0100_20150317_001436	How many of the goddess if to be increased a prayer to the Goddess Zemyna Will He will hear the prayer?
-QUEST_LV_0100_20150317_001437	Here, Chengdu Fedimian God, is the Earth. Please ask {nl} commercial district is Irasshara as it entered it because it is currently in closed.
+QUEST_LV_0100_20150317_001437	Here, Chengdu Fedimian God, is the Earth. Please ask{nl}commercial district is Irasshara as it entered it because it is currently in closed.
 QUEST_LV_0100_20150317_001438	The divine city, Fedimian also has business district besides divine district here.{nl}But, on the divine day, business district was completly destroyed due to the earthquake.
 QUEST_LV_0100_20150317_001439	We are still reviving the city, but since it's too old..{nl}At least, divine district is still left due to Gemina's blessing.
 QUEST_LV_0100_20150317_001440	Follower Albidas
-QUEST_LV_0100_20150317_001441	Since follow believe the Saule goddess, you'll be able to accept this as a high difficulty such. {nl} impiety to, do you think want to who stay like this terrible place?
+QUEST_LV_0100_20150317_001441	Since follow believe the Saule goddess, you'll be able to accept this as a high difficulty such.{nl}impiety to, do you think want to who stay like this terrible place?
 QUEST_LV_0100_20150317_001442	Follower Laminta
 QUEST_LV_0100_20150317_001443	If the vicious atmosphere spreads to other forest..{nl}That forest will also change like Thorny Forest.{nl}And the whole kingdom.. it is scary..
 QUEST_LV_0100_20150317_001444	Follower Evaldas
@@ -1447,9 +1447,9 @@ QUEST_LV_0100_20150317_001446	Follower Zanetta
 QUEST_LV_0100_20150317_001447	I want to tell to the people out there that we are still here.{nl}But, the goddess is keep telling us that everything will be alright when the revelation comes.
 QUEST_LV_0100_20150317_001448	Follower Simas
 QUEST_LV_0100_20150317_001449	
-QUEST_LV_0100_20150317_001450	There are rumors about Golems appearing so don't go far too deep. {nl} It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
+QUEST_LV_0100_20150317_001450	There are rumors about Golems appearing so don't go far too deep.{nl}It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
 QUEST_LV_0100_20150317_001451	So, I guess there is actually someone good among those who say they've dreamed of the Goddess.
-QUEST_LV_0100_20150317_001452	I'm relieved that there are people who dreamed of the Goddess. {nl} But there seems to be too many of them.
+QUEST_LV_0100_20150317_001452	I'm relieved that there are people who dreamed of the Goddess.{nl}But there seems to be too many of them.
 QUEST_LV_0100_20150317_001453	A dream of the disappeared Goddess. Isn't that something amazing?
 QUEST_LV_0100_20150317_001454	The colleague who I used to work with has dissappeared.{nl}Firefly light was with me at the forest, but I can't go there. I am scary.
 QUEST_LV_0100_20150317_001455	Where is he. I am scared.
@@ -1477,8 +1477,8 @@ QUEST_LV_0100_20150317_001476	I received a request to rebuild this architecture,
 QUEST_LV_0100_20150317_001477	I will find the key to open the last seal.{nl}After opening a space with this scroll.
 QUEST_LV_0100_20150317_001478	The space may exist anywhere, but it may also not exist anywhere.
 QUEST_LV_0100_20150317_001479	
-QUEST_LV_0100_20150317_001480	There's nothing better than a trap when you want to gather the enemies and strike them at once. {nl} Of course, it's also the best for running away.
-QUEST_LV_0100_20150317_001481	If you think companion is just a pet, that's a huge mistake. {nl} It's like an inseparable friend to the hunters.
+QUEST_LV_0100_20150317_001480	There's nothing better than a trap when you want to gather the enemies and strike them at once.{nl}Of course, it's also the best for running away.
+QUEST_LV_0100_20150317_001481	If you think companion is just a pet, that's a huge mistake.{nl}It's like an inseparable friend to the hunters.
 QUEST_LV_0100_20150317_001482	Our family has been waiting for you for a long time.{nl}With this igniter, please light the signal at the top.
 QUEST_LV_0100_20150317_001483	Since you, the selected person, has come, it is sending us a signal to greet you.{nl}After you light the signal, tell Niels that I am sorry.
 QUEST_LV_0100_20150317_001484	There's nothing that I can't get.{nl}If you could give me some money.
@@ -1505,7 +1505,7 @@ QUEST_LV_0100_20150317_001504	I think you are scared.{nl}Since the stones are st
 QUEST_LV_0100_20150317_001505	Saugas ran away after it smelled me?{nl}That is possible.
 QUEST_LV_0100_20150317_001506	So only monsters like Sauga came.{nl}Okay. I will go back to the camp slowly since the commander is worrying about me.
 QUEST_LV_0100_20150317_001507	There's a scary monster called Denoptic here.{nl}I need the artifacts that Denoptic swallowed. Can you get them for me?
-QUEST_LV_0100_20150317_001508	Actually I also Denoptic components, please look for the first time to eat stones. {nl} or would Schlenk someone?
+QUEST_LV_0100_20150317_001508	Actually I also Denoptic components, please look for the first time to eat stones.{nl}or would Schlenk someone?
 QUEST_LV_0100_20150317_001509	How did you find the right piece!{nl}Thank you so much.
 QUEST_LV_0100_20150317_001510	Can I ask you one more favor?{nl}I want you to defeat the monster at Odega Hills.{nl}It disturbs my research.
 QUEST_LV_0100_20150317_001511	Thanks.{nl}How come there is no support here when they send mercenaries to those scholars at the entrance of the canyon.
@@ -1530,44 +1530,44 @@ QUEST_LV_0100_20150317_001529	I guess I can't sleep tight.
 QUEST_LV_0100_20150317_001530	Can you hear it? hear it? The screams of those who died without any reasons?
 QUEST_LV_0100_20150317_001531	There are criminals who made counterfeits of the tomb's artifacts.{nl}My face is already known, what should I do..
 QUEST_LV_0100_20150317_001532	There are many monsters here, but I heard the stone statue is moving near the royal tomb.{nl}They attack when the king gets distubed in his sleep.
-QUEST_LV_0100_20150317_001533	What do we do? {nl} To add to all the chaos in the village, the Vubbes kidnapped the village people.
+QUEST_LV_0100_20150317_001533	What do we do?{nl}To add to all the chaos in the village, the Vubbes kidnapped the village people.
 QUEST_LV_0100_20150317_001534	Hunter
-QUEST_LV_0100_20150317_001535	Oh, you're just in time. We need your help. {nl} Monsters stole all the aids and supplies meant for the refugees. {nl}
+QUEST_LV_0100_20150317_001535	Oh, you're just in time. We need your help.{nl}Monsters stole all the aids and supplies meant for the refugees.{nl}
 QUEST_LV_0100_20150317_001536	Fortunately, we found it quickly.
 QUEST_LV_0100_20150317_001537	I'll stay and help the people left here. {nl}You should go ahead and help others who need more help that I do.
 QUEST_LV_0100_20150317_001538	I'm holding it because it looked like it's going to collapse. {nl}We need some stones to do something about it.
 QUEST_LV_0100_20150317_001539	We won't be able to handle it if they siege this place . {nl}How will you stop it then if people are running away even now?
 QUEST_LV_0100_20150317_001540	Alright. That'll be enough.
-QUEST_LV_0100_20150317_001541	I must go back to the village. {nl} But as you can see my arms are shaking. {nl} Can you defeat the monsters while I rest my arms for a while?
-QUEST_LV_0100_20150317_001542	So heartless of the Goddess. {nl} If the Goddess wouldn't have disappeared, the monsters wouldn't have come attacking. 
-QUEST_LV_0100_20150317_001543	Now I can return to village with peace of mind. {nl} This grace I shall never forget.
-QUEST_LV_0100_20150317_001544	I came here to hide from the monsters but even this area is becoming dangerous. {nl} I'm trying to go back to the village so can you bring the other refugees to me?
-QUEST_LV_0100_20150317_001545	I see you've traveled safe. {nl} Well then, I must also prepare to leave.
-QUEST_LV_0100_20150317_001546	What do we do? I think there are even more monsters now than when we first came. {nl} And the patients have not recovered yet. {nl}
+QUEST_LV_0100_20150317_001541	I must go back to the village.{nl}But as you can see my arms are shaking.{nl}Can you defeat the monsters while I rest my arms for a while?
+QUEST_LV_0100_20150317_001542	So heartless of the Goddess.{nl}If the Goddess wouldn't have disappeared, the monsters wouldn't have come attacking.
+QUEST_LV_0100_20150317_001543	Now I can return to village with peace of mind.{nl}This grace I shall never forget.
+QUEST_LV_0100_20150317_001544	I came here to hide from the monsters but even this area is becoming dangerous.{nl}I'm trying to go back to the village so can you bring the other refugees to me?
+QUEST_LV_0100_20150317_001545	I see you've traveled safe.{nl}Well then, I must also prepare to leave.
+QUEST_LV_0100_20150317_001546	What do we do? I think there are even more monsters now than when we first came.{nl}And the patients have not recovered yet.{nl}
 QUEST_LV_0100_20150317_001547	Somehow I'll treat this man. Can you get rid of the monsters around?
 QUEST_LV_0100_20150317_001548	I have to defeat these monsters.{nl}for guys safe return to village..
-QUEST_LV_0100_20150317_001549	Thank you. The patient also regained his consciousness. {nl} But.. I think there is a problem.
+QUEST_LV_0100_20150317_001549	Thank you. The patient also regained his consciousness.{nl}But.. I think there is a problem.
 QUEST_LV_0100_20150317_001550	This is all because of that evidence of salvation or something. {nl}I'm sure that's where the village people were taken away to.
 QUEST_LV_0100_20150317_001551	The Goddess must have helped us. {nl}Follow the way on the right to find vubbe's outpost.
-QUEST_LV_0100_20150317_001552	Thank you for your saving me. {nl} Seems like you're the Revelator who's looking for the evidence of salvation. {nl}
-QUEST_LV_0100_20150317_001553	I was left here because I was late but the rest of the people were all taken into the mine. {nl} I tell you the rest of the story in the Crystal Mine entrance.
-QUEST_LV_0100_20150317_001554	Well, you've come. {nl} Let us first remove the wagon from blocking the way into the mines. {nl}
+QUEST_LV_0100_20150317_001552	Thank you for your saving me.{nl}Seems like you're the Revelator who's looking for the evidence of salvation.{nl}
+QUEST_LV_0100_20150317_001553	I was left here because I was late but the rest of the people were all taken into the mine.{nl}I tell you the rest of the story in the Crystal Mine entrance.
+QUEST_LV_0100_20150317_001554	Well, you've come.{nl}Let us first remove the wagon from blocking the way into the mines.{nl}
 QUEST_LV_0100_20150317_001555	The wagons can be destroyed with the explosives that I have prepared. {nl}I'm concerned about the Vubbes that will come running hearing the explosion {nl}but with your skills, I think we'll be fine.
-QUEST_LV_0100_20150317_001556	Take care of the Vubbes yourself. {nl} I have other businesses to attend to inside. {nl}
-QUEST_LV_0100_20150317_001557	Thank you. Thank you very much. {nl} You're a savior of our town. {nl}
-QUEST_LV_0100_20150317_001558	Oh, have you seen a girl about 5 years of age? {nl} I heard she was together with them when the villagers were kidnapped.
-QUEST_LV_0100_20150317_001559	Don't just stand there. {nl} Move if you want to help or go away.
+QUEST_LV_0100_20150317_001556	Take care of the Vubbes yourself.{nl}I have other businesses to attend to inside.{nl}
+QUEST_LV_0100_20150317_001557	Thank you. Thank you very much.{nl}You're a savior of our town.{nl}
+QUEST_LV_0100_20150317_001558	Oh, have you seen a girl about 5 years of age?{nl}I heard she was together with them when the villagers were kidnapped.
+QUEST_LV_0100_20150317_001559	Don't just stand there.{nl}Move if you want to help or go away.
 QUEST_LV_0100_20150317_001560	Manager of Coal Mine
 QUEST_LV_0100_20150317_001561	I'm hanging on somehow but I'm losing strength in my arms.
-QUEST_LV_0100_20150317_001562	I should have seen more careful. {nl} It's all my fault.
-QUEST_LV_0100_20150317_001563	I have my roots deep in the hunting area. {nl} Do not worry about me and better look after the others.
-QUEST_LV_0100_20150317_001564	As the Mayor, I can't just leave the village like this. {nl} How indifferent of the Goddesses.
-QUEST_LV_0100_20150317_001565	Aren't you the Revelator? The Goddess must have helped us. {nl} In order to enter the mine, you must save a young man name Vaidotas first. {nl}He was kidnapped to the Vubbe outpost. {nl} Please, I ask for your help.
+QUEST_LV_0100_20150317_001562	I should have seen more careful.{nl}It's all my fault.
+QUEST_LV_0100_20150317_001563	I have my roots deep in the hunting area.{nl}Do not worry about me and better look after the others.
+QUEST_LV_0100_20150317_001564	As the Mayor, I can't just leave the village like this.{nl}How indifferent of the Goddesses.
+QUEST_LV_0100_20150317_001565	Aren't you the Revelator? The Goddess must have helped us.{nl}In order to enter the mine, you must save a young man name Vaidotas first. {nl}He was kidnapped to the Vubbe outpost.{nl}Please, I ask for your help.
 QUEST_LV_0100_20150317_001566	Kind Owl Sculptor
 QUEST_LV_0100_20150317_001567	There are so many wandering spirits these days.{nl}This really..
 QUEST_LV_0100_20150317_001568	Big
 QUEST_LV_0100_20150317_001569	That's due to that problem.{nl}It will be better to look at it youself instead of me explaining to you several times.
-QUEST_LV_0100_20150317_001570	What's the problem? {nl} um ... it's big, very much.
+QUEST_LV_0100_20150317_001570	What's the problem?{nl}um ... it's big, very much.
 QUEST_LV_0100_20150317_001571	You saw it right?{nl}He is called Sequoia. {nl}He once protected us owls, but now...{nl}
 QUEST_LV_0100_20150317_001572	Humans attack us owls.{nl}So a few owls have been destroyed and there are many people getting hurt.
 QUEST_LV_0100_20150317_001573	That
@@ -1577,7 +1577,7 @@ QUEST_LV_0100_20150317_001576	We are made of ordinary wood so we are scared of m
 QUEST_LV_0100_20150317_001577	Thank you!{nl}I can't scratch my head because I am a tree..Hehe..{nl}
 QUEST_LV_0100_20150317_001578	Hm! Yes, I finally remembered it! {nl}Go find instabilized owl.{nl}That owl was so close to Sequoia so it must know the method.
 QUEST_LV_0100_20150317_001579	Instabilized Owl Sculpture
-QUEST_LV_0100_20150317_001580	I will tell you as I promised. I mean Sequoia. {nl}
+QUEST_LV_0100_20150317_001580	I will tell you as I promised. I mean Sequoia.{nl}
 QUEST_LV_0100_20150317_001581	Sequoia is obsessed with vicious power.{nl}You face vicious power with divine power.{nl}Yes. We should face it!{nl}
 QUEST_LV_0100_20150317_001582	Please gather wood pieces from the broken sculpture.{nl}Ah. the ones with the power in them. Select well.
 QUEST_LV_0100_20150317_001583	My friends became ordinary. {nl}Yes. Ordinary wooden statues. {nl}They must still have some divine power left, for sure. I believe..
@@ -1614,7 +1614,7 @@ QUEST_LV_0100_20150317_001613	You must succeed.{nl}If you think about those owls
 QUEST_LV_0100_20150317_001614	What?{nl}Sequoia ran away alive?{nl}
 QUEST_LV_0100_20150317_001615	That's a big problem!{nl}Desperate Owl is there..
 QUEST_LV_0100_20150317_001616	It is my mistake. I thought it too easy. {nl}I didn't know this would happen. {nl}If Desperate Owl gets destroyed, then I..{nl}
-QUEST_LV_0100_20150317_001617	Please..{nl}Please help Desperate Owl. {nl}
+QUEST_LV_0100_20150317_001617	Please..{nl}Please help Desperate Owl.{nl}
 QUEST_LV_0100_20150317_001618	Desperate Owl Sculpture
 QUEST_LV_0100_20150317_001619	It was very scary.{nl}Thanks for saving me.{nl}But, it seems that Sequoia is going crazier than usual so I feel relief..{nl}
 QUEST_LV_0100_20150317_001620	Anyways, it seems that Sequoia when to Desperate Owl.{nl}I hope nothing happens..
@@ -1631,7 +1631,7 @@ QUEST_LV_0100_20150317_001630	However, if we let Sequoia act like that, it will 
 QUEST_LV_0100_20150317_001631	The scream from Sequoia is echoing even in my body.{nl}It wouldn't be difficult to defeat him now.{nl}You don't have time to waste anymore anyways.
 QUEST_LV_0100_20150317_001632	You defeated Sequoia.{nl}It was once our protector, but it's death was cruel.{nl}The way we think about Sequoia.. You would never understand.
 QUEST_LV_0100_20150317_001633	There are some purifying devices that doesn't activate right away. {nl}I've put in a guide for it so you just have to follow that.
-QUEST_LV_0100_20150317_001634	There is a shopping plaza in the lower part of Klaipeda. {nl} Stop by and look around if you need anything.
+QUEST_LV_0100_20150317_001634	There is a shopping plaza in the lower part of Klaipeda.{nl}Stop by and look around if you need anything.
 QUEST_LV_0100_20150317_001635	I just want him to run away far. {nl}Nah, in fact, I don't know. He was a really good friend of me..
 QUEST_LV_0100_20150317_001636	Okay.{nl}Please find the Grave Protector Owl from the grave of the unknown warrior.{nl}If he could lend us his power, it will be a good chance to defeat Sequioa.
 QUEST_LV_0100_20150317_001637	Believer Adele
@@ -1706,25 +1706,25 @@ QUEST_LV_0100_20150317_001705	You passed the last test.{nl}Congratulations.{nl}P
 QUEST_LV_0100_20150317_001706	Please go to the forest again.{nl}The person waiting for you is there.{nl}Please put the pieces of the scupture toghther at the designated place.
 QUEST_LV_0100_20150317_001707	Please do not forget your valuable experiences here.{nl}Don't be afraid, please move forward.
 QUEST_LV_0100_20150317_001708	You woke me up to take the test.
-QUEST_LV_0100_20150317_001709	I've been waiting for you. I'm the Swordsman Master, the one who will help you. {nl} I'm not sure if you know about attribute training. {nl}
-QUEST_LV_0100_20150317_001710	Attributes can give additional abilities to stats and skills. {nl} You can learn attributes from each class master by paying them silver.
-QUEST_LV_0100_20150317_001711	You'll be able to fight easier if you learn attributes. {nl}
-QUEST_LV_0100_20150317_001712	You've come to the right place. I'm the Wizard Master. {nl} I'm going to teach you about attribute training. {nl}
-QUEST_LV_0100_20150317_001713	Attributes can give additional abilities to stats and skills. {nl} You can learn attributes from each class master by paying them silver. 
+QUEST_LV_0100_20150317_001709	I've been waiting for you. I'm the Swordsman Master, the one who will help you.{nl}I'm not sure if you know about attribute training.{nl}
+QUEST_LV_0100_20150317_001710	Attributes can give additional abilities to stats and skills.{nl}You can learn attributes from each class master by paying them silver.
+QUEST_LV_0100_20150317_001711	You'll be able to fight easier if you learn attributes.{nl}
+QUEST_LV_0100_20150317_001712	You've come to the right place. I'm the Wizard Master.{nl}I'm going to teach you about attribute training.{nl}
+QUEST_LV_0100_20150317_001713	Attributes can give additional abilities to stats and skills.{nl}You can learn attributes from each class master by paying them silver.
 QUEST_LV_0100_20150317_001714	So did you understand the attributes? Now you'll be able to fight the enemies more easily.
 QUEST_LV_0100_20150317_001715	How you become strong depends on what choice you make. {nl}It differs depending on your choice and thoughts.
-QUEST_LV_0100_20150317_001716	Good to see you. I am the Archer Master. {nl} Do you know about attribute training? {nl}
-QUEST_LV_0100_20150317_001717	Attributes can give additional abilities to stats and skills. {nl} You can learn attributes from each class master by paying them silver. 
+QUEST_LV_0100_20150317_001716	Good to see you. I am the Archer Master.{nl}Do you know about attribute training?{nl}
+QUEST_LV_0100_20150317_001717	Attributes can give additional abilities to stats and skills.{nl}You can learn attributes from each class master by paying them silver.
 QUEST_LV_0100_20150317_001718	Mastering this attribute will help your skills in combat.
-QUEST_LV_0100_20150317_001719	Will is the force to create magic power. {nl} There is not a stronger weapon for a wizard than that. 
+QUEST_LV_0100_20150317_001719	Will is the force to create magic power.{nl}There is not a stronger weapon for a wizard than that.
 QUEST_LV_0100_20150317_001720	Archers give arrow as a present but the enemies take it as death.
-QUEST_LV_0100_20150317_001721	There are ones who fit with the sword and there are those who don't. {nl} It means find something more valuable than your life. 
-QUEST_LV_0100_20150317_001722	A ranger's arrow does not aim at just one target {nl}
-QUEST_LV_0100_20150317_001723	It's very likely you'll be exposed to the enemy when you shoot arrows. {nl} So my theory is that you have to use whatever comes in handy, like shields or stones. 
-QUEST_LV_0100_20150317_001724	One thing I'd like to tell you... I think your attack lacks something. {nl} If you learn skills, you'll be able to make more powerful attacks when you need.
-QUEST_LV_0100_20150317_001725	There are different skills for each class but you will be able to fight better when you learn it. {nl} Also, you can do a lot of things aside from attacking.
-QUEST_LV_0100_20150317_001726	What do you think? There are a lot of useful skills, right? {nl} Using the skills effectively will be of great help in combat. {nl}
-QUEST_LV_0100_20150317_001727	Oh, you said we need to assemble? {nl} Please let the battle commander know about it too. He's over there on the right.
+QUEST_LV_0100_20150317_001721	There are ones who fit with the sword and there are those who don't.{nl}It means find something more valuable than your life.
+QUEST_LV_0100_20150317_001722	A ranger's arrow does not aim at just one target{nl}
+QUEST_LV_0100_20150317_001723	It's very likely you'll be exposed to the enemy when you shoot arrows.{nl}So my theory is that you have to use whatever comes in handy, like shields or stones.
+QUEST_LV_0100_20150317_001724	One thing I'd like to tell you... I think your attack lacks something.{nl}If you learn skills, you'll be able to make more powerful attacks when you need.
+QUEST_LV_0100_20150317_001725	There are different skills for each class but you will be able to fight better when you learn it.{nl}Also, you can do a lot of things aside from attacking.
+QUEST_LV_0100_20150317_001726	What do you think? There are a lot of useful skills, right?{nl}Using the skills effectively will be of great help in combat.{nl}
+QUEST_LV_0100_20150317_001727	Oh, you said we need to assemble?{nl}Please let the battle commander know about it too. He's over there on the right.
 QUEST_LV_0100_20150317_001728	Guiding spirits is an important task, but it's not a pleasant task.{nl}There's nothing happier than living right?
 QUEST_LV_0100_20150317_001729	Blackened boughs can be found when you defeat the monsters nearby.
 QUEST_LV_0100_20150317_001730	Others are violent as well, but Filibos are the worst.{nl}They are resilient as hell.{nl}I think I can relax a bit if they get taken care of.
@@ -1733,10 +1733,10 @@ QUEST_LV_0100_20150317_001732	There are many Tinis when you climb up the hill fr
 QUEST_LV_0100_20150317_001733	We don't have time collect the potion jars again.{nl}Let's go steal the jars that Zigris stole from us. They are the ones who started this.
 QUEST_LV_0100_20150317_001734	Monsters really like the Essences of Spirits.{nl}They become strong when they absorb the power.
 QUEST_LV_0100_20150317_001735	If it goes wrong.. then go meet the Gatekeeper Owl.{nl}He is most clever among us.{nl}May the goddess bless you.
-QUEST_LV_0100_20150317_001736	Nice to meet you, follower of the Goddess. {nl} Do you know about learning attributes?
+QUEST_LV_0100_20150317_001736	Nice to meet you, follower of the Goddess.{nl}Do you know about learning attributes?
 QUEST_LV_0100_20150317_001737	Welcome, you who follow the goal of the goddess.{nl}Do you know about the attributes' training?
-QUEST_LV_0100_20150317_001738	Now do you understand what the attributes are? {nl} Acquiring attributes will help you to easily defeat the enemies. {nl}
-QUEST_LV_0100_20150317_001739	Healing and helping others is the mission of the Clerics. {nl} How can you ignore the people seeking help in the name of the Goddess.
+QUEST_LV_0100_20150317_001738	Now do you understand what the attributes are?{nl}Acquiring attributes will help you to easily defeat the enemies.{nl}
+QUEST_LV_0100_20150317_001739	Healing and helping others is the mission of the Clerics.{nl}How can you ignore the people seeking help in the name of the Goddess.
 QUEST_LV_0100_20150317_001740	People are suffering in body and mind from the wounds of Divine Day.{nl} They need our help.
 QUEST_LV_0100_20150317_001741	I am sorry, but please find my colleague Badat.{nl}I haven't heard anything from him since he left to do research.
 QUEST_LV_0100_20150317_001742	I don't know where he is gone.{nl}He will be in danger without protection from mercenaries.
@@ -1767,7 +1767,7 @@ QUEST_LV_0100_20150317_001766	I am smarter than you guys think!{nl}Do you think 
 QUEST_LV_0100_20150317_001767	It is a real honor to be selected as a member of the research team, but I am afraid that I would make a mistake.
 QUEST_LV_0100_20150317_001768	The man with silver hair requested me something, what was it?{nl}Was it blond hair?
 QUEST_LV_0100_20150317_001769	Forecastor Owl
-QUEST_LV_0100_20150317_001770	Necroventer has obstructed the road to thorn forest. {nl} you must defeat the Necroventer to go to the forest of thorns.
+QUEST_LV_0100_20150317_001770	Necroventer has obstructed the road to thorn forest.{nl}you must defeat the Necroventer to go to the forest of thorns.
 QUEST_LV_0100_20150317_001771	The Owl Sculpture with anger
 QUEST_LV_0100_20150317_001772	Die all those who are resistant to Necroventer.
 QUEST_LV_0100_20150317_001773	
@@ -1882,9 +1882,9 @@ QUEST_LV_0100_20150317_001881	Wait a min. I read it from a book.{nl}Rexipher is 
 QUEST_LV_0100_20150317_001882	Using the name of a demon, that doen't look like a good intent.
 QUEST_LV_0100_20150317_001883	Rexipher?{nl}Doesn't she have silver hair with robe on her body?
 QUEST_LV_0100_20150317_001884	She is a crazy person controlling monsters.{nl}She made me like this and she also destroyed the altar which I used to research on.{nl}
-QUEST_LV_0100_20150317_001885	Go to Cheses altar first. {nl}They are also aiming for Gedula altar too. 
+QUEST_LV_0100_20150317_001885	Go to Cheses altar first. {nl}They are also aiming for Gedula altar too.
 QUEST_LV_0100_20150317_001886	
-QUEST_LV_0100_20150317_001887	I blocked your way.. I'm really sorry. {nl}
+QUEST_LV_0100_20150317_001887	I blocked your way.. I'm really sorry.{nl}
 QUEST_LV_0100_20150317_001888	We shouldn't be hanging around like this.{nl}We should go after Rexipher.
 QUEST_LV_0100_20150317_001889	The seals that haven't been detroyed yet at the king's plateau will block Rexipher.{nl}That means you would have enough time to chase after Rexipher.
 QUEST_LV_0100_20150317_001890	Please go to the royal tomb.{nl}We should find out what Rexipher has in her mind.
@@ -1947,10 +1947,10 @@ QUEST_LV_0100_20150317_001946	The Lizard Man that you sent to us was really live
 QUEST_LV_0100_20150317_001947	The peak of this spell will be Incroberk.{nl}I will give you the stone to control minds so please bring me Incroberk.
 QUEST_LV_0100_20150317_001948	Those Incroberks that you brought me are not enough.{nl}Please try harder.
 QUEST_LV_0100_20150317_001949	Well done.{nl}This will be enough.
-QUEST_LV_0100_20150317_001950	Thank you for making your way here. {nl} I am Knight Commander Uska and I am in charge of Saule and Klaipeda. {nl}
-QUEST_LV_0100_20150317_001951	The bishop told me to send the Revelator to the Crystal Mine as soon as they arrive. {nl} The Goddess told him in his dreams that the evidence of salvation would be found there. {nl}
+QUEST_LV_0100_20150317_001950	Thank you for making your way here.{nl}I am Knight Commander Uska and I am in charge of Saule and Klaipeda.{nl}
+QUEST_LV_0100_20150317_001951	The bishop told me to send the Revelator to the Crystal Mine as soon as they arrive.{nl}The Goddess told him in his dreams that the evidence of salvation would be found there.{nl}
 QUEST_LV_0100_20150317_001952	The monsters there are extremely dangerous so you be careful.
-QUEST_LV_0100_20150317_001953	All right. {nl} Oh, do not forget to offer worship to the Statue of Goddess before you leave. {nl}
+QUEST_LV_0100_20150317_001953	All right.{nl}Oh, do not forget to offer worship to the Statue of Goddess before you leave.{nl}
 QUEST_LV_0100_20150317_001954	Also, drop by the Item Merchant for the warp scrolls I left with him.
 QUEST_LV_0100_20150317_001955	You have so much curiosity.{nl}Okay. Bring me the grass that only grows at Kriakul Stream.
 QUEST_LV_0100_20150317_001956	Please use this stone to Lizard Man.{nl}After getting control of it, it will run to me.
@@ -1990,54 +1990,54 @@ QUEST_LV_0100_20150317_001989	Follower Bronews
 QUEST_LV_0100_20150317_001990	I could survive because of you.{nl}I should warn other priests to be careful.
 QUEST_LV_0100_20150317_001991	Priest Yurga
 QUEST_LV_0100_20150317_001992	I can feel Bramble is suffering.{nl}He is getting paid for extracting all vigor from this land.
-QUEST_LV_0100_20150317_001993	You're the Savior the Goddess sent. What an honor. {nl} Are you ready to fight Bramble?
-QUEST_LV_0100_20150317_001994	You need to be prepared if you want to defeat Bramble. {nl} First, take this.
+QUEST_LV_0100_20150317_001993	You're the Savior the Goddess sent. What an honor.{nl}Are you ready to fight Bramble?
+QUEST_LV_0100_20150317_001994	You need to be prepared if you want to defeat Bramble.{nl}First, take this.
 QUEST_LV_0100_20150317_001995	So it will be hard for Bramble to recover now.{nl}We can save the dying trees as well.
-QUEST_LV_0100_20150317_001996	Try to hold it in even if it's dirty. {nl} This is the best I can do.
-QUEST_LV_0100_20150317_001997	You found the revelation. {nl} Aren't you hurt? {nl}
-QUEST_LV_0100_20150317_001998	Bramble. {nl} Poor thing trying to go against its fate.
+QUEST_LV_0100_20150317_001996	Try to hold it in even if it's dirty.{nl}This is the best I can do.
+QUEST_LV_0100_20150317_001997	You found the revelation.{nl}Aren't you hurt?{nl}
+QUEST_LV_0100_20150317_001998	Bramble.{nl}Poor thing trying to go against its fate.
 QUEST_LV_0100_20150317_001999	The oldman of Andail Village
-QUEST_LV_0100_20150317_002000	So you're the one who wanted to meet Goddess Saule. {nl} Do not worry about the pond. Our priests are preparing it. {nl}
+QUEST_LV_0100_20150317_002000	So you're the one who wanted to meet Goddess Saule.{nl}Do not worry about the pond. Our priests are preparing it.{nl}
 QUEST_LV_0100_20150317_002001	The priest is located in Cerpe crossroads. {nl}I heard he needed the venom of Black Maize so try to get him that as a present.
-QUEST_LV_0100_20150317_002002	We wouldn't have dreamed about the portal if it wasn't for you. {nl} You truly are the blessing of God.
+QUEST_LV_0100_20150317_002002	We wouldn't have dreamed about the portal if it wasn't for you.{nl}You truly are the blessing of God.
 QUEST_LV_0100_20150317_002003	Andail's village Priest
-QUEST_LV_0100_20150317_002004	Isn't this the venom of the black maize? {nl} Thank you very much. {nl}
-QUEST_LV_0100_20150317_002005	You can leave meeting Goddess Saule with me. {nl} Now that the diving pond is purified, we just need to solve the Obelisk.
-QUEST_LV_0100_20150317_002006	Magic letters are carved on the Obelisk. {nl} But some letters were erased as the divine pond became contaminated. {nl}
-QUEST_LV_0100_20150317_002007	If the letters are gone, we just need to write it back on. {nl} Now that you've collected the venom of Black Maize, we just need the sap of the oak tree.
+QUEST_LV_0100_20150317_002004	Isn't this the venom of the black maize?{nl}Thank you very much.{nl}
+QUEST_LV_0100_20150317_002005	You can leave meeting Goddess Saule with me.{nl}Now that the diving pond is purified, we just need to solve the Obelisk.
+QUEST_LV_0100_20150317_002006	Magic letters are carved on the Obelisk.{nl}But some letters were erased as the divine pond became contaminated.{nl}
+QUEST_LV_0100_20150317_002007	If the letters are gone, we just need to write it back on.{nl}Now that you've collected the venom of Black Maize, we just need the sap of the oak tree.
 QUEST_LV_0100_20150317_002008	We just need to restore the Obelisk to meet Goddess Saule.
 QUEST_LV_0100_20150317_002009	Please bring that poison to the Village priest in Cerpe crossroads.
-QUEST_LV_0100_20150317_002010	The dye is complete. {nl} Trace the pattern vaguely left in the Obelisk and draw a new one. {nl}
+QUEST_LV_0100_20150317_002010	The dye is complete.{nl}Trace the pattern vaguely left in the Obelisk and draw a new one.{nl}
 QUEST_LV_0100_20150317_002011	The Obelisk is in the Slepingas stream.
 QUEST_LV_0100_20150317_002012	I'm sure God will be satisfied with you.
-QUEST_LV_0100_20150317_002013	It's almost done. {nl} After completing the rituals to cleanse your body, you will be able to meet the Goddess soon. {nl}
+QUEST_LV_0100_20150317_002013	It's almost done.{nl}After completing the rituals to cleanse your body, you will be able to meet the Goddess soon.{nl}
 QUEST_LV_0100_20150317_002014	
-QUEST_LV_0100_20150317_002015	Use this tranquilizer on the black maize and extract its poison. {nl} The Maize should be weakened for the tranquilizer to work.
+QUEST_LV_0100_20150317_002015	Use this tranquilizer on the black maize and extract its poison.{nl}The Maize should be weakened for the tranquilizer to work.
 QUEST_LV_0100_20150317_002016	Thank you so much! {nl}By the way, what was that vibration?
 QUEST_LV_0100_20150317_002017	The disciple of Andail Village
-QUEST_LV_0100_20150317_002018	You're the Revelator right? {nl} Wupen is preying on the village so I don't we can hold the ritual right away. {nl}
-QUEST_LV_0100_20150317_002019	I'm thinking of making languid flower bombs. {nl} Please bring me lazy flowers from the Narvas tracks.
+QUEST_LV_0100_20150317_002018	You're the Revelator right?{nl}Wupen is preying on the village so I don't we can hold the ritual right away.{nl}
+QUEST_LV_0100_20150317_002019	I'm thinking of making languid flower bombs.{nl}Please bring me lazy flowers from the Narvas tracks.
 QUEST_LV_0100_20150317_002020	It is safe where the languid flowers bloom so do not worry.
-QUEST_LV_0100_20150317_002021	Glad you're back safely. {nl} Didn't the monsters attack?
-QUEST_LV_0100_20150317_002022	Please get the flower of souls in Dvyni swamp too. {nl} Languid flowers alone will not be so effective. {nl}
+QUEST_LV_0100_20150317_002021	Glad you're back safely.{nl}Didn't the monsters attack?
+QUEST_LV_0100_20150317_002022	Please get the flower of souls in Dvyni swamp too.{nl}Languid flowers alone will not be so effective.{nl}
 QUEST_LV_0100_20150317_002023	I hope we'll be successful this time.
 QUEST_LV_0100_20150317_002024	I'll do the ritual right away if you defeat Upent.{nl}So, please get the flower of the soul.
-QUEST_LV_0100_20150317_002025	That is enough. {nl} I'll send the materials to the elderly, so please go and get the explosives.
+QUEST_LV_0100_20150317_002025	That is enough.{nl}I'll send the materials to the elderly, so please go and get the explosives.
 QUEST_LV_0100_20150317_002026	The headman of Andail Village
-QUEST_LV_0100_20150317_002027	Explosives? Ahh. {nl} Go to the warehouse lot in the upper side of the village.
-QUEST_LV_0100_20150317_002028	It's probably in the big container. {nl} It won't explode, so don't worry.
+QUEST_LV_0100_20150317_002027	Explosives? Ahh.{nl}Go to the warehouse lot in the upper side of the village.
+QUEST_LV_0100_20150317_002028	It's probably in the big container.{nl}It won't explode, so don't worry.
 QUEST_LV_0100_20150317_002029	Don't worry, it's safe. It will not explode.
-QUEST_LV_0100_20150317_002030	Was it a small container? {nl} I'm old and I guess I got confused. {nl} Normally, people would have burnt and disappeared without a trace but a Revelator surely is different.
+QUEST_LV_0100_20150317_002030	Was it a small container?{nl}I'm old and I guess I got confused.{nl}Normally, people would have burnt and disappeared without a trace but a Revelator surely is different.
 QUEST_LV_0100_20150317_002031	
-QUEST_LV_0100_20150317_002032	God or Goddess, what you call her doesn't matter. {nl} Aren't we all one eventually? {nl}
-QUEST_LV_0100_20150317_002033	Is it hard to understand? {nl} One day you will realize.
-QUEST_LV_0100_20150317_002034	Here, this is Languid flower bomb. {nl} Take it to the cliff of Melagingas.
-QUEST_LV_0100_20150317_002035	Now, hurry. {nl} We can finally end it this time.
+QUEST_LV_0100_20150317_002032	God or Goddess, what you call her doesn't matter.{nl}Aren't we all one eventually?{nl}
+QUEST_LV_0100_20150317_002033	Is it hard to understand?{nl}One day you will realize.
+QUEST_LV_0100_20150317_002034	Here, this is Languid flower bomb.{nl}Take it to the cliff of Melagingas.
+QUEST_LV_0100_20150317_002035	Now, hurry.{nl}We can finally end it this time.
 QUEST_LV_0100_20150317_002036	This time, it can finally come to an end.
-QUEST_LV_0100_20150317_002037	Hmm. So. The procedure is. {nl} Wash your body in the water and pray, then.. {nl}
+QUEST_LV_0100_20150317_002037	Hmm. So. The procedure is.{nl}Wash your body in the water and pray, then..{nl}
 QUEST_LV_0100_20150317_002038	It's too complicated so I'll explain it later.
 QUEST_LV_0100_20150317_002039	
-QUEST_LV_0100_20150317_002040	Can you step on the Statue of the Goddess? {nl} It doesn't matter. Why do you ask?
+QUEST_LV_0100_20150317_002040	Can you step on the Statue of the Goddess?{nl}It doesn't matter. Why do you ask?
 QUEST_LV_0100_20150317_002041	It will be hard without Colli flowers' fluids because of rain.{nl}When would the rain stop.
 QUEST_LV_0100_20150317_002042	Well done.{nl}This will be enough.
 QUEST_LV_0100_20150317_002043	Burn the thorny bushes that block Rustybe Dead Trees Region using this.{nl}Although it's raining, you will easily burn them.
@@ -2067,35 +2067,35 @@ QUEST_LV_0100_20150317_002066	Thanks.{nl}They would not be able to attack us eas
 QUEST_LV_0100_20150317_002067	Thanks.{nl}The believers are distributed to their areas so find them and help them.
 QUEST_LV_0100_20150317_002068	If you don't have any job to do here, then it will be better to leave this place asap.{nl}It's not good for a person who doesn't know how to purify stays here too long.
 QUEST_LV_0100_20150317_002069	
-QUEST_LV_0100_20150317_002070	Saule goddess Quezon evil aura it is not willing to spread in the other forest. {nl} Therefore, thing we're here.
+QUEST_LV_0100_20150317_002070	Saule goddess Quezon evil aura it is not willing to spread in the other forest.{nl}Therefore, thing we're here.
 QUEST_LV_0100_20150317_002071	I am so angry to see those filthy demons walking around.
 QUEST_LV_0100_20150317_002072	I gave up long time ago since I can't see an end to that vicious atmosphere.{nl}I just think of it as my destiny.
 QUEST_LV_0100_20150317_002073	Now we just need to find out the plan of those Meroggs.{nl}Until then, please face that magician.
-QUEST_LV_0100_20150317_002074	Saule goddess was so do not speak the absolute their presence. {nl} Ramyonsoyo that give me the world of confusion only without any reason.
+QUEST_LV_0100_20150317_002074	Saule goddess was so do not speak the absolute their presence.{nl}Ramyonsoyo that give me the world of confusion only without any reason.
 QUEST_LV_0100_20150317_002075	This is all my fault. I shouldn't have underestimated it.
 QUEST_LV_0100_20150317_002076	
 QUEST_LV_0100_20150317_002077	I am okay about the sample so just break it so that it won't activate.{nl}I am gonna take a look at it myself.
 QUEST_LV_0100_20150317_002078	I get angry everytime I enter that Thorny Foresst.{nl}How could these dirty things happen in this divine forest of the goddess?
 QUEST_LV_0100_20150317_002079	Help me. Meroggs are after me.{nl}When they are moving in a herd like that, I can't face them.
-QUEST_LV_0100_20150317_002080	Good. {nl} Now, we're going to destroy the roots of Bramble.
+QUEST_LV_0100_20150317_002080	Good.{nl}Now, we're going to destroy the roots of Bramble.
 QUEST_LV_0100_20150317_002081	Believer Samanta
 QUEST_LV_0100_20150317_002082	Whenever I tried to purify the Thorny Trees fountain, those monsters attack.{nl}Is there some way to avoid them?
 QUEST_LV_0100_20150317_002083	Monsters are becoming more violent as they enter deeper into the thorny forest.{nl}Maybe that's due to the vicious energy.
 QUEST_LV_0100_20150317_002084	I can relax now and purify the fountain.{nl}Thank you so much.
 QUEST_LV_0100_20150317_002085	I can rely on you.{nl}Please protect the altar until the fountain gets purified.
-QUEST_LV_0100_20150317_002086	Put Merlog's saliva in this potion and shake it. {nl} It will help you withstand the muddy aura of Bramble.
-QUEST_LV_0100_20150317_002087	Bramble is recovering by embedding roots around the Thorn Forest . {nl} Cutting those roots will be very painful.
-QUEST_LV_0100_20150317_002088	You can't let your guards down even if the Brambles weakened. {nl} It is the leader of the demons no matter how injured it is.
-QUEST_LV_0100_20150317_002089	Now we'll make a full-scale attack on Bramble. {nl} I'll go in the Giliaii courtyard and watch on the Brambles first so follow me.
-QUEST_LV_0100_20150317_002090	The most important roots in the Sviesa hills and Tankinta lot. {nl} Cut them both.
+QUEST_LV_0100_20150317_002086	Put Merlog's saliva in this potion and shake it.{nl}It will help you withstand the muddy aura of Bramble.
+QUEST_LV_0100_20150317_002087	Bramble is recovering by embedding roots around the Thorn Forest .{nl}Cutting those roots will be very painful.
+QUEST_LV_0100_20150317_002088	You can't let your guards down even if the Brambles weakened.{nl}It is the leader of the demons no matter how injured it is.
+QUEST_LV_0100_20150317_002089	Now we'll make a full-scale attack on Bramble.{nl}I'll go in the Giliaii courtyard and watch on the Brambles first so follow me.
+QUEST_LV_0100_20150317_002090	The most important roots in the Sviesa hills and Tankinta lot.{nl}Cut them both.
 QUEST_LV_0100_20150317_002091	Even when all vicious energy is removed, this forest will be as it is.{nl}But, we will an end someday.
 QUEST_LV_0100_20150317_002092	Believer Kazis
-QUEST_LV_0100_20150317_002093	Somewhere in the single road Caracas has hidden Honeypin you can not but find. {nl} purification work has been delayed because of the monster.
+QUEST_LV_0100_20150317_002093	Somewhere in the single road Caracas has hidden Honeypin you can not but find.{nl}purification work has been delayed because of the monster.
 QUEST_LV_0100_20150317_002094	You just need to activate the altar of purification.{nl}Without letting Honeypin know.
 QUEST_LV_0100_20150317_002095	You are not hurt?{nl}I heard the Honeypin's wing sound, but I am relieved to see you are okay.
-QUEST_LV_0100_20150317_002096	Bramble and revelation are in the depths of Giliaii courtyard. {nl} The roots for healing the scars have all been cut so it must be agonizing.
-QUEST_LV_0100_20150317_002097	Do not forget to use stimulants every time you run out of breath. {nl} May the blessings of Goddess Saule be with you.
-QUEST_LV_0100_20150317_002098	Do not forget to use stimulants every time you run out of breath. {nl} May the blessings of Goddess Saule be with you.
+QUEST_LV_0100_20150317_002096	Bramble and revelation are in the depths of Giliaii courtyard.{nl}The roots for healing the scars have all been cut so it must be agonizing.
+QUEST_LV_0100_20150317_002097	Do not forget to use stimulants every time you run out of breath.{nl}May the blessings of Goddess Saule be with you.
+QUEST_LV_0100_20150317_002098	Do not forget to use stimulants every time you run out of breath.{nl}May the blessings of Goddess Saule be with you.
 QUEST_LV_0100_20150317_002099	If you feel you are in danger, run away quickly.{nl}The ship is more dangerous due to the vicious atmosphere.
 QUEST_LV_0100_20150317_002100	
 QUEST_LV_0100_20150317_002101	I am not afraid of dying.{nl}The goddess, Saule will guide me well.
@@ -2116,7 +2116,7 @@ QUEST_LV_0100_20150317_002115	Do not disturb Zachariel's rest
 QUEST_LV_0100_20150317_002116	I told you that there's an way to block those demons at Fedimian.{nl}I will complete the jewel of prominence here and help the goddess Gabiya.{nl}
 QUEST_LV_0100_20150317_002117	I hope the goddess stands still until then.
 QUEST_LV_0100_20150317_002118	Well done.{nl}But, this is just an empty stone.{nl}You can complete it by empowering it with various ingredients.
-QUEST_LV_0100_20150317_002119	I will fill the Jewel of Prominence with flame steam.{nl}There is a flame steam with magic possesed in it at the reading room. 
+QUEST_LV_0100_20150317_002119	I will fill the Jewel of Prominence with flame steam.{nl}There is a flame steam with magic possesed in it at the reading room.
 QUEST_LV_0100_20150317_002120	You should search for it hard.{nl}The flame steam is not clearly visible.
 QUEST_LV_0100_20150317_002121	This is enough. Well done.
 QUEST_LV_0100_20150317_002122	Now we have to fill the Essence of Fire into the jewel, but it's complicated.{nl}
@@ -2131,35 +2131,35 @@ QUEST_LV_0100_20150317_002130	We should succeed..
 QUEST_LV_0100_20150317_002131	So this is the Jewel of Prominence.. I can feel it's great energy.{nl}Let's quickly give this to Gabiya. There's stairs to go up on the right side.
 QUEST_LV_0100_20150317_002132	To find the Jewel of Prominence, just use this detector.{nl}When you use this detector near the place where the jewel is located, the jewel will come out.
 QUEST_LV_0100_20150317_002133	The portal that you tried to open is the gate of lies.{nl}The villagers hear are the tricks of Demons' lord, Bramble.
-QUEST_LV_0100_20150317_002134	It's embarrassing but I am also tricked and captured, losing all my strength. {nl} Please destroy the magic circle imprisoning me.
-QUEST_LV_0100_20150317_002135	The magic circle of confinement is located in Drugys Courtyard and Vapsva lot. {nl} Hurry.
-QUEST_LV_0100_20150317_002136	Thank you for saving me. {nl}
-QUEST_LV_0100_20150317_002137	I am Saule, the Goddess of the sun. {nl} Everything is just like how Laima has forseen.
-QUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here. {nl} We've got to find the inspetor, Clymen, hiding in between the gap of dimensions.
-QUEST_LV_0100_20150317_002139	Please bring me the sacrifice tools in the Grand Corridor. {nl} I will try to use the divine power that dwell in the tool.
-QUEST_LV_0100_20150317_002140	Thank you. {nl} This much divine power would be enough.
+QUEST_LV_0100_20150317_002134	It's embarrassing but I am also tricked and captured, losing all my strength.{nl}Please destroy the magic circle imprisoning me.
+QUEST_LV_0100_20150317_002135	The magic circle of confinement is located in Drugys Courtyard and Vapsva lot.{nl}Hurry.
+QUEST_LV_0100_20150317_002136	Thank you for saving me.{nl}
+QUEST_LV_0100_20150317_002137	I am Saule, the Goddess of the sun.{nl}Everything is just like how Laima has forseen.
+QUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here.{nl}We've got to find the inspetor, Clymen, hiding in between the gap of dimensions.
+QUEST_LV_0100_20150317_002139	Please bring me the sacrifice tools in the Grand Corridor.{nl}I will try to use the divine power that dwell in the tool.
+QUEST_LV_0100_20150317_002140	Thank you.{nl}This much divine power would be enough.
 QUEST_LV_0100_20150317_002141	
 QUEST_LV_0100_20150317_002142	Just a bit more. Please suppress the Magi.
 QUEST_LV_0100_20150317_002143	
-QUEST_LV_0100_20150317_002144	It's his key. {nl} Please let me free.
-QUEST_LV_0100_20150317_002145	Thank you in the name of Saule, the Goddess of the sun. {nl}
-QUEST_LV_0100_20150317_002146	It's a shame but the revelation is in the hands of Bramble. {nl} The reason he imprisoned me instead of killing me is to use my divinity to interpret the revelation. {nl}
-QUEST_LV_0100_20150317_002147	But the Bramble is also not in its normal condition due to the previous battle. {nl} Please stop the Bramble in the gateway with my followers and get the revelation back.
-QUEST_LV_0100_20150317_002148	Show me the revelation. {nl} I'll show you its meaning.
-QUEST_LV_0100_20150317_002149	If it's the divine power dwelling on the sacrifice items, then we can surely use it to find Clymen. {nl}
+QUEST_LV_0100_20150317_002144	It's his key.{nl}Please let me free.
+QUEST_LV_0100_20150317_002145	Thank you in the name of Saule, the Goddess of the sun.{nl}
+QUEST_LV_0100_20150317_002146	It's a shame but the revelation is in the hands of Bramble.{nl}The reason he imprisoned me instead of killing me is to use my divinity to interpret the revelation.{nl}
+QUEST_LV_0100_20150317_002147	But the Bramble is also not in its normal condition due to the previous battle.{nl}Please stop the Bramble in the gateway with my followers and get the revelation back.
+QUEST_LV_0100_20150317_002148	Show me the revelation.{nl}I'll show you its meaning.
+QUEST_LV_0100_20150317_002149	If it's the divine power dwelling on the sacrifice items, then we can surely use it to find Clymen.{nl}
 QUEST_LV_0100_20150317_002150	Lyliana
 QUEST_LV_0100_20150317_002151	
-QUEST_LV_0100_20150317_002152	I really want to know how my family is doing but I'm too scared of the monsters to go back. {nl} I just ran out of the house and I regret it a lot.
+QUEST_LV_0100_20150317_002152	I really want to know how my family is doing but I'm too scared of the monsters to go back.{nl}I just ran out of the house and I regret it a lot.
 QUEST_LV_0100_20150317_002153	
 QUEST_LV_0100_20150317_002154	I just feel sorry to my brother.
 QUEST_LV_0100_20150317_002155	Old man of Andail village
 QUEST_LV_0100_20150317_002156	God is looking after our village so our village has clear water and air. And there are no disasters here.
 QUEST_LV_0100_20150317_002157	So finally the revelator has come.{nl}Very healthy and reliable. I gues we can do it this time.
-QUEST_LV_0100_20150317_002158	Aren't you the Revelator? {nl} So, what brings you to our village? {nl}
-QUEST_LV_0100_20150317_002159	Goddess Saule? {nl} We haven't seen her for a long time. {nl}
+QUEST_LV_0100_20150317_002158	Aren't you the Revelator?{nl}So, what brings you to our village?{nl}
+QUEST_LV_0100_20150317_002159	Goddess Saule?{nl}We haven't seen her for a long time.{nl}
 QUEST_LV_0100_20150317_002160	The portal leading to Goddess Saule just won't open. {nl}I think it's all because the diving pond is contaminated.
-QUEST_LV_0100_20150317_002161	Tanu in Zvelgian vacant lot has the purifying stone. {nl} That would be able to purify the pond.
-QUEST_LV_0100_20150317_002162	Just like there are many demons, same goes for the Goddesses. {nl} The five Goddesses are just the ones who became well known.
+QUEST_LV_0100_20150317_002161	Tanu in Zvelgian vacant lot has the purifying stone.{nl}That would be able to purify the pond.
+QUEST_LV_0100_20150317_002162	Just like there are many demons, same goes for the Goddesses.{nl}The five Goddesses are just the ones who became well known.
 QUEST_LV_0100_20150317_002163	Our village serves Goddess Saule who overlooks the sun. {nl}We used to go see her a lot before through the portal but one day, the portal closed.
 QUEST_LV_0100_20150317_002164	I haved carved the owls for a long time.{nl}At one point in time, they got their lives and determination.{nl}
 QUEST_LV_0100_20150317_002165	When I gained my conciousness, a few hundreds of years have passed.
@@ -2181,16 +2181,16 @@ QUEST_LV_0100_20150317_002180	The royal tomb you should go can be reached only t
 QUEST_LV_0100_20150317_002181	It seems that rain won't stop. In fact, it rarely stopped.{nl}Do you think this is because of the vicious energy?
 QUEST_LV_0100_20150317_002182	These thorny bushes just keep growing even after we cut them.{nl}But it's better than doing nothing.
 QUEST_LV_0100_20150317_002183	Even if Bramble gets dissappeared, I think I am gonna stay like this for a while.{nl}Whole forest is covered with thorny bushes. They are so big.
-QUEST_LV_0100_20150317_002184	So, you seem to live up to your reputation. {nl} Our people in the village are just cowards hoping the Goddess will take care of everything.
-QUEST_LV_0100_20150317_002185	But, did you not see the young man of our village? {nl} I told him to ge see how the portal works but I have not heard back since then.
-QUEST_LV_0100_20150317_002186	Thank you. {nl} The portal is in the Nugria Sanctuary.
+QUEST_LV_0100_20150317_002184	So, you seem to live up to your reputation.{nl}Our people in the village are just cowards hoping the Goddess will take care of everything.
+QUEST_LV_0100_20150317_002185	But, did you not see the young man of our village?{nl}I told him to ge see how the portal works but I have not heard back since then.
+QUEST_LV_0100_20150317_002186	Thank you.{nl}The portal is in the Nugria Sanctuary.
 QUEST_LV_0100_20150317_002187	Thanks.{nl}The portal is at Nugria divine place.
 QUEST_LV_0100_20150317_002188	Thank you for saving me.
-QUEST_LV_0100_20150317_002189	So you're the Revelator the Mayor spoke about. {nl} I'm fine so please check the portal of the Sanctuary.
+QUEST_LV_0100_20150317_002189	So you're the Revelator the Mayor spoke about.{nl}I'm fine so please check the portal of the Sanctuary.
 QUEST_LV_0100_20150317_002190	The portal can be opened from the altar in Nugria Sanctuary
-QUEST_LV_0100_20150317_002191	It does not work. {nl} That's a big problem. {nl}
+QUEST_LV_0100_20150317_002191	It does not work.{nl}That's a big problem.{nl}
 QUEST_LV_0100_20150317_002192	
-QUEST_LV_0100_20150317_002193	That portal is.. a fantasy... No. A portal going to Goddess Saule. {nl} Anyway, opening the portal is very important.
+QUEST_LV_0100_20150317_002193	That portal is.. a fantasy... No. A portal going to Goddess Saule.{nl}Anyway, opening the portal is very important.
 QUEST_LV_0100_20150317_002194	Injuries are not that severe so don't worry. Please check the portal in the sanctuary first.
 QUEST_LV_0100_20150317_002195	I will move again if I take a little rest.{nl}First, the portal..
 QUEST_LV_0100_20150317_002196	Ah, so you are the revelator!{nl}It's a real honor for us.
@@ -2208,65 +2208,65 @@ QUEST_LV_0100_20150317_002207	Venucelos is very brave and loyal.{nl}But, if his 
 QUEST_LV_0100_20150317_002208	The proof of powerfulness! Such a beautiful words..{nl}Zachariel was proud to create the gigantic protectors.{nl}And he put the secret documents of the kingdom in those protectors so that the one who defeats them can get those documents.
 QUEST_LV_0100_20150317_002209	The statue of the protector
 QUEST_LV_0100_20150317_002210	Listen quietly with your eyes closed.{nl}The nature keeps singing to us the songs of lives.
-QUEST_LV_0100_20150317_002211	Broker between the life and death of humans. {nl} That's what Bokor is, if you ask.
+QUEST_LV_0100_20150317_002211	Broker between the life and death of humans.{nl}That's what Bokor is, if you ask.
 QUEST_LV_0100_20150317_002212	You don't look like a delivery man. What's up?{nl}
 QUEST_LV_0100_20150317_002213	I can't see the head of the tree with long branches. Do you want me to get it for you?
-QUEST_LV_0100_20150317_002214	Klaipeda is a small and quiet town. {nl} We haven't had so many people come to town before.
+QUEST_LV_0100_20150317_002214	Klaipeda is a small and quiet town.{nl}We haven't had so many people come to town before.
 QUEST_LV_0100_20150317_002215	Did the Goddess mention where she is in the dream of revelation?
-QUEST_LV_0100_20150317_002216	Go ahead to Klaipeda. {nl} Commander Uska is waiting for you in the Central Plaza.{nl}
+QUEST_LV_0100_20150317_002216	Go ahead to Klaipeda.{nl}Commander Uska is waiting for you in the Central Plaza.{nl}
 QUEST_LV_0100_20150317_002217	I heard the bishop also had a dream about the Goddess... And I think it has to do with it.
-QUEST_LV_0100_20150317_002218	That girl. {nl} She just appeared in town some time ago. {nl}
-QUEST_LV_0100_20150317_002219	I mean she didn't speak and her clothes were all dirty. {nl} She seemed hungry so I brought her home to feed her some food and this happened.
-QUEST_LV_0100_20150317_002220	I mean the girl who was confined together with us last time. {nl} Do you think she has a family? It seemed like she can not speak at all. {nl}
-QUEST_LV_0100_20150317_002221	If I was a parent, I probably would have gone around mad looking for my daughter. {nl} Parents nowadays are really irresponsible. {nl}
-QUEST_LV_0100_20150317_002222	The girl did not speak at all. {nl} In addition to that, a young lady all grown up walking all the way to this remote village barefoot. Doesn't it seem strange?
+QUEST_LV_0100_20150317_002218	That girl.{nl}She just appeared in town some time ago.{nl}
+QUEST_LV_0100_20150317_002219	I mean she didn't speak and her clothes were all dirty.{nl}She seemed hungry so I brought her home to feed her some food and this happened.
+QUEST_LV_0100_20150317_002220	I mean the girl who was confined together with us last time.{nl}Do you think she has a family? It seemed like she can not speak at all.{nl}
+QUEST_LV_0100_20150317_002221	If I was a parent, I probably would have gone around mad looking for my daughter.{nl}Parents nowadays are really irresponsible.{nl}
+QUEST_LV_0100_20150317_002222	The girl did not speak at all.{nl}In addition to that, a young lady all grown up walking all the way to this remote village barefoot. Doesn't it seem strange?
 QUEST_LV_0100_20150317_002223	Can we go home..
 QUEST_LV_0100_20150317_002224	I want to go home soon..
 QUEST_LV_0100_20150317_002225	
 QUEST_LV_0100_20150317_002226	Husband of refugee family
 QUEST_LV_0100_20150317_002227	
-QUEST_LV_0100_20150317_002228	Oh, the Accessory Merchant said she has a gift for you. {nl} Would you mind visiting her?
+QUEST_LV_0100_20150317_002228	Oh, the Accessory Merchant said she has a gift for you.{nl}Would you mind visiting her?
 QUEST_LV_0100_20150317_002229	You can meet the Accessory Merchant if you go straight to the left from here.
 QUEST_LV_0100_20150317_002230	Accessory Merchant
-QUEST_LV_0100_20150317_002231	Nice to meet you! Are you the Revelator chasing the dream of the Goddess? {nl} I'm going to give you this accessory as a present. {nl}
-QUEST_LV_0100_20150317_002232	If the armors protect you from physical attacks, accessories protect you from magic attacks. {nl} I hope it would be useful for you.
-QUEST_LV_0100_20150317_002233	You can meet the Accessory Merchant if you go straight to the left from here. {nl}
+QUEST_LV_0100_20150317_002231	Nice to meet you! Are you the Revelator chasing the dream of the Goddess?{nl}I'm going to give you this accessory as a present.{nl}
+QUEST_LV_0100_20150317_002232	If the armors protect you from physical attacks, accessories protect you from magic attacks.{nl}I hope it would be useful for you.
+QUEST_LV_0100_20150317_002233	You can meet the Accessory Merchant if you go straight to the left from here.{nl}
 QUEST_LV_0100_20150317_002234	Ah, I was waiting for you.{nl}You are the person chosen by the eyes of Zachariel right?
 QUEST_LV_0100_20150317_002235	Welcome.
-QUEST_LV_0100_20150317_002236	Oh, seems like you have Yukopus leaves and Kepa stems. {nl} I need a lot of those. Can you share some with me?
-QUEST_LV_0100_20150317_002237	Thank you very much. {nl} I need these to treat the injured men in our village but I don't have enough.
+QUEST_LV_0100_20150317_002236	Oh, seems like you have Yukopus leaves and Kepa stems.{nl}I need a lot of those. Can you share some with me?
+QUEST_LV_0100_20150317_002237	Thank you very much.{nl}I need these to treat the injured men in our village but I don't have enough.
 QUEST_LV_0100_20150317_002238	I know you tried hard but I need some more.
-QUEST_LV_0100_20150317_002239	I still need more Yukopus leaves and Kepa stems. {nl} But I don't want to just take them from you. What about trading it with the potions I have?
+QUEST_LV_0100_20150317_002239	I still need more Yukopus leaves and Kepa stems.{nl}But I don't want to just take them from you. What about trading it with the potions I have?
 QUEST_LV_0100_20150317_002240	Your act of kindness really gives me a lot of strength.
 QUEST_LV_0100_20150317_002241	Thanks you! {nl}I hope it would be helpful for you.
-QUEST_LV_0100_20150317_002242	Yukopus and Kepas appear around the Miner's Village.
-QUEST_LV_0100_20150317_002243	Hey, are you going to take on those Vubbes? {nl} But your equipment seems a bit shabby... Do you mind if I help you with it?
-QUEST_LV_0100_20150317_002244	Get me a few materials and I'll help you craft some new armors. {nl} The materials needed can be obtained from Large Red Kepa, Yukofus, and Vubbe Thief.
-QUEST_LV_0100_20150317_002245	Large Red Kepa, Red Kepa, Yukopus, and Vubbe Thief. {nl} Not sure if it's a good thing but you can craft some pretty useful stuff with what the monsters drop.
-QUEST_LV_0100_20150317_002246	I'll give you the recipe so try crafting the armor with the materials I gave you. {nl} You will feel more reassured. Well then, may the Bless of Goddess be with you!
+QUEST_LV_0100_20150317_002242	Yukopus and Kepas appear around the Miners' Village.
+QUEST_LV_0100_20150317_002243	Hey, are you going to take on those Vubbes?{nl}But your equipment seems a bit shabby... Do you mind if I help you with it?
+QUEST_LV_0100_20150317_002244	Get me a few materials and I'll help you craft some new armors.{nl}The materials needed can be obtained from Large Red Kepa, Yukofus, and Vubbe Thief.
+QUEST_LV_0100_20150317_002245	Large Red Kepa, Red Kepa, Yukopus, and Vubbe Thief.{nl}Not sure if it's a good thing but you can craft some pretty useful stuff with what the monsters drop.
+QUEST_LV_0100_20150317_002246	I'll give you the recipe so try crafting the armor with the materials I gave you.{nl}You will feel more reassured. Well then, may the Bless of Goddess be with you!
 QUEST_LV_0100_20150317_002247	I am looking for medicines to cure wounded ones.
-QUEST_LV_0100_20150317_002248	Oh you brought it. {nl} This is the front plate. {nl} Keep it until we have all the parts ready to craft an armor.
-QUEST_LV_0100_20150317_002249	Oh, here we are. Let's see. {nl} Seems like you brought enough of what we needed. {nl} You can make a Mantle with it. {nl} This reminds me of the good old days.
+QUEST_LV_0100_20150317_002248	Oh you brought it.{nl}This is the front plate.{nl}Keep it until we have all the parts ready to craft an armor.
+QUEST_LV_0100_20150317_002249	Oh, here we are. Let's see.{nl}Seems like you brought enough of what we needed.{nl}You can make a Mantle with it.{nl}This reminds me of the good old days.
 QUEST_LV_0100_20150317_002250	Ordinary Man
-QUEST_LV_0100_20150317_002251	This is the back plate. {nl} I'll let you craft when we have all the other materials ready.
+QUEST_LV_0100_20150317_002251	This is the back plate.{nl}I'll let you craft when we have all the other materials ready.
 QUEST_LV_0100_20150317_002252	Here you go. This is a Chest protector made of leather. {nl}It was fun to do this in a long time.
 QUEST_LV_0100_20150317_002253	Bone fragments are seen in the well.
-QUEST_LV_0100_20150317_002254	I'm furious and upset. {nl} Only if we arrived earlier, we could have saved ourselves from being totally wiped out .. {nl}
+QUEST_LV_0100_20150317_002254	I'm furious and upset.{nl}Only if we arrived earlier, we could have saved ourselves from being totally wiped out ..{nl}
 QUEST_LV_0100_20150317_002255	Dear Revelator, I have a favor to ask of you. {nl}Can you get us back the keepstakes of my comrades?
 QUEST_LV_0100_20150317_002256	It's bad enough that they were killed by the Vubbes but even their keepstakes are being abused. What an awful thing.
-QUEST_LV_0100_20150317_002257	Thank you. {nl} My comrades who passed away will now be able to rest in peace.
-QUEST_LV_0100_20150317_002258	Oh my God. The Vubbes stole all the food supplies. {nl} They took even our immediate food... Please help us with your strength.
-QUEST_LV_0100_20150317_002259	They stole the food meant for both the army and residents. {nl} What do we do if we can't get back our food.. {nl}
-QUEST_LV_0100_20150317_002260	Thank you. {nl} This will at least get us to live for the few days.
-QUEST_LV_0100_20150317_002261	Thank you very much for your help previously but there are more keepstakes that need to be retrieved. {nl} Think of my comrades who can't rest in peace.. {nl}
-QUEST_LV_0100_20150317_002262	So please help us. {nl} If you get us back the rest of the keepstakes, we will compensate for it.
-QUEST_LV_0100_20150317_002263	Thank you, but we still need more... {nl} Sorry.. {nl}
-QUEST_LV_0100_20150317_002264	We collected almost all the keepsakes.. {nl} Please help us til the end.
+QUEST_LV_0100_20150317_002257	Thank you.{nl}My comrades who passed away will now be able to rest in peace.
+QUEST_LV_0100_20150317_002258	Oh my God. The Vubbes stole all the food supplies.{nl}They took even our immediate food... Please help us with your strength.
+QUEST_LV_0100_20150317_002259	They stole the food meant for both the army and residents.{nl}What do we do if we can't get back our food..{nl}
+QUEST_LV_0100_20150317_002260	Thank you.{nl}This will at least get us to live for the few days.
+QUEST_LV_0100_20150317_002261	Thank you very much for your help previously but there are more keepstakes that need to be retrieved.{nl}Think of my comrades who can't rest in peace..{nl}
+QUEST_LV_0100_20150317_002262	So please help us.{nl}If you get us back the rest of the keepstakes, we will compensate for it.
+QUEST_LV_0100_20150317_002263	Thank you, but we still need more...{nl}Sorry..{nl}
+QUEST_LV_0100_20150317_002264	We collected almost all the keepsakes..{nl}Please help us til the end.
 QUEST_LV_0100_20150317_002265	It hurts to think about giving these keepstakes to my dead comrades' families.
-QUEST_LV_0100_20150317_002266	Thank you very much. {nl} My comrades can now rest in peace with the Goddesses.
-QUEST_LV_0100_20150317_002267	We survived immediate danger with your help last time but we still need more. {nl} Could you help us out a bit more?
+QUEST_LV_0100_20150317_002266	Thank you very much.{nl}My comrades can now rest in peace with the Goddesses.
+QUEST_LV_0100_20150317_002267	We survived immediate danger with your help last time but we still need more.{nl}Could you help us out a bit more?
 QUEST_LV_0100_20150317_002268	I'm enraged thinking about the Vubbes who will be hearily satisfied with our food. {nl}Especially at such difficult times nowadays.
-QUEST_LV_0100_20150317_002269	Thank you. {nl} We still lack some but at least we got back this much.
+QUEST_LV_0100_20150317_002269	Thank you.{nl}We still lack some but at least we got back this much.
 QUEST_LV_0100_20150317_002270	Fedimian Resident
 QUEST_LV_0100_20150317_002271	I heard the wise man Maven who built the great cathedral left five necklaces.{nl}I also heard that the one who collects those five necklaces will possess the great power.
 QUEST_LV_0100_20150317_002272	Hey, if you are planning to keep on your journey, don't get close to the cursed city.{nl}It didn't even receive the blessing on the divine day. You will turn into a stone if you get close to the city.
@@ -2274,13 +2274,13 @@ QUEST_LV_0100_20150317_002273	It's true that I am looking for the revelator, but
 QUEST_LV_0100_20150317_002274	There is the great cathedral which was built by Maven beyond Pilgrim's Way.{nl}Ruklys, Lydia Schaffen, Agailla Flurry are all his disciples.
 QUEST_LV_0100_20150317_002275	The great cathedral was destroyed a lot on the divine day so I wonder if there are still people going there, but..{nl}There were many people going there to do various rituals before.
 QUEST_LV_0100_20150317_002276	They call the way to the great cathedral, Pilgrim's Way.
-QUEST_LV_0100_20150317_002277	Welcome. {nl} These items were hard to get.
+QUEST_LV_0100_20150317_002277	Welcome.{nl}These items were hard to get.
 QUEST_LV_0100_20150317_002278	Hawkers of Klaipeda
-QUEST_LV_0100_20150317_002279	I came to pray in the distance Klaipeda. {nl} again as disaster does not occur, I like son between the army returns Moruchonhi.
-QUEST_LV_0100_20150317_002280	Each time you come here along the husband on the Klaipeda, it is always prayer to come here. {nl} I was either God Beast of the day also defended to me was one wishes excluded get to.
+QUEST_LV_0100_20150317_002279	I came to pray in the distance Klaipeda.{nl}again as disaster does not occur, I like son between the army returns Moruchonhi.
+QUEST_LV_0100_20150317_002280	Each time you come here along the husband on the Klaipeda, it is always prayer to come here.{nl}I was either God Beast of the day also defended to me was one wishes excluded get to.
 QUEST_LV_0100_20150317_002281	Don't you ever think about going to the great cathedral.{nl}Besides the dangers due to it's breakages..
-QUEST_LV_0100_20150317_002282	Yes. The Pilgrim's Way that must be passed when you wanna go to the great cathedral.{nl}Ah well.. the spirits of 
-QUEST_LV_0100_20150317_002283	Seal of Vubbe Tribe, Horn of Pantos, Heart of Merlog, HTeeth of Hogma. {nl} That is a lot! {nl}
+QUEST_LV_0100_20150317_002282	Yes. The Pilgrim's Way that must be passed when you wanna go to the great cathedral.{nl}Ah well.. the spirits of
+QUEST_LV_0100_20150317_002283	Seal of Vubbe Tribe, Horn of Pantos, Heart of Merlog, HTeeth of Hogma.{nl}That is a lot!{nl}
 QUEST_LV_0100_20150317_002284	The bootys that you've obtained are not to be boasted about.{nl}How about we bet?
 QUEST_LV_0100_20150317_002285	
 QUEST_LV_0100_20150317_002286	Haha, I lost.{nl}You are great as I heard so. Here, it's your reward as promised/
@@ -2293,72 +2293,72 @@ QUEST_LV_0100_20150317_002292	Without the blessing from the goddess, You must be
 QUEST_LV_0100_20150317_002293	
 QUEST_LV_0100_20150317_002294	We can't revive the people who died by Chapparitions.{nl}I feel sorry, but we can't just do nothing.
 QUEST_LV_0100_20150317_002295	Innocent Spirit
-QUEST_LV_0100_20150317_002296	Do not be surprised. {nl} There's something to give you before returning to the Goddess. {nl}
-QUEST_LV_0100_20150317_002297	I want to apologize to my sister who left house because of me but now I can't even do that. {nl} Can you find my sister and give her this necklace for me?
-QUEST_LV_0100_20150317_002298	My brother asked you to give this necklace to me? {nl} Where is my brother?
+QUEST_LV_0100_20150317_002296	Do not be surprised.{nl}There's something to give you before returning to the Goddess.{nl}
+QUEST_LV_0100_20150317_002297	I want to apologize to my sister who left house because of me but now I can't even do that.{nl}Can you find my sister and give her this necklace for me?
+QUEST_LV_0100_20150317_002298	My brother asked you to give this necklace to me?{nl}Where is my brother?
 QUEST_LV_0100_20150317_002299	Innocent Soldier
 QUEST_LV_0100_20150317_002300	You are new here. Defeat all monsters nearby on behalf of me.{nl}Somehow, I can't move.
 QUEST_LV_0100_20150317_002301	Now I can go back to my hometown.{nl}Do you best, newcomer..
 QUEST_LV_0100_20150317_002302	Errand Man
-QUEST_LV_0100_20150317_002303	What. This isn't the Ripper? {nl}But since you've seen my face, you'll soon be cursed to death. {nl}
-QUEST_LV_0100_20150317_002304	Wait a minute. No. No. {nl} Deliver this letter and I'll bump it. {nl} You just have to deliver it to Ripper, the guard of Fedimian. Do not look at what's written in the letter.
-QUEST_LV_0100_20150317_002305	Letter forme? What is this.. {nl}
+QUEST_LV_0100_20150317_002303	What. This isn't the Ripper? {nl}But since you've seen my face, you'll soon be cursed to death.{nl}
+QUEST_LV_0100_20150317_002304	Wait a minute. No. No.{nl}Deliver this letter and I'll bump it.{nl}You just have to deliver it to Ripper, the guard of Fedimian. Do not look at what's written in the letter.
+QUEST_LV_0100_20150317_002305	Letter forme? What is this..{nl}
 QUEST_LV_0100_20150317_002306	Curse? I get it, I get it!{nl} I'll give you this money, so please tell him to not curse!
-QUEST_LV_0100_20150317_002307	huhu. Poor guy. He won't be able to see the light soon {nl} Whether it's in prison or coffin, only he will know. {nl} I feel sorry for the dead soldiers.
-QUEST_LV_0100_20150317_002308	Oh, I really thank you for last time. {nl}My injury is getting better now that I can move. {nl}
-QUEST_LV_0100_20150317_002309	But, uh, I'm too hungry and do not have energy to go back to boss. If {nl} If you have anything to eat, can you share some?
-QUEST_LV_0100_20150317_002310	Oh, thank you so much! {nl} I'll take this to recover and return to the commander for sure.
+QUEST_LV_0100_20150317_002307	huhu. Poor guy. He won't be able to see the light soon{nl}Whether it's in prison or coffin, only he will know.{nl}I feel sorry for the dead soldiers.
+QUEST_LV_0100_20150317_002308	Oh, I really thank you for last time. {nl}My injury is getting better now that I can move.{nl}
+QUEST_LV_0100_20150317_002309	But, uh, I'm too hungry and do not have energy to go back to boss. If{nl}If you have anything to eat, can you share some?
+QUEST_LV_0100_20150317_002310	Oh, thank you so much!{nl}I'll take this to recover and return to the commander for sure.
 QUEST_LV_0100_20150317_002311	Chicks.. They remind me of Sparnas.{nl}I don't wanna see him even in my dreams.
 QUEST_LV_0100_20150317_002312	Hm, Okay. I have accessories that will fit on that.{nl}I don't need them anymore so I want to give them to you if you could take care of the monsters nearby.
 QUEST_LV_0100_20150317_002313	Not yet?{nl}They will fit on you nicely.
 QUEST_LV_0100_20150317_002314	Yes. Well done.{nl}Here you go. It's a gift to you as promised.{nl}
 QUEST_LV_0100_20150317_002315	Don't underestimate it. It was a strong animal in the old stories.{nl}In some places, one becomes an enemy to all other people just by touching that animal.
 QUEST_LV_0100_20150317_002316	
-QUEST_LV_0100_20150317_002317	The canyon area is like a grave for many explorers and historians. {nl} And we study to find more factual history on top of their graves.
-QUEST_LV_0100_20150317_002318	Thank you. {nl} Our academia will not forget him too. 
-QUEST_LV_0100_20150317_002319	The revelator is lying here after he said such thing.{nl}If he survives after facing the nearby monsters for 2 minutes, 
-QUEST_LV_0100_20150317_002320	Next time, be careful when using public utilities. {nl} Well that's that and you have some great power. 
-QUEST_LV_0100_20150317_002321	Oh.. It's absurdity gets me at loss for words every time I look at it. {nl} Was is really this fragile..
+QUEST_LV_0100_20150317_002317	The canyon area is like a grave for many explorers and historians.{nl}And we study to find more factual history on top of their graves.
+QUEST_LV_0100_20150317_002318	Thank you.{nl}Our academia will not forget him too.
+QUEST_LV_0100_20150317_002319	The revelator is lying here after he said such thing.{nl}If he survives after facing the nearby monsters for 2 minutes,
+QUEST_LV_0100_20150317_002320	Next time, be careful when using public utilities.{nl}Well that's that and you have some great power.
+QUEST_LV_0100_20150317_002321	Oh.. It's absurdity gets me at loss for words every time I look at it.{nl}Was is really this fragile..
 QUEST_LV_0100_20150317_002322	I don't feel good.{nl}We may have to evacuate from here.
 QUEST_LV_0100_20150317_002323	
 QUEST_LV_0100_20150317_002324	I will pray for that monsterl.{nl}If there are spirits who would listen to my prayer..
-QUEST_LV_0100_20150317_002325	Unfortunately... I don't know where my brother is. {nl} He also probably won't know my whereabouts too.
+QUEST_LV_0100_20150317_002325	Unfortunately... I don't know where my brother is.{nl}He also probably won't know my whereabouts too.
 QUEST_LV_0100_20150317_002326	I can't leave here unless I complete the mission..
-QUEST_LV_0100_20150317_002327	He is so stupid. {nl} He could have given it sooner in good terms rather than getting on each other's nerves. {nl} Hmm. Maybe I belittled myself too much.
-QUEST_LV_0100_20150317_002328	Don't you act like you know me anymore! {nl} It not my fault. That's the one who's bad!
-QUEST_LV_0100_20150317_002329	Are we there yet? {nl} I think we need to eat something to regain strength.
+QUEST_LV_0100_20150317_002327	He is so stupid.{nl}He could have given it sooner in good terms rather than getting on each other's nerves.{nl}Hmm. Maybe I belittled myself too much.
+QUEST_LV_0100_20150317_002328	Don't you act like you know me anymore!{nl}It not my fault. That's the one who's bad!
+QUEST_LV_0100_20150317_002329	Are we there yet?{nl}I think we need to eat something to regain strength.
 QUEST_LV_0100_20150317_002330	Frankly, I'm afraid of what the world will turn into.
 QUEST_LV_0100_20150317_002331	Cyrenia Odell
 QUEST_LV_0100_20150317_002332	Hmm.. where is this place?{nl}What about Rexipher? Where is he?
 QUEST_LV_0100_20150317_002333	Ah? Woman. I forgot.{nl}I will release you as promised so make her alive.
-QUEST_LV_0100_20150317_002334	Sincerity is our strength. {nl} There will be no problems if you sincerely believe and follow the goddess.
-QUEST_LV_0100_20150317_002335	I think being confined in there caused my throat and now my throat hurts. {nl} But what about the girl who was together? Where did she go?
-QUEST_LV_0100_20150317_002336	Aren't you the Revelator who saved us last time? {nl} We were more than glad to see you back then.
+QUEST_LV_0100_20150317_002334	Sincerity is our strength.{nl}There will be no problems if you sincerely believe and follow the goddess.
+QUEST_LV_0100_20150317_002335	I think being confined in there caused my throat and now my throat hurts.{nl}But what about the girl who was together? Where did she go?
+QUEST_LV_0100_20150317_002336	Aren't you the Revelator who saved us last time?{nl}We were more than glad to see you back then.
 QUEST_LV_0100_20150317_002337	The goddess must have sent you.{nl}If that's not it.. we already.. It's too scary to think about it.
-QUEST_LV_0100_20150317_002338	It was horrible in captivity. {nl} Vubbes come and smell us.. {nl} and make us dig here and there using pickax..
+QUEST_LV_0100_20150317_002338	It was horrible in captivity.{nl}Vubbes come and smell us..{nl}and make us dig here and there using pickax..
 QUEST_LV_0100_20150317_002339	Rexipher .. he would have been really Asmodian?
-QUEST_LV_0100_20150317_002340	You saved us. Thank you so much. {nl} But I have a question for you.
-QUEST_LV_0100_20150317_002341	Healing magic. {nl} Can people easily do it?
-QUEST_LV_0100_20150317_002342	But listen to me my story. {nl} When I was taken to the mine, I injured my knee. {nl}
-QUEST_LV_0100_20150317_002343	But a girl touched my knee and the pain was gone. {nl} Even the wound is gone. {nl}
-QUEST_LV_0100_20150317_002344	Amazing huh? I make her a flower ring if we meet again. {nl} But I don't know where she's gone to.
+QUEST_LV_0100_20150317_002340	You saved us. Thank you so much.{nl}But I have a question for you.
+QUEST_LV_0100_20150317_002341	Healing magic.{nl}Can people easily do it?
+QUEST_LV_0100_20150317_002342	But listen to me my story.{nl}When I was taken to the mine, I injured my knee.{nl}
+QUEST_LV_0100_20150317_002343	But a girl touched my knee and the pain was gone.{nl}Even the wound is gone.{nl}
+QUEST_LV_0100_20150317_002344	Amazing huh? I make her a flower ring if we meet again.{nl}But I don't know where she's gone to.
 QUEST_LV_0100_20150317_002345	Good job.{nl}I will take the Jewel of Prominence.
 QUEST_LV_0100_20150317_002346	Strange Sack
 QUEST_LV_0100_20150317_002347	Found a letter in the sack
 QUEST_LV_0100_20150317_002348	The letter in the sack
 QUEST_LV_0100_20150317_002349	Receiver: Drashoes{nl}Address: Virdului Cabin{nl}I am sending you the head of the tree with long branches that you ordered.
-QUEST_LV_0100_20150317_002350	400 years would have passed by when this revelation reaches you. {nl} Thank you in advance for your continued pursuit of finding the revelation. . {nl}
-QUEST_LV_0100_20150317_002351	As I'm sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin. {nl} if you find this revelation, it would mean that he had done an excellent job in fulfilling his mission. {nl}
-QUEST_LV_0100_20150317_002352	The demons have been chasing the revelation before I made this revelation. {nl} Gesti, the leader of the demons whom you have met is one of them. {nl}
-QUEST_LV_0100_20150317_002353	Three demon Kings and the demon leaders who follow them. {nl}Giltine is the one who controls all of them. {nl}
-QUEST_LV_0100_20150317_002354	All these catastrophes are her plans. {nl} The disasters will continue and at the end of it will be the end of human race. {nl}
-QUEST_LV_0100_20150317_002355	I am a very fatal existence for them as I can see all of this. {nl}That's why Giltine will try to revert me to the world's waters. {nl}
-QUEST_LV_0100_20150317_002356	Also, they will extend their evil powers to the Goddesses who go against their will. {nl}
-QUEST_LV_0100_20150317_002357	But disasters are happening just as I saw them to be. {nl}And it means that the hope, which I saw further away, will also definitely come. {nl}
-QUEST_LV_0100_20150317_002358	Dear Savior, our sister Saule is losing her light. {nl} Find her back the light from the colorful valley and you will be guided to the next revelation.
+QUEST_LV_0100_20150317_002350	400 years would have passed by when this revelation reaches you.{nl}Thank you in advance for your continued pursuit of finding the revelation. .{nl}
+QUEST_LV_0100_20150317_002351	As I'm sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin.{nl}if you find this revelation, it would mean that he had done an excellent job in fulfilling his mission.{nl}
+QUEST_LV_0100_20150317_002352	The demons have been chasing the revelation before I made this revelation.{nl}Gesti, the leader of the demons whom you have met is one of them.{nl}
+QUEST_LV_0100_20150317_002353	Three demon Kings and the demon leaders who follow them. {nl}Giltine is the one who controls all of them.{nl}
+QUEST_LV_0100_20150317_002354	All these catastrophes are her plans.{nl}The disasters will continue and at the end of it will be the end of human race.{nl}
+QUEST_LV_0100_20150317_002355	I am a very fatal existence for them as I can see all of this. {nl}That's why Giltine will try to revert me to the world's waters.{nl}
+QUEST_LV_0100_20150317_002356	Also, they will extend their evil powers to the Goddesses who go against their will.{nl}
+QUEST_LV_0100_20150317_002357	But disasters are happening just as I saw them to be. {nl}And it means that the hope, which I saw further away, will also definitely come.{nl}
+QUEST_LV_0100_20150317_002358	Dear Savior, our sister Saule is losing her light.{nl}Find her back the light from the colorful valley and you will be guided to the next revelation.
 QUEST_LV_0100_20150317_002359	The revelation of crystal mine
-QUEST_LV_0100_20150317_002360	Dear Savior, {nl} in order for me to regain my whole appearance and stop the demons, {nl} you must find all the revelations hidden in the axis of all times. {nl}
-QUEST_LV_0100_20150317_002361	But only you and I can save the world. {nl} I will wait for you in the highest gardens
+QUEST_LV_0100_20150317_002360	Dear Savior,{nl}in order for me to regain my whole appearance and stop the demons,{nl}you must find all the revelations hidden in the axis of all times.{nl}
+QUEST_LV_0100_20150317_002361	But only you and I can save the world.{nl}I will wait for you in the highest gardens
 QUEST_LV_0100_20150317_002362	The revelation of Tenet Cathedral
 QUEST_LV_0100_20150317_002363	The revelation of Thorny Forest
 QUEST_LV_0100_20150317_002364	The revelation of Zachariel Royal Tomb
@@ -2409,7 +2409,7 @@ QUEST_LV_0100_20150317_002408	Not really my problem
 QUEST_LV_0100_20150317_002409	Threats of Eastern Woods
 QUEST_LV_0100_20150317_002410	Emphasize that it's important
 QUEST_LV_0100_20150317_002411	Wait until the problem is solved
-QUEST_LV_0100_20150317_002412	About the Miner's Village
+QUEST_LV_0100_20150317_002412	About the Miners' Village
 QUEST_LV_0100_20150317_002413	Sentinel's Favor (1)
 QUEST_LV_0100_20150317_002414	I'll get rid of the Chupacabra
 QUEST_LV_0100_20150317_002415	You should take care of it yourself
@@ -2436,7 +2436,7 @@ QUEST_LV_0100_20150317_002435	I'll get rid of the Pokubus
 QUEST_LV_0100_20150317_002436	I'll just get rid of the Vubbe Fighter right away
 QUEST_LV_0100_20150317_002437	I'll wait for back up troops
 QUEST_LV_0100_20150317_002438	Entering the Coal Mine Village
-QUEST_LV_0100_20150317_002439	Ask for the Miner's Village what he promised
+QUEST_LV_0100_20150317_002439	Ask for the Miners' Village what he promised
 QUEST_LV_0100_20150317_002440	Give me some time to prepare
 QUEST_LV_0100_20150317_002441	Rescue Village residents
 QUEST_LV_0100_20150317_002442	I'll find the village residents first
@@ -2456,8 +2456,8 @@ QUEST_LV_0100_20150317_002455	Notice/!/Jonna Jolem appeared with the treasure bo
 QUEST_LV_0100_20150317_002456	Notice/The treasure box just dissappeared!{nl}Right click on the treasure map to find the next location!
 QUEST_LV_0100_20150317_002457	Treasure Map of the Stonemason's Family(2)
 QUEST_LV_0100_20150317_002458	Checking/SITGROPE/2/TRACK_BEFORE/SSN_HATE_AROUND
-QUEST_LV_0100_20150317_002459	Notice /!/Treasure chest appeared again! {nl} avoid interference with the monsters, check inside the treasure chest! #7
-QUEST_LV_0100_20150317_002460	Notice/The treasure chest is empty! {nl} Right click on the map and find the next area! #5
+QUEST_LV_0100_20150317_002459	Notice /!/Treasure chest appeared again!{nl}avoid interference with the monsters, check inside the treasure chest! #7
+QUEST_LV_0100_20150317_002460	Notice/The treasure chest is empty!{nl}Right click on the map and find the next area! #5
 QUEST_LV_0100_20150317_002461	Treasure Map of the Stonemason's Family(3)
 QUEST_LV_0100_20150317_002462	Notice/!/The box appeared again!{nl}Please check the box inside while avoiding monsters' attacks!#7
 QUEST_LV_0100_20150317_002463	Notice/The box is empty!{nl}Right click on the treasure map to check the next location!
@@ -2623,11 +2623,11 @@ QUEST_LV_0100_20150317_002622	That seems difficult
 QUEST_LV_0100_20150317_002623	About the monsters in the mine
 QUEST_LV_0100_20150317_002624	Missing Parts of Entrance Purifier (1)
 QUEST_LV_0100_20150317_002625	Checking Purifier /HANDLING_LEFT/3/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002626	Notice/Some parts of the purifier are missing. {nl} Chack for any parts on the floor! #5
+QUEST_LV_0100_20150317_002626	Notice/Some parts of the purifier are missing.{nl}Chack for any parts on the floor! #5
 QUEST_LV_0100_20150317_002627	Of the component assembly/GROPE/2/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002628	Notice/Some parts are still missing. {nl} Find the missig parts from Vubbes with question marks on top of its head. #5
+QUEST_LV_0100_20150317_002628	Notice/Some parts are still missing.{nl}Find the missig parts from Vubbes with question marks on top of its head. #5
 QUEST_LV_0100_20150317_002629	Entrance Purifier's missing parts
-QUEST_LV_0100_20150317_002630	Notice/!/Some parts of the Purifier are missing. {nl} Find the parts from the Vubbe with a question mark on its head. #5
+QUEST_LV_0100_20150317_002630	Notice/!/Some parts of the Purifier are missing.{nl}Find the parts from the Vubbe with a question mark on its head. #5
 QUEST_LV_0100_20150317_002631	Repairing Purifier/HANDLING_LEFT/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002632	Notice/Repair complete. {nl}Entrance Purifier is activated again. #5
 QUEST_LV_0100_20150317_002633	Purifier parts scattered on the floor
@@ -2635,41 +2635,41 @@ QUEST_LV_0100_20150317_002634	Purify toxic steam in 2nd floor
 QUEST_LV_0100_20150317_002635	Notice/All purifers are fixed. {nl}Go to 3rd Gallery and meet Vaidotas. #5
 QUEST_LV_0100_20150317_002636	Fix the Central Purifier (1)
 QUEST_LV_0100_20150317_002637	Opening the valve /HANDLING_LEFT/3/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002638	Notice/critical device seems to be broken or lost. {nl} find that the parts be replaced using a compass mine! #5
+QUEST_LV_0100_20150317_002638	Notice/critical device seems to be broken or lost.{nl}find that the parts be replaced using a compass mine! #5
 QUEST_LV_0100_20150317_002639	Fix the Central Purifier (2)
-QUEST_LV_0100_20150317_002640	Notice/Mining compass is pointing to the four zones. Go to {nl} 4 zones: Searching for spare parts. #5
+QUEST_LV_0100_20150317_002640	Notice/Mining compass is pointing to the four zones. Go to{nl}4 zones: Searching for spare parts. #5
 QUEST_LV_0100_20150317_002641	Notice/Kill the Bearkaras that appeared in front of the spare purifier! #5
 QUEST_LV_0100_20150317_002642	Of the replacement parts/MAKING/3/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002643	Notice/Succesfully repaired the Central Purifier! {nl} The Purifiers is working now. #5
+QUEST_LV_0100_20150317_002643	Notice/Succesfully repaired the Central Purifier!{nl}The Purifiers is working now. #5
 QUEST_LV_0100_20150317_002644	Attack of Cyclops in Crystal Mines
 QUEST_LV_0100_20150317_002645	Of looking at/MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002646	Activate the Passage Purifier (1)
-QUEST_LV_0100_20150317_002647	Notice/important parts seemed to have disappeared. {nl} Find the parts using compass mine! #5
+QUEST_LV_0100_20150317_002647	Notice/important parts seemed to have disappeared.{nl}Find the parts using compass mine! #5
 QUEST_LV_0100_20150317_002648	Notice/Mining compass is pointing to the 6th zone.{nl}Go to 6th zone and search for the parts!#5
 QUEST_LV_0100_20150317_002649	Activate the Passage Purifier (2)
-QUEST_LV_0100_20150317_002650	Notice/Mining compass is pointing to District 6. {nl} Go to District 6 and find the parts! #5
-QUEST_LV_0100_20150317_002651	Notice /!/Compass is pointing to Spector monarch. {nl} Kill Spector monarch and regain your part. #5
+QUEST_LV_0100_20150317_002650	Notice/Mining compass is pointing to District 6.{nl}Go to District 6 and find the parts! #5
+QUEST_LV_0100_20150317_002651	Notice /!/Compass is pointing to Spector monarch.{nl}Kill Spector monarch and regain your part. #5
 QUEST_LV_0100_20150317_002652	Notice/!/Found the parts! {nl}Return to passage purifier and fix it #5
 QUEST_LV_0100_20150317_002653	Activate the Passage Purifier (3)
-QUEST_LV_0100_20150317_002654	Notice/Succesfully repaired the Passage Purifier! {nl} Purifier is now working. #5
+QUEST_LV_0100_20150317_002654	Notice/Succesfully repaired the Passage Purifier!{nl}Purifier is now working. #5
 QUEST_LV_0100_20150317_002655	Problem of circulation purifier (1)
 QUEST_LV_0100_20150317_002656	Checking Purifier/LOOK/3/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002657	Notice/There seems to be a problem in the Purifier Pipe. {nl} Check the Purifier Pipe in 3rd District! #5
+QUEST_LV_0100_20150317_002657	Notice/There seems to be a problem in the Purifier Pipe.{nl}Check the Purifier Pipe in 3rd District! #5
 QUEST_LV_0100_20150317_002658	Cechking Purifier Pipe/LOOK/3/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002659	Notice /!/Opened the valve. {nl} Return to the circulation purifier. #5
+QUEST_LV_0100_20150317_002659	Notice /!/Opened the valve.{nl}Return to the circulation purifier. #5
 QUEST_LV_0100_20150317_002660	Purifier working/HANDLING_LEFT/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002661	Notice /!/Circulation purifier is still not working! Check the Purifier Pipe in 2nd District #5
 QUEST_LV_0100_20150317_002662	Problem of circulation purifier (2)
 QUEST_LV_0100_20150317_002663	Notice/Get rid of Carapace blocking the way to the purifier! #5
 QUEST_LV_0100_20150317_002664	Problem of circulation purifier (3)
-QUEST_LV_0100_20150317_002665	Notice/You got rid of the Carapace. {nl} Check the Purifier Pipe in the 2nd District #5
+QUEST_LV_0100_20150317_002665	Notice/You got rid of the Carapace.{nl}Check the Purifier Pipe in the 2nd District #5
 QUEST_LV_0100_20150317_002666	Checking Purifier Pipe/GROPE/3/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002667	Notice/Opened the purifier valve. {nl} Return to circulataion purifier and activate it again. #5
+QUEST_LV_0100_20150317_002667	Notice/Opened the purifier valve.{nl}Return to circulataion purifier and activate it again. #5
 QUEST_LV_0100_20150317_002668	Operating of the purifier/HANDLING_LEFT/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002669	Notice/circulation purifier is staring to activate.
 QUEST_LV_0100_20150317_002670	Secondary Purifier stopped working (1)
 QUEST_LV_0100_20150317_002671	Checking/LOOK/3/TRACK_BEFORE/Nonev
-QUEST_LV_0100_20150317_002672	Notice/Power supply is not working properly. {nl} Try the mining compass. #5
+QUEST_LV_0100_20150317_002672	Notice/Power supply is not working properly.{nl}Try the mining compass. #5
 QUEST_LV_0100_20150317_002673	Notice/Mining compass is pointing to District 4. {nl}Check the spell supply device in District 4. #5
 QUEST_LV_0100_20150317_002674	Secondary Purifier stopped working (2)
 QUEST_LV_0100_20150317_002675	Of looking at/LOOK_SIT/3/TRACK_BEFORE/None
@@ -2677,12 +2677,12 @@ QUEST_LV_0100_20150317_002676	Notice/The device is rusty and not working. {nl}Us
 QUEST_LV_0100_20150317_002677	Secondary Purifier stopped working (3)
 QUEST_LV_0100_20150317_002678	Notice/Mining compass is still pointing to District 4. {nl}Go around District 4 to find a way to remove the rust. #5
 QUEST_LV_0100_20150317_002679	You are greased/SITREAD/2/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_002680	Notice/Spell supply device is fixed. {nl} Try running the secondary purifier. #5
+QUEST_LV_0100_20150317_002680	Notice/Spell supply device is fixed.{nl}Try running the secondary purifier. #5
 QUEST_LV_0100_20150317_002681	Secondary Purifier stopped working (4)
 QUEST_LV_0100_20150317_002682	Notice/secondary Purifier is working again. #5
 QUEST_LV_0100_20150317_002683	Destroyer of the Main Purifier (1)
-QUEST_LV_0100_20150317_002684	Notice/Some parts of the purifier seems to have disappeared. {nl} Find the parts using compass mine. #5
-QUEST_LV_0100_20150317_002685	Notice/Mining compass is pointing to the six areas. {nl} 6 Try searching for parts in the area. #5
+QUEST_LV_0100_20150317_002684	Notice/Some parts of the purifier seems to have disappeared.{nl}Find the parts using compass mine. #5
+QUEST_LV_0100_20150317_002685	Notice/Mining compass is pointing to the six areas.{nl}6 Try searching for parts in the area. #5
 QUEST_LV_0100_20150317_002686	Destroyer of the Main Purifier (2)
 QUEST_LV_0100_20150317_002687	Notice/The mine compass is pointing to the 7th zone.{nl}Go to 7th zone and look for the parts on the ground.#5
 QUEST_LV_0100_20150317_002688	Notice/One part is missing.{nl}Go to 6th zone to look for the missing part.#5
@@ -2690,7 +2690,7 @@ QUEST_LV_0100_20150317_002689	Notice/Defeat the Stone Whale that interferes with
 QUEST_LV_0100_20150317_002690	Part of the recovery/SITGROPE/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002691	Notice /!/Retrieved parts of the purifier! {nl}Fix the Main Purifier and activate it. #5
 QUEST_LV_0100_20150317_002692	Destroyer of the Main Purifier (3)
-QUEST_LV_0100_20150317_002693	Notice/Successfuly repaired the Main Purifier! {nl} Main Purifier is now working.
+QUEST_LV_0100_20150317_002693	Notice/Successfuly repaired the Main Purifier!{nl}Main Purifier is now working.
 QUEST_LV_0100_20150317_002694	The seal of the royal family(1)
 QUEST_LV_0100_20150317_002695	
 QUEST_LV_0100_20150317_002696	The threat on the ground
@@ -2973,7 +2973,7 @@ QUEST_LV_0100_20150317_002972	Destroy the contaminated lanterns
 QUEST_LV_0100_20150317_002973	Check the stone lantern /LOOK/1.5/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_002974	Notice /Destroy the contaminated stone lanterns!
 QUEST_LV_0100_20150317_002975	The polluted lamp(2)
-QUEST_LV_0100_20150317_002976	Notice /These are not the only contaminated lanterns. {nl} Find and destroy other contaminated lanterns. #5
+QUEST_LV_0100_20150317_002976	Notice /These are not the only contaminated lanterns.{nl}Find and destroy other contaminated lanterns. #5
 QUEST_LV_0100_20150317_002977	Disgrace
 QUEST_LV_0100_20150317_002978	Go to destroy royal spell suppressor
 QUEST_LV_0100_20150317_002979	For the revelator, by the revelator
@@ -3012,7 +3012,7 @@ QUEST_LV_0100_20150317_003011	Preventive Measures (1)
 QUEST_LV_0100_20150317_003012	Preventive Measures (2)
 QUEST_LV_0100_20150317_003013	I'll gather the sample first
 QUEST_LV_0100_20150317_003014	Preventive Measures (3)
-QUEST_LV_0100_20150317_003015	I'll get it 
+QUEST_LV_0100_20150317_003015	I'll get it
 QUEST_LV_0100_20150317_003016	Goddess Gabija (1)
 QUEST_LV_0100_20150317_003017	
 QUEST_LV_0100_20150317_003018	Goddess Gabija (2)
@@ -3024,7 +3024,7 @@ QUEST_LV_0100_20150317_003023	Let's go ignite fire
 QUEST_LV_0100_20150317_003024	I'm not ready yet
 QUEST_LV_0100_20150317_003025	Goddess Gabija (4)
 QUEST_LV_0100_20150317_003026	Move to teleport magic circle
-QUEST_LV_0100_20150317_003027	Let's find a safer way 
+QUEST_LV_0100_20150317_003027	Let's find a safer way
 QUEST_LV_0100_20150317_003028	Goddess Gabija (5)
 QUEST_LV_0100_20150317_003029	Go to another magic circle
 QUEST_LV_0100_20150317_003030	Operation of/SITABSORB/2/TRACK_BEFORE/None
@@ -3052,7 +3052,7 @@ QUEST_LV_0100_20150317_003051	Lunatic Wizard (1)
 QUEST_LV_0100_20150317_003052	Say to go quickly
 QUEST_LV_0100_20150317_003053	Lunatic Wizard (2)
 QUEST_LV_0100_20150317_003054	Let's stop Antares
-QUEST_LV_0100_20150317_003055	Just ignore it and go up 
+QUEST_LV_0100_20150317_003055	Just ignore it and go up
 QUEST_LV_0100_20150317_003056	Notice /! /Destroy the spell controlling the valve! #5
 QUEST_LV_0100_20150317_003057	Lunatic Wizard (3)
 QUEST_LV_0100_20150317_003058	I'll find the data
@@ -3113,7 +3113,7 @@ QUEST_LV_0100_20150317_003112	That's blasphemous
 QUEST_LV_0100_20150317_003113	Historical Trick (1)
 QUEST_LV_0100_20150317_003114	It looks fun
 QUEST_LV_0100_20150317_003115	Looks like we'll be caught soon. Let just stop.
-QUEST_LV_0100_20150317_003116	Now that you've lost the spell, what are you going to do? 
+QUEST_LV_0100_20150317_003116	Now that you've lost the spell, what are you going to do?
 QUEST_LV_0100_20150317_003117	I need some time to thinnk
 QUEST_LV_0100_20150317_003118	Come to your senses!(2)
 QUEST_LV_0100_20150317_003119	It could be difficult but I'll try
@@ -3134,7 +3134,7 @@ QUEST_LV_0100_20150317_003133	It doesn't seem like a good idea
 QUEST_LV_0100_20150317_003134	Raid of Light (2)
 QUEST_LV_0100_20150317_003135	Hmm, Ok
 QUEST_LV_0100_20150317_003136	I need more preparation
-QUEST_LV_0100_20150317_003137	Till the last drop 
+QUEST_LV_0100_20150317_003137	Till the last drop
 QUEST_LV_0100_20150317_003138	I can help you
 QUEST_LV_0100_20150317_003139	Hold on a little longer
 QUEST_LV_0100_20150317_003140	Bully
@@ -3344,13 +3344,13 @@ QUEST_LV_0100_20150317_003343	Too many Seals (1)
 QUEST_LV_0100_20150317_003344	Seems suspicious but grant his wish
 QUEST_LV_0100_20150317_003345	Too many Seals (2)
 QUEST_LV_0100_20150317_003346	Release the seal
-QUEST_LV_0100_20150317_003347	You're busy so just ignore 
+QUEST_LV_0100_20150317_003347	You're busy so just ignore
 QUEST_LV_0100_20150317_003348	NPCChat/FTOWER43_SQ_03 /Freedom. I'm finally free..
 QUEST_LV_0100_20150317_003349	Scream in the silence
 QUEST_LV_0100_20150317_003350	Seems strange but let's help
 QUEST_LV_0100_20150317_003351	Pretend you didn't hear it
 QUEST_LV_0100_20150317_003352	Transmuter Furry Ode (1)
-QUEST_LV_0100_20150317_003353	I'll find the mutated whip혞
+QUEST_LV_0100_20150317_003353	I'll find the mutated whip?
 QUEST_LV_0100_20150317_003354	That's tough
 QUEST_LV_0100_20150317_003355	Transmuter Furry Ode (2)
 QUEST_LV_0100_20150317_003356	I'll collect it so go ahead
@@ -3368,7 +3368,7 @@ QUEST_LV_0100_20150317_003367	I'm sorry, but I don't think I can
 QUEST_LV_0100_20150317_003368	Hot-blooded Simon Shaw (2)
 QUEST_LV_0100_20150317_003369	Don't worry
 QUEST_LV_0100_20150317_003370	Hot-blooded Simon Shaw (3)
-QUEST_LV_0100_20150317_003371	I'll defeat the Bearkaras for you 
+QUEST_LV_0100_20150317_003371	I'll defeat the Bearkaras for you
 QUEST_LV_0100_20150317_003372	Better run away quickly
 QUEST_LV_0100_20150317_003373	Identity of the Suspicous Seals (1)
 QUEST_LV_0100_20150317_003374	Defeat the monsters observing
@@ -3388,7 +3388,7 @@ QUEST_LV_0100_20150317_003387	Parts Thief
 QUEST_LV_0100_20150317_003388	I'll get it to you
 QUEST_LV_0100_20150317_003389	About repairing the cable car
 QUEST_LV_0100_20150317_003390	Find the lever
-QUEST_LV_0100_20150317_003391	I'll bring it 
+QUEST_LV_0100_20150317_003391	I'll bring it
 QUEST_LV_0100_20150317_003392	Lure the Baby Pantos
 QUEST_LV_0100_20150317_003393	About the Pantos
 QUEST_LV_0100_20150317_003394	Collect recycling materials
@@ -3461,7 +3461,7 @@ QUEST_LV_0100_20150317_003460	Girl in Danger
 QUEST_LV_0100_20150317_003461	Oppotunity and Preparation
 QUEST_LV_0100_20150317_003462	I'll find what you want
 QUEST_LV_0100_20150317_003463	Close book
-QUEST_LV_0100_20150317_003464	Brother, and after 
+QUEST_LV_0100_20150317_003464	Brother, and after
 QUEST_LV_0100_20150317_003465	I appreciate it
 QUEST_LV_0100_20150317_003466	Opening box with the key/# SITGROPESET2/3/TRACK_BEFORE/SSN_HATE_AROUND
 QUEST_LV_0100_20150317_003467	Crafting and materials
@@ -3540,7 +3540,7 @@ QUEST_LV_0100_20150317_003539	I'll participate
 QUEST_LV_0100_20150317_003540	Using Status
 QUEST_LV_0100_20150317_003541	Try using status
 QUEST_LV_0100_20150317_003542	to check status #7
-QUEST_LV_0100_20150317_003543	The road back 
+QUEST_LV_0100_20150317_003543	The road back
 QUEST_LV_0100_20150317_003544	Not as intended (2)
 QUEST_LV_0100_20150317_003545	Seal of the Royal Family (3)
 QUEST_LV_0100_20150317_003546	I'll release the final seal
@@ -3568,7 +3568,7 @@ QUEST_LV_0100_20150317_003567	Mop up the Forger (1)
 QUEST_LV_0100_20150317_003568	It's the famous genius of forgery
 QUEST_LV_0100_20150317_003569	You came to the wrong place
 QUEST_LV_0100_20150317_003570	Mop up the Forger (2)
-QUEST_LV_0100_20150317_003571	I'll get the limestone 
+QUEST_LV_0100_20150317_003571	I'll get the limestone
 QUEST_LV_0100_20150317_003572	I can't do such dirty job
 QUEST_LV_0100_20150317_003573	Mop up the Forger (3)
 QUEST_LV_0100_20150317_003574	Data of Sculptor Hilda (1)
@@ -3601,17 +3601,17 @@ QUEST_LV_0100_20150317_003600	Trace of the Star (1)
 QUEST_LV_0100_20150317_003601	I am interested
 QUEST_LV_0100_20150317_003602	About Lydia Schaffen
 QUEST_LV_0100_20150317_003603	Working on the copy /MAKING/2/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_003604	Notice /You read the first tombstone of Lydia Schaffen. {nl} Let's read the rest of it too.
+QUEST_LV_0100_20150317_003604	Notice /You read the first tombstone of Lydia Schaffen.{nl}Let's read the rest of it too.
 QUEST_LV_0100_20150317_003605	Trace of the Star (2)
 QUEST_LV_0100_20150317_003606	Trace of the Star (3)
 QUEST_LV_0100_20150317_003607	Trace of the Star (4)
 QUEST_LV_0100_20150317_003608	Good bye. (go to check on the tombstone)
 QUEST_LV_0100_20150317_003609	Stop it here
-QUEST_LV_0100_20150317_003610	Notice /You checked the fourth tombstone of Lydia Schaffen. {nl} Let's go check the last tombstone.
+QUEST_LV_0100_20150317_003610	Notice /You checked the fourth tombstone of Lydia Schaffen.{nl}Let's go check the last tombstone.
 QUEST_LV_0100_20150317_003611	Trace of the Star (5)
-QUEST_LV_0100_20150317_003612	Notice /You've defeated the Chapparition that was blocking you to read the tombstone. {nl} Let's check the last tombstone of Lydia Schaffen.
+QUEST_LV_0100_20150317_003612	Notice /You've defeated the Chapparition that was blocking you to read the tombstone.{nl}Let's check the last tombstone of Lydia Schaffen.
 QUEST_LV_0100_20150317_003613	Epitaph of Flurry (1)
-QUEST_LV_0100_20150317_003614	Notice /You've read the tombstone of Agailla Flurry. {nl} Let's read the rest of the tombstone in order to obtain Flurry's legacy.
+QUEST_LV_0100_20150317_003614	Notice /You've read the tombstone of Agailla Flurry.{nl}Let's read the rest of the tombstone in order to obtain Flurry's legacy.
 QUEST_LV_0100_20150317_003615	Epitaph of Flurry (2)
 QUEST_LV_0100_20150317_003616	Look for tombstone pieces from surrounding monsters.
 QUEST_LV_0100_20150317_003617	Let's quit since you don't know where it is
@@ -3685,7 +3685,7 @@ QUEST_LV_0100_20150317_003684	I think that's a good idea
 QUEST_LV_0100_20150317_003685	Doesn't sound so good
 QUEST_LV_0100_20150317_003686	About the Followers
 QUEST_LV_0100_20150317_003687	My ring!
-QUEST_LV_0100_20150317_003688	I'll get you the ring if I pick it up 
+QUEST_LV_0100_20150317_003688	I'll get you the ring if I pick it up
 QUEST_LV_0100_20150317_003689	It's probably digested by now
 QUEST_LV_0100_20150317_003690	Checking the pouch/SITGROPE/2.5/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003691	Fight venom with venom (2)
@@ -3713,7 +3713,7 @@ QUEST_LV_0100_20150317_003712	Willingly accept
 QUEST_LV_0100_20150317_003713	
 QUEST_LV_0100_20150317_003714	Can't do anything
 QUEST_LV_0100_20150317_003715	I'll take care of it right away
-QUEST_LV_0100_20150317_003716	It will be safer to let the other believers know 
+QUEST_LV_0100_20150317_003716	It will be safer to let the other believers know
 QUEST_LV_0100_20150317_003717	Skill of Interference
 QUEST_LV_0100_20150317_003718	I can give it a try
 QUEST_LV_0100_20150317_003719	I don't feel it
@@ -3727,7 +3727,7 @@ QUEST_LV_0100_20150317_003726	Something blasphemous
 QUEST_LV_0100_20150317_003727	I'll get rid of Archon
 QUEST_LV_0100_20150317_003728	Leave vicinity
 QUEST_LV_0100_20150317_003729	Raid of Merog
-QUEST_LV_0100_20150317_003730	It will be okay if you hide 
+QUEST_LV_0100_20150317_003730	It will be okay if you hide
 QUEST_LV_0100_20150317_003731	Notice/Defeat the Merof and Chaferer that followed Bronews!
 QUEST_LV_0100_20150317_003732	
 QUEST_LV_0100_20150317_003733	I will protect the altar from the monster
@@ -3741,7 +3741,7 @@ QUEST_LV_0100_20150317_003740	Root of Tinkanta Vacant Lot
 QUEST_LV_0100_20150317_003741	Notice/You touched the roots and Molech is blocking the way!#5
 QUEST_LV_0100_20150317_003742	
 QUEST_LV_0100_20150317_003743	I'll help the purifying job
-QUEST_LV_0100_20150317_003744	It's dangerous. Give up. 
+QUEST_LV_0100_20150317_003744	It's dangerous. Give up.
 QUEST_LV_0100_20150317_003745	Notice/Succesfully activated the altar of purification!#3
 QUEST_LV_0100_20150317_003746	Bramble Strategy (3)
 QUEST_LV_0100_20150317_003747	I'll get rid of the Bramble and retrieve the Revelation
@@ -3842,7 +3842,7 @@ QUEST_LV_0100_20150317_003841	Remind the scout again that there is an order to a
 QUEST_LV_0100_20150317_003842	Defeat the Leaf Bugs and collect luggage
 QUEST_LV_0100_20150317_003843	The scout says he can't return until he finds his luggage. Find the scout's stolen luggage from the leaf bugs.
 QUEST_LV_0100_20150317_003844	Give luggage to the scout
-QUEST_LV_0100_20150317_003845	Return the luggage to the scout and tell him to return to Klaipeda. 
+QUEST_LV_0100_20150317_003845	Return the luggage to the scout and tell him to return to Klaipeda.
 QUEST_LV_0100_20150317_003846	Defeat the Leaf Bugs and obtain %s
 QUEST_LV_0100_20150317_003847	Talk to the Battle Commander
 QUEST_LV_0100_20150317_003848	Talk to the Battle Commander.
@@ -3906,14 +3906,14 @@ QUEST_LV_0100_20150317_003905	The Eastern Woods base camp seems to be in danger 
 QUEST_LV_0100_20150317_003906	Defeat the Poatas in the Eastern Woods Base Camp
 QUEST_LV_0100_20150317_003907	Poatas appeared to save the Baby Poatas. Defeat hem.
 QUEST_LV_0100_20150317_003908	Talk to Knight Aras
-QUEST_LV_0100_20150317_003909	You got rid of the Poatas that were threatening Aras. Go and report him about it. 
+QUEST_LV_0100_20150317_003909	You got rid of the Poatas that were threatening Aras. Go and report him about it.
 QUEST_LV_0100_20150317_003910	Defeat the Poata that raided the outpost
-QUEST_LV_0100_20150317_003911	Get permission from Knight Aras to enter Miner's Village
-QUEST_LV_0100_20150317_003912	Ask Knight Aras for permission to enter the Miner's Village.
+QUEST_LV_0100_20150317_003911	Get permission from Knight Aras to enter Miners' Village
+QUEST_LV_0100_20150317_003912	Ask Knight Aras for permission to enter the Miners' Village.
 QUEST_LV_0100_20150317_003913	Defeat the Pokubus in the farm
 QUEST_LV_0100_20150317_003914	You have to accept Aras' proposal to help his troops in order to go to the Miners' Village. First, let's get rid of Pokubus that occupy the farm.
 QUEST_LV_0100_20150317_003915	Report to Aras
-QUEST_LV_0100_20150317_003916	Report the defeat of Pokubus, one of the assignments for going to Miner's Village, to Aras.
+QUEST_LV_0100_20150317_003916	Report the defeat of Pokubus, one of the assignments for going to Miners' Village, to Aras.
 QUEST_LV_0100_20150317_003917	Listen to the Sentinel's Chupacabra extermination plan.
 QUEST_LV_0100_20150317_003918	Let's help the Sentinel exterminate Chupacabras who threaten the troops.
 QUEST_LV_0100_20150317_003919	Hunt Chupacabras
@@ -3933,7 +3933,7 @@ QUEST_LV_0100_20150317_003932	Defeat the Large Gray Chupacabras
 QUEST_LV_0100_20150317_003933	Large Gray Chupacabras appear when you defeat a Ahupacabra. Defeat the Large Gray Chupacabras.
 QUEST_LV_0100_20150317_003934	Report back to the supply officer
 QUEST_LV_0100_20150317_003935	Report to supply officer that you got rid of the Large Gray Chupacabras.
-QUEST_LV_0100_20150317_003936	Defeat Large Gray Chupacabras that appear when you defeated a Chupacabra 
+QUEST_LV_0100_20150317_003936	Defeat Large Gray Chupacabras that appear when you defeated a Chupacabra
 QUEST_LV_0100_20150317_003937	Talk to Supply Officer
 QUEST_LV_0100_20150317_003938	Seems like the supply officer is in trouble. Try to talk to him.
 QUEST_LV_0100_20150317_003939	Move to the marked location
@@ -3979,10 +3979,10 @@ QUEST_LV_0100_20150317_003978	Search scout says the Vubbe Fighter is in the Nude
 QUEST_LV_0100_20150317_003979	Notify search scout that the Vubbe Fighter was killed
 QUEST_LV_0100_20150317_003980	Return to Vubbe Fighter and let him know that the Vubbe fighter is defeated.
 QUEST_LV_0100_20150317_003981	Defeat the Vubbe Fighter
-QUEST_LV_0100_20150317_003982	Return and report to Aras 
+QUEST_LV_0100_20150317_003982	Return and report to Aras
 QUEST_LV_0100_20150317_003983	Return to Aras and tell him the Vubbe Fighter was killed.
-QUEST_LV_0100_20150317_003984	Talk about Miner's Village with Aras
-QUEST_LV_0100_20150317_003985	You thought that you can finally go into the Crystal Mines but the Vubbes are attacking. Let's get rid of them first. 
+QUEST_LV_0100_20150317_003984	Talk about Miners' Village with Aras
+QUEST_LV_0100_20150317_003985	You thought that you can finally go into the Crystal Mines but the Vubbes are attacking. Let's get rid of them first.
 QUEST_LV_0100_20150317_003986	Talk to Aras agian
 QUEST_LV_0100_20150317_003987	Defeated the Vubbes that barged in. Return to Aras and get permission to enter the Mines.
 QUEST_LV_0100_20150317_003988	Defeat the monsters chasing the refugees
@@ -4009,20 +4009,20 @@ QUEST_LV_0100_20150317_004008	Defeatthe monsters that attacked
 QUEST_LV_0100_20150317_004009	Move to the area marked in Pipoti's map
 QUEST_LV_0100_20150317_004010	There is a mark in Pipoti's map. Right click on the map and move to the marked area.
 QUEST_LV_0100_20150317_004011	Avoid the monsters and check the treasure box
-QUEST_LV_0100_20150317_004012	Something hidden is marked in Pipoti's map. Avoid Yonazolem and open the treasure box. 
+QUEST_LV_0100_20150317_004012	Something hidden is marked in Pipoti's map. Avoid Yonazolem and open the treasure box.
 QUEST_LV_0100_20150317_004013	Obtain %s from Yonazolem
 QUEST_LV_0100_20150317_004014	Defeat Yonazolem
 QUEST_LV_0100_20150317_004015	Move to the marked area in Pipoti's map
 QUEST_LV_0100_20150317_004016	There are other marked areas in Pipoti's map. Right click on the map and move to the marked area.
 QUEST_LV_0100_20150317_004017	Avoid the monsters and check the treasure box
-QUEST_LV_0100_20150317_004018	Something hidden is marked in Pipoti's map. Avoid the monsters and open the treasure box. 
+QUEST_LV_0100_20150317_004018	Something hidden is marked in Pipoti's map. Avoid the monsters and open the treasure box.
 QUEST_LV_0100_20150317_004019	There are other marked areas in Pipoti's map. Right click on the map and move to the marked area.
 QUEST_LV_0100_20150317_004020	There are other marked areas in Pipoti's map. Right click on the map and move to the marked area.
 QUEST_LV_0100_20150317_004021	The map that a stonemason Pipoti gave me is displayed where the something was hidded. Open the box by defeating the interceptive Werewolf.
 QUEST_LV_0100_20150317_004022	Talk to Explorer Varkis
 QUEST_LV_0100_20150317_004023	Explorer Varkis seems like he's in trouble. Talk to him.
 QUEST_LV_0100_20150317_004024	Retrieve Varkis' lost journal
-QUEST_LV_0100_20150317_004025	Varkis says the monsters stole his bag. Better find him back his journal at least. 
+QUEST_LV_0100_20150317_004025	Varkis says the monsters stole his bag. Better find him back his journal at least.
 QUEST_LV_0100_20150317_004026	Found Varkis' journal. Return to Varkis and give it to him.
 QUEST_LV_0100_20150317_004027	Rescue Varkis who is under attack
 QUEST_LV_0100_20150317_004028	Varkis is under attack! Defeat the monsters and rescue him.
@@ -4048,7 +4048,7 @@ QUEST_LV_0100_20150317_004047	Stonemaker hasn't gone home yet. Talk to him.
 QUEST_LV_0100_20150317_004048	
 QUEST_LV_0100_20150317_004049	
 QUEST_LV_0100_20150317_004050	Defeat Achat and obtain %s
-QUEST_LV_0100_20150317_004051	Buy stonemason tools from the blacksmith in Klaipeda 
+QUEST_LV_0100_20150317_004051	Buy stonemason tools from the blacksmith in Klaipeda
 QUEST_LV_0100_20150317_004052	You collected the materials and now you need the tools. Buy stonemason tools from the blacksmith in Klaipeda.
 QUEST_LV_0100_20150317_004053	Give it to Stonemason Pipoti
 QUEST_LV_0100_20150317_004054	You got all the materials and tools needed. Return to Pipoti and give it to him.
@@ -4057,12 +4057,12 @@ QUEST_LV_0100_20150317_004056
 QUEST_LV_0100_20150317_004057	
 QUEST_LV_0100_20150317_004058	Talk to Morcus Jonas
 QUEST_LV_0100_20150317_004059	You have to continue the journey to find King Zachariel's legacy. Morcus is waiting for you in Overlong Valley.
-QUEST_LV_0100_20150317_004060	Use the scroll and summon the hidden key 
+QUEST_LV_0100_20150317_004060	Use the scroll and summon the hidden key
 QUEST_LV_0100_20150317_004061	You can get the key to King Zachariel's legacy in a certain place by using the scroll. Use the scroll and find the key.
 QUEST_LV_0100_20150317_004062	Talk to Morcus
 QUEST_LV_0100_20150317_004063	Found the key! Return to Morcus and talk to him.
 QUEST_LV_0100_20150317_004064	Gather %s from the crack
-QUEST_LV_0100_20150317_004065	Talk to the supply officer in the farm. He seems to have a problem. 
+QUEST_LV_0100_20150317_004065	Talk to the supply officer in the farm. He seems to have a problem.
 QUEST_LV_0100_20150317_004066	Retrieve the supplies box
 QUEST_LV_0100_20150317_004067	The monsters took all the supplies to be sent to the village. Retrieve the supplies box that the monsters stole around the supplies camp.
 QUEST_LV_0100_20150317_004068	Give supplies box to the supply officer
@@ -4078,7 +4078,7 @@ QUEST_LV_0100_20150317_004077	Vubbe
 QUEST_LV_0100_20150317_004078	Talk to Soldier Blak
 QUEST_LV_0100_20150317_004079	There is a soldier who looks very anxious. Approach him and talk to him.
 QUEST_LV_0100_20150317_004080	Find the Supplies
-QUEST_LV_0100_20150317_004081	Soldier black says the monster raided the base camp. Bring the supplies from the 1st supplies warehouse. 
+QUEST_LV_0100_20150317_004081	Soldier black says the monster raided the base camp. Bring the supplies from the 1st supplies warehouse.
 QUEST_LV_0100_20150317_004082	You were able to get the supplies left. Take it to soldier Blak.
 QUEST_LV_0100_20150317_004083	Defeat Siaulago eyeing the supplies
 QUEST_LV_0100_20150317_004084	Looks like Soldier Blak has something to say about the monsters that raided the warehous. Talk to him again.
@@ -4092,19 +4092,19 @@ QUEST_LV_0100_20150317_004091	Defeated the Siaulamb Lagoons. Tell Soldier York a
 QUEST_LV_0100_20150317_004092	Talk to Adjutant Polyna
 QUEST_LV_0100_20150317_004093	Adjutant Polyna seems angry. Talk to him.
 QUEST_LV_0100_20150317_004094	Retrieving the supplies stolen by the Siaulambs in each warehouse
-QUEST_LV_0100_20150317_004095	Polyna states that the stolen supplies must be retrieved. Get back the supplies from the Siaulambs nearby each warehouse. 
+QUEST_LV_0100_20150317_004095	Polyna states that the stolen supplies must be retrieved. Get back the supplies from the Siaulambs nearby each warehouse.
 QUEST_LV_0100_20150317_004096	Deliver to Polyna
 QUEST_LV_0100_20150317_004097	Retrieved much of the stolen supplies. Give it to Adjutant Volda in Central Supplies Camp.
 QUEST_LV_0100_20150317_004098	Collect %s from Siaulamb Shaman
 QUEST_LV_0100_20150317_004099	Talk to Officer Liudas
 QUEST_LV_0100_20150317_004100	Ready to hunt Sparnas. Talk to Officer Liudas.
-QUEST_LV_0100_20150317_004101	Lure Sparnas in the last District. 
-QUEST_LV_0100_20150317_004102	Ludas told you to lure Sparnas with bait and get rid of it. Place the bait in Malkos felled area and kill Sparnas when it appears. 
+QUEST_LV_0100_20150317_004101	Lure Sparnas in the last District.
+QUEST_LV_0100_20150317_004102	Ludas told you to lure Sparnas with bait and get rid of it. Place the bait in Malkos felled area and kill Sparnas when it appears.
 QUEST_LV_0100_20150317_004103	Report to Liudas
-QUEST_LV_0100_20150317_004104	Successfully defeated Sparnas. Return and report to Officer Liudas. 
-QUEST_LV_0100_20150317_004105	Defeatthe lured Sparnas. 
+QUEST_LV_0100_20150317_004104	Successfully defeated Sparnas. Return and report to Officer Liudas.
+QUEST_LV_0100_20150317_004105	Defeatthe lured Sparnas.
 QUEST_LV_0100_20150317_004106	Talk to messenger Niels
-QUEST_LV_0100_20150317_004107	Safely arrived at Gateway of the Great King. Look for the person in charge. 
+QUEST_LV_0100_20150317_004107	Safely arrived at Gateway of the Great King. Look for the person in charge.
 QUEST_LV_0100_20150317_004108	Find madman recorder Jonas.
 QUEST_LV_0100_20150317_004109	Messenger Niels is looking for an old man named Jonas. Better bring him when you find him.
 QUEST_LV_0100_20150317_004110	Find Recorder Jonas
@@ -4113,56 +4113,56 @@ QUEST_LV_0100_20150317_004112	You were proved as the right person by the Eye of 
 QUEST_LV_0100_20150317_004113	Light a signal fire
 QUEST_LV_0100_20150317_004114	The recorder Jonas wants to light up the signal to let the families know that the chosen one has come. Light up the signal at the top of the valley.
 QUEST_LV_0100_20150317_004115	Return to messenger Niels of the searcch camp.
-QUEST_LV_0100_20150317_004116	Seems like the fire was lit well. Return to Niels of the search camp. 
-QUEST_LV_0100_20150317_004117	Recorder Jonas isn't the only problem of Niels. Help Niels. 
+QUEST_LV_0100_20150317_004116	Seems like the fire was lit well. Return to Niels of the search camp.
+QUEST_LV_0100_20150317_004117	Recorder Jonas isn't the only problem of Niels. Help Niels.
 QUEST_LV_0100_20150317_004118	Find soldier Martha
-QUEST_LV_0100_20150317_004119	Niels is worried about losing touch with historian Kepek. Soldier Martha went to look for Kepek but he is also missing. First, try to look for soldier Martha. 
-QUEST_LV_0100_20150317_004120	Found soldier Martha but he looks injured. Ask him what happened. 
+QUEST_LV_0100_20150317_004119	Niels is worried about losing touch with historian Kepek. Soldier Martha went to look for Kepek but he is also missing. First, try to look for soldier Martha.
+QUEST_LV_0100_20150317_004120	Found soldier Martha but he looks injured. Ask him what happened.
 QUEST_LV_0100_20150317_004121	Talk to historian Bierd
 QUEST_LV_0100_20150317_004122	Historian Bierd has a serious face. Let's try talking to him.
 QUEST_LV_0100_20150317_004123	Get rid of the monsters attacking the camp
 QUEST_LV_0100_20150317_004124	Monsters are attacking the camp. Get rid of them.
-QUEST_LV_0100_20150317_004125	That was close. Talk to Bierd who is hiding in a safe place. 
+QUEST_LV_0100_20150317_004125	That was close. Talk to Bierd who is hiding in a safe place.
 QUEST_LV_0100_20150317_004126	Get rid of the monsters that threaten the historian
 QUEST_LV_0100_20150317_004127	Talk to Historian Kepek
-QUEST_LV_0100_20150317_004128	Looks like Kepek want some help. Talk to Kepek again. 
+QUEST_LV_0100_20150317_004128	Looks like Kepek want some help. Talk to Kepek again.
 QUEST_LV_0100_20150317_004129	Record of Artifact that Kepek Found
-QUEST_LV_0100_20150317_004130	Kepek is in a hurry and needs your help. Go and take a recodrd of the artifacts of the Underground Mausoleum at the right side of Apvija Unhill. 
+QUEST_LV_0100_20150317_004130	Kepek is in a hurry and needs your help. Go and take a recodrd of the artifacts of the Underground Mausoleum at the right side of Apvija Unhill.
 QUEST_LV_0100_20150317_004131	Successfully recorded the articfacts of Underground Mausoleum. Give it to messeneger Niels.
 QUEST_LV_0100_20150317_004132	Defeat Ginklas
 QUEST_LV_0100_20150317_004133	Talk to soldier Alan
-QUEST_LV_0100_20150317_004134	Soldier Alan is staring at you. Talk to him. 
+QUEST_LV_0100_20150317_004134	Soldier Alan is staring at you. Talk to him.
 QUEST_LV_0100_20150317_004135	Check the upper area of Valdyti Vancant Lot
 QUEST_LV_0100_20150317_004136	Soldier Alan think a new recruit came. Strange, but check the northern area of the Valdyti Vacant Lot.
 QUEST_LV_0100_20150317_004137	Report to Soldier Alan
-QUEST_LV_0100_20150317_004138	Monsters appeared but you took care of it well. Return to Soldier Alan and report about it. 
-QUEST_LV_0100_20150317_004139	Soldier Alan says he remembered something terrible. Talk to him. 
+QUEST_LV_0100_20150317_004138	Monsters appeared but you took care of it well. Return to Soldier Alan and report about it.
+QUEST_LV_0100_20150317_004139	Soldier Alan says he remembered something terrible. Talk to him.
 QUEST_LV_0100_20150317_004140	Deliver to Commander Wallace
-QUEST_LV_0100_20150317_004141	Alans wants you to deliver the report to Commander Wallace. Talk to Commander Wallace in Bird Footprint Crossroad. 
+QUEST_LV_0100_20150317_004141	Alans wants you to deliver the report to Commander Wallace. Talk to Commander Wallace in Bird Footprint Crossroad.
 QUEST_LV_0100_20150317_004142	Talk to Commander Wallace
-QUEST_LV_0100_20150317_004143	Commander Wallace also thinks you are a new recruit. Talk to Commander Wallace. 
+QUEST_LV_0100_20150317_004143	Commander Wallace also thinks you are a new recruit. Talk to Commander Wallace.
 QUEST_LV_0100_20150317_004144	Get Kepa Raider Extract
-QUEST_LV_0100_20150317_004145	Commander Wallace asked you to gather materials needed for hunting Gaigalas. Collect Kepa Raider Extract from Kepa Raider in Bird Footstep Crossroad and Ianutis Falls. 
-QUEST_LV_0100_20150317_004146	Collected Kepa Raider Extracts needed. Give it to Commander Wallace. 
+QUEST_LV_0100_20150317_004145	Commander Wallace asked you to gather materials needed for hunting Gaigalas. Collect Kepa Raider Extract from Kepa Raider in Bird Footstep Crossroad and Ianutis Falls.
+QUEST_LV_0100_20150317_004146	Collected Kepa Raider Extracts needed. Give it to Commander Wallace.
 QUEST_LV_0100_20150317_004147	Talk to Soldier Weiz
-QUEST_LV_0100_20150317_004148	Soldier Weiz is getting ready for battle. Talk to him. 
+QUEST_LV_0100_20150317_004148	Soldier Weiz is getting ready for battle. Talk to him.
 QUEST_LV_0100_20150317_004149	Collect Duckey Oil
 QUEST_LV_0100_20150317_004150	Weiz says he needs Ducky Oil to battle against Gaigalas. Defeat Ducky in Rangbas Garden and collect Ducky Oil.
 QUEST_LV_0100_20150317_004151	Give to Soldier Weiz
-QUEST_LV_0100_20150317_004152	Collected the Duckey Oil needed. Give it to Soldier Weiz. 
+QUEST_LV_0100_20150317_004152	Collected the Duckey Oil needed. Give it to Soldier Weiz.
 QUEST_LV_0100_20150317_004153	Defeat Ducky and obtain %s
 QUEST_LV_0100_20150317_004154	Talk to Commander Wallace to gather the next materials.
 QUEST_LV_0100_20150317_004155	Collect Cronewt leather
 QUEST_LV_0100_20150317_004156	The next material needed to defeat Gaigalas is Cronewt leather. Collect Cronewt leather from the Cronewt in Langbas Garden.
 QUEST_LV_0100_20150317_004157	Collected the Cronewt leather needed. Give it to Commander Wallace.
 QUEST_LV_0100_20150317_004158	Defeat Cronewt and obtain %s
-QUEST_LV_0100_20150317_004159	Soldier Weiz wants to hunt Gaigalas quickly. Talk to Weiz again. 
+QUEST_LV_0100_20150317_004159	Soldier Weiz wants to hunt Gaigalas quickly. Talk to Weiz again.
 QUEST_LV_0100_20150317_004160	Ignite fire in the marked area
-QUEST_LV_0100_20150317_004161	Weiz says Gaigalas will appear when it smells the Duckey Oil burning. Light fire and burn the Duckey Oil in an airy area of Langbas Garden. 
+QUEST_LV_0100_20150317_004161	Weiz says Gaigalas will appear when it smells the Duckey Oil burning. Light fire and burn the Duckey Oil in an airy area of Langbas Garden.
 QUEST_LV_0100_20150317_004162	Report to Soldier Weiz
 QUEST_LV_0100_20150317_004163	You burned Duckey Oil and Gaigalas appeared. Quickly return to Weiz and let him know that Gaigalas appeared.
 QUEST_LV_0100_20150317_004164	Talk to the Old Owl Statue
-QUEST_LV_0100_20150317_004165	While the battle with Gaigalas is going on, and owl statue is looking at you strangely. Talk to the Old Owl Statue. 
+QUEST_LV_0100_20150317_004165	While the battle with Gaigalas is going on, and owl statue is looking at you strangely. Talk to the Old Owl Statue.
 QUEST_LV_0100_20150317_004166	Collect Infroholder's Horn
 QUEST_LV_0100_20150317_004167	The Old Owl Statue says you can't defeat Gaigalas if you just go like that. Gather Infroholder's horn to make fragments of memory.
 QUEST_LV_0100_20150317_004168	Give it to Old Owl Statue
@@ -4200,7 +4200,7 @@ QUEST_LV_0100_20150317_004199	You destroyed the western barrier as requested by 
 QUEST_LV_0100_20150317_004200	Destroy the West Barrier
 QUEST_LV_0100_20150317_004201	The Archeologist Dezik is desperately waiting for someone's help. Go talk to Dezik again.
 QUEST_LV_0100_20150317_004202	Go talk to the Archeologist Dezik.
-QUEST_LV_0100_20150317_004203	The Archeologist Dezik told you that Irene is imprisoned in the barrier device at Rodoma 1st Archeological Site. 
+QUEST_LV_0100_20150317_004203	The Archeologist Dezik told you that Irene is imprisoned in the barrier device at Rodoma 1st Archeological Site.
 QUEST_LV_0100_20150317_004204	Talk to the assistant Irene
 QUEST_LV_0100_20150317_004205	You found the assistant Irene. Get to her quietly to avoid monsters' attacks on her.
 QUEST_LV_0100_20150317_004206	Talk to Irene
@@ -4230,7 +4230,7 @@ QUEST_LV_0100_20150317_004229	Defeat Scorpio
 QUEST_LV_0100_20150317_004230	Talk to the new researcher of the royal tomb
 QUEST_LV_0100_20150317_004231	The new researches seems to be in trouble. You better help him.
 QUEST_LV_0100_20150317_004232	Find the lost research documents
-QUEST_LV_0100_20150317_004233	The new researcher told you that he lost all the research documents and the reports at Abondoned Old Workplace. Pino, Zepetto and Tontus may be hanging around there. 
+QUEST_LV_0100_20150317_004233	The new researcher told you that he lost all the research documents and the reports at Abondoned Old Workplace. Pino, Zepetto and Tontus may be hanging around there.
 QUEST_LV_0100_20150317_004234	Return to the new researcher
 QUEST_LV_0100_20150317_004235	It seems that you collected all the documents that the new researcher mentioned. Go back to the new researcher.
 QUEST_LV_0100_20150317_004236	Defeated Pino, Zepetto and Tontus and obtained %s
@@ -4309,7 +4309,7 @@ QUEST_LV_0100_20150317_004308	Search for Purifier parts on the floor
 QUEST_LV_0100_20150317_004309	Repair Purifier in 2nd Gallery
 QUEST_LV_0100_20150317_004310	Fix all the Purifiers in 2nd Gallery.
 QUEST_LV_0100_20150317_004311	Check Central Purifier+
-QUEST_LV_0100_20150317_004312	 The mine compass is poiting to the central purifying device in 1st Floor. Check the purifying device. 
+QUEST_LV_0100_20150317_004312	 The mine compass is poiting to the central purifying device in 1st Floor. Check the purifying device.
 QUEST_LV_0100_20150317_004313	Use Mine compass
 QUEST_LV_0100_20150317_004314	Use the compass to find the spare purifier located somwehere in the 1st Gallery.
 QUEST_LV_0100_20150317_004315	Search spare purifier in District 4
@@ -4318,7 +4318,7 @@ QUEST_LV_0100_20150317_004317	Get parts from the Spare Purifier in District 4 .
 QUEST_LV_0100_20150317_004318	Get the replacement parts from the spare purifier.
 QUEST_LV_0100_20150317_004319	Obtained spare parts for the Central Purifier. Replace the parts of the purifier.
 QUEST_LV_0100_20150317_004320	Kill the Cyclops in Crystal Mines
-QUEST_LV_0100_20150317_004321	Cyclops is going wild in Crystal Mines. Defeat cyclops. 
+QUEST_LV_0100_20150317_004321	Cyclops is going wild in Crystal Mines. Defeat cyclops.
 QUEST_LV_0100_20150317_004322	Defeat the Cyclops
 QUEST_LV_0100_20150317_004323	Check the Passage Purifier in 1st Gallery
 QUEST_LV_0100_20150317_004324	There is a problem with the purifier on the way to 2nd Gallery. Go and check it.
@@ -4344,7 +4344,7 @@ QUEST_LV_0100_20150317_004343	Secondary Purifier in 2nd Gallery has stopped work
 QUEST_LV_0100_20150317_004344	Use Mining Compass
 QUEST_LV_0100_20150317_004345	Use mining compass to check what you need to fix the secondary purifier.
 QUEST_LV_0100_20150317_004346	Check the spell device
-QUEST_LV_0100_20150317_004347	 The mine compass is pointing to the spell device in 4th area. Check what the problem is. 
+QUEST_LV_0100_20150317_004347	 The mine compass is pointing to the spell device in 4th area. Check what the problem is.
 QUEST_LV_0100_20150317_004348	Use mining compass to check what you need to fix the secondary purifier.
 QUEST_LV_0100_20150317_004349	Search for tools to remove rust
 QUEST_LV_0100_20150317_004350	Follow the compass to find a way to remove the rust.
@@ -4419,7 +4419,7 @@ QUEST_LV_0100_20150317_004418	You have defeated all the monsters. Look at the po
 QUEST_LV_0100_20150317_004419	Defeat Wendigo
 QUEST_LV_0100_20150317_004420	Defeat Woodfung
 QUEST_LV_0100_20150317_004421	Defeat Dumaro
-QUEST_LV_0100_20150317_004422	There is an unknown pole on the upper side of Long Bridge Valley.  Investigate the pole. 
+QUEST_LV_0100_20150317_004422	There is an unknown pole on the upper side of Long Bridge Valley.  Investigate the pole.
 QUEST_LV_0100_20150317_004423	As you touched the pole, Shnayim appeared! Take the artifacts away from Shnayim!
 QUEST_LV_0100_20150317_004424	Obtain %s by defeating Shnayim
 QUEST_LV_0100_20150317_004425	Defeat Shnayim
@@ -4473,12 +4473,12 @@ QUEST_LV_0100_20150317_004472	You finally unleased the first seal. Talk to Gusta
 QUEST_LV_0100_20150317_004473	
 QUEST_LV_0100_20150317_004474	
 QUEST_LV_0100_20150317_004475	
-QUEST_LV_0100_20150317_004476	Go to the Miner's Village Mayor to find out the village's situation.
+QUEST_LV_0100_20150317_004476	Go to the Miners' Village Mayor to find out the village's situation.
 QUEST_LV_0100_20150317_004477	
 QUEST_LV_0100_20150317_004478	Talk to the Hunter
 QUEST_LV_0100_20150317_004479	You need to go to the Cyrstal Mines as told by the Goddess in bishop's dream but you can't just leave the refugees. Help the angry hunter.
 QUEST_LV_0100_20150317_004480	The hunter says that monsters stole all the relief goods meant for the village residents. Try to pick up at least what's left on the road.
-QUEST_LV_0100_20150317_004481	Gathered all the aid boxes. Talk to the hunter. 
+QUEST_LV_0100_20150317_004481	Gathered all the aid boxes. Talk to the hunter.
 QUEST_LV_0100_20150317_004482	Talk to Mine Director Brinker
 QUEST_LV_0100_20150317_004483	You need to go to the Cyrstal Mines as told by the Goddess in bishop's dream but you can't just leave the refugees. Mine Director Brinker is standing by the wall with one hand on the wall. Ask what is happening.
 QUEST_LV_0100_20150317_004484	Collect material for reinforcement from the rubble nearby
@@ -4489,19 +4489,19 @@ QUEST_LV_0100_20150317_004488	Repaired the wall but Brinker still looks anxious.
 QUEST_LV_0100_20150317_004489	Kill the monsters nearby
 QUEST_LV_0100_20150317_004490	Kill the monsters nearby so that Brinker can return safely.
 QUEST_LV_0100_20150317_004491	Tell Brinker that it is safe
-QUEST_LV_0100_20150317_004492	Tell Brinker that he can return safely. 
+QUEST_LV_0100_20150317_004492	Tell Brinker that he can return safely.
 QUEST_LV_0100_20150317_004493	Talk to the Healer Lady
 QUEST_LV_0100_20150317_004494	You need to go to the Cyrstal Mines as told by the Goddess in bishop's dream but you can't just leave the refugees. Help the healer lady to treat injured people.
 QUEST_LV_0100_20150317_004495	Bringing the refugees
 QUEST_LV_0100_20150317_004496	Healer Lady is asking a favor for you to bring the other refugees. Bring the couple near the Statue of Goddess Zemyna to the Healer Lady.
 QUEST_LV_0100_20150317_004497	Turn over the refugees to the Healer Lady
-QUEST_LV_0100_20150317_004498	Brought back the regugees safely. Talk to the healing lady. 
+QUEST_LV_0100_20150317_004498	Brought back the regugees safely. Talk to the healing lady.
 QUEST_LV_0100_20150317_004499	Tell the Healer lady to go back to the village again.
 QUEST_LV_0100_20150317_004500	Kill the monsters
-QUEST_LV_0100_20150317_004501	The lady says she can't go back with her patients because there are too many monters. Get rid of the monsters for her. 
-QUEST_LV_0100_20150317_004502	Got rid of the monsters. Tell the lady to go back to the village. 
-QUEST_LV_0100_20150317_004503	Talk to Miner's Village Mayor
-QUEST_LV_0100_20150317_004504	Talk to the mayor again to enter the Crystal Mines. 
+QUEST_LV_0100_20150317_004501	The lady says she can't go back with her patients because there are too many monters. Get rid of the monsters for her.
+QUEST_LV_0100_20150317_004502	Got rid of the monsters. Tell the lady to go back to the village.
+QUEST_LV_0100_20150317_004503	Talk to Miners' Village Mayor
+QUEST_LV_0100_20150317_004504	Talk to the mayor again to enter the Crystal Mines.
 QUEST_LV_0100_20150317_004505	Rescue Vaidotas who is kidnapped by the Vubbes
 QUEST_LV_0100_20150317_004506	Revelation of Goddess is important but you can't leave the residents kidnapped. To save the residents trapped in the Mines, go to the Vubbe's base and save Vaidotas first.
 QUEST_LV_0100_20150317_004507	Block Vubbe's raid
@@ -4518,7 +4518,7 @@ QUEST_LV_0100_20150317_004517	Red Vubbe Fighter appeared when you kicked the box
 QUEST_LV_0100_20150317_004518	There were no kidnapped people but only Vubbes. You better go back to Vaitodas.
 QUEST_LV_0100_20150317_004519	You need to remove the wagons in order to enter the mines. Talk to Vaitodas on how you can remove it.
 QUEST_LV_0100_20150317_004520	Get rid of the Vubbes that heard the explosives and started to rush in. .
-QUEST_LV_0100_20150317_004521	Vaitodas says the wagon can be cleared with explosives. But the Vubbes can come marching in when they hear the explosives so you must be cautious. 
+QUEST_LV_0100_20150317_004521	Vaitodas says the wagon can be cleared with explosives. But the Vubbes can come marching in when they hear the explosives so you must be cautious.
 QUEST_LV_0100_20150317_004522	Enter Crystal Mine 1st Gallery
 QUEST_LV_0100_20150317_004523	You removed the wagons and can finally enter the Crystal Mines. Meet Vaitodas in Crystal Mine 1st Gallery.
 QUEST_LV_0100_20150317_004524	Talk to Kind Owl Sculpture
@@ -4535,7 +4535,7 @@ QUEST_LV_0100_20150317_004534	remember the owl to solve the problem, you defeate
 QUEST_LV_0100_20150317_004535	Defeat Elloguas
 QUEST_LV_0100_20150317_004536	Talk to the unstable Owl Sculpture
 QUEST_LV_0100_20150317_004537	Talk to the unstable Owl Sculpture to ask for a way to move Sequoia from blocking the road.
-QUEST_LV_0100_20150317_004538	Collect the divine wood fragments 
+QUEST_LV_0100_20150317_004538	Collect the divine wood fragments
 QUEST_LV_0100_20150317_004539	To move Sequoia from blocking the road, the unstable owl told you to face it with the divine power. Go get divine wood fragments from broken owl sculpture.
 QUEST_LV_0100_20150317_004540	You have collected enough divine wood fragments to move Sequoia from blocking the road. Go back to unstable owl.
 QUEST_LV_0100_20150317_004541	The unstable owl seems little confused, but it knows the way to move Sequoia from blocking the road. Talk to the unstable owl again.
@@ -4590,7 +4590,7 @@ QUEST_LV_0100_20150317_004589	Defeat Sequoia
 QUEST_LV_0100_20150317_004590	The gatekeeper owl told you that the stick isn't useless so if you directly attack Sequoia with it, you may defeat it.  Defeat Sequoia at the Cradle of Sequoia.
 QUEST_LV_0100_20150317_004591	You finally defeated Sequoia. Ask the gatekeeper about the way to the Sculptor
 QUEST_LV_0100_20150317_004592	Check the epitaph of the royal tomb
-QUEST_LV_0100_20150317_004593	Various writings on how to prepare when the demons attack are engraved on the epitaph. Read the epitaph. 
+QUEST_LV_0100_20150317_004593	Various writings on how to prepare when the demons attack are engraved on the epitaph. Read the epitaph.
 QUEST_LV_0100_20150317_004594	Defeat Boowook near the royal tomb's cube and suck it's power into the cube.
 QUEST_LV_0100_20150317_004595	The polluted Boowook can't distinguish Pia. Defeat Boowook and suck it's power into the cube.
 QUEST_LV_0100_20150317_004596	Read the epitaph
@@ -4681,11 +4681,11 @@ QUEST_LV_0100_20150317_004680	key to open Skill window and learn skills. Try lea
 QUEST_LV_0100_20150317_004681	You have succeeded learning a new skill. Talk to the soldier again
 QUEST_LV_0100_20150317_004682	Talk to the stone statue of the protector
 QUEST_LV_0100_20150317_004683	Defeat the polluted protector
-QUEST_LV_0100_20150317_004684	A few protectors have been already polluted due to the vicious energy that pervaded due to the flow of the magic. Destroy the polluted protectors. 
+QUEST_LV_0100_20150317_004684	A few protectors have been already polluted due to the vicious energy that pervaded due to the flow of the magic. Destroy the polluted protectors.
 QUEST_LV_0100_20150317_004685	Contaminated guardian I was completely exterminate. Talk to the guardian of the stone statue.
 QUEST_LV_0100_20150317_004686	Defeat the polluted Bikaaras Mage
 QUEST_LV_0100_20150317_004687	Collect the condensed magic source
-QUEST_LV_0100_20150317_004688	The stone statue of the protector told you that you should defeat them using the condensed magic source before the polluted protectors that are sleeping wake up. Collect the condensed magic source. 
+QUEST_LV_0100_20150317_004688	The stone statue of the protector told you that you should defeat them using the condensed magic source before the polluted protectors that are sleeping wake up. Collect the condensed magic source.
 QUEST_LV_0100_20150317_004689	You collected enough of it. Go back to the stone statue of the protector.
 QUEST_LV_0100_20150317_004690	You have collected the condensed magic source to destroy the polluted protectors that are in sleep. Talk to the stone statue of the protector.
 QUEST_LV_0100_20150317_004691	Use the condensed magic source to the protectors that are in sleep
@@ -4697,7 +4697,7 @@ QUEST_LV_0100_20150317_004696	Talk to the epigraphist, Raymond
 QUEST_LV_0100_20150317_004697	You promised to Ethan that you will deliver the lump of epitaph fragments to Raymond. Deliver the lump to Raymond.
 QUEST_LV_0100_20150317_004698	Talk to the epigraphist, Smid at Irody Square
 QUEST_LV_0100_20150317_004699	You told him that you will deliver the restored fragments of the epitaph that you received from Raymond to his assistant Smid.
-QUEST_LV_0100_20150317_004700	Destroy the source of the pollution,Denoptic 
+QUEST_LV_0100_20150317_004700	Destroy the source of the pollution,Denoptic
 QUEST_LV_0100_20150317_004701	The stone statue of the protector told you that Denoptics are polluting the protectors. Go find Denoptic and destroy it.
 QUEST_LV_0100_20150317_004702	Read the design plan of the royal tomb
 QUEST_LV_0100_20150317_004703	Find the place where the collapse started
@@ -4767,7 +4767,7 @@ QUEST_LV_0100_20150317_004766	Find the secret letter of the royal tomb
 QUEST_LV_0100_20150317_004767	You defeated the tombroad that blocked your way. Now, go find the secret letter.
 QUEST_LV_0100_20150317_004768	Defeat the Tomblord
 QUEST_LV_0100_20150317_004769	Collect the burning magic sources
-QUEST_LV_0100_20150317_004770	The stone statue of the protector told you that the magic to suppress the protectors was distorted due to demons' trick. To fix this, get the burning magic sources that are inside the protectors. 
+QUEST_LV_0100_20150317_004770	The stone statue of the protector told you that the magic to suppress the protectors was distorted due to demons' trick. To fix this, get the burning magic sources that are inside the protectors.
 QUEST_LV_0100_20150317_004771	You've collected enough amount of burning magic sources. Go back to the stone statue of the protector.
 QUEST_LV_0100_20150317_004772	Obtained %s by defeating Vikaras and Vekarabe
 QUEST_LV_0100_20150317_004773	Obtained the magnet of the royal tomb
@@ -4783,11 +4783,11 @@ QUEST_LV_0100_20150317_004782	Remove the polluted lump
 QUEST_LV_0100_20150317_004783	The stone statue of the protector told you that thare are lots of polluted lumps caused by the vicious energy. Find the lumps and remove them.
 QUEST_LV_0100_20150317_004784	You completely removed all the lumps. Go back to the stone statue of the protector.
 QUEST_LV_0100_20150317_004785	Destroy the polluted stone statue
-QUEST_LV_0100_20150317_004786	The vicious energy is spreading more pollution as it pollutes the lamp while moving with the flow of the magic. Destroy the polluted lamp. 
+QUEST_LV_0100_20150317_004786	The vicious energy is spreading more pollution as it pollutes the lamp while moving with the flow of the magic. Destroy the polluted lamp.
 QUEST_LV_0100_20150317_004787	Destroy the polluted lamp.
 QUEST_LV_0100_20150317_004788	The vicious energy is spreading more pollution as it pollutes the lamp while moving with the flow of the magic. Talk to the stone statue of the protector.
 QUEST_LV_0100_20150317_004789	Destroy the polluted suppressor
-QUEST_LV_0100_20150317_004790	The vicious energy is spreading more pollution as it pollutes the lamp while moving with the flow of the magic. Destroy the polluted lamp. 
+QUEST_LV_0100_20150317_004790	The vicious energy is spreading more pollution as it pollutes the lamp while moving with the flow of the magic. Destroy the polluted lamp.
 QUEST_LV_0100_20150317_004791	You've destroyed the polluted suppressor and it's sources. Go back to the stone statue of the protector.
 QUEST_LV_0100_20150317_004792	Defeat the Arkon
 QUEST_LV_0100_20150317_004793	Check the records of the royal tomb
@@ -4824,7 +4824,7 @@ QUEST_LV_0100_20150317_004823	Coben is excited to hear that the person once chal
 QUEST_LV_0100_20150317_004824	Check the writings on the second epitaph
 QUEST_LV_0100_20150317_004825	Coben told you to look for the next epitaph and he also told you that if the epitaph is unreadable due to its breakages, you can read the writings again when you rub them with Cockatries' fat. Get the fat near the empty space and check what is written on the second epitaph.
 QUEST_LV_0100_20150317_004826	Tell Coben about what was written on the epitaph
-QUEST_LV_0100_20150317_004827	The second epitaph was written about the person promised himself to do something at the Magicians' Tower to become the greatest thief of all time. Tell Coben about it. 
+QUEST_LV_0100_20150317_004827	The second epitaph was written about the person promised himself to do something at the Magicians' Tower to become the greatest thief of all time. Tell Coben about it.
 QUEST_LV_0100_20150317_004828	Coben disappeared after telling you that he will follow his colleague's footsteps. Find Coben and talk to him.
 QUEST_LV_0100_20150317_004829	Check what is written on the third epitaph
 QUEST_LV_0100_20150317_004830	Coben told you that the third epitaph is located at the left way of Negyvas field. Check what is written on the third epitaph on behalf of Coben.
@@ -4866,7 +4866,7 @@ QUEST_LV_0100_20150317_004865	Obtain %s from Hallowventer
 QUEST_LV_0100_20150317_004866	Collect dust samples
 QUEST_LV_0100_20150317_004867	It seems that Tara Miles' investigation is not done yet. Talk to Tara Miles again.
 QUEST_LV_0100_20150317_004868	Obtain the tail of Big Cockatries
-QUEST_LV_0100_20150317_004869	Tara Miles wants the tail of Big Cockatries that already got the disease. Get the tail of Big Cockatries beyond the camp of beekepers 
+QUEST_LV_0100_20150317_004869	Tara Miles wants the tail of Big Cockatries that already got the disease. Get the tail of Big Cockatries beyond the camp of beekepers
 QUEST_LV_0100_20150317_004870	Hand over the tail of Big Cockatries to Tara Miles
 QUEST_LV_0100_20150317_004871	You obtained many tails of Big Cockatries. Go back to Tara Miles.
 QUEST_LV_0100_20150317_004872	Obtain the tail of Big Cockatries
@@ -4985,7 +4985,7 @@ QUEST_LV_0100_20150317_004984	You destroyed all four magic suppressors which Hel
 QUEST_LV_0100_20150317_004985	Defeat Helgacircle
 QUEST_LV_0100_20150317_004986	Defeat Helgacircle
 QUEST_LV_0100_20150317_004987	Use the Jewel of Prominence
-QUEST_LV_0100_20150317_004988	You should help Gabiya now with the Jewel of Prominence. Put the jewels in the center of Keturidu great hall. 
+QUEST_LV_0100_20150317_004988	You should help Gabiya now with the Jewel of Prominence. Put the jewels in the center of Keturidu great hall.
 QUEST_LV_0100_20150317_004989	Talk to the goddess, Gabiya
 QUEST_LV_0100_20150317_004990	You received the revelation from the goddess. Ask the goddess what to do next.
 QUEST_LV_0100_20150317_004991	Now, you should destroy the 2nd valve. Talk to Gritta.
@@ -5033,14 +5033,14 @@ QUEST_LV_0100_20150317_005032	Pitt is crying due to the sadness of Spion's death
 QUEST_LV_0100_20150317_005033	Chase after the herb broker to the Big Rock Face Hills
 QUEST_LV_0100_20150317_005034	Pitt wants avenge the herb broker for Spion's death. It seems that the herb broker went to the direction of Big Rock Face Hills. Chase after the herb broker.
 QUEST_LV_0100_20150317_005035	Report to the commander Raimondas
-QUEST_LV_0100_20150317_005036	Spion who was definitely dead became violent because of the herb broker so you had no other choice,  but to defeat him. Go back to Raimondas and tell him what happened. 
+QUEST_LV_0100_20150317_005036	Spion who was definitely dead became violent because of the herb broker so you had no other choice,  but to defeat him. Go back to Raimondas and tell him what happened.
 QUEST_LV_0100_20150317_005037	Defeat Bebraspion
 QUEST_LV_0100_20150317_005038	You should now return to meet Raimondas since you obtained the symbol. Talk to Alryus before you meet Raimondas.
 QUEST_LV_0100_20150317_005039	It seems that you are qualifed to become an official soldier since you obtained the symbol. Go meet Raimondas and show him the symbol.
 QUEST_LV_0100_20150317_005040	Talk to the follower, Baidutis
 QUEST_LV_0100_20150317_005041	Meet the follower, Baidutis at the 1st floor of Tenet Cathedral
 QUEST_LV_0100_20150317_005042	Collect the Essences of Power
-QUEST_LV_0100_20150317_005043	Baidutis told you that in order to deactivate the barriers of demons at the entrance of the cathedral, you should collect the Essences of Power from Corylus and make the Essence of Light. Defeat Corylus at the worship preparation room and obtin the Essences of Power. 
+QUEST_LV_0100_20150317_005043	Baidutis told you that in order to deactivate the barriers of demons at the entrance of the cathedral, you should collect the Essences of Power from Corylus and make the Essence of Light. Defeat Corylus at the worship preparation room and obtin the Essences of Power.
 QUEST_LV_0100_20150317_005044	As Baidutis had planned, you have collected enough Essences of Power. Go back to Baidutis.
 QUEST_LV_0100_20150317_005045	Obtained %s by defeating Corylus
 QUEST_LV_0100_20150317_005046	The Essence of Light is ready. Talk to Baidutis.
@@ -5052,7 +5052,7 @@ QUEST_LV_0100_20150317_005051
 QUEST_LV_0100_20150317_005052	The entrance of Katyn Forest
 QUEST_LV_0100_20150317_005053	Baidutis is looking for help from somebody at the 1st floor of Tenet Cathedral
 QUEST_LV_0100_20150317_005054	Defeat Pawndel and Pawndu
-QUEST_LV_0100_20150317_005055	Baidutis asked you to defeat Pawndel and Pawndu that are roaming around at the 1st floor of Tenet Cathedral. 
+QUEST_LV_0100_20150317_005055	Baidutis asked you to defeat Pawndel and Pawndu that are roaming around at the 1st floor of Tenet Cathedral.
 QUEST_LV_0100_20150317_005056	You have defeated enough Pawndels and Pawndus as Baidutis requested. Go back to Baidutis.
 QUEST_LV_0100_20150317_005057	Defeat Pawndel
 QUEST_LV_0100_20150317_005058	Defeat Pawndu
@@ -5074,7 +5074,7 @@ QUEST_LV_0100_20150317_005073	Transform demons at the Altar of Clozevas
 QUEST_LV_0100_20150317_005074	Donatas told you that you are able to transform the demons using the power of the Altar of Clozevas. Activate the power and if you attack those demons at an area where the influence of the altar's power reaches, you can transform those demons.
 QUEST_LV_0100_20150317_005075	You have transformed the demons. Go back to Donatas.
 QUEST_LV_0100_20150317_005076	Check the central altar
-QUEST_LV_0100_20150317_005077	Donatas told you to check the central barrier that had stopped working. 
+QUEST_LV_0100_20150317_005077	Donatas told you to check the central barrier that had stopped working.
 QUEST_LV_0100_20150317_005078	You defeated Malletwyvern at the central altar. Talk to Donatas.
 QUEST_LV_0100_20150317_005079	Defeat Malletwyvern
 QUEST_LV_0100_20150317_005080	Talk to Thomas
@@ -5096,7 +5096,7 @@ QUEST_LV_0100_20150317_005095	Obtaine the purified essence.
 QUEST_LV_0100_20150317_005096	Tiberiyus told you to bring the vicious essences after defeating the demons and purified water from the Altar of Purification to make divine bombs.
 QUEST_LV_0100_20150317_005097	You have collected enough Purified Water as Tiberiyus requested to you. Return to Tiberiyus.
 QUEST_LV_0100_20150317_005098	Defeat Glizardon using the divine bomb
-QUEST_LV_0100_20150317_005099	Tiberiyus wants to test Divine Bombs on Glizardon. Drink Romuva Divine Water to hide yourself and put the bomb onto the back of Glizardon. 
+QUEST_LV_0100_20150317_005099	Tiberiyus wants to test Divine Bombs on Glizardon. Drink Romuva Divine Water to hide yourself and put the bomb onto the back of Glizardon.
 QUEST_LV_0100_20150317_005100	Glizardon died right away after the bomb exploded at the back of Glizardon. Go back to Tiberiyus and tell him about it.
 QUEST_LV_0100_20150317_005101	Talk to Baidas.
 QUEST_LV_0100_20150317_005102	Baidas is waiting for someone's help at the 1st basement of Tenet Cathedral.
@@ -5108,37 +5108,37 @@ QUEST_LV_0100_20150317_005107	Baidas asked you to defeat Glizardon that walks ar
 QUEST_LV_0100_20150317_005108	You defeated Glizardon as Baidas requested. Go back to Baidas.
 QUEST_LV_0100_20150317_005109	Baidas asked you to find Baidutis at the 1st floor.
 QUEST_LV_0100_20150317_005110	Deactivate the barrier of Gesti
-QUEST_LV_0100_20150317_005111	Baidas told you that 
+QUEST_LV_0100_20150317_005111	Baidas told you that
 QUEST_LV_0100_20150317_005112	Find Follower Vaidutis
 QUEST_LV_0100_20150317_005113	Removed the barrier that was blocking the way to the 1st floor and defeated Cyclops. Avoid Cyclops and look for Vaidutis who ran away to the 1st floor.
 QUEST_LV_0100_20150317_005114	Defeat the Cyclops
 QUEST_LV_0100_20150317_005115	Talk to Follower Algis
-QUEST_LV_0100_20150317_005116	Algis was waiting for you in 2nd Floor. Talk to him and ask what to do. 
+QUEST_LV_0100_20150317_005116	Algis was waiting for you in 2nd Floor. Talk to him and ask what to do.
 QUEST_LV_0100_20150317_005117	Go to the Bell Tower
 QUEST_LV_0100_20150317_005118	Saw Gesti scolding her subordinates
 QUEST_LV_0100_20150317_005119	Amost got caught by Gesti but you earned some good information. Gesti hasn't found the revelation yet. Ask algis for the next plan.
 QUEST_LV_0100_20150317_005120	Gesti disappeared to the Central hall. Talk to Algis.
-QUEST_LV_0100_20150317_005121	Algis says that in order to enter the hidden sanctuary, you need the hidden seal of space in Central altar but Gesti is roaming around the area and it is dangerous. Seize the Bell Tower and stay at a better location to look for another chance. 
-QUEST_LV_0100_20150317_005122	Seized the Bell Tower. Talk to Algis. 
-QUEST_LV_0100_20150317_005123	Seized the Bell Tower. Ask Algis what to do next. 
+QUEST_LV_0100_20150317_005121	Algis says that in order to enter the hidden sanctuary, you need the hidden seal of space in Central altar but Gesti is roaming around the area and it is dangerous. Seize the Bell Tower and stay at a better location to look for another chance.
+QUEST_LV_0100_20150317_005122	Seized the Bell Tower. Talk to Algis.
+QUEST_LV_0100_20150317_005123	Seized the Bell Tower. Ask Algis what to do next.
 QUEST_LV_0100_20150317_005124	Gesti destroyed the barrier in Central Hall!
-QUEST_LV_0100_20150317_005125	Gesti destroyed the Central altar of Sventove and stole the seal of space. You can't get the revelation this way and you'll be killed if you meet Gesti. Talk to Algis on how to solve the situation. 
+QUEST_LV_0100_20150317_005125	Gesti destroyed the Central altar of Sventove and stole the seal of space. You can't get the revelation this way and you'll be killed if you meet Gesti. Talk to Algis on how to solve the situation.
 QUEST_LV_0100_20150317_005126	Make a trap in the Central hall
 QUEST_LV_0100_20150317_005127	Algis suggested using the pieces of destroyed altar to emasculate Gesti. Collect the pieces of altar and place it on the eight pillars of Central hall.
 QUEST_LV_0100_20150317_005128	Placed the altar pieces on the eight pillars. Go back to Algis.
-QUEST_LV_0100_20150317_005129	Algis is waiting for the revelator in Tenet Chapel 2nd Floor. 
+QUEST_LV_0100_20150317_005129	Algis is waiting for the revelator in Tenet Chapel 2nd Floor.
 QUEST_LV_0100_20150317_005130	Algis says he can't handle watching the place alone and asked you to use the power of altar to stamp demons with its power and get rid of them.
 QUEST_LV_0100_20150317_005131	Got rid of the demons and activated the altar. Go back to Algis.
 QUEST_LV_0100_20150317_005132	Charge the low level spirit crystal
-QUEST_LV_0100_20150317_005133	Algis says you need to get rid of the demons following us. Use Auka altar to get rid of the demons and prevent them from chasing you. 
+QUEST_LV_0100_20150317_005133	Algis says you need to get rid of the demons following us. Use Auka altar to get rid of the demons and prevent them from chasing you.
 QUEST_LV_0100_20150317_005134	Activated the altar and shifted the demons' interest to the altar. Go back to Algis.
 QUEST_LV_0100_20150317_005135	Defeat Egnome
 QUEST_LV_0100_20150317_005136	Algis asked you to get rid of the Egnome going around the chape.
-QUEST_LV_0100_20150317_005137	Killed enough Egnome. Go back to Algis. 
-QUEST_LV_0100_20150317_005138	Placed the pieces of barriers on the eight pillars of Sventove Central hall. Gesti doesn't know it yet. Proceed to the next plan with Algis. 
+QUEST_LV_0100_20150317_005137	Killed enough Egnome. Go back to Algis.
+QUEST_LV_0100_20150317_005138	Placed the pieces of barriers on the eight pillars of Sventove Central hall. Gesti doesn't know it yet. Proceed to the next plan with Algis.
 QUEST_LV_0100_20150317_005139	Fight with Gesti
 QUEST_LV_0100_20150317_005140	Weakened Gesti with the power of central altar and eight pillars. Now you can fight on with Gesti. Emasculate Gesti while Algis prepares the spiritual crystal.
-QUEST_LV_0100_20150317_005141	Failed to defeat Gesti but she ran away with serious injury. Talk to Algis. 
+QUEST_LV_0100_20150317_005141	Failed to defeat Gesti but she ran away with serious injury. Talk to Algis.
 QUEST_LV_0100_20150317_005142	Gesti ran away but there are still more things left to do in the church. Talk to Algis again.
 QUEST_LV_0100_20150317_005143	Find the revelation in hidden sanctuary
 QUEST_LV_0100_20150317_005144	use the seal of space on the pillar to enter the sanctuary and get the revelation.
@@ -5151,43 +5151,43 @@ QUEST_LV_0100_20150317_005150	Allen asked you to collect the pieces of barrier t
 QUEST_LV_0100_20150317_005151	Talk to Followe Kayetonas
 QUEST_LV_0100_20150317_005152	Collected enough pieces of barrier. Go and give the pieces to Kayetonas.
 QUEST_LV_0100_20150317_005153	Charge the barrier of wooden guard post
-QUEST_LV_0100_20150317_005154	Help Allen get rid of the demons around the Wooden Guard Post and charge its soul on the barrier. 
-QUEST_LV_0100_20150317_005155	Guard post has been charged enough. Tell Kayetanos about it. 
+QUEST_LV_0100_20150317_005154	Help Allen get rid of the demons around the Wooden Guard Post and charge its soul on the barrier.
+QUEST_LV_0100_20150317_005155	Guard post has been charged enough. Tell Kayetanos about it.
 QUEST_LV_0100_20150317_005156	Talk to guard Kenneth
 QUEST_LV_0100_20150317_005157	
 QUEST_LV_0100_20150317_005158	Remove the demon summon circle
 QUEST_LV_0100_20150317_005159	Gaurd Kenneth is worried about the demons summoned in Mairunas hills. Get rid of the demons around Mairunas hills and remove the summon circle.
 QUEST_LV_0100_20150317_005160	Talk to Kayetonas
-QUEST_LV_0100_20150317_005161	Removed the demon summon circle Kenneth asked you. Tell Kayetonas in Flower Peak that there was a demon summon circle. 
+QUEST_LV_0100_20150317_005161	Removed the demon summon circle Kenneth asked you. Tell Kayetonas in Flower Peak that there was a demon summon circle.
 QUEST_LV_0100_20150317_005162	Defeat the separated soul of demon
-QUEST_LV_0100_20150317_005163	Kenneth told you to exhaust demon's HP to less than half and use the holiness of barrier to separate the soul and get rid of it. 
+QUEST_LV_0100_20150317_005163	Kenneth told you to exhaust demon's HP to less than half and use the holiness of barrier to separate the soul and get rid of it.
 QUEST_LV_0100_20150317_005164	Got rid of enough separated souls in Pumpura hill. Report to Kayetonas.
 QUEST_LV_0100_20150317_005165	Defeat the demon monsters around Kenneth
 QUEST_LV_0100_20150317_005166	Kenneth asked you to kill the monsters nearby while he takes a rest.
-QUEST_LV_0100_20150317_005167	Killed the monsters while Kenneth took rest. Tell Kayetonas about it. 
+QUEST_LV_0100_20150317_005167	Killed the monsters while Kenneth took rest. Tell Kayetonas about it.
 QUEST_LV_0100_20150317_005168	
-QUEST_LV_0100_20150317_005169	Minatours appeared from the sky like Kayetonas said. Defeat the Minotaurs so that it won't get to the Paladin Master. 
+QUEST_LV_0100_20150317_005169	Minatours appeared from the sky like Kayetonas said. Defeat the Minotaurs so that it won't get to the Paladin Master.
 QUEST_LV_0100_20150317_005170	Defeated Minotaurs with Kayetonas. Talk to Kayetonas.
 QUEST_LV_0100_20150317_005171	
 QUEST_LV_0100_20150317_005172	Listen to Algis' explanations
-QUEST_LV_0100_20150317_005173	The Paladin Master told you to listen to Algis about Tenet church, first paladin, and the seal of space. Listen to Algis before he leaves. 
-QUEST_LV_0100_20150317_005174	Listened to Algis' explanations. Report to the Paladin Master and follow the next orders. 
+QUEST_LV_0100_20150317_005173	The Paladin Master told you to listen to Algis about Tenet church, first paladin, and the seal of space. Listen to Algis before he leaves.
+QUEST_LV_0100_20150317_005174	Listened to Algis' explanations. Report to the Paladin Master and follow the next orders.
 QUEST_LV_0100_20150317_005175	The Paladin Master is looking for you
 QUEST_LV_0100_20150317_005176	Activate the barrier of Piliaroze Peak
 QUEST_LV_0100_20150317_005177	Gesti appeared. Help the Paladin Master!
 QUEST_LV_0100_20150317_005178	The scripture and was only able to inflict a wound that was hit in the demon. Please be talking again with the Paladin Master.
 QUEST_LV_0100_20150317_005179	
-QUEST_LV_0100_20150317_005180	The Paladin Master asked you to clear the area while he focuses on the crystals. Kill the Throneweavers coming to attack you. 
+QUEST_LV_0100_20150317_005180	The Paladin Master asked you to clear the area while he focuses on the crystals. Kill the Throneweavers coming to attack you.
 QUEST_LV_0100_20150317_005181	Defeat the Throne weavers
 QUEST_LV_0100_20150317_005182	Defeat the contaminated mausoleum guardians
-QUEST_LV_0100_20150317_005183	Guardian statue says you can't change back the contaminated guardians. Get rid of it instead. 
-QUEST_LV_0100_20150317_005184	Get rid of the mausoleum guardians 
+QUEST_LV_0100_20150317_005183	Guardian statue says you can't change back the contaminated guardians. Get rid of it instead.
+QUEST_LV_0100_20150317_005184	Get rid of the mausoleum guardians
 QUEST_LV_0100_20150317_005185	Read the mausoleum gravestone
 QUEST_LV_0100_20150317_005186	There is a guardian statue fuming strange forces. Read the statue.
 QUEST_LV_0100_20150317_005187	Defeat the contaminated masoleum guardians
 QUEST_LV_0100_20150317_005188	The statue contaminated with evil force is summoning guardians. Get rid of the contaminated guardians.
 QUEST_LV_0100_20150317_005189	Find the hidden treasure
-QUEST_LV_0100_20150317_005190	There is a hidden treasure. Find it and get the treasure. 
+QUEST_LV_0100_20150317_005190	There is a hidden treasure. Find it and get the treasure.
 QUEST_LV_0100_20150317_005191	It was a trap. Get rid of the contaminated guardian.
 QUEST_LV_0100_20150317_005192	It was a warning on the contaminated guardian. Kill them.
 QUEST_LV_0100_20150317_005193	Defeat Rusrat
@@ -5198,13 +5198,13 @@ QUEST_LV_0100_20150317_005197
 QUEST_LV_0100_20150317_005198	Find the map in Vienisa Plateau
 QUEST_LV_0100_20150317_005199	Rolandas says the map for King Zachariel's Legacy is hidden where nobody knows. You have to check around because you don't know where it is exactly. First, check the southern area of Vienisa Plateau.
 QUEST_LV_0100_20150317_005200	Talk to Rolandas
-QUEST_LV_0100_20150317_005201	You can't possible find it at once. It was fruitless. Go back to Rolandas and ask for the next area. 
+QUEST_LV_0100_20150317_005201	You can't possible find it at once. It was fruitless. Go back to Rolandas and ask for the next area.
 QUEST_LV_0100_20150317_005202	Check the area Rolandas Jonas told you
 QUEST_LV_0100_20150317_005203	Check the area Rolandas told you
 QUEST_LV_0100_20150317_005204	Search for the map in Radas Fork Road
 QUEST_LV_0100_20150317_005205	Rolandas says the map for King Zachariel's Legacy is hidden where nobody knows. You have to check around because you don't know where it is exactly. {nl}Search for the map in Radas Fork Road.
 QUEST_LV_0100_20150317_005206	Find the map in Rodoma Ruins 1
-QUEST_LV_0100_20150317_005207	1Rolandas says the map for King Zachariel's Legacy is hidden where nobody knows. You have to check around because you don't know where it is exactly. Could it be found in Rodoma Ruins 1? 
+QUEST_LV_0100_20150317_005207	1Rolandas says the map for King Zachariel's Legacy is hidden where nobody knows. You have to check around because you don't know where it is exactly. Could it be found in Rodoma Ruins 1?
 QUEST_LV_0100_20150317_005208	Search the area Rolandas told you
 QUEST_LV_0100_20150317_005209	Search for the map nearby grave manager's cabin
 QUEST_LV_0100_20150317_005210	Rolandas says the map for King Zachariel's Legacy is hidden where nobody knows. You have to check around because you don't know where it is exactly. Check around the cabin of grave manager.
@@ -5230,27 +5230,27 @@ QUEST_LV_0100_20150317_005229	Talk to Historian Rexipher
 QUEST_LV_0100_20150317_005230	
 QUEST_LV_0100_20150317_005231	Read the epitaph of Isvalyta Ruins
 QUEST_LV_0100_20150317_005232	Rexipher is asking for your cooperation for the common objective of getting to the Mausoleum. Follow Rexipher's guide and read the epitaph of Isvalyta Ruins.
-QUEST_LV_0100_20150317_005233	Got the clues to the King's dilemma. Talk to Rexipher. 
-QUEST_LV_0100_20150317_005234	The epitaph mentions about the dilemma on proving the revelator. Talk to Rexipher about the location of next epitaph. 
+QUEST_LV_0100_20150317_005233	Got the clues to the King's dilemma. Talk to Rexipher.
+QUEST_LV_0100_20150317_005234	The epitaph mentions about the dilemma on proving the revelator. Talk to Rexipher about the location of next epitaph.
 QUEST_LV_0100_20150317_005235	Read the epitaph of Shirnas Plateau
-QUEST_LV_0100_20150317_005236	Rexipher says the next epitaph is in Shirnas Plateau. Go there and check the next epitaph. 
+QUEST_LV_0100_20150317_005236	Rexipher says the next epitaph is in Shirnas Plateau. Go there and check the next epitaph.
 QUEST_LV_0100_20150317_005237	
-QUEST_LV_0100_20150317_005238	You must solve all the dilemmas of King Zachariel in order to approach the Mausoleum. Talk to rexipher for clues to the next dilemma. 
+QUEST_LV_0100_20150317_005238	You must solve all the dilemmas of King Zachariel in order to approach the Mausoleum. Talk to rexipher for clues to the next dilemma.
 QUEST_LV_0100_20150317_005239	Read the third epitaph along the way to Dykine Fork Road
-QUEST_LV_0100_20150317_005240	The next epitaph is in Dykine Fork Road. Find the epitaph near the road. 
-QUEST_LV_0100_20150317_005241	The power of guardian on the epitaph almost got Rexipher in trouble. Talk to him agian. 
+QUEST_LV_0100_20150317_005240	The next epitaph is in Dykine Fork Road. Find the epitaph near the road.
+QUEST_LV_0100_20150317_005241	The power of guardian on the epitaph almost got Rexipher in trouble. Talk to him agian.
 QUEST_LV_0100_20150317_005242	
 QUEST_LV_0100_20150317_005243	Read the epitaph on the left of Dykine Fork Road
 QUEST_LV_0100_20150317_005244	
 QUEST_LV_0100_20150317_005245	Got the fourth clue. Go back to Rexipher who showed up from somewhere and talk to him.
-QUEST_LV_0100_20150317_005246	There is only one epitaph left for the clue. Talk to Rexipher for the location of the epitaph. 
+QUEST_LV_0100_20150317_005246	There is only one epitaph left for the clue. Talk to Rexipher for the location of the epitaph.
 QUEST_LV_0100_20150317_005247	Read the last epitaph in Apati Cliff
-QUEST_LV_0100_20150317_005248	It is the last clue prepared by King Zachariel. Read the epitaph in Apati Cliff and get the fifth clue. 
+QUEST_LV_0100_20150317_005248	It is the last clue prepared by King Zachariel. Read the epitaph in Apati Cliff and get the fifth clue.
 QUEST_LV_0100_20150317_005249	Got the fifth clue. Go back and talk to Rexipher.
 QUEST_LV_0100_20150317_005250	Protect the Mausoleum Stone Lantern
-QUEST_LV_0100_20150317_005251	The guardian statue says the flow of spell in the Mausoleum will be twisted if the stone lanterns are destroyed. Protect the stone lantern from demons. 
+QUEST_LV_0100_20150317_005251	The guardian statue says the flow of spell in the Mausoleum will be twisted if the stone lanterns are destroyed. Protect the stone lantern from demons.
 QUEST_LV_0100_20150317_005252	Follow Rexipher to Mausoleum 3rd Floor
-QUEST_LV_0100_20150317_005253	Rexipher destroyed the stone lantern and disappeared to the deeper area. Follow him to the 3rd Floor. 
+QUEST_LV_0100_20150317_005253	Rexipher destroyed the stone lantern and disappeared to the deeper area. Follow him to the 3rd Floor.
 QUEST_LV_0100_20150317_005254	Defeat the contaminated guardian
 QUEST_LV_0100_20150317_005255	The twisted spell is causing the guardian to attack both enemies and allies. Defeat the contaminated guardians.
 QUEST_LV_0100_20150317_005256	Get rid of the Echad that can't idenify friend or enemy
@@ -5258,110 +5258,110 @@ QUEST_LV_0100_20150317_005257	Search the deeper part of the Mausoleum
 QUEST_LV_0100_20150317_005258	Defeat the Shnayim that thinks you are foe
 QUEST_LV_0100_20150317_005259	Much of the Mausoleum are not functioning well because of the polluted spell. Kill the Shnayims that identify you as enemy.
 QUEST_LV_0100_20150317_005260	Talk to Vincent
-QUEST_LV_0100_20150317_005261	Vincent seems to have found out. Talk to Vincent again. 
+QUEST_LV_0100_20150317_005261	Vincent seems to have found out. Talk to Vincent again.
 QUEST_LV_0100_20150317_005262	Defeat the monster that followed Toby
 QUEST_LV_0100_20150317_005263	Todou is being chased by Yonazolem! Defeat the Yonazolem.
 QUEST_LV_0100_20150317_005264	Defeat Yonazolem that Todou brought along
-xQUEST_LV_0100_20150317_005265	Rexipher is thinking deeply, looking at the clues. Talk to him.
-xQUEST_LV_0100_20150317_005266	Get Hogma Teeth
-xQUEST_LV_0100_20150317_005267	Rexipher says the clues are covered with something and needs Hogma's teeth to use as an abrasive. Get him Hogma's teeth.
-xQUEST_LV_0100_20150317_005268	Got Hogma teeth. Talk to Rexipher. 
+QUEST_LV_0100_20150317_005265	Rexipher is thinking deeply looking at the clues. Talk to him.
+QUEST_LV_0100_20150317_005266	Get the Teeth of Hogma
+QUEST_LV_0100_20150317_005267	Rexipher says the clues is covered with something and needs Hogma's teeth to use as abrasive. Get him Hogma's teeth.
+QUEST_LV_0100_20150317_005268	Got Hogma's teeth. Talk to Rexipher.
 QUEST_LV_0100_20150317_005269	Get %s
-xQUEST_LV_0100_20150317_005270	Get Hogma Teeth
-xQUEST_LV_0100_20150317_005271	Find out Rexipher's Whereabouts
-xQUEST_LV_0100_20150317_005272	Rexipher disappeared with Zachariel's clues. Go to Liason Official Veil and ask about Rexipher's whereabouts.
-xQUEST_LV_0100_20150317_005273	Veil says he doesn't know Rexipher. Ask other historians for Rexipher's whereabouts.
-xQUEST_LV_0100_20150317_005274	Historian Colin says he doesn't know Rexipher, either. Ask other historians for Rexipher's whereabouts.
-xQUEST_LV_0100_20150317_005275	Ask Cyrenia Odelle for Rexipher's Whereabouts
-xQUEST_LV_0100_20150317_005276	Rexipher took all of Zachariel's clues; you must find him, no matter what. Ask about him again. 
-xQUEST_LV_0100_20150317_005277	Trace Rexipher's Whereabouts
-xQUEST_LV_0100_20150317_005278	You were not able to find Rexipher's whereabouts, but you found out that Rexipher is a demon's name. Continue investigating Rexipher. 
-xQUEST_LV_0100_20150317_005279	Go to the Chesed Altar where Rexipher once Rested
-xQUEST_LV_0100_20150317_005280	A man looking like Rexipher is attacking historians at the Chesed and Gedula Altars to take control of the area. First, go the the Chesed Altar.
-xQUEST_LV_0100_20150317_005281	Defeat the Hogmas
+QUEST_LV_0100_20150317_005270	Get Hogma's Teeth
+QUEST_LV_0100_20150317_005271	Find out Rexipher's whereabouts
+QUEST_LV_0100_20150317_005272	Rexipher disappeared with Zachariel's clues. Go to liason official Veil and ask about Rexipher's whereabouts.
+QUEST_LV_0100_20150317_005273	Veil says he doesn't know Rexipher. Ask other historians for Rexipher's whereabouts.
+QUEST_LV_0100_20150317_005274	Historian Colin says he doesn't know Rexipher. Ask other historians for Rexipher's whereabouts.
+QUEST_LV_0100_20150317_005275	Ask Cyrenia Odelle for Rexipher's whereabouts
+QUEST_LV_0100_20150317_005276	Rexipher took all the clues of Zachariel so you must find him no matter what. Ask about him again.
+QUEST_LV_0100_20150317_005277	Trace Rexipher's whereabouts
+QUEST_LV_0100_20150317_005278	You were not able to find Rexipher's wherabouts but you found out that Rexipher is a demon's name. Continue investigating about Rexipher.
+QUEST_LV_0100_20150317_005279	Go to Chesed Altar where Rexepher stayed
+QUEST_LV_0100_20150317_005280	A man looking like Rexipher is attacking historians in Chesed Altar and Gedula Altar to control the altar. First, go the the Chesed altar.
+QUEST_LV_0100_20150317_005281	Defeat the Hogmas
 QUEST_LV_0100_20150317_005282	
 QUEST_LV_0100_20150317_005283	
-xQUEST_LV_0100_20150317_005284	Talk to Historian Cyrenia Odelle
-xQUEST_LV_0100_20150317_005285	Cyrenia Odelle came to the altar. Talk to her.
-xQUEST_LV_0100_20150317_005286	Talk to Historian Cyrenia Odelle
+QUEST_LV_0100_20150317_005284	Talk to historian Cyrenia Odelle
+QUEST_LV_0100_20150317_005285	Cyrenia Odelle came near the altar. Talk to her.
+QUEST_LV_0100_20150317_005286	Talk to historian Cyrenia Odelle
 QUEST_LV_0100_20150317_005287	
 QUEST_LV_0100_20150317_005288	
 QUEST_LV_0100_20150317_005289	
-xQUEST_LV_0100_20150317_005290	Talk to Cyrenia Odelle
+QUEST_LV_0100_20150317_005290	Talk to Cyrenia Odelle
 QUEST_LV_0100_20150317_005291	
 QUEST_LV_0100_20150317_005292	
 QUEST_LV_0100_20150317_005293	
 QUEST_LV_0100_20150317_005294	
 QUEST_LV_0100_20150317_005295	
 QUEST_LV_0100_20150317_005296	
-xQUEST_LV_0100_20150317_005297	Go to Cyrenia Odelle
-xQUEST_LV_0100_20150317_005298	The Cetek Altar was destroyed but you managed to release the seal of Sviesa Altar. Talk to Cyrenia Odelle.
-xQUEST_LV_0100_20150317_005299	Defeat Rexipher's Subordinates
-xQUEST_LV_0100_20150317_005300	Rexipher kidnapped Cyrenia Odelle! Better kill his subordinates and follow him.
+QUEST_LV_0100_20150317_005297	Go to Cyrenia Odelle
+QUEST_LV_0100_20150317_005298	Cetek Altar was destroyed but you managed to release the seal of Sviesa Altar. Talk to Cyrenia Odelle.
+QUEST_LV_0100_20150317_005299	Defeat Rexipher's subordinates
+QUEST_LV_0100_20150317_005300	Rexipher kidnapped Cyrenia Odelle! Vetter kill his subordinates and follow him.
 QUEST_LV_0100_20150317_005301	
-xQUEST_LV_0100_20150317_005302	Create Crude Explorer Stick
-xQUEST_LV_0100_20150317_005303	Epigraphis Raymond wants to use Small Tree Branches to make a Crude Explorer Stick, useful for finding the Gravestone Pieces. 
-xQUEST_LV_0100_20150317_005304	Find the First Piece of Gravestone
-xQUEST_LV_0100_20150317_005305	Raymond asked you to gather Small Tree Branches and make a Crude Explorer Stick. 
-xQUEST_LV_0100_20150317_005306	Small Tree Branch
-xQUEST_LV_0100_20150317_005307	Find the First Piece of Gravestone
-xQUEST_LV_0100_20150317_005308	Made the Crude Explorer stick using the Small Tree Branches. Use it to find the First Piece of Gravestone.
-xQUEST_LV_0100_20150317_005309	Found the First Piece of Gravestone. Go back to Raymond. 
-xQUEST_LV_0100_20150317_005310	Find the Second Piece of Gravestone under Sekrus Bridge
-xQUEST_LV_0100_20150317_005311	Raymond told you where the Second Piece of Gravestone might be. First, make sure this unique slate is actually the Second Piece of Gravestone.
-xQUEST_LV_0100_20150317_005312	The unique slate wasn't the real thing, but you defeated Echat and got the Second Piece of Gravestone. Go back to Raymond. 
-xQUEST_LV_0100_20150317_005313	Defeat Echat
-xQUEST_LV_0100_20150317_005314	Collect the Dusty Ruins
-xQUEST_LV_0100_20150317_005315	Raymond asked you to collect pieces of the Dusty Ruins from Gaisra Battlefield. He told you to kill the Treeambuloes and get the Dusty Ruins back if they happen to steal any from you. 
-xQUEST_LV_0100_20150317_005316	Gathered enough Dusty Ruins. Give them to Raymond. 
-xQUEST_LV_0100_20150317_005317	Burn Treeambuloes and get Carbonized Pieces
-xQUEST_LV_0100_20150317_005318	Raymond told you to light the firewood in Gaisra Battlefield and kill the Treeambuloes, then burn them to get carbonized pieces. 
-xQUEST_LV_0100_20150317_005319	Collected enough Carbonized Pieces. Take them to Ryamond. 
-xQUEST_LV_0100_20150317_005320	Collect Carbonized Pieces of Ruin
+QUEST_LV_0100_20150317_005302	Create Crude Explorer Stick
+QUEST_LV_0100_20150317_005303	Epigraphis Raymond wants to use the branches of small tree to make an explorer stick and find the piece of memorial stone.
+QUEST_LV_0100_20150317_005304	Find the first piece of Memorial stone
+QUEST_LV_0100_20150317_005305	Raymond asked you to gather small tree branches from small tree and make an explorer stick.
+QUEST_LV_0100_20150317_005306	Small tree branch
+QUEST_LV_0100_20150317_005307	Find the first piece of Gravestone
+QUEST_LV_0100_20150317_005308	Made the Crude Explorer stick using the samll tree. Use it to find the firest piece of gravestone.
+QUEST_LV_0100_20150317_005309	Fond the first piece of gravestone. Go back to Raymond.
+QUEST_LV_0100_20150317_005310	Find the second piece of gravestone under Sekrus Bridge
+QUEST_LV_0100_20150317_005311	Raymond told you where the seconds piece of gravestone might be. First, check if this unique slate is the the second piece of gravestone.
+QUEST_LV_0100_20150317_005312	Could not find it in the unique slate but you defeated Echat and got the second piece of gravestone. Go back to Raymond.
+QUEST_LV_0100_20150317_005313	Defeat Echat
+QUEST_LV_0100_20150317_005314	Collect the dusty ruins
+QUEST_LV_0100_20150317_005315	Raymond asked you to collect pieces of dusty ruins from Gaisra Battlefield. He tols you to kill the Treeambulo and get it back if it steals the ruins from you.
+QUEST_LV_0100_20150317_005316	Gathered enough pieces of dusty ruins. Give it to Raymond.
+QUEST_LV_0100_20150317_005317	Burn Treeambulo and get carbonized pieces
+QUEST_LV_0100_20150317_005318	Raymond told you to light the firewood in Gaisra Battlefield and kill the Treeambulos to burn it to get carbonized pieces.
+QUEST_LV_0100_20150317_005319	Collected enough carbonized pieces. Take it to Ryamond.
+QUEST_LV_0100_20150317_005320	Collect carbonized pieces of ruins
 QUEST_LV_0100_20150317_005321	Go and talk to the Cleric Master in Klaipeda
 QUEST_LV_0100_20150317_005322	Learn about the Attributes
 QUEST_LV_0100_20150317_005323	Learn attributes and talk to the Cleric Master
 QUEST_LV_0100_20150317_005324	Read the Mausoleum cornerstone
 QUEST_LV_0100_20150317_005325	There is a cornerstone in the Mausoleum. Read it.
 QUEST_LV_0100_20150317_005326	Wake the sleeping Boowook
-QUEST_LV_0100_20150317_005327	Cornerstone says wake the sleeping guardians to and block the demons when they intrude. Wake the sleeping Boowook and block the demons. 
+QUEST_LV_0100_20150317_005327	Cornerstone says wake the sleeping guardians to and block the demons when they intrude. Wake the sleeping Boowook and block the demons.
 QUEST_LV_0100_20150317_005328	Find another epitaph
 QUEST_LV_0100_20150317_005329	Talk to Guard Rikke
 QUEST_LV_0100_20150317_005330	
 QUEST_LV_0100_20150317_005331	Remove the beehive
-QUEST_LV_0100_20150317_005332	Rikke is worried about the Bitereginas from Katyn Forest. Remove the beehives for Rikke. 
+QUEST_LV_0100_20150317_005332	Rikke is worried about the Bitereginas from Katyn Forest. Remove the beehives for Rikke.
 QUEST_LV_0100_20150317_005333	You barely defeated the angry Biteregina that appeared when you removed the beehive. Tell Rikke that there will no longer be threats to worry about.
 QUEST_LV_0100_20150317_005334	Talk to guard Era
 QUEST_LV_0100_20150317_005335	
 QUEST_LV_0100_20150317_005336	Get rid of Seedmia
-QUEST_LV_0100_20150317_005337	The Seedmias are causing trouble for Guard Era. Get rid of the Seedmias and go back to Era. 
-QUEST_LV_0100_20150317_005338	Got rid of seedmias as Era requested. Let Era know about it. 
+QUEST_LV_0100_20150317_005337	The Seedmias are causing trouble for Guard Era. Get rid of the Seedmias and go back to Era.
+QUEST_LV_0100_20150317_005338	Got rid of seedmias as Era requested. Let Era know about it.
 QUEST_LV_0100_20150317_005339	Get fats of Malidu
 QUEST_LV_0100_20150317_005340	Era says you need to wake up the sleeping Nepenthers before extracting from it. Kill the Maladus and get its fats to burn Nepenthers.
 QUEST_LV_0100_20150317_005341	Gathered enough fats as Era requested. Go back the guard .
 QUEST_LV_0100_20150317_005342	Get %s from Maladu
 QUEST_LV_0100_20150317_005343	Collect Maladu's fats
 QUEST_LV_0100_20150317_005344	Extract spiritual sap from Nepenthers
-QUEST_LV_0100_20150317_005345	Era told you to wake up the sleeping Nepenthers in Piene Plain by setting it on fire and get its extracts.  
-QUEST_LV_0100_20150317_005346	Collected all the spiritual extracts needed. Go back to Era. 
+QUEST_LV_0100_20150317_005345	Era told you to wake up the sleeping Nepenthers in Piene Plain by setting it on fire and get its extracts. 
+QUEST_LV_0100_20150317_005346	Collected all the spiritual extracts needed. Go back to Era.
 QUEST_LV_0100_20150317_005347	Brainwash the Pantos
-QUEST_LV_0100_20150317_005348	Rikke suggested to use the charm to brainwash Pantos like how the guards did long ago. 
-QUEST_LV_0100_20150317_005349	Successfully brainwashed Pantos but it is attacking the caster. Complain about it to Rikke. 
+QUEST_LV_0100_20150317_005348	Rikke suggested to use the charm to brainwash Pantos like how the guards did long ago.
+QUEST_LV_0100_20150317_005349	Successfully brainwashed Pantos but it is attacking the caster. Complain about it to Rikke.
 QUEST_LV_0100_20150317_005350	Control the Pantos to defeat Large Panto Spearman
 QUEST_LV_0100_20150317_005351	Rikke gave you a stronger charm as a sign of apology. Burn the Panto totem in Valyma Sanctuary and try again. Out pantos must also defeat the Large Panto Spearman.
-QUEST_LV_0100_20150317_005352	The Pantos are following orders when you burned the Panto Totem. Pantos defeated the Large Panto Spearman and the old charm seems useful. Tell Rikke about it. 
+QUEST_LV_0100_20150317_005352	The Pantos are following orders when you burned the Panto Totem. Pantos defeated the Large Panto Spearman and the old charm seems useful. Tell Rikke about it.
 QUEST_LV_0100_20150317_005353	Talk to Follower Alfonsas
 QUEST_LV_0100_20150317_005354	
 QUEST_LV_0100_20150317_005355	Alfonsas can't handle all the demons himself and asked for your help. Kill the demons along the way to the Church Courtyard.
-QUEST_LV_0100_20150317_005356	Killed enough demons as Alfonso asked. Go back to him. 
+QUEST_LV_0100_20150317_005356	Killed enough demons as Alfonso asked. Go back to him.
 QUEST_LV_0100_20150317_005357	Turn the demon summon circle
-QUEST_LV_0100_20150317_005358	Alsonsas says playing a trick with the demon's summon circle has great effects. Spoil the demon's summon circle. 
-QUEST_LV_0100_20150317_005359	A little vandalism on the summon circle absorbed back the summoned demons. It was small but a good try. Go back and let Alfonsas know about it. 
+QUEST_LV_0100_20150317_005358	Alsonsas says playing a trick with the demon's summon circle has great effects. Spoil the demon's summon circle.
+QUEST_LV_0100_20150317_005359	A little vandalism on the summon circle absorbed back the summoned demons. It was small but a good try. Go back and let Alfonsas know about it.
 QUEST_LV_0100_20150317_005360	Go to Alfonsas
 QUEST_LV_0100_20150317_005361	
 QUEST_LV_0100_20150317_005362	Chase Gesti
 QUEST_LV_0100_20150317_005363	Arrived at the church courtyard and saw Gesti entering the church. Defeat the Chapparition and follow Gesti.
-QUEST_LV_0100_20150317_005364	Defeated Chapparition but Gesti already blocked the entrance. Ask Algis for the next plan. 
+QUEST_LV_0100_20150317_005364	Defeated Chapparition but Gesti already blocked the entrance. Ask Algis for the next plan.
 QUEST_LV_0100_20150317_005365	Trace Rexipher
 QUEST_LV_0100_20150317_005366	
 QUEST_LV_0100_20150317_005367	Destroy the mausoleum protection device in Sesija Road
@@ -5371,8 +5371,8 @@ QUEST_LV_0100_20150317_005370	Destroyed the device in mausoleum as Rexipher want
 QUEST_LV_0100_20150317_005371	Mausoleum has had multiple devices to be protected from the demons. Humans can just pass by but guardians can be summoned if necessary. If there are reasons to summon, then activate the summoning device.
 QUEST_LV_0100_20150317_005372	Get rid of the Mausoleum guardians in Sesija Road
 QUEST_LV_0100_20150317_005373	Bearkaras appeared when you activated the device. Defeat it.
-QUEST_LV_0100_20150317_005374	When you defeat the guardians of Sesija Road, Rexipher disappeared through the road. You have to pass the road and follow Rexipher to save Cyrenia Odelle. He must be somewhere not too far. 
-QUEST_LV_0100_20150317_005375	Kill the Cactusvel summoned by Repxipher 
+QUEST_LV_0100_20150317_005374	When you defeat the guardians of Sesija Road, Rexipher disappeared through the road. You have to pass the road and follow Rexipher to save Cyrenia Odelle. He must be somewhere not too far.
+QUEST_LV_0100_20150317_005375	Kill the Cactusvel summoned by Repxipher
 QUEST_LV_0100_20150317_005376	Rexipher says he will spare Cyrenia Odell's life but.. Rexipher's summon suddenly attacked!
 QUEST_LV_0100_20150317_005377	Check the safety of Cyrenia Odelle
 QUEST_LV_0100_20150317_005378	Barely defeated Cactusvel. Check if Cyrenia Odelle is safe.
@@ -5389,27 +5389,27 @@ QUEST_LV_0100_20150317_005388	Help epigraphis Smid
 QUEST_LV_0100_20150317_005389	Magburk attacked and killed Smid as he was trying to get the rubbings of Ruklys memorial stone. Kill the Marbuk for Smid's revenge.
 QUEST_LV_0100_20150317_005390	Defeat Magburk
 QUEST_LV_0100_20150317_005391	Open the Gate
-QUEST_LV_0100_20150317_005392	Defeated Mummyghast. Open the church gate. 
-QUEST_LV_0100_20150317_005393	Opened the church gate. Talk to Follower Donatas. 
+QUEST_LV_0100_20150317_005392	Defeated Mummyghast. Open the church gate.
+QUEST_LV_0100_20150317_005393	Opened the church gate. Talk to Follower Donatas.
 QUEST_LV_0100_20150317_005394	Check the last gravestone
-QUEST_LV_0100_20150317_005395	Find the last gravestone of Lydia Schaffen in the Goddess' old courtyard and be enlightened. 
+QUEST_LV_0100_20150317_005395	Find the last gravestone of Lydia Schaffen in the Goddess' old courtyard and be enlightened.
 QUEST_LV_0100_20150317_005396	Talk to Hunter Tallus
 QUEST_LV_0100_20150317_005397	Hunter Tallus in the Old Courtyard of Goddess is looking for someone's help.
 QUEST_LV_0100_20150317_005398	Make a well-heated arrowhead
-QUEST_LV_0100_20150317_005399	Tallus asked you to make a heated arrowhead. Approach the Infro Burk in Shiluma Altar and heat the arrow that Tallus gave you. 
+QUEST_LV_0100_20150317_005399	Tallus asked you to make a heated arrowhead. Approach the Infro Burk in Shiluma Altar and heat the arrow that Tallus gave you.
 QUEST_LV_0100_20150317_005400	Made the heated arrowhead. Give it to Tallus.
 QUEST_LV_0100_20150317_005401	Talk to Necromancer Drasius
 QUEST_LV_0100_20150317_005402	Drasius in the Old Courtyard of Goddess is looking for someone to help his experiment.
-QUEST_LV_0100_20150317_005403	Bring the sacrifice to offering pot in Dumbal pond. 
+QUEST_LV_0100_20150317_005403	Bring the sacrifice to offering pot in Dumbal pond.
 QUEST_LV_0100_20150317_005404	Draius asked you to bring the sacrifies fo the offering pot in Dumbal pond for necromancing experiment.
 QUEST_LV_0100_20150317_005405	Defeat the Necroventer out of control
-QUEST_LV_0100_20150317_005406	Necroventer was summoned as a result of necromancing experiment. But it is out of control. Kill it before it causes too much harm. 
-QUEST_LV_0100_20150317_005407	The experiment failed but you managed to defeat the Necroventer. Tell Drasius about it. 
+QUEST_LV_0100_20150317_005406	Necroventer was summoned as a result of necromancing experiment. But it is out of control. Kill it before it causes too much harm.
+QUEST_LV_0100_20150317_005407	The experiment failed but you managed to defeat the Necroventer. Tell Drasius about it.
 QUEST_LV_0100_20150317_005408	Defeat Necroventer
 QUEST_LV_0100_20150317_005409	Talk to the wandering soul
 QUEST_LV_0100_20150317_005410	
 QUEST_LV_0100_20150317_005411	Return the trophy of war
-QUEST_LV_0100_20150317_005412	The wandering soul wants you to return the unicorn horn which was a trophy of war obtained by defeating the unicorn in Fedimian to Fedimian military official. Go find the military official. 
+QUEST_LV_0100_20150317_005412	The wandering soul wants you to return the unicorn horn which was a trophy of war obtained by defeating the unicorn in Fedimian to Fedimian military official. Go find the military official.
 QUEST_LV_0100_20150317_005413	Talk to the girl
 QUEST_LV_0100_20150317_005414	Tell the wandering soul's sister about her brother's death
 QUEST_LV_0100_20150317_005415	Talk to technician Orion
@@ -5431,7 +5431,7 @@ QUEST_LV_0100_20150317_005430	Place the amulet on the stone pillar
 QUEST_LV_0100_20150317_005431	Collected all amulets. Place the amulet in the stone pillar on the south of Geltonas Plateau.
 QUEST_LV_0100_20150317_005432	Monsters suddenly attacked. Get rid of them all.
 QUEST_LV_0100_20150317_005433	Talk to Archaeologist Fridka
-QUEST_LV_0100_20150317_005434	Got a very old map from the stone pillars. Give it to Fridka. 
+QUEST_LV_0100_20150317_005434	Got a very old map from the stone pillars. Give it to Fridka.
 QUEST_LV_0100_20150317_005435	Kill the monsters
 QUEST_LV_0100_20150317_005436	Looks like you broke the wooden seal for practice. Talk to the Highlander Master.
 QUEST_LV_0100_20150317_005437	Gather materials for repairing the wooden seal
@@ -5455,9 +5455,9 @@ QUEST_LV_0100_20150317_005454	Killed 15 monsters in 2 minutes. Talk to Romas.
 QUEST_LV_0100_20150317_005455	Kill monsters within 2 minutes
 QUEST_LV_0100_20150317_005456	The Paladin Master has something to say. Talk to him.
 QUEST_LV_0100_20150317_005457	Get rid of Field Boss Chapparition
-QUEST_LV_0100_20150317_005458	The Paladin Master says there is a monster slaying people. Find and defeat the spooky chapparition in Tenet Chapel. 
+QUEST_LV_0100_20150317_005458	The Paladin Master says there is a monster slaying people. Find and defeat the spooky chapparition in Tenet Chapel.
 QUEST_LV_0100_20150317_005459	Tenet Chapel
-QUEST_LV_0100_20150317_005460	Defeated the Chapparition. Report to the Paladin Master. 
+QUEST_LV_0100_20150317_005460	Defeated the Chapparition. Report to the Paladin Master.
 QUEST_LV_0100_20150317_005461	Defeat spooky Chaparition
 QUEST_LV_0100_20150317_005462	Talk to the resentful soul
 QUEST_LV_0100_20150317_005463	There is a person you see for the first time, but if blurry. Talk to him.
@@ -5473,7 +5473,7 @@ QUEST_LV_0100_20150317_005472	Talk to the messenger
 QUEST_LV_0100_20150317_005473	A messenger suddenly appeared. Talk to him.
 QUEST_LV_0100_20150317_005474	Deliver the letter to Ripper in Fedimian
 QUEST_LV_0100_20150317_005475	You can't just call on the messenger anytime. As a sign of apology, deliver the letter to Officer Ripper in Fedimian.
-QUEST_LV_0100_20150317_005476	Delivered the letter to Officer Ripper in Fedimian and received money. Give money to the messenger. 
+QUEST_LV_0100_20150317_005476	Delivered the letter to Officer Ripper in Fedimian and received money. Give money to the messenger.
 QUEST_LV_0100_20150317_005477	Mercenary Lint is staring at the food and looks pitiful. Talk to him.
 QUEST_LV_0100_20150317_005478	Get some food to give mercenary Lint.
 QUEST_LV_0100_20150317_005479	Lint wants the food you are preparing. Share the food with Lint. Doesn't matter if you cook it yourself or buy it.
@@ -5502,7 +5502,7 @@ QUEST_LV_0100_20150317_005501	Talk to the Archer Master
 QUEST_LV_0100_20150317_005502	Talk to Young Magician Owyn
 QUEST_LV_0100_20150317_005503	There is a young magician standing at the marked area of the map. He seems to need some help.
 QUEST_LV_0100_20150317_005504	Defeat the Phyracon seizing Maze Tower
-QUEST_LV_0100_20150317_005505	Owyn is trying to save the Maze Tower from the Demons. Get rid of the monsters nearby to help him. 
+QUEST_LV_0100_20150317_005505	Owyn is trying to save the Maze Tower from the Demons. Get rid of the monsters nearby to help him.
 QUEST_LV_0100_20150317_005506	Report to Owyn
 QUEST_LV_0100_20150317_005507	Done what Owyn requested. Go back to him.
 QUEST_LV_0100_20150317_005508	Defeat the Phyracon seizing Maze Tower 1st Floor
@@ -5537,7 +5537,7 @@ QUEST_LV_0100_20150317_005536	Talk to the Seal Stone
 QUEST_LV_0100_20150317_005537	Defeated the Blindlem and Beleggs. Return to the Seal stone and release the trapped soul.
 QUEST_LV_0100_20150317_005538	Kill the Blindlem
 QUEST_LV_0100_20150317_005539	Kill the Belegg
-QUEST_LV_0100_20150317_005540	Seal stone is in the forum. It seems like it needs help so talk to it. 
+QUEST_LV_0100_20150317_005540	Seal stone is in the forum. It seems like it needs help so talk to it.
 QUEST_LV_0100_20150317_005541	Kill the observer Golem
 QUEST_LV_0100_20150317_005542	Seal stone asked you to kill the observer and free its soul. Do the stone a favor.
 QUEST_LV_0100_20150317_005543	Killed the Golem. Talk to the Seal Stone.
@@ -5551,7 +5551,7 @@ QUEST_LV_0100_20150317_005550	The seal stone needs help. Talk to the stone.
 QUEST_LV_0100_20150317_005551	Kill the monsters nearby and get piece of Holy Ark.
 QUEST_LV_0100_20150317_005552	Seal stone says it need a Holy Ark to hold the soul. Get the pieces of Holy Ark from monsters nearby.
 QUEST_LV_0100_20150317_005553	Return to the seal stone and release the soul.
-QUEST_LV_0100_20150317_005554	There is a seal stone in the office. Talk to it. 
+QUEST_LV_0100_20150317_005554	There is a seal stone in the office. Talk to it.
 QUEST_LV_0100_20150317_005555	Kill the monsters nearby to release
 QUEST_LV_0100_20150317_005556	The soul restraint on the seal stone wants to be free. Kill the Blindlem and Shaman dolls to free it.
 QUEST_LV_0100_20150317_005557	Killed the Blindlem and Shaman doll. Return to the seal stone and free its soul.
@@ -5563,7 +5563,7 @@ QUEST_LV_0100_20150317_005562	Seal stone says it will do no harm and asks you to
 QUEST_LV_0100_20150317_005563	Report to the Seal Stone
 QUEST_LV_0100_20150317_005564	Killed the Observer Infro Rocktor as the seal stone wanted. Return to the stone and talk to it.
 QUEST_LV_0100_20150317_005565	Seal stone has more favors to ask. Talk to the stone.
-QUEST_LV_0100_20150317_005566	Kill Fallenlem and get the voice of seal stone 
+QUEST_LV_0100_20150317_005566	Kill Fallenlem and get the voice of seal stone
 QUEST_LV_0100_20150317_005567	The Seal Stone wants you to get back its stolen voice. Gather the voices of seal stone held by Fallenlem.
 QUEST_LV_0100_20150317_005568	Return and talk to the stone
 QUEST_LV_0100_20150317_005569	Gathered all the voices. Go back and give it to the stone.
@@ -5573,23 +5573,23 @@ QUEST_LV_0100_20150317_005572	Kill the monster that mocked the seal stone
 QUEST_LV_0100_20150317_005573	The seal stone asked you to get rid of the evil spirits that mocked it. Get rid of the evil spirits foir the stone.
 QUEST_LV_0100_20150317_005574	Got rid of the spirits that mocked the stone. Report to the stone.
 QUEST_LV_0100_20150317_005575	Kill Fallenlem
-QUEST_LV_0100_20150317_005576	Soul of the seal stone wants to be freed. Talk to it. 
+QUEST_LV_0100_20150317_005576	Soul of the seal stone wants to be freed. Talk to it.
 QUEST_LV_0100_20150317_005577	Kill the monsters nearby and get Trap Crystal
 QUEST_LV_0100_20150317_005578	The soul of seal stone wants to be freed. Gather Trap Crystal from the monsters nearby.
 QUEST_LV_0100_20150317_005579	Collected all the crystals. Go back and report to the seal stone.
 QUEST_LV_0100_20150317_005580	Find the suspicious table
-QUEST_LV_0100_20150317_005581	There is a suspicious table in the office. Can you talk to it? 
+QUEST_LV_0100_20150317_005581	There is a suspicious table in the office. Can you talk to it?
 QUEST_LV_0100_20150317_005582	Get rid of the Golems
-QUEST_LV_0100_20150317_005583	Golem is aiming your back like the table said. Kill the Golem first. 
+QUEST_LV_0100_20150317_005583	Golem is aiming your back like the table said. Kill the Golem first.
 QUEST_LV_0100_20150317_005584	Talk to the suspicous table
 QUEST_LV_0100_20150317_005585	Seems like you got out of danger. Talk to the weird and polite table.
 QUEST_LV_0100_20150317_005586	Get rid of the Gray Golem
 QUEST_LV_0100_20150317_005587	Talk to transmuter Furry Ode
-QUEST_LV_0100_20150317_005588	There is a lady wizard in the resting area. Talk to her. 
+QUEST_LV_0100_20150317_005588	There is a lady wizard in the resting area. Talk to her.
 QUEST_LV_0100_20150317_005589	Kill the monsters nearby and get mutant whip
 QUEST_LV_0100_20150317_005590	Furry Ode needs more mutant whips to get rid of the monsters effectively. Get the whip from monsters nearby.
 QUEST_LV_0100_20150317_005591	Give the whip to Furry Ode
-QUEST_LV_0100_20150317_005592	Collected all the whips needed. Give it to Furry Ode. 
+QUEST_LV_0100_20150317_005592	Collected all the whips needed. Give it to Furry Ode.
 QUEST_LV_0100_20150317_005593	Furry Ode seems to have more favors to ask. Talk to her again.
 QUEST_LV_0100_20150317_005594	Kill the monsters and get the hardened crystal
 QUEST_LV_0100_20150317_005595	Furry Ode says let's meet in Machinery room 1 and tells you to bring the hardened crystal when you meet her. Get the crystals from the monsters nearby.
@@ -5598,23 +5598,23 @@ QUEST_LV_0100_20150317_005597	Got the hardened crystals. Join Furry Ode in Machi
 QUEST_LV_0100_20150317_005598	Met Furry Ode near the machine room. Talk to her.
 QUEST_LV_0100_20150317_005599	Defeat Yonazolem
 QUEST_LV_0100_20150317_005600	Furry Ode says she saw Yonazolem inside the machine room. Kill Yonazolem while Furry Ode blocks the monsters in the entrance.
-QUEST_LV_0100_20150317_005601	Defeated Yonazolem. Go back to Furry Ode. 
-QUEST_LV_0100_20150317_005602	There is a seal stone near the spell stabilizer. Talk to it. 
+QUEST_LV_0100_20150317_005601	Defeated Yonazolem. Go back to Furry Ode.
+QUEST_LV_0100_20150317_005602	There is a seal stone near the spell stabilizer. Talk to it.
 QUEST_LV_0100_20150317_005603	Seal stone asked you to kill the monsters nearby so that it can be freed. What will happen when all of it are freed? First, get rid of the monsters as the seal requested.
 QUEST_LV_0100_20150317_005604	Finished the request of the seal stone. Release the soul.
 QUEST_LV_0100_20150317_005605	Find the Seal Stone
-QUEST_LV_0100_20150317_005606	There is a seal stone in Machine Room 2. Talk to it. 
+QUEST_LV_0100_20150317_005606	There is a seal stone in Machine Room 2. Talk to it.
 QUEST_LV_0100_20150317_005607	Killed the monsters around. Go to the stone and release the possessed soul.
 QUEST_LV_0100_20150317_005608	Talk to Simon Shaw
 QUEST_LV_0100_20150317_005609	There is a well dressed gentleman-like wizard blocking the monsters. Talk to Simon Shaw.
 QUEST_LV_0100_20150317_005610	Kill Black Drake and retrieve the Flame Charms
-QUEST_LV_0100_20150317_005611	Simon Shaw is doing his best to block the monsters. Help him retrieve the flame charms that he planted on monsters. 
+QUEST_LV_0100_20150317_005611	Simon Shaw is doing his best to block the monsters. Help him retrieve the flame charms that he planted on monsters.
 QUEST_LV_0100_20150317_005612	Give flame charms to Simon Shaw
 QUEST_LV_0100_20150317_005613	Retrieved all flame charms. Give it to Simon Shaw.
 QUEST_LV_0100_20150317_005614	Kill Black Drake and get %s
 QUEST_LV_0100_20150317_005615	Simon Shaw saw something. Talk to thim.
 QUEST_LV_0100_20150317_005616	Get rid of the monsters nearby
-QUEST_LV_0100_20150317_005617	Simon Shaw says he saw Bearkaras and will chase him. Block the monsters marching in while Simon chases Bearkaras. 
+QUEST_LV_0100_20150317_005617	Simon Shaw says he saw Bearkaras and will chase him. Block the monsters marching in while Simon chases Bearkaras.
 QUEST_LV_0100_20150317_005618	Find Simon Shaw
 QUEST_LV_0100_20150317_005619	Simon Shaw is not coming back. Go to the small hall where he went chasing Bearkaras.
 QUEST_LV_0100_20150317_005620	Simon looks very tired. Talk to him.
@@ -5637,35 +5637,35 @@ QUEST_LV_0100_20150317_005636	Defeat Helga Sercle that invaded the Maze Tower
 QUEST_LV_0100_20150317_005637	Talk to guard Gilbert
 QUEST_LV_0100_20150317_005638	
 QUEST_LV_0100_20150317_005639	Get rid of Grummer and Seedmia
-QUEST_LV_0100_20150317_005640	Gilbert wants you to get rid of the monsters that destroyed the cable car. Get rid of them in Cholas Crooked Road and tell Gilbert about it. 
-QUEST_LV_0100_20150317_005641	Scolded and Grummer and Seedmia. Tell Gilbert you taught them a lesson. 
+QUEST_LV_0100_20150317_005640	Gilbert wants you to get rid of the monsters that destroyed the cable car. Get rid of them in Cholas Crooked Road and tell Gilbert about it.
+QUEST_LV_0100_20150317_005641	Scolded and Grummer and Seedmia. Tell Gilbert you taught them a lesson.
 QUEST_LV_0100_20150317_005642	Kill the Zignuts
 QUEST_LV_0100_20150317_005643	Kill the Grumers
 QUEST_LV_0100_20150317_005644	Kill the Pantos and retreive the cogwheel
-QUEST_LV_0100_20150317_005645	Gilbert says that Pantos in Mieguista Hill stole cable car cogwheels. Get rid of them to get back the wheels and return it to Gilbert. 
-QUEST_LV_0100_20150317_005646	Got the cogwheels by defeating the Pantos. Return it to Gilbert. 
+QUEST_LV_0100_20150317_005645	Gilbert says that Pantos in Mieguista Hill stole cable car cogwheels. Get rid of them to get back the wheels and return it to Gilbert.
+QUEST_LV_0100_20150317_005646	Got the cogwheels by defeating the Pantos. Return it to Gilbert.
 QUEST_LV_0100_20150317_005647	Kill Pantos and get %s
 QUEST_LV_0100_20150317_005648	Get rid of the Pantos
 QUEST_LV_0100_20150317_005649	Fing the lever handle clamp
-QUEST_LV_0100_20150317_005650	Pantos in Mieguista Hill stole cable car parts and hid it in the grass. Find the lever handle from the grass. 
-QUEST_LV_0100_20150317_005651	Found the level handle clamp in the grass. Go back to Gilbert. 
+QUEST_LV_0100_20150317_005650	Pantos in Mieguista Hill stole cable car parts and hid it in the grass. Find the lever handle from the grass.
+QUEST_LV_0100_20150317_005651	Found the level handle clamp in the grass. Go back to Gilbert.
 QUEST_LV_0100_20150317_005652	Talk to the guard
 QUEST_LV_0100_20150317_005653	Give sugar beets to baby panto
 QUEST_LV_0100_20150317_005654	Molly says you can use the sugar beets to lure the Baby Pantos. Approach the Baby Pantos and use the sugar beets!
-QUEST_LV_0100_20150317_005655	Lured the baby pantos with sugar beets. Listen to Molly's next plans. 
+QUEST_LV_0100_20150317_005655	Lured the baby pantos with sugar beets. Listen to Molly's next plans.
 QUEST_LV_0100_20150317_005656	Talk to guard Mathew
 QUEST_LV_0100_20150317_005657	Retrieve cable car parts
 QUEST_LV_0100_20150317_005658	Guard Mathew asked for your felp to find cable car parts that the Zignuts swallowed around the Nepavy Area.
-QUEST_LV_0100_20150317_005659	Found all the cable car parts as Mathew asked. Give it to Mathew. 
-QUEST_LV_0100_20150317_005660	Retrieve parts swallowed by Zignuts %s 
+QUEST_LV_0100_20150317_005659	Found all the cable car parts as Mathew asked. Give it to Mathew.
+QUEST_LV_0100_20150317_005660	Retrieve parts swallowed by Zignuts %s
 QUEST_LV_0100_20150317_005661	Kill Poatas that threaten the cable car
-QUEST_LV_0100_20150317_005662	Mathew asked you to get rid of the Pantos that might destroy the cable car again. Soil Poata's habitat in Margas Hills and lure them to get rid of them. 
-QUEST_LV_0100_20150317_005663	Got rid of Poatas as Mathew requested. Tell the good news to Mathew. 
+QUEST_LV_0100_20150317_005662	Mathew asked you to get rid of the Pantos that might destroy the cable car again. Soil Poata's habitat in Margas Hills and lure them to get rid of them.
+QUEST_LV_0100_20150317_005663	Got rid of Poatas as Mathew requested. Tell the good news to Mathew.
 QUEST_LV_0100_20150317_005664	Get rid of Poata
 QUEST_LV_0100_20150317_005665	Talk to Molly
 QUEST_LV_0100_20150317_005666	Molly is looking for someone brave to help her great plan.
 QUEST_LV_0100_20150317_005667	Bring the baby pantos and find Capria
-QUEST_LV_0100_20150317_005668	Molly said try to persuade the Capria with baby pantos. But you're not sure it will work. You can find Capria on the way to Leaf Veil Plateau after Spilva Crossroad.  
+QUEST_LV_0100_20150317_005668	Molly said try to persuade the Capria with baby pantos. But you're not sure it will work. You can find Capria on the way to Leaf Veil Plateau after Spilva Crossroad. 
 QUEST_LV_0100_20150317_005669	
 QUEST_LV_0100_20150317_005670	Capria treatment
 QUEST_LV_0100_20150317_005671	Meet the Paladin Master
@@ -5684,32 +5684,32 @@ QUEST_LV_0100_20150317_005683	Block Simorph
 QUEST_LV_0100_20150317_005684	Defeat Simorph with the shaman dolls
 QUEST_LV_0100_20150317_005685	Defeat Simorph in Valio Uphill
 QUEST_LV_0100_20150317_005686	Destroyed all the totems as requested. Search and find Simorph.
-QUEST_LV_0100_20150317_005687	Defeated Simorph with the shaman dolls as Mori requested. Tell Mori about it. 
+QUEST_LV_0100_20150317_005687	Defeated Simorph with the shaman dolls as Mori requested. Tell Mori about it.
 QUEST_LV_0100_20150317_005688	Purify the Demon polluted area
-QUEST_LV_0100_20150317_005689	Use the summon scroll to summon shaman dolls and bring them to Labure Road. Shaman dolls will find the demon polluted area. 
+QUEST_LV_0100_20150317_005689	Use the summon scroll to summon shaman dolls and bring them to Labure Road. Shaman dolls will find the demon polluted area.
 QUEST_LV_0100_20150317_005690	Defeat the wild Carnivore
 QUEST_LV_0100_20150317_005691	Defeat the Carnivore that has gone wild because of the demon pollution
 QUEST_LV_0100_20150317_005692	Defeat the wild Carnivore in Pasiulyma Plains
-QUEST_LV_0100_20150317_005693	Purified the polluted area and defeated Carnivore are Mori requested. Tell Mori about it. 
+QUEST_LV_0100_20150317_005693	Purified the polluted area and defeated Carnivore are Mori requested. Tell Mori about it.
 QUEST_LV_0100_20150317_005694	Collect rope for ritual
-QUEST_LV_0100_20150317_005695	Basil says the Pantos in Forest Keeper Cabin have the rope needed to restore the shaman dolls. He says you can use force if words won't do and looks like you will have to. 
+QUEST_LV_0100_20150317_005695	Basil says the Pantos in Forest Keeper Cabin have the rope needed to restore the shaman dolls. He says you can use force if words won't do and looks like you will have to.
 QUEST_LV_0100_20150317_005696	Used some force to gather enough ropes. Give it to Basil.
 QUEST_LV_0100_20150317_005697	Kill Panto Shamans and get %s
 QUEST_LV_0100_20150317_005698	Get rope for ritual
 QUEST_LV_0100_20150317_005699	Collect mane with spiritual force
-QUEST_LV_0100_20150317_005700	Basil asked you go hunt the Mushcarias in Tustinti Plateau and collect manes with spiritual forces. 
+QUEST_LV_0100_20150317_005700	Basil asked you go hunt the Mushcarias in Tustinti Plateau and collect manes with spiritual forces.
 QUEST_LV_0100_20150317_005701	Hunted Mushcarias and got the manes. Give it to Basil.
 QUEST_LV_0100_20150317_005702	Kill Mushcaria and get %s
 QUEST_LV_0100_20150317_005703	Get mane with spiritual force
 QUEST_LV_0100_20150317_005704	Talk to Goddess Saule
 QUEST_LV_0100_20150317_005705	The lady trapped was Goddess Saule. Talk to Goddess Saule.
 QUEST_LV_0100_20150317_005706	Destroy the restraining magic circle
-QUEST_LV_0100_20150317_005707	Goddess is trapped by the demons and can't use her powers. Destroy the magic circle that is trapping the Goddess in Drugys Courtyard and Vapsva Vacant Lot. 
-QUEST_LV_0100_20150317_005708	Destroyed all the restraining magic circle. Talk to Goddess Saule. 
+QUEST_LV_0100_20150317_005707	Goddess is trapped by the demons and can't use her powers. Destroy the magic circle that is trapping the Goddess in Drugys Courtyard and Vapsva Vacant Lot.
+QUEST_LV_0100_20150317_005708	Destroyed all the restraining magic circle. Talk to Goddess Saule.
 QUEST_LV_0100_20150317_005709	Check the barrier of the Grand Altar
 QUEST_LV_0100_20150317_005710	You're blocked by the barrier. Check the Grand Altar barrier. ]
 QUEST_LV_0100_20150317_005711	Kill the demon restraining the Goddess
-QUEST_LV_0100_20150317_005712	The barrier disappeared and you can someone trapped by the demons. First. get rid of the demons. 
+QUEST_LV_0100_20150317_005712	The barrier disappeared and you can someone trapped by the demons. First. get rid of the demons.
 QUEST_LV_0100_20150317_005713	Talk to the lady
 QUEST_LV_0100_20150317_005714	Defeated the demons that were trapping the lady. She seens to have a strong and holy power. Talk to the lady.
 QUEST_LV_0100_20150317_005715	Kill the Harpeia
@@ -5720,7 +5720,7 @@ QUEST_LV_0100_20150317_005719	There is a restraining magic circle with dark aura
 QUEST_LV_0100_20150317_005720	Defeat Merge
 QUEST_LV_0100_20150317_005721	Removed the magic circle that was trapping Goddess Saule but it is not enough. Talk to Goddess Saule again.
 QUEST_LV_0100_20150317_005722	Collect materials for memorial in Grand Hall
-QUEST_LV_0100_20150317_005723	Goddess Saule says the observer Clymen hid into the gap of dimension but her strength is not recovered yet so she can't find him. Get materials for memorial in Grand Hall to help the Goddess regain her powers. 
+QUEST_LV_0100_20150317_005723	Goddess Saule says the observer Clymen hid into the gap of dimension but her strength is not recovered yet so she can't find him. Get materials for memorial in Grand Hall to help the Goddess regain her powers.
 QUEST_LV_0100_20150317_005724	Give it to Goddess Saule
 QUEST_LV_0100_20150317_005725	Found the materials to help the Goddess. Give it to the Goddess.
 QUEST_LV_0100_20150317_005726	Done preparing to help the Goddess regain her strength. Talk to Goddess Saule.
@@ -5729,20 +5729,20 @@ QUEST_LV_0100_20150317_005728	Goddess Saule says getting rid of the monsters nea
 QUEST_LV_0100_20150317_005729	Seems like Goddess Saule found the demons. Go back to Goddess Saule.
 QUEST_LV_0100_20150317_005730	Defeat the monsters near the Grand Altar
 QUEST_LV_0100_20150317_005731	Release the Demon barrier
-QUEST_LV_0100_20150317_005732	Goddess Saule got her strength back with the help of memorial materials. She found the barrier with the demon who has the key. Go 
+QUEST_LV_0100_20150317_005732	Goddess Saule got her strength back with the help of memorial materials. She found the barrier with the demon who has the key. Go
 QUEST_LV_0100_20150317_005733	Kill the demon that has the key
-QUEST_LV_0100_20150317_005734	Goddess Saule successfully regained her strength from the materials and found the barrier where the demon with key is located. Defeat the demons that appear from the barrier and get the key. 
-QUEST_LV_0100_20150317_005735	Found the key for releasing Goddess Saule. Bring the key to the Goddess. 
+QUEST_LV_0100_20150317_005734	Goddess Saule successfully regained her strength from the materials and found the barrier where the demon with key is located. Defeat the demons that appear from the barrier and get the key.
+QUEST_LV_0100_20150317_005735	Found the key for releasing Goddess Saule. Bring the key to the Goddess.
 QUEST_LV_0100_20150317_005736	Remove the circle trapping Goddess Saule
 QUEST_LV_0100_20150317_005737	Use the key to release Goddess Saule.
 QUEST_LV_0100_20150317_005738	Goddess Saule is freed. Talk to her.
-QUEST_LV_0100_20150317_005739	Defeated Bramble and got the revelation. Go back to Goddess Saule. 
+QUEST_LV_0100_20150317_005739	Defeated Bramble and got the revelation. Go back to Goddess Saule.
 QUEST_LV_0100_20150317_005740	The revelation tells you to go to King Zachariel's Mausoleum. Talk to the Goddess.
 QUEST_LV_0100_20150317_005741	
 QUEST_LV_0100_20150317_005742	
 QUEST_LV_0100_20150317_005743	Colelt Purifying Stone of Tanu
-QUEST_LV_0100_20150317_005744	You need to use the porta to go to Goddess Saule but it is not working. The old mans you need to collect Purifying stone of Tanu to activate the the portal. 
-QUEST_LV_0100_20150317_005745	Collected all the purifying stones needed. Use it to purify the Holy Pond. 
+QUEST_LV_0100_20150317_005744	You need to use the porta to go to Goddess Saule but it is not working. The old mans you need to collect Purifying stone of Tanu to activate the the portal.
+QUEST_LV_0100_20150317_005745	Collected all the purifying stones needed. Use it to purify the Holy Pond.
 QUEST_LV_0100_20150317_005746	Purify the holy  Pond to use the portal.
 QUEST_LV_0100_20150317_005747	Report the to the Old Man
 QUEST_LV_0100_20150317_005748	Purified the Holy Pond. Go back to the old man and ask about the portal mentioned in the revelation.
@@ -5752,35 +5752,35 @@ QUEST_LV_0100_20150317_005751	The old man says he sent a villager to Nugria Sanc
 QUEST_LV_0100_20150317_005752	Talk to the injured villager
 QUEST_LV_0100_20150317_005753	Defeated the monster that attacked the villager. Talk to the villager.
 QUEST_LV_0100_20150317_005754	Kill the monster that attacked the villager
-QUEST_LV_0100_20150317_005755	Found the villager but he seems hurt. Ask what happened. 
+QUEST_LV_0100_20150317_005755	Found the villager but he seems hurt. Ask what happened.
 QUEST_LV_0100_20150317_005756	Check Altar in Nugria Altar
 QUEST_LV_0100_20150317_005757	The villager says he was attacked on his way to check on the portal. Go and check if the portal in Nugria Sanctuary is open for the villager.
-QUEST_LV_0100_20150317_005758	Purified the Holy Pond but the portal in Nugria Sanctuary did not open. Go back to the injured villager and ask what to do. 
+QUEST_LV_0100_20150317_005758	Purified the Holy Pond but the portal in Nugria Sanctuary did not open. Go back to the injured villager and ask what to do.
 QUEST_LV_0100_20150317_005759	Check the Portal of Nugria Sanctuary
 QUEST_LV_0100_20150317_005760	Check the Portal in Nugria Sanctuary.
 QUEST_LV_0100_20150317_005761	Get rid of the Moyabruka
 QUEST_LV_0100_20150317_005762	Check the source of pollution in Veidma Uphill
-QUEST_LV_0100_20150317_005763	Something is polluting the surroundings of Veidma Uphills. Get rid of the source. 
-QUEST_LV_0100_20150317_005764	The source of pollution is becoming stronger with the monsters. Get rid of the monsters nearby and remove the source when it is weakened. 
+QUEST_LV_0100_20150317_005763	Something is polluting the surroundings of Veidma Uphills. Get rid of the source.
+QUEST_LV_0100_20150317_005764	The source of pollution is becoming stronger with the monsters. Get rid of the monsters nearby and remove the source when it is weakened.
 QUEST_LV_0100_20150317_005765	Check the Holy Pond
-QUEST_LV_0100_20150317_005766	The pollution in the Holy Pond seems serious. Check the Pond. 
+QUEST_LV_0100_20150317_005766	The pollution in the Holy Pond seems serious. Check the Pond.
 QUEST_LV_0100_20150317_005767	Defeat Merregina
 QUEST_LV_0100_20150317_005768	Go to the Altar of Nugria Sanctuary
 QUEST_LV_0100_20150317_005769	
 QUEST_LV_0100_20150317_005770	Use the seal of space
 QUEST_LV_0100_20150317_005771	
 QUEST_LV_0100_20150317_005772	Hidden mausoleum book appeared
-QUEST_LV_0100_20150317_005773	A book hidden somewhere in the 5th floof of mausoleum appeared. Talk to it. 
+QUEST_LV_0100_20150317_005773	A book hidden somewhere in the 5th floof of mausoleum appeared. Talk to it.
 QUEST_LV_0100_20150317_005774	Get the mission item
-QUEST_LV_0100_20150317_005775	The mausoleum book wants blood stone. Better get it before the book disappeares. Lizardman in the Old Courtyard of Goddess will be an answer. 
+QUEST_LV_0100_20150317_005775	The mausoleum book wants blood stone. Better get it before the book disappeares. Lizardman in the Old Courtyard of Goddess will be an answer.
 QUEST_LV_0100_20150317_005776	Talk to the mausoleum book
-QUEST_LV_0100_20150317_005777	Talk to the book again. If the book disappeared, you have to wait until it appears again. 
+QUEST_LV_0100_20150317_005777	Talk to the book again. If the book disappeared, you have to wait until it appears again.
 QUEST_LV_0100_20150317_005778	Bring %s
-QUEST_LV_0100_20150317_005779	Talk to Koven 
+QUEST_LV_0100_20150317_005779	Talk to Koven
 QUEST_LV_0100_20150317_005780	Find the Treasure Chest
 QUEST_LV_0100_20150317_005781	Find the Treasure chest hidden somehwere in the Crystal Stream. It can be opened it with the key Koven gave you.
 QUEST_LV_0100_20150317_005782	Talk to Furry Ode
-QUEST_LV_0100_20150317_005783	Furry Ode is surprised with the bag full of Drake's Horn. Talk to her. 
+QUEST_LV_0100_20150317_005783	Furry Ode is surprised with the bag full of Drake's Horn. Talk to her.
 QUEST_LV_0100_20150317_005784	Make badge of Drake
 QUEST_LV_0100_20150317_005785	Received recipe from Furry Ode
 QUEST_LV_0100_20150317_005786	key can be used to create the badge of Drake
@@ -5790,7 +5790,7 @@ QUEST_LV_0100_20150317_005789	Talk to all the masters. Talk to the Thaumaturge M
 QUEST_LV_0100_20150317_005790	Find the Wizards in Maze Tower
 QUEST_LV_0100_20150317_005791	The Thaumaturge Master offered a bet. You have to meet all the wizards in Maze Tower and solve the quiz question sthey give.
 QUEST_LV_0100_20150317_005792	Solve the quiz of Simon Shaw in Maze Tower 5th Floor
-QUEST_LV_0100_20150317_005793	Solved quizzes of three wizards. Talk to Simon Shaw in Maze Tower 5th Floor for the last quiz question. 
+QUEST_LV_0100_20150317_005793	Solved quizzes of three wizards. Talk to Simon Shaw in Maze Tower 5th Floor for the last quiz question.
 QUEST_LV_0100_20150317_005794	Talk to Simon Shaw for the last quiz question.
 QUEST_LV_0100_20150317_005795	Find the page of book in Maze Tower 3rd Floor Laboratory
 QUEST_LV_0100_20150317_005796	Simon Shaw offered bringing him a page of book instead of the quiz. Find the book in Maze Tower 3rd Flood Laboratory.
@@ -5798,26 +5798,26 @@ QUEST_LV_0100_20150317_005797	Give it to Simon Shaw
 QUEST_LV_0100_20150317_005798	Found all the pages. Talk to Simon Shaw.
 QUEST_LV_0100_20150317_005799	The Sadhu Master is looking at you with a grin. Talk to him,
 QUEST_LV_0100_20150317_005800	Collect amber with lizard in it
-QUEST_LV_0100_20150317_005801	The Sadhu Master wants you to bring him something dearly. Get him the amber with lizard in it. 
+QUEST_LV_0100_20150317_005801	The Sadhu Master wants you to bring him something dearly. Get him the amber with lizard in it.
 QUEST_LV_0100_20150317_005802	Got the amber with lizard. Give it to the Sadhu Master.
 QUEST_LV_0100_20150317_005803	Get %s
 QUEST_LV_0100_20150317_005804	Talk to unknown being
 QUEST_LV_0100_20150317_005805	You can hear a stange voice somewhere. Talk to the unknown being.
 QUEST_LV_0100_20150317_005806	Enter the clue
-QUEST_LV_0100_20150317_005807	The unknown being says you need to bring more clues for him to talk. Find and enter the five clues from Crustal Mines 1st Floor. 
-QUEST_LV_0100_20150317_005808	Found the glues about the unknown being. Talk to the unknow being again. 
+QUEST_LV_0100_20150317_005807	The unknown being says you need to bring more clues for him to talk. Find and enter the five clues from Crustal Mines 1st Floor.
+QUEST_LV_0100_20150317_005808	Found the glues about the unknown being. Talk to the unknow being again.
 QUEST_LV_0100_20150317_005809	Hunting.
 QUEST_LV_0100_20150317_005810	The unknown being gave you a riddle stating,
 QUEST_LV_0100_20150317_005811	the thing to do, thing that has been done, and will keep doing.
 QUEST_LV_0100_20150317_005812	Show your answer through action.
-QUEST_LV_0100_20150317_005813	Solved the riddle. Talk to the unknown being. 
+QUEST_LV_0100_20150317_005813	Solved the riddle. Talk to the unknown being.
 QUEST_LV_0100_20150317_005814	Answer to the riddle
 QUEST_LV_0100_20150317_005815	Release the seal in Pasaga Cliff
 QUEST_LV_0100_20150317_005816	
-QUEST_LV_0100_20150317_005817	Monsters suddenly appeared as you tried to remove the seal. Get rid of them and protect yourself. 
-QUEST_LV_0100_20150317_005818	Killed all the monsters that were interfering. Try to release the seal again. 
+QUEST_LV_0100_20150317_005817	Monsters suddenly appeared as you tried to remove the seal. Get rid of them and protect yourself.
+QUEST_LV_0100_20150317_005818	Killed all the monsters that were interfering. Try to release the seal again.
 QUEST_LV_0100_20150317_005819	
-QUEST_LV_0100_20150317_005820	You removed the seal then other protection devices were summoned. Destroy all the protective devices. 
+QUEST_LV_0100_20150317_005820	You removed the seal then other protection devices were summoned. Destroy all the protective devices.
 QUEST_LV_0100_20150317_005821	Destroy the protective device
 QUEST_LV_0100_20150317_005822	
 QUEST_LV_0100_20150317_005823	BiteRegina appeared when you removed the seal! Defeaat it!
@@ -5826,7 +5826,7 @@ QUEST_LV_0100_20150317_005825	Check the stone pillars of Alkune Uphill
 QUEST_LV_0100_20150317_005826	Now that you have taken care of the monsters, check the stones pillars around Alkune Uphill. You will be able to find traces of relics in the pillars.
 QUEST_LV_0100_20150317_005827	Retrieved all the relics of Raudi. Go back and give the relics to Raune.
 QUEST_LV_0100_20150317_005828	Check the Epitaph
-QUEST_LV_0100_20150317_005829	There are epitaphs about the mausoleum in Shirnas Plateau. Check the epitaph of Shirnas which is one of it. 
+QUEST_LV_0100_20150317_005829	There are epitaphs about the mausoleum in Shirnas Plateau. Check the epitaph of Shirnas which is one of it.
 QUEST_LV_0100_20150317_005830	Get rid of the monsters nearby the Epitaph
 QUEST_LV_0100_20150317_005831	Monsters appeared as if to protect the epitaph when you touched it! Get rid of the monsters first then check the epitaph.
 QUEST_LV_0100_20150317_005832	Check the epitaph again
@@ -5840,9 +5840,9 @@ QUEST_LV_0100_20150317_005839	Defeat Zinutekas
 QUEST_LV_0100_20150317_005840	Body of the collapsed mercenary
 QUEST_LV_0100_20150317_005841	There are many dead people around due to the monsters' raid. Approach and comfort them.
 QUEST_LV_0100_20150317_005842	Ambush of Hogmas
-QUEST_LV_0100_20150317_005843	Hogmas hiding appeared when you touched the dead body. Get rid of them. 
+QUEST_LV_0100_20150317_005843	Hogmas hiding appeared when you touched the dead body. Get rid of them.
 QUEST_LV_0100_20150317_005844	Confort the body to rest in peace
-QUEST_LV_0100_20150317_005845	Defeated all the monsters nearby. Comfor the bodies to rest in peace. 
+QUEST_LV_0100_20150317_005845	Defeated all the monsters nearby. Comfor the bodies to rest in peace.
 QUEST_LV_0100_20150317_005846	Defeat the Hogmas ambushing
 QUEST_LV_0100_20150317_005847	Altar of Cedek
 QUEST_LV_0100_20150317_005848	
@@ -5862,7 +5862,7 @@ QUEST_LV_0100_20150317_005861	What the guard is searching for
 QUEST_LV_0100_20150317_005862	Told him that the treasure chest was empty. But the guard still seems like he needs more help. Talk to him.
 QUEST_LV_0100_20150317_005863	Find necklace from the Hogmas
 QUEST_LV_0100_20150317_005864	When you use the V key, the body of hogma leader with the necklace will shine. Find the necklace and give it to the guard.
-QUEST_LV_0100_20150317_005865	Bring the neckalce 
+QUEST_LV_0100_20150317_005865	Bring the neckalce
 QUEST_LV_0100_20150317_005866	Found the necklace the guard was looking for. Bring it to the guard.
 QUEST_LV_0100_20150317_005867	
 QUEST_LV_0100_20150317_005868	
@@ -5895,40 +5895,40 @@ QUEST_LV_0100_20150317_005894
 QUEST_LV_0100_20150317_005895	Interferance of Lepus blocking the way
 QUEST_LV_0100_20150317_005896	Defeat Lepus that is blocking the way
 QUEST_LV_0100_20150317_005897	Talk to soldier Moody
-QUEST_LV_0100_20150317_005898	Commander Liudas is asking Moody to bring the report on Sparnas. Go find Soldier Moody in Amzina Crooked Road. 
+QUEST_LV_0100_20150317_005898	Commander Liudas is asking Moody to bring the report on Sparnas. Go find Soldier Moody in Amzina Crooked Road.
 QUEST_LV_0100_20150317_005899	Retrieve the report that Siaulambs took away
 QUEST_LV_0100_20150317_005900	Moody says he lost the report while fighting against the Siaulambs. Find the report for him.
 QUEST_LV_0100_20150317_005901	Give it to Officer Liudas
-QUEST_LV_0100_20150317_005902	Moody found the lost report. Give the report to Officer Liudas. 
+QUEST_LV_0100_20150317_005902	Moody found the lost report. Give the report to Officer Liudas.
 QUEST_LV_0100_20150317_005903	Defeat Siaulago and get %s
 QUEST_LV_0100_20150317_005904	Siaulago
 QUEST_LV_0100_20150317_005905	Talk to Adjudant Volda
-QUEST_LV_0100_20150317_005906	Volda got back the stolen supplies and is enraged for revenge. Talk to Volda again. 
+QUEST_LV_0100_20150317_005906	Volda got back the stolen supplies and is enraged for revenge. Talk to Volda again.
 QUEST_LV_0100_20150317_005907	Stealing the Trophy box
-QUEST_LV_0100_20150317_005908	Volda says revenge must be made by stealing the Siaulamb's trophy box. Steal the pile of Siaulamb's trphy boxes in Ziedo pond. 
-QUEST_LV_0100_20150317_005909	Stole all of Siaulamb's trophies. Give it to Volda. 
+QUEST_LV_0100_20150317_005908	Volda says revenge must be made by stealing the Siaulamb's trophy box. Steal the pile of Siaulamb's trphy boxes in Ziedo pond.
+QUEST_LV_0100_20150317_005909	Stole all of Siaulamb's trophies. Give it to Volda.
 QUEST_LV_0100_20150317_005910	Kill the monster guarding the box
-QUEST_LV_0100_20150317_005911	Volda know a sure way to get rid of the Siaulambs. Talk to Volda. 
+QUEST_LV_0100_20150317_005911	Volda know a sure way to get rid of the Siaulambs. Talk to Volda.
 QUEST_LV_0100_20150317_005912	Check insid ethe shabby box
-QUEST_LV_0100_20150317_005913	Volda says we should get rid of the brush trap balls that the Siaulambs eat. Find the brush trap balls inside the shabby box in the 4th Supplies Warehouse. 
+QUEST_LV_0100_20150317_005913	Volda says we should get rid of the brush trap balls that the Siaulambs eat. Find the brush trap balls inside the shabby box in the 4th Supplies Warehouse.
 QUEST_LV_0100_20150317_005914	Burn the brush trap balls
-QUEST_LV_0100_20150317_005915	Found the brush trap balls in the shabby box. Burn all of it in the fire beside it. 
+QUEST_LV_0100_20150317_005915	Found the brush trap balls in the shabby box. Burn all of it in the fire beside it.
 QUEST_LV_0100_20150317_005916	Report to Volda
-QUEST_LV_0100_20150317_005917	Burned all the brush trap balls in the box. Return to volda and report. 
+QUEST_LV_0100_20150317_005917	Burned all the brush trap balls in the box. Return to volda and report.
 QUEST_LV_0100_20150317_005918	Get rid of the Siaulambs that ambushed
 QUEST_LV_0100_20150317_005919	Check the shabby box
-QUEST_LV_0100_20150317_005920	Volda says we should get rid of the brush trap balls that the Siaulambs eat. Find the brush trap balls inside the shabby box in the 2nd Supplies Warehouse. 
+QUEST_LV_0100_20150317_005920	Volda says we should get rid of the brush trap balls that the Siaulambs eat. Find the brush trap balls inside the shabby box in the 2nd Supplies Warehouse.
 QUEST_LV_0100_20150317_005921	Defeat the remnants of Siaulambs
 QUEST_LV_0100_20150317_005922	Found the pouch full of brush trap balls and the siaulambs went mad and start to attack. Get rid of all the Siaulambs.
-QUEST_LV_0100_20150317_005923	Defeated all remnanats of Siaulambds but there is no place to burn the brash trap balls. Give it to Volda. 
+QUEST_LV_0100_20150317_005923	Defeated all remnanats of Siaulambds but there is no place to burn the brash trap balls. Give it to Volda.
 QUEST_LV_0100_20150317_005924	You must give Moody's report to Officer Liudas. Return to Liudas in Central Supplies Camp and talk to him.
 QUEST_LV_0100_20150317_005925	Check the monster in Amzina Crooked Road
-QUEST_LV_0100_20150317_005926	Liudas says he got a report about a large monster showing up. Check the monster in Amzina Crooked Road. 
-QUEST_LV_0100_20150317_005927	The large monster in A,zina rooked Road was Tutu, not Sparnas. Report about it to Liudas. 
+QUEST_LV_0100_20150317_005926	Liudas says he got a report about a large monster showing up. Check the monster in Amzina Crooked Road.
+QUEST_LV_0100_20150317_005927	The large monster in A,zina rooked Road was Tutu, not Sparnas. Report about it to Liudas.
 QUEST_LV_0100_20150317_005928	Lure and kill Tutu
 QUEST_LV_0100_20150317_005929	Officer Liudas is frustated at the current situation. Talk to him again.
 QUEST_LV_0100_20150317_005930	Talk to Liudas in Malkos Felled Area
-QUEST_LV_0100_20150317_005931	Liudas says he has to take care of things himself. Follow Liudas to M<alkos Felled Area. 
+QUEST_LV_0100_20150317_005931	Liudas says he has to take care of things himself. Follow Liudas to M<alkos Felled Area.
 QUEST_LV_0100_20150317_005932	Defeat the monsters attacking Liudas
 QUEST_LV_0100_20150317_005933	Talk to the scout
 QUEST_LV_0100_20150317_005934	Talk to the scout.
@@ -5938,7 +5938,7 @@ QUEST_LV_0100_20150317_005937	Talk to the Scout
 QUEST_LV_0100_20150317_005938	Talk to the scout again
 QUEST_LV_0100_20150317_005939	On the road back
 QUEST_LV_0100_20150317_005940	You feel something suspicious when woshipping the Goddess Statue. Talk to the Statue again.
-QUEST_LV_0100_20150317_005941	Mushkaria appeared! Get rid of theses guys. 
+QUEST_LV_0100_20150317_005941	Mushkaria appeared! Get rid of theses guys.
 QUEST_LV_0100_20150317_005942	Defeated Mushkaria!
 QUEST_LV_0100_20150317_005943	You have completed retrieving the supplies. Talk to the Supply Officer again.
 QUEST_LV_0100_20150317_005944	Get rid of the Tutu
@@ -5946,13 +5946,13 @@ QUEST_LV_0100_20150317_005945	Tutu made a surprise ambush. Defeat Tutu.
 QUEST_LV_0100_20150317_005946	You defeated the Tutu. Talk to the supply officer.
 QUEST_LV_0100_20150317_005947	Gustas Jonas seems to welcome you. Ask him about the location of Kign Zachariel's legacy.
 QUEST_LV_0100_20150317_005948	Release the seal located on the left of the crumbled sanctuary.
-QUEST_LV_0100_20150317_005949	Gustas says there is one seal left but he sensed a dangerous aura. Release the on the left of the crumbled sanctuary. You also need to be careful of the monsters' attacks. 
+QUEST_LV_0100_20150317_005949	Gustas says there is one seal left but he sensed a dangerous aura. Release the on the left of the crumbled sanctuary. You also need to be careful of the monsters' attacks.
 QUEST_LV_0100_20150317_005950	Released the last seal. Go back to Gustas Jonas.
 QUEST_LV_0100_20150317_005951	Talk to Liaison Officer Nian
 QUEST_LV_0100_20150317_005952	Nian is infroming you about the mysterious stone
 QUEST_LV_0100_20150317_005953	Kill the monster attacking Nian
-QUEST_LV_0100_20150317_005954	Touched the mysterious stone to take a closer look but then monsters appeared! Better get rid of the monsters first. 
-QUEST_LV_0100_20150317_005955	Defeated the monsters. Talk to Nian about what happened. 
+QUEST_LV_0100_20150317_005954	Touched the mysterious stone to take a closer look but then monsters appeared! Better get rid of the monsters first.
+QUEST_LV_0100_20150317_005955	Defeated the monsters. Talk to Nian about what happened.
 QUEST_LV_0100_20150317_005956	Talk to Historian Adelle
 QUEST_LV_0100_20150317_005957	Adelle know it was someone Nian sent. Ask why she is not withdrawing.
 QUEST_LV_0100_20150317_005958	Collect stones with mysterious patterns
@@ -5962,7 +5962,7 @@ QUEST_LV_0100_20150317_005961	Gathered enough stones with patterns. Give it to A
 QUEST_LV_0100_20150317_005962	Kill Hogma archer and get %s
 QUEST_LV_0100_20150317_005963	Kill Hogma archer and get stones with mysterious pattern
 QUEST_LV_0100_20150317_005964	Talk to archaeologist Fridka
-QUEST_LV_0100_20150317_005965	Fridka is looking for someone to do a great mission with him. Talk to Fridka. 
+QUEST_LV_0100_20150317_005965	Fridka is looking for someone to do a great mission with him. Talk to Fridka.
 QUEST_LV_0100_20150317_005966	Get the monster's amulet
 QUEST_LV_0100_20150317_005967	Fridka is looking for someone who can help him. First, get teh amulets from the monsters.
 QUEST_LV_0100_20150317_005968	Fridka is carefully looking at the map from the stone pillars. Talk to him.
@@ -5974,7 +5974,7 @@ QUEST_LV_0100_20150317_005973	You got Adelle the stones she want so try to persu
 QUEST_LV_0100_20150317_005974	Block the monsters attacking
 QUEST_LV_0100_20150317_005975	Could it be because of the stones? Monsters are attacking. Protect yourself from the attacks.
 QUEST_LV_0100_20150317_005976	Defeated all the monsters that attacked. Persuade Adelle quickly to withdraw.
-QUEST_LV_0100_20150317_005977	Kolin says he doesn't know Rexipher. Ask another historian about Rexipher. 
+QUEST_LV_0100_20150317_005977	Kolin says he doesn't know Rexipher. Ask another historian about Rexipher.
 QUEST_LV_0100_20150317_005978	Gorath seems to be in trouble. Talk to him.
 QUEST_LV_0100_20150317_005979	Talk to Badat
 QUEST_LV_0100_20150317_005980	Gorath is asking you to find his lost friends. His friend's name is Badat so look around for him.
@@ -5988,86 +5988,86 @@ QUEST_LV_0100_20150317_005987	Defeat Tontus and retrieve the research material
 QUEST_LV_0100_20150317_005988	Talk to Kevin
 QUEST_LV_0100_20150317_005989	There's a suspicious person looking like a forger. Talk to Kevin.
 QUEST_LV_0100_20150317_005990	Gathering firewood
-QUEST_LV_0100_20150317_005991	Kevin says he is going to make counterfeits and asks you to gather firewood. First, bring him what he wants for definite evidence. 
+QUEST_LV_0100_20150317_005991	Kevin says he is going to make counterfeits and asks you to gather firewood. First, bring him what he wants for definite evidence.
 QUEST_LV_0100_20150317_005992	Gathered all the firewood needed. Talk to Kevin again.
 QUEST_LV_0100_20150317_005993	Looks like the preparations are complete. Wonder how Kevin makes counterfeits. Talk to him again.
 QUEST_LV_0100_20150317_005994	Collect hard lime from monsters
-QUEST_LV_0100_20150317_005995	Kevin says he can never show you how he works and asks you to get hard lime from monsters nearby. Get him the lime first. 
+QUEST_LV_0100_20150317_005995	Kevin says he can never show you how he works and asks you to get hard lime from monsters nearby. Get him the lime first.
 QUEST_LV_0100_20150317_005996	Gathered enough lime. Go back to Kevin.
 QUEST_LV_0100_20150317_005997	Kill nearby monsters and get %s
 QUEST_LV_0100_20150317_005998	Desert Chupacabra/Zinute
 QUEST_LV_0100_20150317_005999	Vincent looks somewhat tiresome. Talk to him.
 QUEST_LV_0100_20150317_006000	Making Conterfeit
-QUEST_LV_0100_20150317_006001	Vincent is lazy and asked you to do his work for him. Finish the conterfeit first as he wants. Notice will appear when the conterfeit is complete in the mold. 
+QUEST_LV_0100_20150317_006001	Vincent is lazy and asked you to do his work for him. Finish the conterfeit first as he wants. Notice will appear when the conterfeit is complete in the mold.
 QUEST_LV_0100_20150317_006002	Give the counterfeit to Vincent
-QUEST_LV_0100_20150317_006003	Took out the conterfeit. Give it to Vincent to finish. 
+QUEST_LV_0100_20150317_006003	Took out the conterfeit. Give it to Vincent to finish.
 QUEST_LV_0100_20150317_006004	Talk to Sculptor Hilda
 QUEST_LV_0100_20150317_006005	Scultor Hilda seems to be looking around. Talk to her and find out what is going on.
 QUEST_LV_0100_20150317_006006	Find the cool pillar Hilda talked about
-QUEST_LV_0100_20150317_006007	Hilda wants to see a unique and cool pillar. If you find a cool pillar among the ancient pillars, pick up its debris and show it to Hilda. 
-QUEST_LV_0100_20150317_006008	You found some pillars that Hilda would like. Show Hilda the debris that you picked up. 
-QUEST_LV_0100_20150317_006009	Seems like Hilda needs help. Talk to her. 
+QUEST_LV_0100_20150317_006007	Hilda wants to see a unique and cool pillar. If you find a cool pillar among the ancient pillars, pick up its debris and show it to Hilda.
+QUEST_LV_0100_20150317_006008	You found some pillars that Hilda would like. Show Hilda the debris that you picked up.
+QUEST_LV_0100_20150317_006009	Seems like Hilda needs help. Talk to her.
 QUEST_LV_0100_20150317_006010	Protect Scultor Hilda
-QUEST_LV_0100_20150317_006011	Hilda asked you to guard her while she observes the pillars. Please respond to her passion for pillars. 
-QUEST_LV_0100_20150317_006012	Hilda is done observing the pillars. Talk to her again. 
-QUEST_LV_0100_20150317_006013	Talk to Hilda who has sparkling eyes looking  at the pillars. 
+QUEST_LV_0100_20150317_006011	Hilda asked you to guard her while she observes the pillars. Please respond to her passion for pillars.
+QUEST_LV_0100_20150317_006012	Hilda is done observing the pillars. Talk to her again.
+QUEST_LV_0100_20150317_006013	Talk to Hilda who has sparkling eyes looking  at the pillars.
 QUEST_LV_0100_20150317_006014	Protect Sculptor Hilda
-QUEST_LV_0100_20150317_006015	Hilda want to observe the pillar longer. Protect her from the monsters while she observes the pillars. 
-QUEST_LV_0100_20150317_006016	Seem like Hilda is done checking the pillars. Talk to her. 
-QUEST_LV_0100_20150317_006017	You have to block the demons attaking the mausoleum while chasing Rexipher. Talk to the Statue of guardian. 
+QUEST_LV_0100_20150317_006015	Hilda want to observe the pillar longer. Protect her from the monsters while she observes the pillars.
+QUEST_LV_0100_20150317_006016	Seem like Hilda is done checking the pillars. Talk to her.
+QUEST_LV_0100_20150317_006017	You have to block the demons attaking the mausoleum while chasing Rexipher. Talk to the Statue of guardian.
 QUEST_LV_0100_20150317_006018	Get piece of Royal Slate
-QUEST_LV_0100_20150317_006019	Mausoleum guardians are protecting the stones that Rexipher destroyed. Collect the pieces of slate from the Mausolem guardians. 
+QUEST_LV_0100_20150317_006019	Mausoleum guardians are protecting the stones that Rexipher destroyed. Collect the pieces of slate from the Mausolem guardians.
 QUEST_LV_0100_20150317_006020	Collected all pieces of the slate. Talk to the statue of guardian.
 QUEST_LV_0100_20150317_006021	Defeat the guardian and get %s
 QUEST_LV_0100_20150317_006022	Retrieve Pieces of Royal Slate
 QUEST_LV_0100_20150317_006023	Messenge Niels say Yonas' family is looking for you. Talk to Ahilas in the Search Camp.
 QUEST_LV_0100_20150317_006024	Collect Precious Tree Sap
-QUEST_LV_0100_20150317_006025	Ahilas needs to prepare the legacy of Zachariel for the chosen one. He needs the Precious Tree Sap which is called the tears of Goddess Zemuna. Go to Zeme Plateau and get the sap. 
+QUEST_LV_0100_20150317_006025	Ahilas needs to prepare the legacy of Zachariel for the chosen one. He needs the Precious Tree Sap which is called the tears of Goddess Zemuna. Go to Zeme Plateau and get the sap.
 QUEST_LV_0100_20150317_006026	Talk to Ahilas
-QUEST_LV_0100_20150317_006027	Got enough tree sap. Bring it to Ahilas. 
-QUEST_LV_0100_20150317_006028	Seems like Ahilas is maching a crystal to release the seal so that you can approach King Zachariel's legacy. 
+QUEST_LV_0100_20150317_006027	Got enough tree sap. Bring it to Ahilas.
+QUEST_LV_0100_20150317_006028	Seems like Ahilas is maching a crystal to release the seal so that you can approach King Zachariel's legacy.
 QUEST_LV_0100_20150317_006029	Save Amalas Canyon
-QUEST_LV_0100_20150317_006030	Ahilas says he needs Amalas to make the crystal for unseal. Get the Amalas from Pamirsit Plateau. Amalas is difficult to collect so be careful. 
+QUEST_LV_0100_20150317_006030	Ahilas says he needs Amalas to make the crystal for unseal. Get the Amalas from Pamirsit Plateau. Amalas is difficult to collect so be careful.
 QUEST_LV_0100_20150317_006031	Give to Ahilas
-QUEST_LV_0100_20150317_006032	Got enough Amalas. Give it to Ahilas. 
+QUEST_LV_0100_20150317_006032	Got enough Amalas. Give it to Ahilas.
 QUEST_LV_0100_20150317_006033	
 QUEST_LV_0100_20150317_006034	Get rid of Tama
-QUEST_LV_0100_20150317_006035	Treasure Hunter asked you to get rid of the Tama in the northen area if you want to help his search for treasure. 
+QUEST_LV_0100_20150317_006035	Treasure Hunter asked you to get rid of the Tama in the northen area if you want to help his search for treasure.
 QUEST_LV_0100_20150317_006036	Killed enough Tamas as Ethan requested. Return to Ethan.
 QUEST_LV_0100_20150317_006037	Find the Fourth Piece of Gravestone
-QUEST_LV_0100_20150317_006038	Treasure Hunter says he's sure that Tama swallowed the relics. Kill Tama and get the relics. 
+QUEST_LV_0100_20150317_006038	Treasure Hunter says he's sure that Tama swallowed the relics. Kill Tama and get the relics.
 QUEST_LV_0100_20150317_006039	Tama has the fourth gravestone piece as the treasure hunter said. Go and give it to Ethan.
 QUEST_LV_0100_20150317_006040	Kill Tama and get %s
 QUEST_LV_0100_20150317_006041	Collect sap of Small Tree
 QUEST_LV_0100_20150317_006042	Treasure Hunter Ethan asked you to collect the sap of Small Tree for its worth. Attack the sap collector to the small tree and get the sap after some time.
-QUEST_LV_0100_20150317_006043	Collected enough Small tree sap. Go to Ethan for rewards. 
+QUEST_LV_0100_20150317_006043	Collected enough Small tree sap. Go to Ethan for rewards.
 QUEST_LV_0100_20150317_006044	Finding fragments of ruins
 QUEST_LV_0100_20150317_006045	Ethan asked you to get the fragments of ruins buried in the Crossroad Vacant Lot.
 QUEST_LV_0100_20150317_006046	Found the fragments of ruins asked by Ethan. Return and give it to him.
 QUEST_LV_0100_20150317_006047	Get the first rubbing of Villurie Cabin
 QUEST_LV_0100_20150317_006048	Hunter Tallus asked you to get a rubbing of Lydia Schaffen's Gravestone in Villurie Cabin.
 QUEST_LV_0100_20150317_006049	The Second Rubbings
-QUEST_LV_0100_20150317_006050	You need to find the gravestone of Lydia Schaffen that is left here as Hunter TAllus says. Find the seconds gravestone and get its rubbings. 
+QUEST_LV_0100_20150317_006050	You need to find the gravestone of Lydia Schaffen that is left here as Hunter TAllus says. Find the seconds gravestone and get its rubbings.
 QUEST_LV_0100_20150317_006051	Made the first and seconds rubbings of Lydia Schaffens' gravestone. Return to Tallus.
 QUEST_LV_0100_20150317_006052	Get charcoal and work on the third rubbings in Kriakul Stream.
-QUEST_LV_0100_20150317_006053	Tallus used up all the charcoal. Use soy bomb on long sleeve trees to kill it for charcoals. Then get the third gravestone rubbings in Kriakul Stream. 
-QUEST_LV_0100_20150317_006054	Made the rubbings of the gravestone like Tallus said. Return to Tallus. 
+QUEST_LV_0100_20150317_006053	Tallus used up all the charcoal. Use soy bomb on long sleeve trees to kill it for charcoals. Then get the third gravestone rubbings in Kriakul Stream.
+QUEST_LV_0100_20150317_006054	Made the rubbings of the gravestone like Tallus said. Return to Tallus.
 QUEST_LV_0100_20150317_006055	Check the fourth gravestone in Shiluma Altar Area
-QUEST_LV_0100_20150317_006056	Hunter Tallus said let's part ways here and told you the last gravestone's location. Check the gravestone in Shiluma Altar Area. 
+QUEST_LV_0100_20150317_006056	Hunter Tallus said let's part ways here and told you the last gravestone's location. Check the gravestone in Shiluma Altar Area.
 QUEST_LV_0100_20150317_006057	Finding the Last Gravestone
-QUEST_LV_0100_20150317_006058	Find the last gravestone of Lydia Schaffen over the Griuve Trail and be enlighted. 
+QUEST_LV_0100_20150317_006058	Find the last gravestone of Lydia Schaffen over the Griuve Trail and be enlighted.
 QUEST_LV_0100_20150317_006059	Find the Last Gravestone in Griuve Trail
-QUEST_LV_0100_20150317_006060	Search  inscription of Agailla Flurry 
+QUEST_LV_0100_20150317_006060	Search  inscription of Agailla Flurry
 QUEST_LV_0100_20150317_006061	There are Agailla Flurry monument known as the builder of the tower of the wizard. Please find all of the zeolite in order to obtain the Agailla Flurry Higi
-QUEST_LV_0100_20150317_006062	Read the inscription of Agailla Flurry 
-QUEST_LV_0100_20150317_006063	Restore the damaged inscription of Agailla Flurry 
-QUEST_LV_0100_20150317_006064	Can't read the rest of the writings because Old Hook destroyed it. Find the gravestone pieces broken by the Old Hooks and restore it. 
+QUEST_LV_0100_20150317_006062	Read the inscription of Agailla Flurry
+QUEST_LV_0100_20150317_006063	Restore the damaged inscription of Agailla Flurry
+QUEST_LV_0100_20150317_006064	Can't read the rest of the writings because Old Hook destroyed it. Find the gravestone pieces broken by the Old Hooks and restore it.
 QUEST_LV_0100_20150317_006065	Gravestone is restored enough to read. Read the rest of Agaila Flurry's epitaph.
 QUEST_LV_0100_20150317_006066	Get rid of Old Hook
 QUEST_LV_0100_20150317_006067	Do Town Person's Favor
 QUEST_LV_0100_20150317_006068	Epitaph of Agaila Flurry is destroyed but someone knows what was written there. Town man says he'll tell you if you get him his stolen luggage from the Zolem.
 QUEST_LV_0100_20150317_006069	Give the luggage to town man
-QUEST_LV_0100_20150317_006070	Got the town man's luggage from the Zolem. Give it to him and ask for the writings on the epitaph. 
+QUEST_LV_0100_20150317_006070	Got the town man's luggage from the Zolem. Give it to him and ask for the writings on the epitaph.
 QUEST_LV_0100_20150317_006071	Get %s from Zolem
 QUEST_LV_0100_20150317_006072	Find the town man's luggage
 QUEST_LV_0100_20150317_006073	Talk to the town man
@@ -6076,32 +6076,32 @@ QUEST_LV_0100_20150317_006075	Found the last epitaph but the reaverpede is guard
 QUEST_LV_0100_20150317_006076	Read the last epitaph of Agaila Flurry and get her Divination.
 QUEST_LV_0100_20150317_006077	Get rid of the monsters nearby Ruklys' memorial stone
 QUEST_LV_0100_20150317_006078	Epigraphist Smid asked you to get rid of the monsters near the memorial stone while he prepares to restore the stone.
-QUEST_LV_0100_20150317_006079	Got rid of the monsters as Smid asked you. Go to him and help him restore. 
+QUEST_LV_0100_20150317_006079	Got rid of the monsters as Smid asked you. Go to him and help him restore.
 QUEST_LV_0100_20150317_006080	Check the strange sack
 QUEST_LV_0100_20150317_006081	There is a strange sack in front. Looks like it's empty.
 QUEST_LV_0100_20150317_006082	Collect experiment materials
-QUEST_LV_0100_20150317_006083	Found the luggage of necromancer Drasius in Vidullri Cabin. There is a memo of the things inside and a request to collect the lost things. Let's kill the long sleeve trees and retrieve experiment materials for Drasius. 
+QUEST_LV_0100_20150317_006083	Found the luggage of necromancer Drasius in Vidullri Cabin. There is a memo of the things inside and a request to collect the lost things. Let's kill the long sleeve trees and retrieve experiment materials for Drasius.
 QUEST_LV_0100_20150317_006084	Collected all the lost experiment materials. Give it to Drasius.
 QUEST_LV_0100_20150317_006085	Kill Long Sleeve Tree and get %s
 QUEST_LV_0100_20150317_006086	Kill Long Sleeve Trees
 QUEST_LV_0100_20150317_006087	Drasius is waiting for someone's help in the old yard of Goddess.
 QUEST_LV_0100_20150317_006088	Collet Water Plants
 QUEST_LV_0100_20150317_006089	Drasius asked you to collect water plants needed for the experiments. Get the water plants Kriakil Stream.
-QUEST_LV_0100_20150317_006090	Collected enough water plants. Return to Drasius. 
+QUEST_LV_0100_20150317_006090	Collected enough water plants. Return to Drasius.
 QUEST_LV_0100_20150317_006091	Mind invasion of Lizardman
 QUEST_LV_0100_20150317_006092	Lizard Man's Mind Control
 QUEST_LV_0100_20150317_006093	Drasius need lizardman for necromancing. Use the mind control stones on lizardman near the Dumbal Pond and attack to brainwash it.
-QUEST_LV_0100_20150317_006094	Gathered enough lizardman. Return to Drasius. 
+QUEST_LV_0100_20150317_006094	Gathered enough lizardman. Return to Drasius.
 QUEST_LV_0100_20150317_006095	Infro Burke's Mind Control
 QUEST_LV_0100_20150317_006096	Drasius needs Infro Burkes for necromancing. Use the mind control stones on Infro Burkes near the Nardima Twin Falls and attack to brainwash it.
-QUEST_LV_0100_20150317_006097	Gathered enough Infro Burkes. Return to Drasius. 
+QUEST_LV_0100_20150317_006097	Gathered enough Infro Burkes. Return to Drasius.
 QUEST_LV_0100_20150317_006098	Worship the statue and talk to item merchant
 QUEST_LV_0100_20150317_006099	Prepare to leave for the East Forest by worshipping the Goddess Statue in Central Plaza.
 QUEST_LV_0100_20150317_006100	Talk to the item merchant
 QUEST_LV_0100_20150317_006101	Knight commander Uska has left warp scrolls for you to use. Talk to the item merchant and receive the warp scrolls.
 QUEST_LV_0100_20150317_006102	
 QUEST_LV_0100_20150317_006103	Check Military Backpack
-QUEST_LV_0100_20150317_006104	The Ghost disappeared when you approached it and only the pouch is left. Check what's insdie the pouch. 
+QUEST_LV_0100_20150317_006104	The Ghost disappeared when you approached it and only the pouch is left. Check what's insdie the pouch.
 QUEST_LV_0100_20150317_006105	
 QUEST_LV_0100_20150317_006106	Start the Tree Ravine Plan
 QUEST_LV_0100_20150317_006107	Found the command for Tree Ravine Plan in the backpack. The plan is to kill the Zolems around Neryshkus sanctuary, then using Zolem stone to summon unicorns and kill it. The wandering soul seems to have been in an accident while carrying out the plan. Continue the plan to comfort the soul.
@@ -6115,7 +6115,7 @@ QUEST_LV_0100_20150317_006114	Get rid of the Unicorn
 QUEST_LV_0100_20150317_006115	Placed the Zolem Stone in the bag then unicorn appeared. Kill the unicorn.
 QUEST_LV_0100_20150317_006116	Report to the wandering soul
 QUEST_LV_0100_20150317_006117	Completed the Tree Ravine Plan. Let the wandering soul know about it.
-QUEST_LV_0100_20150317_006118	Kill Unicorn and acquire %s 
+QUEST_LV_0100_20150317_006118	Kill Unicorn and acquire %s
 QUEST_LV_0100_20150317_006119	Talk to Kayhil
 QUEST_LV_0100_20150317_006120	Kayhil is complaining about something. Talk to him.
 QUEST_LV_0100_20150317_006121	Talk to Moze
@@ -6163,22 +6163,22 @@ QUEST_LV_0100_20150317_006162	Goddess Saule's Follower Adelle needs your help.
 QUEST_LV_0100_20150317_006163	Collect poisonous mushrooms of Truffles
 QUEST_LV_0100_20150317_006164	Adelle says she needs poisonous mushrooms of Truffles for the acid solution. Kill the Truffles in Azidu Fork Road and gather the mushrooms.
 QUEST_LV_0100_20150317_006165	Give mushrooms to Adelle
-QUEST_LV_0100_20150317_006166	Gathered enough mushrooms of Truffles. Give it to Adelle so that she can make the acid solution. 
+QUEST_LV_0100_20150317_006166	Gathered enough mushrooms of Truffles. Give it to Adelle so that she can make the acid solution.
 QUEST_LV_0100_20150317_006167	Make mixed solution in Harmony Altar
-QUEST_LV_0100_20150317_006168	Gathered all materials. Go to the Harmony magic circle in Azidu Fork Road, then combine Triffules poisonous mushroom and Verwriggler claws to make mix solution. 
+QUEST_LV_0100_20150317_006168	Gathered all materials. Go to the Harmony magic circle in Azidu Fork Road, then combine Triffules poisonous mushroom and Verwriggler claws to make mix solution.
 QUEST_LV_0100_20150317_006169	Give mix solution to Adelle
 QUEST_LV_0100_20150317_006170	Successfully made the mix solution in Harmony Altar. Give it to Adelle.
 QUEST_LV_0100_20150317_006171	Melt the Thorn vines using acid solution.
-QUEST_LV_0100_20150317_006172	Adelle made acid solution with the mix solution you brought. Bring the solution to Gate Route and melt the Thorn vines. 
+QUEST_LV_0100_20150317_006172	Adelle made acid solution with the mix solution you brought. Bring the solution to Gate Route and melt the Thorn vines.
 QUEST_LV_0100_20150317_006173	Talk to Follower Virgis
 QUEST_LV_0100_20150317_006174	Virgis wants your help.
-QUEST_LV_0100_20150317_006175	Charge spell crystal in the condensed spell area. 
-QUEST_LV_0100_20150317_006176	Memo of Virgis: First, charge the spell crystal I gave you. Look for the condensed spell area in Pavydo Woodland. 
+QUEST_LV_0100_20150317_006175	Charge spell crystal in the condensed spell area.
+QUEST_LV_0100_20150317_006176	Memo of Virgis: First, charge the spell crystal I gave you. Look for the condensed spell area in Pavydo Woodland.
 QUEST_LV_0100_20150317_006177	Collect Operor's sting to refine the spell crystal.
-QUEST_LV_0100_20150317_006178	Memo of Vargis: Great. But you can't use the spell crystal right away because it has absorbed foul energy together. So collect the Operor's stingers that have purifying effects. 
+QUEST_LV_0100_20150317_006178	Memo of Vargis: Great. But you can't use the spell crystal right away because it has absorbed foul energy together. So collect the Operor's stingers that have purifying effects.
 QUEST_LV_0100_20150317_006179	Kill Operor and get %s
 QUEST_LV_0100_20150317_006180	Refine the spell of spell crystal
-QUEST_LV_0100_20150317_006181	Memo of Vargis: Did you collect all the stingers? The Purifying Altar is in Lenistwo Wasteland. Go there and use the Operor's stingers to refine the spell crystals. 
+QUEST_LV_0100_20150317_006181	Memo of Vargis: Did you collect all the stingers? The Purifying Altar is in Lenistwo Wasteland. Go there and use the Operor's stingers to refine the spell crystals.
 QUEST_LV_0100_20150317_006182	Get refined spell crystals
 QUEST_LV_0100_20150317_006183	Use spell crystals to remove Thorn vines
 QUEST_LV_0100_20150317_006184	Memo of Vargis: Very good. Now use the clean spell crystal and show those Thorn vines the power of Goddess Saule's Followers.
@@ -6186,7 +6186,7 @@ QUEST_LV_0100_20150317_006185	Memo of Vargis: Very good. Now use the clean spell
 QUEST_LV_0100_20150317_006186	Talk to Follower Nojus
 QUEST_LV_0100_20150317_006187	Goddess Saule Follower Nojus is anxiously waiting for you.
 QUEST_LV_0100_20150317_006188	Trace the omnious voice
-QUEST_LV_0100_20150317_006189	Nojus told you where the omnious voice is coming from. Go and find it. 
+QUEST_LV_0100_20150317_006189	Nojus told you where the omnious voice is coming from. Go and find it.
 QUEST_LV_0100_20150317_006190	
 QUEST_LV_0100_20150317_006191	Defeated the poatas summoned by the watcher. Go deep into the Thorn Forest to find Bramble.
 QUEST_LV_0100_20150317_006192	Kill the summoned Poatas
@@ -6197,8 +6197,8 @@ QUEST_LV_0100_20150317_006196
 QUEST_LV_0100_20150317_006197	Helped all the followers of  Goddess Salue. Talk to Alvidas.
 QUEST_LV_0100_20150317_006198	Talk to Follower Raminta
 QUEST_LV_0100_20150317_006199	Saule Goddess Follower Raminta needs your help.
-QUEST_LV_0100_20150317_006200	Get rid of the source of evil aura. 
-QUEST_LV_0100_20150317_006201	Raminta says he found the demon spreading evil aura around. Kill Rikaus for him. 
+QUEST_LV_0100_20150317_006200	Get rid of the source of evil aura.
+QUEST_LV_0100_20150317_006201	Raminta says he found the demon spreading evil aura around. Kill Rikaus for him.
 QUEST_LV_0100_20150317_006202	Report to Raminta
 QUEST_LV_0100_20150317_006203	Killed Rikaus that was spreading evil aura. Report to Raminta.
 QUEST_LV_0100_20150317_006204	Kill Rikaus
@@ -6207,14 +6207,14 @@ QUEST_LV_0100_20150317_006206	Saule Goddess Follower Evaldas needs your help.
 QUEST_LV_0100_20150317_006207	Get rid of the Merog Shaman
 QUEST_LV_0100_20150317_006208	Evaldas asked you to get rid of the Shaman. Break into the Merog Shamans in their rituals and get rid of them.
 QUEST_LV_0100_20150317_006209	Report to Evaldas
-QUEST_LV_0100_20150317_006210	Get rid of the Merog Shaman. Tell Evaldas about it. 
+QUEST_LV_0100_20150317_006210	Get rid of the Merog Shaman. Tell Evaldas about it.
 QUEST_LV_0100_20150317_006211	Kill the Merog Shaman installing magic circle
 QUEST_LV_0100_20150317_006212	Talk to Follower Zaneta
 QUEST_LV_0100_20150317_006213	Saule Goddess Follower Zaneta needs your help.
 QUEST_LV_0100_20150317_006214	Destroy the demon summoning crystal
 QUEST_LV_0100_20150317_006215	Those Merogs a installed magic circle summoning demons in Goddess Saule Altar. Destroy the summon crystal in the middle and stop the demons.
 QUEST_LV_0100_20150317_006216	Report to Zaneta
-QUEST_LV_0100_20150317_006217	Destroyed all the summon crystal. Go and comfor Zaneta. 
+QUEST_LV_0100_20150317_006217	Destroyed all the summon crystal. Go and comfor Zaneta.
 QUEST_LV_0100_20150317_006218	Talk to Follower Simas
 QUEST_LV_0100_20150317_006219	Goddess Saule Follower Simas needs your help.
 QUEST_LV_0100_20150317_006220	Destroy the Demon Summon Circle fuming murky aura
@@ -6227,11 +6227,11 @@ QUEST_LV_0100_20150317_006226	Goddess Saule Follower Onute needs your help.
 QUEST_LV_0100_20150317_006227	Get rid of the Archon and Demon Summon Circle
 QUEST_LV_0100_20150317_006228	Onute is angry that the altar turned into Demon's Magic Circle. Kill the Archons and destroy the magic circle to teach them a lesson about the Goddess' Powers.
 QUEST_LV_0100_20150317_006229	Report to Onute
-QUEST_LV_0100_20150317_006230	Got rid of all the omnious things Onute mentioned. Report it to Onute. 
+QUEST_LV_0100_20150317_006230	Got rid of all the omnious things Onute mentioned. Report it to Onute.
 QUEST_LV_0100_20150317_006231	Talk to Follower Bronius
 QUEST_LV_0100_20150317_006232	Goddess Saule Follower Bronius is in hiding and anxiously waiting for your help.
 QUEST_LV_0100_20150317_006233	Get rid of the Merogs
-QUEST_LV_0100_20150317_006234	Bronius says the monters are targetting him. Kill the monsters. 
+QUEST_LV_0100_20150317_006234	Bronius says the monters are targetting him. Kill the monsters.
 QUEST_LV_0100_20150317_006235	Killed the monsters. Talk to Bronius.
 QUEST_LV_0100_20150317_006236	Kill the monster that tried to kill the followers
 QUEST_LV_0100_20150317_006237	Talk to Follower Samantha
@@ -6247,9 +6247,9 @@ QUEST_LV_0100_20150317_006246	Talk to Jurga
 QUEST_LV_0100_20150317_006247	You cut off Bramble's roots. Go back and talk to Jurga.
 QUEST_LV_0100_20150317_006248	Gaigalas guarding Bramble's roots
 QUEST_LV_0100_20150317_006249	Destroy Bramble's roots
-QUEST_LV_0100_20150317_006250	Jurga is following the Goddess in watching over Bramble and is waiting for you. 
+QUEST_LV_0100_20150317_006250	Jurga is following the Goddess in watching over Bramble and is waiting for you.
 QUEST_LV_0100_20150317_006251	Get Merog's stinger and make Thorn Flower stimulant
-QUEST_LV_0100_20150317_006252	Bramble says he needs to make medication for withstanding the evil aura before getting into the battle. Go to Kruva swell and get Merog's stingers. 
+QUEST_LV_0100_20150317_006252	Bramble says he needs to make medication for withstanding the evil aura before getting into the battle. Go to Kruva swell and get Merog's stingers.
 QUEST_LV_0100_20150317_006253	Collect all of Merog's stingers needed. Go back to Jurga.
 QUEST_LV_0100_20150317_006254	Check the Tankinta Vacant Lot
 QUEST_LV_0100_20150317_006255	Jurga says one of Bramble's roots is in Tankinta Vacant Lot. Go anc check the Lot.
@@ -6276,45 +6276,45 @@ QUEST_LV_0100_20150317_006275	Go to Andale's village priest
 QUEST_LV_0100_20150317_006276	Collected Black Maize's venom. Go to Andale Priest in Cerpe Crossroad.
 QUEST_LV_0100_20150317_006277	Kill Black Maize to get %s
 QUEST_LV_0100_20150317_006278	Talk to Village Priest
-QUEST_LV_0100_20150317_006279	Village Priest says you can activate the Obelisk if you follow his instructions. Talk to him again. 
+QUEST_LV_0100_20150317_006279	Village Priest says you can activate the Obelisk if you follow his instructions. Talk to him again.
 QUEST_LV_0100_20150317_006280	Collect the tree sap from White Oak Forest
 QUEST_LV_0100_20150317_006281	Tree sap is needed to make the dye for restroing Obelisk. Collect tree sap from White Oak Forest.
 QUEST_LV_0100_20150317_006282	Obatin %s from tree sap pickup baskets
 QUEST_LV_0100_20150317_006283	
 QUEST_LV_0100_20150317_006284	
 QUEST_LV_0100_20150317_006285	
-QUEST_LV_0100_20150317_006286	Made the dye for restoring Obelisk. Get the dye from the altar. 
-QUEST_LV_0100_20150317_006287	Got the dye for restoring obelisk. Go back and talk to the priest again for what to do next. 
+QUEST_LV_0100_20150317_006286	Made the dye for restoring Obelisk. Get the dye from the altar.
+QUEST_LV_0100_20150317_006287	Got the dye for restoring obelisk. Go back and talk to the priest again for what to do next.
 QUEST_LV_0100_20150317_006288	Restore the Obelisk
 QUEST_LV_0100_20150317_006289	Seems like the Obelisk can now be restored. Write back the erased letters on the Obelisk in Slepingas Stream.
 QUEST_LV_0100_20150317_006290	
-QUEST_LV_0100_20150317_006291	Succesfully restored the Obelisk. Go back to Village Priest. 
+QUEST_LV_0100_20150317_006291	Succesfully restored the Obelisk. Go back to Village Priest.
 QUEST_LV_0100_20150317_006292	Go to Nefrito Gorge
-QUEST_LV_0100_20150317_006293	There is a strong force felt in the swift currents of Nefrito Gorge. Find out what it is. 
+QUEST_LV_0100_20150317_006293	There is a strong force felt in the swift currents of Nefrito Gorge. Find out what it is.
 QUEST_LV_0100_20150317_006294	Get rid of Moldihorn
 QUEST_LV_0100_20150317_006295	
 QUEST_LV_0100_20150317_006296	
 QUEST_LV_0100_20150317_006297	Kill the monsters that react to onmious force
-QUEST_LV_0100_20150317_006298	Monsters turned aggressice when the omnious force fumed from the Dye Altar. Kill the monsters that reacted to it. 
+QUEST_LV_0100_20150317_006298	Monsters turned aggressice when the omnious force fumed from the Dye Altar. Kill the monsters that reacted to it.
 QUEST_LV_0100_20150317_006299	Check the Obelisk
-QUEST_LV_0100_20150317_006300	Check the Obelisk in Slepingas Gorge. 
+QUEST_LV_0100_20150317_006300	Check the Obelisk in Slepingas Gorge.
 QUEST_LV_0100_20150317_006301	Kill the Blue Woorspirit
 QUEST_LV_0100_20150317_006302	Find the Priest of Andale village
 QUEST_LV_0100_20150317_006303	
 QUEST_LV_0100_20150317_006304	Collect the Languid Flower
 QUEST_LV_0100_20150317_006305	Let's create Languid Bomb to get rid of monstes threatening Andale Village. Collect Languid Flowers need for making the bomb.
 QUEST_LV_0100_20150317_006306	Talk to Andale village Disciple
-QUEST_LV_0100_20150317_006307	Gathered enough Languid Flowers. Talk to the disciple in Andale Village. 
+QUEST_LV_0100_20150317_006307	Gathered enough Languid Flowers. Talk to the disciple in Andale Village.
 QUEST_LV_0100_20150317_006308	Ask the disciple what else is needed to make the Languid bomb.
 QUEST_LV_0100_20150317_006309	Collect soul flowers with strong scent
 QUEST_LV_0100_20150317_006310	Strong scented soul flowers are needed to make stong bombs. Look for the flowers with strong scent.
-QUEST_LV_0100_20150317_006311	Collected the flowers. Ask the village disciple what to do. 
+QUEST_LV_0100_20150317_006311	Collected the flowers. Ask the village disciple what to do.
 QUEST_LV_0100_20150317_006312	Talk to Andale village Mayor
-QUEST_LV_0100_20150317_006313	He says the bomb used before must be somewhere. Talk to the Mayor who knows where the bomb is. 
+QUEST_LV_0100_20150317_006313	He says the bomb used before must be somewhere. Talk to the Mayor who knows where the bomb is.
 QUEST_LV_0100_20150317_006314	Find Bombs
 QUEST_LV_0100_20150317_006315	Mayor says the bombs are in the northern warehouse. Go and look for the bombs.
-QUEST_LV_0100_20150317_006316	Unlike what the mayor said, the bombs were in a small container. Ask the Mayor what happened. 
-QUEST_LV_0100_20150317_006317	Made the Languid Bomb. Now ask the Mayor what to do next. 
+QUEST_LV_0100_20150317_006316	Unlike what the mayor said, the bombs were in a small container. Ask the Mayor what happened.
+QUEST_LV_0100_20150317_006317	Made the Languid Bomb. Now ask the Mayor what to do next.
 QUEST_LV_0100_20150317_006318	Use the Languid bomb on sleeping Upent
 QUEST_LV_0100_20150317_006319	Mayor says let's use it on the Upent in Melagingas hill. Take the bomb to Melagingas Hill.
 QUEST_LV_0100_20150317_006320	
@@ -6323,7 +6323,7 @@ QUEST_LV_0100_20150317_006322	Kill the Demon Resident
 QUEST_LV_0100_20150317_006323	Go to the old well
 QUEST_LV_0100_20150317_006324	
 QUEST_LV_0100_20150317_006325	Look for something to put in the old well
-QUEST_LV_0100_20150317_006326	There is something in the old well but you can't see it clearly. Look for something that you can use to get the thing out of the well. 
+QUEST_LV_0100_20150317_006326	There is something in the old well but you can't see it clearly. Look for something that you can use to get the thing out of the well.
 QUEST_LV_0100_20150317_006327	Use the long rope and bucket to get the thing out of the well.
 QUEST_LV_0100_20150317_006328	Go to the Dvyni Swamp
 QUEST_LV_0100_20150317_006329	Look for the strong scented soul flower in Dvyni Swamp.
@@ -6331,10 +6331,10 @@ QUEST_LV_0100_20150317_006330
 QUEST_LV_0100_20150317_006331	
 QUEST_LV_0100_20150317_006332	
 QUEST_LV_0100_20150317_006333	Be careful of the trick of watcher
-QUEST_LV_0100_20150317_006334	A mysterious watcher appeared to share the belief of Goddess. Let's hear what he has to say. 
+QUEST_LV_0100_20150317_006334	A mysterious watcher appeared to share the belief of Goddess. Let's hear what he has to say.
 QUEST_LV_0100_20150317_006335	Jurga says there are more thing to do other than making the stimulant. Talk to Jurga.
 QUEST_LV_0100_20150317_006336	Destroy Bramble's roots
-QUEST_LV_0100_20150317_006337	Jurga says we must destroy the roots placed to heal Bramble's wound. The roots are in Sviesa Hills and Tankinta Vancant Lot. 
+QUEST_LV_0100_20150317_006337	Jurga says we must destroy the roots placed to heal Bramble's wound. The roots are in Sviesa Hills and Tankinta Vancant Lot.
 QUEST_LV_0100_20150317_006338	Removed all of Bramble's roots. Talk to Jurga.
 QUEST_LV_0100_20150317_006339	Seems like the Item Merchant has something left to say. Talk to the Item Merchant.
 QUEST_LV_0100_20150317_006340	Talk to the Accessory Merchant
@@ -6358,12 +6358,12 @@ QUEST_LV_0100_20150317_006357	Retrieve the stolen food supplies from the Vubbes
 QUEST_LV_0100_20150317_006358	Edgar says the Vubbes stole all the food supplies. Go and get it back from the Vubbes.
 QUEST_LV_0100_20150317_006359	This much food seems enough. Bring it back to Soldier Edgar.
 QUEST_LV_0100_20150317_006360	Defeat Vubbes and retrieve %s
-QUEST_LV_0100_20150317_006361	Talk to Miner's Village Mayor.
+QUEST_LV_0100_20150317_006361	Talk to Miners' Village Mayor.
 QUEST_LV_0100_20150317_006362	
 QUEST_LV_0100_20150317_006363	Miners' Village
-QUEST_LV_0100_20150317_006364	is found at the further right of the 
+QUEST_LV_0100_20150317_006364	is found at the further right of the
 QUEST_LV_0100_20150317_006365	
-QUEST_LV_0100_20150317_006366	which is located below the twin bridge of 
+QUEST_LV_0100_20150317_006366	which is located below the twin bridge of
 QUEST_LV_0100_20150317_006367	Leaf Veil Plateau
 QUEST_LV_0100_20150317_006368	is able go to there.
 QUEST_LV_0100_20150317_006369	
@@ -6376,11 +6376,11 @@ QUEST_LV_0100_20150317_006375
 QUEST_LV_0100_20150317_006376	Meet Rolindas Jonas
 QUEST_LV_0100_20150317_006377	
 QUEST_LV_0100_20150317_006378	Talk to the pharmacist
-QUEST_LV_0100_20150317_006379	Looks like healer lady has something to say. Talk to her. 
+QUEST_LV_0100_20150317_006379	Looks like healer lady has something to say. Talk to her.
 QUEST_LV_0100_20150317_006380	Give medicinal herb
 QUEST_LV_0100_20150317_006381	The pharmacist needs Yukopus leaves and Kepa stem to use as treatment for injured people.
 QUEST_LV_0100_20150317_006382	Pharmacist's Favor
-QUEST_LV_0100_20150317_006383	Give the Yukopus leaves and Kepa Stems that the Pharmacist requested. 
+QUEST_LV_0100_20150317_006383	Give the Yukopus leaves and Kepa Stems that the Pharmacist requested.
 QUEST_LV_0100_20150317_006384	Ask the pharmacist if she needs anything else.
 QUEST_LV_0100_20150317_006385	Get Medicine Materials
 QUEST_LV_0100_20150317_006386	She needs more Yukopus leaves and Kepa Stem to make more medicine.
@@ -6403,72 +6403,72 @@ QUEST_LV_0100_20150317_006402	Mr. Juan asked you to bring him Yukopus Leather to
 QUEST_LV_0100_20150317_006403	Acquired Yukopus Leather! Bring it to Mr. Juan.
 QUEST_LV_0100_20150317_006404	Mr. Juan asked you to bring him Vubbe Theif's Leather to make the armor.
 QUEST_LV_0100_20150317_006405	Acquired Vubbe Thief's Leather! Bring it to Mr. Juan.
-QUEST_LV_0100_20150323_006406	Now take the unsealing stone and go to Ramstis Ridge. {nl}Student of Gustas will teach you how to release the seal there. 
+QUEST_LV_0100_20150323_006406	Now take the unsealing stone and go to Ramstis Ridge. {nl}Student of Gustas will teach you how to release the seal there.
 QUEST_LV_0100_20150323_006407	Were you not guided yet?{nl}It's the student of Gustas in Ramstis Ridge.{nl}It is made to let only the chosen one enter.
 QUEST_LV_0100_20150323_006408	Ask the mayor for directions to Gele Plateau. {nl}I will sent the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
-QUEST_LV_0100_20150323_006409	The high gardens that the Goddess mentioned must be referring to the Gele Plateau. {nl}I heared the Paladin Master is there to keep a long term promise. 
+QUEST_LV_0100_20150323_006409	The high gardens that the Goddess mentioned must be referring to the Gele Plateau. {nl}I heared the Paladin Master is there to keep a long term promise.
 QUEST_LV_0100_20150323_006410	
 QUEST_LV_0100_20150323_006411	
-QUEST_LV_0100_20150323_006412	If you ever fight against us Rodeleros, better be careful of your legs. {nl}Swords pop out from below the shield. {nl}
+QUEST_LV_0100_20150323_006412	If you ever fight against us Rodeleros, better be careful of your legs. {nl}Swords pop out from below the shield.{nl}
 QUEST_LV_0100_20150323_006413	The simplest is the strongest. {nl}If you want to study the roots of everything, take the path of Elementalist.
 QUEST_LV_0100_20150323_006414	Go straight down the Twin Bridge and you'll arrive at Srautas Gorge.{nl}Go further into the right from the Srautas Gorge and you'll be able to get to Gele Plateau.
 QUEST_LV_0100_20150323_006415	The Paladin Master is in Gele Plateau.{nl}You can get there by riding the cable car.
-QUEST_LV_0100_20150323_006416	It is a device that the first Paladin set in preparation for the invasion of the demons. {nl}Many of it are placed to cover the whole of Nefritas Cliff. {nl}
+QUEST_LV_0100_20150323_006416	It is a device that the first Paladin set in preparation for the invasion of the demons. {nl}Many of it are placed to cover the whole of Nefritas Cliff.{nl}
 QUEST_LV_0100_20150323_006417	You need to find Goddess Saule..{nl}The colorful stream mentioned in the revelation must refer to the stream beginning at the Veja Ravine. {nl}Well then, may the blessings of Goddess be with you.
 QUEST_LV_0100_20150323_006418	This is the holy weapon used to fight against Gesti in Nefritas Cliff. {nl}It has been handed down from since the first Paladin.
 QUEST_LV_0100_20150323_006419	Go. Tenet Cathedral is in Tenet Garden.{nl}Be sure to stop the revelation from falling into the hands of Gesti.
 QUEST_LV_0100_20150323_006420	Go find Gesti. {nl}Tenet Cathedral is in Tenet Garden.
 QUEST_LV_0100_20150323_006421	There is a way to stop it but only you can do it. {nl}Please, come to Karsta battlefield in Fedimian outskirt.
-QUEST_LV_0100_20150323_006422	You need to use the cable car to go from Srautas to Leaf Veil Plateau. {nl}I heard people used to hang baskets on ropes in the past. {nl}Well the cable cars are scary enough for me. 
-QUEST_LV_0100_20150323_006423	I came to protect the diving land from the demons. {nl}I heard the Paladin Master is also in Gele Plateau. It surely must be a big problem. {nl}
+QUEST_LV_0100_20150323_006422	You need to use the cable car to go from Srautas to Leaf Veil Plateau. {nl}I heard people used to hang baskets on ropes in the past. {nl}Well the cable cars are scary enough for me.
+QUEST_LV_0100_20150323_006423	I came to protect the diving land from the demons. {nl}I heard the Paladin Master is also in Gele Plateau. It surely must be a big problem.{nl}
 QUEST_LV_0100_20150323_006424	I'm worried about my brother in Nefritas Cliff. {nl}I hope nothing happens to him.{nl}
 QUEST_LV_0100_20150323_006425	We have to stick with the dolls left. {nl}Everyone's lives are at stake in Nefritas Cliff and I can't complain about this, right?
-QUEST_LV_0100_20150323_006426	And if you're talking about Rukas Plateau, that place isn't worthy of research so it's been a while since we pulled out. 
-QUEST_LV_0100_20150323_006427	Understanding the root of everything becomes the power of Elementalist. {nl}Wind, Water, Fire, Earth. We pull the strongest powers from the simplest forms. 
-QUEST_LV_0100_20150323_006428	Bring the Crystal and find students of Gustas in Ramstis Ridge. {nl}They will teach you about the seal. 
+QUEST_LV_0100_20150323_006426	And if you're talking about Rukas Plateau, that place isn't worthy of research so it's been a while since we pulled out.
+QUEST_LV_0100_20150323_006427	Understanding the root of everything becomes the power of Elementalist. {nl}Wind, Water, Fire, Earth. We pull the strongest powers from the simplest forms.
+QUEST_LV_0100_20150323_006428	Bring the Crystal and find students of Gustas in Ramstis Ridge. {nl}They will teach you about the seal.
 QUEST_LV_0100_20150323_006429	The Netherbovines are causing trouble again? {nl}As long as the Rodeleros are here, no monster can set foot here.{nl}
 QUEST_LV_0100_20150323_006430	I used to live in the woods but I came here to do what I had to. {nl}I will do whatever that can be of help.
-QUEST_LV_0100_20150323_006431	Physical enhancing magic is a profound and mysterious field. {nl}If you make good use of it, you can easily identiry your friends or enemies. 
+QUEST_LV_0100_20150323_006431	Physical enhancing magic is a profound and mysterious field. {nl}If you make good use of it, you can easily identiry your friends or enemies.
 QUEST_LV_0100_20150323_006432	If the seal is released, you must go to the next seal in Ramstis Ridge.
 QUEST_LV_0100_20150323_006433	Death may be the price I pay for my sin. {nl}Even if it is the curse of the demons, it is still a sin I've made.
 QUEST_LV_0100_20150323_006434	I don't want to.. die like this.. {nl}Mother..
-QUEST_LV_0100_20150323_006435	Wait. Isn't the the eye of Succubus? {nl}Oh my. How did you get that.. Can I take a look? 
-QUEST_LV_0100_20150323_006436	I've heard about the eyes. {nl}Succubus envied the necklace with the blessings of Cathedral so she put it in her eyes. {nl}
-QUEST_LV_0100_20150323_006437	As you know, I may be an aspiring Elementalist? {nl}I can turn that back into a necklace. {nl}
+QUEST_LV_0100_20150323_006435	Wait. Isn't the the eye of Succubus? {nl}Oh my. How did you get that.. Can I take a look?
+QUEST_LV_0100_20150323_006436	I've heard about the eyes. {nl}Succubus envied the necklace with the blessings of Cathedral so she put it in her eyes.{nl}
+QUEST_LV_0100_20150323_006437	As you know, I may be an aspiring Elementalist? {nl}I can turn that back into a necklace.{nl}
 QUEST_LV_0100_20150323_006438	Done. {nl}Do you know about the five necklaces of Mayvern?{nl}
 QUEST_LV_0100_20150323_006439	It was created to remind people of the 5 sins. {nl}Though Naktis made it look like a curse on the Pilgrim's Way.{nl}
 QUEST_LV_0100_20150323_006440	Looks like the necklace belongs to you. {nl}If it wasn't for you, teachings of Mayvern would have been left as a curse.
-QUEST_LV_0100_20150323_006441	Actually, I want to go to Kvailas Forest. {nl}I want to see the source of evel with my two eyes. 
-QUEST_LV_0100_20150323_006442	Thank you. The blacksmith in Klaipeda sells the tools. {nl}But before that, stones in Stele Road are known for their fine quality so I ask of your favor. 
+QUEST_LV_0100_20150323_006441	Actually, I want to go to Kvailas Forest. {nl}I want to see the source of evel with my two eyes.
+QUEST_LV_0100_20150323_006442	Thank you. The blacksmith in Klaipeda sells the tools. {nl}But before that, stones in Stele Road are known for their fine quality so I ask of your favor.
 QUEST_LV_0100_20150323_006443	Done. Please place this in the entrance of Underground Mausoleum in Zachariel Crossroad. {nl}Will this be enough commfort.
 QUEST_LV_0100_20150323_006444	Hmm. You're really good as they say. {nl}Rolandas is waiting for you in Akmens Ridge.
 QUEST_LV_0100_20150323_006445	Please be careful. {nl}A dark aura similar to the voice a while ago is covering the Thron Forest. {nl}Especially the Kavilas Forest.. I have sharp ears for things like this..
 QUEST_LV_0100_20150323_006446	The Necroventer that occupied Kule Peak is gone. {nl}Kule Peak will be peaceful again.
-QUEST_LV_0100_20150323_006447	It's preparation for releasing the seal of Tiltas Vallye. {nl}The sap was collected little by little over centuries. {nl}Please handle it with care. 
-QUEST_LV_0100_20150323_006448	This is it. {nl}Bring the Release Crystal to Ramstis Ridge. {nl}Students of Ramstis will be welcome you there. 
+QUEST_LV_0100_20150323_006447	It's preparation for releasing the seal of Tiltas Vallye. {nl}The sap was collected little by little over centuries. {nl}Please handle it with care.
+QUEST_LV_0100_20150323_006448	This is it. {nl}Bring the Release Crystal to Ramstis Ridge. {nl}Students of Ramstis will be welcome you there.
 QUEST_LV_0100_20150323_006449	The day for the Great King's legacy finding its true owner has come. {nl}Hurry, go to the students of Gustas in Ramstis Ridge.
-QUEST_LV_0100_20150323_006450	The teacher is poisoned and can't breathe. {nl}Quickly borrow antidote from others in Akmens Ridge. 
-QUEST_LV_0100_20150323_006451	I had no idea about Rukas Plateau. {nl}What are they trying to by releasing the seal? {nl}
+QUEST_LV_0100_20150323_006450	The teacher is poisoned and can't breathe. {nl}Quickly borrow antidote from others in Akmens Ridge.
+QUEST_LV_0100_20150323_006451	I had no idea about Rukas Plateau. {nl}What are they trying to by releasing the seal?{nl}
 QUEST_LV_0100_20150323_006452	Follow the road on the right and go to Cobalt Forest. {nl}Our town priest is waiting for you.
 QUEST_LV_0100_20150323_006453	When you have all materials ready, combine it in Ershike altar.
 QUEST_LV_0100_20150323_006454	The evil force was first felt in Kvailas Forest. {nl}The force was very strong so it will remain this way for a while even if you get rid of Bramble.
-QUEST_LV_0100_20150323_006455	The evil force of Kvailas Forest is becomeing stronger but our followers are becoming weak. {nl}I hope you can help us. {nl}
-QUEST_LV_0100_20150323_006456	Maybe the source of evil of Kavilas Forest has become the forest itself. {nl}Though I hope this is just an idel fear. 
+QUEST_LV_0100_20150323_006455	The evil force of Kvailas Forest is becomeing stronger but our followers are becoming weak. {nl}I hope you can help us.{nl}
+QUEST_LV_0100_20150323_006456	Maybe the source of evil of Kavilas Forest has become the forest itself. {nl}Though I hope this is just an idel fear.
 QUEST_LV_0100_20150323_006457	It will come to and end when the evil force deep inside Kavailas Forest is removed. {nl}It's a pity everyone is chasing only what's right in front of them.
-QUEST_LV_0100_20150323_006458	Kvailas Forest is the worst. {nl}The evil force is at high and even your lives are at stake. 
+QUEST_LV_0100_20150323_006458	Kvailas Forest is the worst. {nl}The evil force is at high and even your lives are at stake.
 QUEST_LV_0100_20150323_006459	I miss my family in Cobalt Forest. {nl}And.. I want to apologize to my brother for the fight we had.
 QUEST_LV_0100_20150323_006460	I remember singing and playing the the streams of Cobalt Forest
-QUEST_LV_0100_20150323_006461	Can you tell it to the elderly in Vieta Gorge? {nl}Just go a little upward to the left. 
-QUEST_LV_0100_20150323_006462	The most important root must be somewhere in Kvailas Forest. {nl}Maybe we've going going around too much. {nl}Cutting off that root will reduce the forces of this forest. 
-QUEST_LV_0100_20150323_006463	I knew it was the poison of Evonipons. {nl}Its the only poison this strong. 
-QUEST_LV_0100_20150323_006464	Don't worry. I'll give you the recipe. {nl}Ridimed leaves from there will be enough to make it. 
+QUEST_LV_0100_20150323_006461	Can you tell it to the elderly in Vieta Gorge? {nl}Just go a little upward to the left.
+QUEST_LV_0100_20150323_006462	The most important root must be somewhere in Kvailas Forest. {nl}Maybe we've going going around too much. {nl}Cutting off that root will reduce the forces of this forest.
+QUEST_LV_0100_20150323_006463	I knew it was the poison of Evonipons. {nl}Its the only poison this strong.
+QUEST_LV_0100_20150323_006464	Don't worry. I'll give you the recipe. {nl}Ridimed leaves from there will be enough to make it.
 QUEST_LV_0100_20150323_006465	Is the antidote ready yet? {nl}That's terrible. He is getting worse.
-QUEST_LV_0100_20150323_006466	Evonipon sure are vicious. {nl}We need to hunt it down before it cause more damage. 
-QUEST_LV_0100_20150323_006467	Oh is it antidote? {nl}Thank you very much. I will let him take it right away. {nl}
+QUEST_LV_0100_20150323_006466	Evonipon sure are vicious. {nl}We need to hunt it down before it cause more damage.
+QUEST_LV_0100_20150323_006467	Oh is it antidote? {nl}Thank you very much. I will let him take it right away.{nl}
 QUEST_LV_0100_20150323_006468	If it weren't for you, many workers could have lost their lives for nothing. {nl}I will report about this to Sir Uska. {nl}Truly.. You were sent by the Goddess!{nl}
-QUEST_LV_0100_20150323_006469	A monster in the Owl Grave is a fair bet for you. {nl}Isn't it? 
+QUEST_LV_0100_20150323_006469	A monster in the Owl Grave is a fair bet for you. {nl}Isn't it?
 QUEST_LV_0100_20150323_006470	Chaparition of Escanciu Village took a lot of lives. {nl}Please defeat that monster in the name of the Goddess.
-QUEST_LV_0100_20150323_006471	I'm sorry but can you burn this oration in front of the epitaph in Rukas Plateau? {nl}You have explored different areas of the valley. {nl}I think you are more than qualified to comfort their souls. 
+QUEST_LV_0100_20150323_006471	I'm sorry but can you burn this oration in front of the epitaph in Rukas Plateau? {nl}You have explored different areas of the valley. {nl}I think you are more than qualified to comfort their souls.
 QUEST_LV_0100_20150323_006472	It's going for a killing spree of the monsters in the Owl Grave. {nl}Around 40 of them? I bet that you can't make it.
 QUEST_LV_0100_20150323_006473	I'll go to Ramstis Ridge and release the seal
 QUEST_LV_0100_20150323_006474	Let's go help Grita in Fedimian Outskirts
@@ -6504,25 +6504,25 @@ QUEST_LV_0100_20150323_006503	OK. (Stop the pursuit)
 QUEST_LV_0100_20150323_006504	Ask about the antidote
 QUEST_LV_0100_20150323_006505	
 QUEST_LV_0100_20150323_006506	Collect stones from Stele Road
-QUEST_LV_0100_20150323_006507	Stonemason Pipoti want to set up a memorial stone for his friend and other explorers who lost their lives here. Bring him the stones from Stele Road. 
+QUEST_LV_0100_20150323_006507	Stonemason Pipoti want to set up a memorial stone for his friend and other explorers who lost their lives here. Bring him the stones from Stele Road.
 QUEST_LV_0100_20150323_006508	Install memorial stone at the entrance of Underground Mausoleum in Zachariel Crossroads.
-QUEST_LV_0100_20150323_006509	The Mausoluem entrance is just the fit place to commemorate the lives lost in this area. Install the memorial stone at the Mausoleum entrance in Zachariel Corssroad. 
+QUEST_LV_0100_20150323_006509	The Mausoluem entrance is just the fit place to commemorate the lives lost in this area. Install the memorial stone at the Mausoleum entrance in Zachariel Corssroad.
 QUEST_LV_0100_20150323_006510	Pick up and retrieve the purifier tube on the way to district 7.
-QUEST_LV_0100_20150323_006511	Arrive at Miner's Village
-QUEST_LV_0100_20150323_006512	You must enter the Crystal Mines but the Miner's Village where the  Crystal Mine is located in is under attack by the Vubbes. Move to Miner's Village Quickly!
+QUEST_LV_0100_20150323_006511	Arrive at Miners' Village
+QUEST_LV_0100_20150323_006512	You must enter the Crystal Mines but the Miners' Village where the  Crystal Mine is located in is under attack by the Vubbes. Move to Miners' Village Quickly!
 QUEST_LV_0100_20150323_006513	Treasure Hunter Edang of Stele Road is looking for someone who can deliver the the stones.
 QUEST_LV_0100_20150323_006514	Talk to Grita in Fedimian Outskirts
 QUEST_LV_0100_20150323_006515	Grita is waiting in Karsta Battlefiield of Fedimian Outskirts. Go and talk to Grita.
 QUEST_LV_0100_20150323_006516	Came to Karsta Battlefiield and Grita is waiting for you. Go and talk to Grita.
 QUEST_LV_0100_20150323_006517	Goddess Gabija says you need to strengthen your powers in Katyn Forest Entrance. Pass by Tenet GArdens and go to Katyn Forest Entrance.
-QUEST_LV_0100_20150323_006518	Missed Gesti again but got back the revelation safely. Go to the Paladin Master in Nefritas Cliff. 
+QUEST_LV_0100_20150323_006518	Missed Gesti again but got back the revelation safely. Go to the Paladin Master in Nefritas Cliff.
 QUEST_LV_0100_20150323_006519	Guard Alen of Neritas Cliff is waiting for someone's help.
 QUEST_LV_0100_20150323_006520	Guard Kenneth of Nefritas Cliff is waiting for someone's help.
 QUEST_LV_0100_20150323_006521	Follower Kayetonas of Nefritas Cliff is looking for someone who can fight with him.
-QUEST_LV_0100_20150323_006522	The Paladin Master of Nefritas Cliff is waiting for you in Uzbaiga Highlands. 
+QUEST_LV_0100_20150323_006522	The Paladin Master of Nefritas Cliff is waiting for you in Uzbaiga Highlands.
 QUEST_LV_0100_20150323_006523	The Paladin Master is waiting for your help in Nefritas Cliff.
 QUEST_LV_0100_20150323_006524	Arrived at Akmens Ridge and Rolanda is waiting for you. Talk to Rolanda to find the legacy of King Zachariel.
-QUEST_LV_0100_20150323_006525	Archaeologist Dezek's status is getting worse. Cable car managers might have the antidote. Ask if others in Akmens Ridge have the antidote. 
+QUEST_LV_0100_20150323_006525	Archaeologist Dezek's status is getting worse. Cable car managers might have the antidote. Ask if others in Akmens Ridge have the antidote.
 QUEST_LV_0100_20150323_006526	Release all seals of Tiltas Valley
 QUEST_LV_0100_20150323_006527	Take the key from Overlong Bridge Valley and use the map from Akmens Ridge to release all seals of Awaiting Stone Bridge.
 QUEST_LV_0100_20150323_006528	Enter Underground Mausoleum in Zachariel Crossroad
@@ -6542,11 +6542,11 @@ QUEST_LV_0100_20150323_006541	The Highlander Master tells you to repair the wood
 QUEST_LV_0100_20150323_006542	Neritas Cliff/Tenet Garden
 QUEST_LV_0100_20150323_006543	The Highlander Master tells you to repair the wooden seal that you destroyed. To repair the seal, get woods from the Pyrent and ropes from the Red Panto Thrower in Nefritas Cliff.
 QUEST_LV_0100_20150323_006544	Defeat the monsters roaming around the Owl Grave.
-QUEST_LV_0100_20150323_006545	Hames suggested a bet. Defeat the monsters in Owl Grave. 
+QUEST_LV_0100_20150323_006545	Hames suggested a bet. Defeat the monsters in Owl Grave.
 QUEST_LV_0100_20150323_006546	Defeat the monsters in Owl Grave
 QUEST_LV_0100_20150323_006547	Defeat the monsters in Lemprasa Pond
 QUEST_LV_0100_20150323_006548	Officer Liudas say he'll give you an accessory if you defeat the monsters around. Defeat the monsters around Lamprasa Pond.
-QUEST_LV_0100_20150323_006549	Defeated a lot of monsters in Lamprasa Pond. Report to Offier Liudas. 
+QUEST_LV_0100_20150323_006549	Defeated a lot of monsters in Lamprasa Pond. Report to Offier Liudas.
 QUEST_LV_0100_20150323_006550	Historian Collin wants to honor the exploere who died while exploring this area. Burn the oration in their honor in front of the epitaph in Rukas Plateau.
 QUEST_LV_0100_20150323_006551	Burned the oration in fron of the epitaph in Rukas Plateau. Report to Historian Collin.
 QUEST_LV_0100_20150323_006552	Guards in Strautas are waiting for someone's help.
@@ -6567,7 +6567,7 @@ QUEST_LV_0100_20150323_006566	Tree Root Crystal of Laziness in the upper area of
 QUEST_LV_0100_20150323_006567	Tree Root Crystals of Laziness are in the upper area of Paskuti Trail Plaza. Take a closer look at it to find out what to do with it.
 QUEST_LV_0100_20150323_006568	Separate the soul of pilgrim
 QUEST_LV_0100_20150323_006569	Reduce the monster's HP near the Tree Root Crystal of Laziness and release the entrapped soul of pilgrim. Then break the soul to destroy the Tree Root Crystal.
-QUEST_LV_0100_20150323_006570	It might get its mind back if Witas' belongings is among the things you found. Talk to Pilgrim Witas. 
+QUEST_LV_0100_20150323_006570	It might get its mind back if Witas' belongings is among the things you found. Talk to Pilgrim Witas.
 QUEST_LV_0100_20150323_006571	When you showed the things, he raged and turned into a monster. Hold him back and try to talk to him again.
 QUEST_LV_0100_20150323_006572	Successfully stopped Witas that turned into a monster. Talk to Pilgrim Witas again.
 QUEST_LV_0100_20150323_006573	Defeat King Liverwort that Witas transformed to
@@ -6576,7 +6576,7 @@ QUEST_LV_0100_20150323_006575	Pilgrim Witas died. Make a grave for him.
 QUEST_LV_0100_20150323_006576	Pilgrim Theophilis is suddenly looking for you. Talk to him.
 QUEST_LV_0100_20150323_006577	Theophilis took out the Necklace of Envy from Succubus eyes. Talk to him again.
 QUEST_LV_0100_20150323_006578	The details of slate found in Crystal Mines mentions revelation of the Goddess about blocking the threats to Gele Plateau. Report about it to Commander Uska.
-QUEST_LV_0100_20150323_006579	Knight Commander Uska thinks the high gardens in the revelation refers to Gele Plateau and told you to go the the Paladin Master. Drop by the Mayor of Miner's Village and ask for directions to Gele Plateau.
+QUEST_LV_0100_20150323_006579	Knight Commander Uska thinks the high gardens in the revelation refers to Gele Plateau and told you to go the the Paladin Master. Drop by the Mayor of Miners' Village and ask for directions to Gele Plateau.
 QUEST_LV_0100_20150323_006580	Treasure Hunter of Stele Road is waiting for someone's help.
 QUEST_LV_0100_20150323_006581	Talk to the wandering soldier of Escanciu Village.
 QUEST_LV_0100_20150323_006582	Found a written command while checking the military bag of wandering soul in Escanciu Village. Check the details of the command.
@@ -6590,15 +6590,15 @@ QUEST_LV_0100_20150323_006589	Colleted all materials needed to restore the obeli
 QUEST_LV_0100_20150323_006590	Retrieve dye from Ershike Altar
 QUEST_LV_0100_20150323_006591	Move to Cobalt Forest
 QUEST_LV_0100_20150323_006592	Check Ershike Altar
-QUEST_LV_0100_20150323_006593	Omnius force is felt from the Ershike altar. Check what is happening. 
-QUEST_LV_0100_20150323_006594	Priest of Vieta Gorge told you to go to the priest in Andale Village. To go the Andale Village of Cobalt Forest. 
+QUEST_LV_0100_20150323_006593	Omnius force is felt from the Ershike altar. Check what is happening.
+QUEST_LV_0100_20150323_006594	Priest of Vieta Gorge told you to go to the priest in Andale Village. To go the Andale Village of Cobalt Forest.
 QUEST_LV_0100_20150323_006595	Check the portal of Veja Ravine
 QUEST_LV_0100_20150323_006596	The villagers were disguised as Demons. Run away to the portal in Veja Ravine.
 QUEST_LV_0100_20150323_006597	Check the old well in Coblat Forest.
 QUEST_LV_0100_20150323_006598	Move to Akmens Ridge
 QUEST_LV_0100_20150323_006599	Morcus Jonas says you can listen to the next story from Rolandas Jonas in Akmens Ridge.
 QUEST_LV_0100_20150323_006600	Go and meet Rolandas Jonas in Akmens Ridge.
-QUEST_LV_0100_20150323_006601	Goddess Saule says Bramble of Kvailas Forest is in Thorn Forest. Pass through Gate Route and Spine Heart Dale to Kvailas Forest to find the revelation. 
+QUEST_LV_0100_20150323_006601	Goddess Saule says Bramble of Kvailas Forest is in Thorn Forest. Pass through Gate Route and Spine Heart Dale to Kvailas Forest to find the revelation.
 QUEST_LV_0100_20150323_006602	Kvailas Forest
 QUEST_LV_0100_20150323_006603	Move to Gele Plateau
 QUEST_LV_0100_20150323_006604	Gele Plateau
@@ -6621,11 +6621,11 @@ QUEST_LV_0100_20150406_006620	Looking for information on Varkis/SITGROPE_LOOP/3/
 QUEST_LV_0100_20150406_006621	Notice/!/Can't find research data and Unknocker suddenly appreared!{nl}Unknocker might have the research data! Defeat Unknocker!#7
 QUEST_LV_0100_20150406_006622	Defeat Ritorex
 QUEST_LV_0100_20150406_006623	Defeat Unknocker and get %s
-QUEST_LV_0100_20150414_006624	They are already gone from this world. {nl}They are repeating what happened back then because of their anger for Gaigalas. 
-QUEST_LV_0100_20150414_006625	This cable car does work. {nl}But the monsters around make it such a hassle to maintain it. 
-QUEST_LV_0100_20150414_006626	Can you take care of it? 
-QUEST_LV_0100_20150414_006627	Better use the cable car rather than going throught the monsters. 
-QUEST_LV_0100_20150414_006628	I thinks monsters are crawling out of the mysterious barrier in Nuotori Cliff. {nl}Can you get rid of that barrier? 
+QUEST_LV_0100_20150414_006624	They are already gone from this world. {nl}They are repeating what happened back then because of their anger for Gaigalas.
+QUEST_LV_0100_20150414_006625	This cable car does work. {nl}But the monsters around make it such a hassle to maintain it.
+QUEST_LV_0100_20150414_006626	Can you take care of it?
+QUEST_LV_0100_20150414_006627	Better use the cable car rather than going throught the monsters.
+QUEST_LV_0100_20150414_006628	I thinks monsters are crawling out of the mysterious barrier in Nuotori Cliff. {nl}Can you get rid of that barrier?
 QUEST_LV_0100_20150414_006629	Maintenance would be easier now that the barrier is gone.
 QUEST_LV_0100_20150414_006630	Go down from the middle of Twin Bridge and you'll arrive at Srautas Gorge. {nl}Go further into the left from there and you'll get to Geli Plateau.
 QUEST_LV_0100_20150414_006631	First, get rid of the Hanamings around. {nl}And gather Hanaming flowers while you're at it.
@@ -6640,7 +6640,7 @@ QUEST_LV_0100_20150414_006639	Denoptik is trying to control the contaminated gua
 QUEST_LV_0100_20150414_006640	Thank you in the name of the Goddes! {nl}Please get rid of the filthy Cockatrice first that are spreading diseases.
 QUEST_LV_0100_20150414_006641	Get your hands on the demons a bit then use the power of barrier to extract the soul. {nl}Then, you get rid of the soul. Would you give it a try?
 QUEST_LV_0100_20150414_006642	Our squad was given order to hunt down the Unicorn. {nl}Details should be in the command plan..
-QUEST_LV_0100_20150414_006643	The plan is to transform into a demon and confuse them. {nl} Please collect Pondel and Pond's clothings first.
+QUEST_LV_0100_20150414_006643	The plan is to transform into a demon and confuse them.{nl}Please collect Pondel and Pond's clothings first.
 QUEST_LV_0100_20150414_006644	Activate Malda Altar and the demons nearby it will be sealed. {nl}You must get rid of those demons.
 QUEST_LV_0100_20150414_006645	I'm tired. I want to rest. {nl}I just need a lilttle time so can you take care of the demons around?
 QUEST_LV_0100_20150414_006646	Kill whenever you see it. {nl}Only then our brothers can feel safe to protect the Church.
@@ -6650,7 +6650,7 @@ QUEST_LV_0100_20150414_006649	I am here and all over the world. {nl}I am collect
 QUEST_LV_0100_20150414_006650	Where are my other pieces..
 QUEST_LV_0100_20150414_006651	I am Demon Monarch Houberg. {nl}Helga Sercle torn up my soul and a part of me is in the barrier of this tower, {nl}and the rest was spead in the world.
 QUEST_LV_0100_20150414_006652	You still have business left?
-QUEST_LV_0100_20150414_006653	Altars here are defensive devices againt Mausoleum intruders. {nl}It was built a long time ago so it should be activated again {nl}but no one knew how. {nl}
+QUEST_LV_0100_20150414_006653	Altars here are defensive devices againt Mausoleum intruders. {nl}It was built a long time ago so it should be activated again {nl}but no one knew how.{nl}
 QUEST_LV_0100_20150414_006654	But the seal in Rukas Plateau was the answer. {nl}The altar will not function if it is destroyed {nl}but if we get to activate it before that..
 QUEST_LV_0100_20150414_006655	I don't know what Rexipher want to do{nl}but it sure can block him from doing it.
 QUEST_LV_0100_20150414_006656	It's either Rexipher destroying the seal, or us activating the altar. {nl}Run and don't look back!
@@ -6698,16 +6698,16 @@ QUEST_LV_0100_20150414_006697	Domas says he needs Cauliflower sap because of the
 QUEST_LV_0100_20150414_006698	Combine Ridimed leaf and detox solvent to make antidote.
 QUEST_LV_0100_20150428_006699	I heard the sound of figthing so I cam here in a hurry..Have you defeated it?{nl}I only spotted Siaulambs.{nl}Well done. You have performanced a meritorious deed.
 QUEST_LV_0100_20150428_006700	I feel stuffy.
-QUEST_LV_0100_20150428_006701	)} {nl} If you have time, Please tell our troops to assemble.{nl}If you don't want to, you may just go ahead to Klaipeda.
+QUEST_LV_0100_20150428_006701	)}{nl}If you have time, Please tell our troops to assemble.{nl}If you don't want to, you may just go ahead to Klaipeda.
 QUEST_LV_0100_20150428_006702	Thank you so much for your support.{nl}Follow the road on the left of the camp crossroads. {-scp SCR_DIALOG_NPC_ANIM(
-QUEST_LV_0100_20150428_006703	Vubbe Figther is hiding deep in the Nudegi Felled Area. {nl} We got the orders to kill but it may be safer to wait for additional troops.
+QUEST_LV_0100_20150428_006703	Vubbe Figther is hiding deep in the Nudegi Felled Area.{nl}We got the orders to kill but it may be safer to wait for additional troops.
 QUEST_LV_0100_20150428_006704	We should check by rubbing Hallowventer's wooden coals.{nl}The next epitaph is at the right side of Negibas Fields.
 QUEST_LV_0100_20150428_006705	We can suppress the vicious energy if the magic of the tomb get unleashed.{nl}I need the activating stone that is located inside the protector.
 QUEST_LV_0100_20150428_006706	It seems that there are more monsters here now compared to the number monsters that were present before I lost my conciousness.{nl}Did something happen to Gabiya?
 QUEST_LV_0100_20150428_006707	It mya be better for Gabiy to let her know that we are here.{nl}There's a people that we can ignite light on. Let's go.
 QUEST_LV_0100_20150428_006708	Good. Since she knows that we came, she will recover her health.{nl}Let's go up to see Gabiya.{nl{nl}
-QUEST_LV_0100_20150428_006709	I could handle it myself. {nl}Those weaklings would come trembling on their knees to return the parts. {nl} But what if more thieves come while I'm at it?
-QUEST_LV_0100_20150428_006710	Welcome, I'm glad to see that you've had a safe journey here. {nl}Before anything else, there are things about this place that the Revelator should know. {nl}
+QUEST_LV_0100_20150428_006709	I could handle it myself. {nl}Those weaklings would come trembling on their knees to return the parts.{nl}But what if more thieves come while I'm at it?
+QUEST_LV_0100_20150428_006710	Welcome, I'm glad to see that you've had a safe journey here. {nl}Before anything else, there are things about this place that the Revelator should know.{nl}
 QUEST_LV_0100_20150428_006711	That's why I am thinking about setting fire.{nl}I hope you collect the fats by defeating Malidus.
 QUEST_LV_0100_20150428_006712	I leave Ruklys on this land with my regrets and tears.{nl}If there's someone who wants to continue his will, I want to leave my secret on this gravestone.{nl}I will summarize the long writings here.
 QUEST_LV_0100_20150428_006713	Even if a person is in danger, if he knows that someone will come to help him, he will have the extra energy to endure longer.
@@ -6747,12 +6747,12 @@ QUEST_LV_0100_20150428_006746	This is then entrance to the tower.{nl}I became un
 QUEST_LV_0100_20150428_006747	I will take care of you and take you to Gabiya.{nl}Are you ready?
 QUEST_LV_0100_20150428_006748	All other magicians either died or ran away.{nl}You are the last hope of us. Let's go it.
 QUEST_LV_0100_20150428_006749	Gabiya had not disappeared herself.{nl}To protect the tower from demons, she just could not appear.{nl}
-QUEST_LV_0100_20150428_006750	Agailla Flurry's is not found is successor, I heard and was borne away instead. To refer it's in order to ensure that a {nl} something important .. I don't know exactly.
+QUEST_LV_0100_20150428_006750	Agailla Flurry's is not found is successor, I heard and was borne away instead. To refer it's in order to ensure that a{nl}something important .. I don't know exactly.
 QUEST_LV_0100_20150428_006751	I was sealed when my spirit is ripped off by high class demon.{nl}Please get rid of Infrorotor for me. I promise you that I will not be burden to you.
 QUEST_LV_0100_20150428_006752	Eyes of Surveillance are attached to Infroroktor.
 QUEST_LV_0100_20150428_006753	Those pieces of another me lost the voices to call you.{nl}Please find my voice again from Arma.
 QUEST_LV_0100_20150428_006754	Let's meet at Technical Room 1. {nl}Ah, it will be better if you could get the Blackened Essence from monsters.
-QUEST_LV_0100_20150428_006755	We need the rope for ceremony to make the shaman doll. {nl} It's on the waist of the Panto Shaman in the Cottage. {nl} Bring it to me.
+QUEST_LV_0100_20150428_006755	We need the rope for ceremony to make the shaman doll.{nl}It's on the waist of the Panto Shaman in the Cottage.{nl}Bring it to me.
 QUEST_LV_0100_20150428_006756	Please go to Viesa's Altar.{nl}I will follow you.
 QUEST_LV_0100_20150428_006757	It's either Rexipher destroying the altar, or us activating the altar. {nl}Run and don't look back!
 QUEST_LV_0100_20150428_006758	Looks like the necklace and collection belongs to you. {nl}If it wasn't for you, teachings of Mayvern would have been left as a curse.
@@ -6786,12 +6786,12 @@ QUEST_LV_0100_20150428_006785	To find the Jewel of Prominence, just use this det
 QUEST_LV_0100_20150428_006786	The portal that you tried to open is the gate of lies.{nl}The villagers hear are the tricks of Demons' lord, Bramble.
 QUEST_LV_0100_20150428_006787	I am Saule, the Goddess of the sun.{nl}Everything is just like how Lamia has forseen.
 QUEST_LV_0100_20150428_006788	It's true that I am looking for the revelator, but I need someone skillful.{nl}I am sorry, but you don't look like the revelator I am looking for.
-QUEST_LV_0100_20150428_006789	Welcome. {nl} These items were hard to get.
-QUEST_LV_0100_20150428_006790	I'm sorry but can you burn this oration in front of the epitaph in Rukas Plateau? {nl}You have explored different areas of the valley. {nl}I think you are more than qualified to comfort their souls. 
-QUEST_LV_0100_20150428_006791	This place is like a grave for many explorers and historians. {nl} And we study to find more factual history on top of their graves.
+QUEST_LV_0100_20150428_006789	Welcome.{nl}These items were hard to get.
+QUEST_LV_0100_20150428_006790	I'm sorry but can you burn this oration in front of the epitaph in Rukas Plateau? {nl}You have explored different areas of the valley. {nl}I think you are more than qualified to comfort their souls.
+QUEST_LV_0100_20150428_006791	This place is like a grave for many explorers and historians.{nl}And we study to find more factual history on top of their graves.
 QUEST_LV_0100_20150428_006792	Good job.{nl}I will take the Jewel of Prominence.
 QUEST_LV_0100_20150428_006793	We came here from the Vubbes' attack.{nl}But, This place seems to be not safe.
-QUEST_LV_0100_20150428_006794	The demons have been chasing the revelation before I made this revelation. {nl} Gesti, the leader of the demons whom you have met is one of them. {nl}
+QUEST_LV_0100_20150428_006794	The demons have been chasing the revelation before I made this revelation.{nl}Gesti, the leader of the demons whom you have met is one of them.{nl}
 QUEST_LV_0100_20150428_006795	Alright, I will tell the troops to assemble
 QUEST_LV_0100_20150428_006796	Notice/!/Jonna Jolem appeared with the treasure box from the marked place.{nl}Defeat Jonna Jolem and find a clue to open the box!#7
 QUEST_LV_0100_20150428_006797	Notice/!Unknocker suddenly appeared!{nl}Unknocker might have the research data! Defeat Unknocker!#7
@@ -6826,9 +6826,9 @@ QUEST_LV_0100_20150428_006825	Fortunately, it seems that you protected the altar
 QUEST_LV_0100_20150428_006826	The altar of Cheteque is destroyed, but you successfully activated the altar of Sviesa. Talk to Historian Cyrenia Odell.
 QUEST_LV_0100_20150428_006827	Obtained the fat of Miladu
 QUEST_LV_0100_20150428_006828	Rexipher kidnapped the historian, Cyrenia Odell. Go follow Rexipher to the Zachariel Intersection.
-QUEST_LV_0100_20150428_006829	As Rexipher ordered, after you defeated the protectors of the royal tomb of Sesija parvis, Rexipher disappeared through the parvis. To find Cyrenia Odell, you should go past the parvis and go after Rexipher. He must be at the place not far away. 
+QUEST_LV_0100_20150428_006829	As Rexipher ordered, after you defeated the protectors of the royal tomb of Sesija parvis, Rexipher disappeared through the parvis. To find Cyrenia Odell, you should go past the parvis and go after Rexipher. He must be at the place not far away.
 QUEST_LV_0100_20150428_006830	Restore the monument of Ruklys
-QUEST_LV_0100_20150428_006831	The Highlander Master is telling you that since you broke the practice wooden seal, you should pay for it by repairing it. First, obtain the woods from Firent at Nepritas Cliffs, the rope from Panto archer that are the materials for the repair. 
+QUEST_LV_0100_20150428_006831	The Highlander Master is telling you that since you broke the practice wooden seal, you should pay for it by repairing it. First, obtain the woods from Firent at Nepritas Cliffs, the rope from Panto archer that are the materials for the repair.
 QUEST_LV_0100_20150428_006832	Obtain %s from Panto Archer
 QUEST_LV_0100_20150428_006833	Defeat Red InfroRocter
 QUEST_LV_0100_20150428_006834	The sealed stone told you that it won't do anything bad to you and defeat the oberserver for it. Defeat Red InfroRocter for the sealed stone.
@@ -6871,10 +6871,10 @@ QUEST_LV_0100_20150511_006870	I think, these words are indicating a very dangero
 QUEST_LV_0100_20150511_006871	Ah, if you don't have confidence, you should be caught easily.{nl}Before you use the scroll, it is important to gain some confidence by fighting against the demons.
 QUEST_LV_0100_20150511_006872	I feel happy to see them being defeated.{nl}But, I think i need more research on it.
 QUEST_LV_0100_20150511_006873	You should be ready before you take the essence of light to the entrance.{nl}It could attract a powerful monster.
-QUEST_LV_0100_20150511_006874	I feel relieved to have you beside.{nl}I feel that the fact that Laima has chosen you is very fortunate. 
+QUEST_LV_0100_20150511_006874	I feel relieved to have you beside.{nl}I feel that the fact that Laima has chosen you is very fortunate.
 QUEST_LV_0100_20150511_006875	Explosion, that was too dangerous.{nl}Let's find a safer way to destroy it.
 QUEST_LV_0100_20150511_006876	There are many things to protect so we should not irritate those demons and defeat them quietly.{nl}I feel so relieved to have you, revelator.
-QUEST_LV_0100_20150511_006877	There are rumors about Golems appearing so don't go far too deep. {nl} It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
+QUEST_LV_0100_20150511_006877	There are rumors about Golems appearing so don't go far too deep.{nl}It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
 QUEST_LV_0100_20150511_006878	You are easily exposed to enemies' attacks when you are using a bow.{nl}So my strategy is to use anything such as a shield or a stone to protect myself.
 QUEST_LV_0100_20150511_006879	Most of them are already in my head, but that is a really important material.{nl}It contains information on how to enter the royal tomb and such.
 QUEST_LV_0100_20150511_006880	This map marks all the locations of the sealed devices at Tiltas Canyon.{nl}When you release all those seals with the key of the great king, you will know what to do yourself.
@@ -6911,7 +6911,7 @@ QUEST_LV_0100_20150511_006910	Look for research materials of Bakis near Apati Cl
 QUEST_LV_0100_20150511_006911	Monsters are attacking. You better defeat them quickly.
 QUEST_LV_0100_20150511_006912	It seems that Bakis doesn't have regrets on his research anymore. Talk to him again.
 QUEST_LV_0100_20150511_006913	It seems that the newcomer seems to be in a trouble. You better help him out.
-QUEST_LV_0100_20150511_006914	The unstable owl told you that it would be better to face Sequoia with divine power. Let's collect the wooden pieces with the divine power of the broken owl sculpture in them. 
+QUEST_LV_0100_20150511_006914	The unstable owl told you that it would be better to face Sequoia with divine power. Let's collect the wooden pieces with the divine power of the broken owl sculpture in them.
 QUEST_LV_0100_20150511_006915	At the end of the Stone Pole Hill, the portal that leads to the secret place of the royal tomb was opened after releasing all the seals! Use the portal to go to the secret place.
 QUEST_LV_0100_20150511_006916	The treasure hunter, Ethan is saying confidently that he is sure that the tama swalloed all the artifacts. Defeat the tama and look for the artifacts.
 QUEST_LV_0100_20150714_006917	


### PR DESCRIPTION
- Removed many unnecessary whitespaces
- Updated dialogue in lines 001 - 510
- Replaced Miner's Village with Miners' Village (unless there really
  only is one miner and it's his village)

QUEST_LV_0100_20150317_000113 - previous line mentions assistant named
Irene and then uses "he" to refer to said assistant. Irene being a
womans name I changed this to she instead. Irene is also later referred
to as "her". but without context it's hard to know if this line is
actually referring to Irene at all. could be someone else entirely.
QUEST_LV_0100_20150317_000173 - changed Greak to Great as Greak isn't a
word and it doesn't seem to appear anywhere else in the document, so I'm
assuming it's a typo
QUEST_LV_0100_20150317_000255 - not sure what to make of this line
really
QUEST_LV_0100_20150317_000278 - I am not sure what to make of this bit
{nl}{-scp
SCR_DIALOG_NPC_ANIM( .. does it need to be there or not?
QUEST_LV_0100_20150317_000279 - a number of lines including this one
start with the symbols )}.. is there a reason for this?
