### PR TITLE
Update SKILL.tsv

### DIFF
--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -8,8 +8,8 @@ SKILL_20150317_000007	[Puragi] Physical, Hit, Posion Property, Normal Attack 1 t
 SKILL_20150317_000008	[Puragi] Physical, Strike, Posion Property, Attack 1 time(s)
 SKILL_20150317_000009	[Puragi] Physical, Strike, Posion Property, Stomp 1 time(s)
 SKILL_20150317_000010	[Zigri] Normal Attack, Fan shaped attack area
-SKILL_20150317_000011	[Zigri] Rotating Attack
-SKILL_20150317_000012	[Zigri] Jump and Somping shock
+SKILL_20150317_000011	[Zigri] Spinning Attack
+SKILL_20150317_000012	[Zigri] Jump and Stomping shock
 SKILL_20150317_000013	[Fisherman] Physical, Strike, Ice Property, Strike with Fishing Rod
 SKILL_20150317_000014	[Fisherman] Magic, Buff, Magic,
 SKILL_20150317_000015	[Pokuborn] Physical, Stab, Lightning Property, Strike with horn
@@ -54,9 +54,9 @@ SKILL_20150317_000053	[Mini Griba] Physical, Strike, Posion Property, Two-hand S
 SKILL_20150317_000054	[Griba] Physical, Strike, Ice Property Attack 1 time(s)
 SKILL_20150317_000055	[Griba] Magic, Magic, Ice Property Attack 1 time(s)
 SKILL_20150317_000056	[Old Kepa] Normal Attack, Fan Shape Attack Area
-SKILL_20150317_000057	[Tree Ghost] One-hand Strike,,,
+SKILL_20150317_000057	[Tree Ghost] One-hand strike
 SKILL_20150317_000058	[Tree Ghost] Two hand clap
-SKILL_20150317_000059	[Tree Ghost] Stomp ground
+SKILL_20150317_000059	[Tree Ghost] Stomp
 SKILL_20150317_000060	[Cockatrice] Magic, Magic, Fire Property, Fume fire 3 time(s)
 SKILL_20150317_000061	[Zinute] Physical Stab Fire Property Attack 1 time(s)
 SKILL_20150317_000062	[Zinute] Physical Slash Fire Property Attack 1 time(s)
@@ -77,7 +77,7 @@ SKILL_20150317_000076	[Desmodus] Physical, Stab, Dark Property Body Blow
 SKILL_20150317_000077	[Pino] Physical Blow, Earth Property Attack 1 time(s)
 SKILL_20150317_000078	[Cauliflower] Physical, Stab, Posion Property, Smash with tentacle
 SKILL_20150317_000079	[Cauliflower] Physical, Stab, Posion Property, Smash with tentacle
-SKILL_20150317_000080	[Cauliflower] Physical, Stab, Posion Property, 바닥을 내려치기
+SKILL_20150317_000080	[Cauliflower] Physical, Stab, Posion Property, stomp
 SKILL_20150317_000081	[Helmet Bug] Physical, Stab, Earth Property, Attack 1 time(s)
 SKILL_20150317_000082	[Helmet Bug] Normal Attack2
 SKILL_20150317_000083	[Bikaaras Mage] Magic, Magic, Fire Property, Attack 1 time(s)
@@ -85,7 +85,7 @@ SKILL_20150317_000084	[Bikaaras Mage] Physical, Slash, Fire Property, Attack 1 t
 SKILL_20150317_000085	[Vikaras] Physical, Slash, Fire Property, Attack 1 time(s)
 SKILL_20150317_000086	[Vikaras] Physical, Slash, Fire Property, Smash Ground
 SKILL_20150317_000087	[Mutant Chinency] Normal Attack, Forward Missile
-SKILL_20150317_000088	[Zinute] One-hand Blow,,,
+SKILL_20150317_000088	[Zinute] One-hand strike
 SKILL_20150317_000089	[Zinute] Two-hand clap
 SKILL_20150317_000090	[Zinute] Smash ground
 SKILL_20150317_000091	[Lauzinute] Physical, Stab, Fire Property Attack 1 time(s)


### PR DESCRIPTION
Edited lines:
11: Grammatical:Rotating to Spinning, spinning is generally used more than rotating.
12: Spelling: Added a 't' to 'somping'.
57: Clean-up: Removed ,,, not sure why it was there. Also un-capitalized 's' in 'strike' for uniformity.
59: Grammatical: Removed ground, just 'stomp' should be enough.
80: Translation: Had some Korean that translated to stomp.
88: Clean-up: Removed ,,,
88: Grammatical: Changed 'blow' to 'strike' previous translations translated it to strike, change for uniformity.

Ah jeez I hope I'm doing this right.
