### PR TITLE
Update ITEM.tsv

### DIFF
--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -2713,69 +2713,69 @@ ITEM_20150317_002712	Devilglove Fragment
 ITEM_20150317_002713	 
 ITEM_20150317_002714	Moa Feather 
 ITEM_20150317_002715	 
-ITEM_20150317_002716	Parchment 
-ITEM_20150317_002717	Luxurious parchment. You can write anything on it. Purchasable from the Pardoner Master. 
-ITEM_20150317_002718	Synthetic Stone 
-ITEM_20150317_002719	A material used for item synthesis. 
-ITEM_20150317_002720	String Amulet 
-ITEM_20150317_002721	Magic Amulet 
-ITEM_20150317_002722	Skull Amulet 
-ITEM_20150317_002723	Bone Amulet 
-ITEM_20150317_002724	Crave Amulet 
-ITEM_20150317_002725	Emoticon: Kepa (Joy) 
-ITEM_20150317_002726	Add this emoticon to the list. 
-ITEM_20150317_002727	You can add chat emoticons to quickslots. Right-click to use. 
-ITEM_20150317_002728	Emoticon: Kepa (Sadness) 
-ITEM_20150317_002729	Copper Ore 
-ITEM_20150317_002730	Iron Ore 
-ITEM_20150317_002731	A very common ore. 
-ITEM_20150317_002732	Steel Ore 
-ITEM_20150317_002733	An ore harder than Iron Ore. 
-ITEM_20150317_002734	Titanium Ore 
-ITEM_20150317_002735	Strong yet light ore. 
-ITEM_20150317_002736	Mithril Ore 
-ITEM_20150317_002737	Shining, silvery ore. It is used for crafting powerful equipment since it contains magic power. 
-ITEM_20150317_002738	Orichalcum Ore 
-ITEM_20150317_002739	Ithildin Ore 
-ITEM_20150317_002740	During the Kingdom's founding period, it used to be an ore mined only with the Goddess' guidance. It is more commonly found today. 
-ITEM_20150317_002741	Annotation 
-ITEM_20150317_002742	Obtainable from Corylus. 
-ITEM_20150317_002743	Titanium 
-ITEM_20150317_002744	Amber 
-ITEM_20150317_002745	Gemstone 
-ITEM_20150317_002746	Tree sap that hardened into a gem over the course of several years. 
-ITEM_20150317_002747	Fossilized Lizard Amber 
-ITEM_20150317_002748	A very rare amber in which a lizard is trapped inside. 
-ITEM_20150317_002749	Topaz 
-ITEM_20150317_002750	A yellow gemstone. It is said to contain the power to banish Demons. 
-ITEM_20150317_002751	Opal 
-ITEM_20150317_002752	A gemstone that shines in various colors. 
-ITEM_20150317_002753	Garnet 
-ITEM_20150317_002754	A red colored gemstone similar to Ruby, however more common. 
-ITEM_20150317_002755	Obsidian 
-ITEM_20150317_002756	A black, opaque gemstone. 
-ITEM_20150317_002757	Peridot 
-ITEM_20150317_002758	Green gemstone that is said to protect the holder from evil spirits. 
-ITEM_20150317_002759	Zircon 
-ITEM_20150317_002760	A brown colored gem. 
+xITEM_20150317_002716	Parchment 
+xITEM_20150317_002717	Luxurious parchment. You can write anything on it. Purchasable from the Pardoner Master. 
+xITEM_20150317_002718	Synthetic Stone 
+xITEM_20150317_002719	A material used for item synthesis. 
+xITEM_20150317_002720	String Amulet 
+xITEM_20150317_002721	Magic Amulet 
+xITEM_20150317_002722	Skull Amulet 
+xITEM_20150317_002723	Bone Amulet 
+xITEM_20150317_002724	Crave Amulet 
+xITEM_20150317_002725	Emoticon: Kepa (Joy) 
+xITEM_20150317_002726	Add this emoticon to the list. 
+xITEM_20150317_002727	You can add chat emoticons to quickslots. Right-click to use. 
+xITEM_20150317_002728	Emoticon: Kepa (Sadness) 
+xITEM_20150317_002729	Copper Ore 
+xITEM_20150317_002730	Iron Ore 
+xITEM_20150317_002731	A very common ore. 
+xITEM_20150317_002732	Steel Ore 
+xITEM_20150317_002733	An ore harder than Iron Ore. 
+xITEM_20150317_002734	Titanium Ore 
+xITEM_20150317_002735	A strong, yet light, ore. 
+xITEM_20150317_002736	Mithril Ore 
+xITEM_20150317_002737	A shining, silvery ore. It is used for crafting powerful equipment, since it contains magic power. 
+xITEM_20150317_002738	Orichalcum Ore 
+xITEM_20150317_002739	Ithildin Ore 
+xITEM_20150317_002740	During the Kingdom's founding period, it used to be an ore mined only with the Goddess' guidance. It is more common, today. 
+xITEM_20150317_002741	Annotation 
+xITEM_20150317_002742	Obtainable from Corylus. 
+xITEM_20150317_002743	Titanium 
+xITEM_20150317_002744	Amber 
+xITEM_20150317_002745	Gemstone 
+xITEM_20150317_002746	Tree sap that hardened into a gem over the course of several years. 
+xITEM_20150317_002747	Fossilized Lizard Amber 
+xITEM_20150317_002748	A very rare piece of amber in which a lizard is trapped inside. 
+xITEM_20150317_002749	Topaz 
+xITEM_20150317_002750	A yellow gemstone. It is said to contain the power to banish Demons. 
+xITEM_20150317_002751	Opal 
+xITEM_20150317_002752	A gemstone that shines in various colors. 
+xITEM_20150317_002753	Garnet 
+xITEM_20150317_002754	A red colored gemstone similar to a Ruby, however, it is far more common. 
+xITEM_20150317_002755	Obsidian 
+xITEM_20150317_002756	A black, opaque gemstone. 
+xITEM_20150317_002757	Peridot 
+xITEM_20150317_002758	Green gemstone that is said to protect the holder from evil spirits. 
+xITEM_20150317_002759	Zircon 
+xITEM_20150317_002760	A brown colored gem. 
 ITEM_20150317_002761	Pyrite 
-ITEM_20150317_002762	A stone containing the condensed power of flame. Purchasable from Pyromancer Master. 
-ITEM_20150317_002763	Bloodstone 
-ITEM_20150317_002764	Blood-colored gemstone. It is said to have healing powers. 
+xITEM_20150317_002762	A stone containing the condensed power of flame. Purchasable from Pyromancer Master. 
+xITEM_20150317_002763	Bloodstone 
+xITEM_20150317_002764	Blood-colored gemstone. It is said to have healing powers. 
 ITEM_20150317_002765	Cryorite 
-ITEM_20150317_002766	A stone infused with the power of frost. 
-ITEM_20150317_002767	Pyrostone 
-ITEM_20150317_002768	A Pyrite enhanced and processed by magic. The recipe can be purchased from the Tool Shop Merchant. 
-ITEM_20150317_002769	Cryostone 
-ITEM_20150317_002770	A Cryorite enhanced and processed by magic. The recipe can be purchased from the Tool Shop Merchant. 
-ITEM_20150317_002771	Pyranium 
-ITEM_20150317_002772	Ore made by fusing the properties of metal into a Pyrostone. 
-ITEM_20150317_002773	Cryonium 
-ITEM_20150317_002774	Ore made by iusing the properties of metal into a Cryostone. 
-ITEM_20150317_002775	Diamond 
-ITEM_20150317_002776	A colorless, transparent gemstone. Harder than metals and very rare even amongst gemstones. 
-ITEM_20150317_002777	Sapphire 
-ITEM_20150317_002778	Beautiful blue gemstone. Its price increases relative to the shade of blue of the stone. 
+xITEM_20150317_002766	A stone infused with the power of frost. 
+xITEM_20150317_002767	Pyrostone 
+ITEM_20150317_002768	Pyrite enhanced and processed by magic. The recipe can be purchased from the Tool Shop Merchant. 
+xITEM_20150317_002769	Cryostone 
+ITEM_20150317_002770	Cryorite enhanced and processed by magic. The recipe can be purchased from the Tool Shop Merchant. 
+xITEM_20150317_002771	Pyranium 
+xITEM_20150317_002772	Ore made by fusing the properties of metal into a Pyrostone. 
+xITEM_20150317_002773	Cryonium 
+xITEM_20150317_002774	Ore made by fusing the properties of metal into a Cryostone. 
+xITEM_20150317_002775	Diamond 
+xITEM_20150317_002776	A colorless, transparent gemstone. Harder than any metal, and very rare even amongst gemstones. 
+xITEM_20150317_002777	Sapphire 
+xITEM_20150317_002778	Beautiful blue gemstone. Its price increases relative to its shade of blue. 
 ITEM_20150317_002779	Book Name 
 ITEM_20150317_002780	Right-click to read 
 ITEM_20150317_002781	Lydia Schaffen and the Fletcher 


### PR DESCRIPTION
Edit and Review of lines 2716 through  2778

---

Lines 2761, 2765, 2768, and 2770 discuss stones referred to as "Pyrite" and "Cryorite." For pyrite, the english meaning of the stone also  refers to "Fool's Gold." I'm not exactly sure if this is meant to be the case, or if calling it "Pyroite" would be better suited.  For Cryorite, there is a real stone called "Cryolite."  As with "Pyrite," I'm not sure if we're referring to real (magically enhanced) or purely magical stones.  This being said, I left the terms untouched and the lines without x's for now.  Of the various options to go with, I feel like we have:

"Pyrorite" and "Cryorite" (Most fitting in magical terms, but least tied to real-world stones) [My vote]
"Pyrolite" and "Cryolite" (Also fitting, but both stones have real world meanings [Pyrolite is a theoretical stone in the earth's mantle])
"Pyrite" and "Cryorite" (Everything left as is)
"Pyrite" and "Cryolite" (Most realistic - all stones are the names of actual minerals in the english language)
