### PR TITLE
QUEST_JOBSTEP.tsv lines 450-599

### DIFF
--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -500,103 +500,103 @@ QUEST_JOBSTEP_20150317_000499	Take it. It is the jewel that is cursed by a vicio
 QUEST_JOBSTEP_20150317_000500	Since we are also curious about that, please come back sometime later.
 QUEST_JOBSTEP_20150317_000501	I feel something bad.{nl}I hope nothing bad occurs...{nl}
 QUEST_JOBSTEP_20150317_000502	You've brought it.{nl}But...damn.
-QUEST_JOBSTEP_20150317_000503	The curse in this jewel is calling Tutu here.{nl}While I am handling this curse somehow, there is something that you should do.
-QUEST_JOBSTEP_20150317_000504	First, tell Krivis Master to prepare the memorial service.{nl}After that, please go to the east forest of Siaulai and block Tutu.
+QUEST_JOBSTEP_20150317_000503	The curse in this jewel is calling Tutu here.{nl}While I handle this curse somehow, there is something that you should do.
+QUEST_JOBSTEP_20150317_000504	First, tell the Krivis Master to prepare the memorial service.{nl}After that, please go to the eastern forest of Siaulai and block Tutu.
 QUEST_JOBSTEP_20150317_000505	This thing could happen when the power of the curse gets stronger.{nl}Our mission is to stop that.
-QUEST_JOBSTEP_20150317_000506	Yes. In fact, that jewel is the one which a young priest from the village picked up.{nl}After he brought this jewel, he suffered from nightmares so I made a request to Bokor Master.
-QUEST_JOBSTEP_20150317_000507	Okay anyways. I will prepare the memorial service.{nl}Don't worry about it and you just block Tutu from the east forest of Siaulai before it comes to Klaipeda.
-QUEST_JOBSTEP_20150317_000508	This thing happens since the world is in chaos.{nl}The goddess must feel sad about it..
+QUEST_JOBSTEP_20150317_000506	Yes. In fact, that jewel is the one that a young priest from the village picked up.{nl}After he brought this jewel, he suffered from nightmares so I made a request to Bokor Master.
+QUEST_JOBSTEP_20150317_000507	Okay anyways. I will prepare the memorial service.{nl}Don't worry about it and just block Tutu from the eastern forest of Siaulai before it comes to Klaipeda.
+QUEST_JOBSTEP_20150317_000508	This thing happens since the world is in chaos.{nl}The goddess must feel sad about it...
 QUEST_JOBSTEP_20150317_000509	I was able to deal with it cleverly because of your help.{nl}As a Bokor, I can expect your growth from now on.
 QUEST_JOBSTEP_20150317_000510	You defeated that Tutu. Well done.{nl}As a result, I can prepare the memorial service without any problem.{nl}
-QUEST_JOBSTEP_20150317_000511	Return to Bokor Master fast and tell her about it.
-QUEST_JOBSTEP_20150317_000512	It's good that you learn the skills from me, but I want you to also understand the importance of the care after that.{nl}The priests at Klaipeda requested to care for the statue of the goddess, how about it?
+QUEST_JOBSTEP_20150317_000511	Return to the the Bokor Master fast and tell her about it.
+QUEST_JOBSTEP_20150317_000512	It's good that you are learning the skills from me, but I want you to also understand the importance of the care after that.{nl}The priests at Klaipeda requested to care for the statue of the goddess, how about it?
 QUEST_JOBSTEP_20150317_000513	I want you to get the perfumed oil for the maintenance of the statue first.{nl}If you ask the priests, they will give it to you.
 QUEST_JOBSTEP_20150317_000514	This is the perfumed oil.{nl}Since Tesla is too old, I was worried that my request may be too much, but i guess it's alright now.{nl}
-QUEST_JOBSTEP_20150317_000515	This is all I have..{nl}I heard Krivis Master also has some.
-QUEST_JOBSTEP_20150317_000516	Perfumed Oil? Ah, here it is.{nl}Please take care for the statue.
+QUEST_JOBSTEP_20150317_000515	This is all I have..{nl}I heard the Krivis Master also has some.
+QUEST_JOBSTEP_20150317_000516	Perfumed Oil? Ah, here it is.{nl}Please take care of the statue.
 QUEST_JOBSTEP_20150317_000517	Please tell Tesla that I am okay.
 QUEST_JOBSTEP_20150317_000518	Go meet Priest Master too.{nl}The amount of perfumed oil you have may not be enough.
-QUEST_JOBSTEP_20150317_000519	That's the task we requested to you so if you need it, we will give to you. {nl}Here you go.
-QUEST_JOBSTEP_20150317_000520	Even if you receive perfumed oil from Priest Master, it may not be enough.{nl}Since you should take care for it with the greatest care.
-QUEST_JOBSTEP_20150317_000521	The amount of perfumed oil you have seems lacking a bit.{nl}Since Bokor Master also has the oil, why don't you go meet him?
-QUEST_JOBSTEP_20150317_000522	Perfumed Oil? we will definitely give it to you.{nl}Tesla told us that he doesn't need any pay for that so we felt sorry about it.
+QUEST_JOBSTEP_20150317_000519	That's the task we intrusted to you, so if you need it we will give to you. {nl}Here you go.
+QUEST_JOBSTEP_20150317_000520	Even if you receive perfumed oil from the Priest Master, it may not be enough.{nl}Since you should take care of it with the greatest care.
+QUEST_JOBSTEP_20150317_000521	The amount of perfumed oil you have seems a bit lacking.{nl}Since the Bokor Master also has some oil, why don't you go meet him?
+QUEST_JOBSTEP_20150317_000522	Perfumed Oil? we will definitely give it to you.{nl}Tesla told us that he doesn't need any pay for that, so we felt sorry about it.
 QUEST_JOBSTEP_20150317_000523	Too bad I can't go with you since I don't have enough time.
-QUEST_JOBSTEP_20150317_000524	The statues that we requested to you are the statue in Fedimian and the statue in Klaipeda.{nl}Okay then, I am counting on you.
-QUEST_JOBSTEP_20150317_000525	If you use the absolute power of the goddess, you may get to Fedimian little easier.
-QUEST_JOBSTEP_20150317_000526	Well don.{nl}Go back to Tesla.
-QUEST_JOBSTEP_20150317_000527	It is also a task of Divdirbys to take care for the work besides creating the work.{nl}Don't forget about thie feeling if you want to learn the skills of Divdirbys.{nl}{nl}Oh, you came back already. {nl}Well done. {nl}
+QUEST_JOBSTEP_20150317_000524	The statues that we intrusted to you is the statue in Fedimian and the statue in Klaipeda.{nl}Okay then, I am counting on you.
+QUEST_JOBSTEP_20150317_000525	If you use the absolute power of the goddess, you may get to Fedimian a little easier.
+QUEST_JOBSTEP_20150317_000526	Well done.{nl}Go back to Tesla.
+QUEST_JOBSTEP_20150317_000527	It is also a task of a Divdirbys to take care for the work besides creating the work.{nl}Don't forget about thie feeling if you want to learn the skills of Divdirbys.{nl}{nl}Oh, you came back already. {nl}Well done. {nl}
 QUEST_JOBSTEP_20150317_000528	It is also a task of a Dievdirbys to take care for the work besides creating the work.{nl}Don't forget about thie feeling if you want to learn the skills of Divdirbys.
-QUEST_JOBSTEP_20150317_000529	The number of monsters increased a lot at Starving Demon's Road and they are threatening the villagers there.{nl}If you want to step forward as a true Sadhu, then share your abilities.
+QUEST_JOBSTEP_20150317_000529	The number of monsters increased a lot at Starving Demon's Road, and they are threatening the villagers there.{nl}If you want to step forward as a true Sadhu, then share your abilities.
 QUEST_JOBSTEP_20150317_000530	Doing penance is not just for yourself, but to also be kind to others.
-QUEST_JOBSTEP_20150317_000531	As you become kind to others, you will reach to a higher stage.{nl}As a Sadhu Master, I will lead that way for you.
-QUEST_JOBSTEP_20150317_000532	First of all, Paladin shows by acting rather than telling.{nl}Prove your religious belief of the goddess by dueling against me.
-QUEST_JOBSTEP_20150317_000533	First of all, the religious belief is the power to us, Paladins.{nl}You possess the great religious belief.{nl}
-QUEST_JOBSTEP_20150317_000534	You passed the test.{nl}You should be prepared since I will train your spirit more harder from now on.
+QUEST_JOBSTEP_20150317_000531	As you become kinder to others, you will reach a higher stage.{nl}As a Sadhu Master, I will lead the way for you.
+QUEST_JOBSTEP_20150317_000532	First of all, a Paladin shows by acting rather than telling.{nl}Prove your religious belief of the goddess by dueling against me.
+QUEST_JOBSTEP_20150317_000533	First of all, the religious belief is the power to us Paladins.{nl}You possess great religious belief.{nl}
+QUEST_JOBSTEP_20150317_000534	You passed the test.{nl}You should be prepared since I will train your spirit harder from now on.
 QUEST_JOBSTEP_20150317_000535	Monk Master
-QUEST_JOBSTEP_20150317_000536	The religious belief gets completed when you have a well trained body.{nl}I will test you.
+QUEST_JOBSTEP_20150317_000536	Religious belief gets completed when you have a well trained body.{nl}I will test you.
 QUEST_JOBSTEP_20150317_000537	Good. Your religious belief is very strong.{nl}I will accept you as a monk. You should be prepared since our training is very hard.
 QUEST_JOBSTEP_20150317_000538	Pardoner Master
 QUEST_JOBSTEP_20150317_000539	Ordinally, the best way to get accepted as a Pardoner is to contribute a lot of money.{nl}But, I think completing an assignment would be better for you.{nl}
-QUEST_JOBSTEP_20150317_000540	Please bring me the fire pot.{nl}I heard the rumor that the merchants in Fedimian saw that pot.
+QUEST_JOBSTEP_20150317_000540	Please bring me the fire pot.{nl}I heard a rumor that the merchants in Fedimian saw it.
 QUEST_JOBSTEP_20150317_000541	Wow! Welcome.{nl}Do you need anything?
-QUEST_JOBSTEP_20150317_000542	Mostem? I saw it at Crystal Brook. {nl}Pardoner Master was looking for it as well. I guess he couldn't find it.
+QUEST_JOBSTEP_20150317_000542	Fire pot? I saw it at Crystal Brook. {nl}The Pardoner Master was looking for it as well. I guess he couldn't find it.
 QUEST_JOBSTEP_20150317_000543	Oh the Pardoner Master. {nl}There's a lot he doesn't know..
 QUEST_JOBSTEP_20150317_000544	Oh. Yes! This is it.{nl}I will accept you as a Pardoner.
-QUEST_JOBSTEP_20150317_000545	Please return to Pardoner Master.{nl}He was looking for the fire pot for a long time.
-QUEST_JOBSTEP_20150317_000546	Fire Pot? Of course I know it.{nl}But you know I am a merchant. If you could get me the hardened oil from the monsters at Way of Big Starving Demon..
+QUEST_JOBSTEP_20150317_000545	Please return to the Pardoner Master.{nl}He was looking for the fire pot for a long time.
+QUEST_JOBSTEP_20150317_000546	Fire Pot? Of course I know of it.{nl}But you know I am a merchant. If you could get me the hardened oil from the monsters at Way of Big Starving Demon...
 QUEST_JOBSTEP_20150317_000547	If you don't need it, then I am also good with it.{nl}Since I am busy, I will just do my work.
-QUEST_JOBSTEP_20150317_000548	Oh, Thank you.{nl}A monster called Mostem keeps his hands on the fire pot all the time.{nl}
+QUEST_JOBSTEP_20150317_000548	Oh, Thank you.{nl}A monster called Mostem keeps his hands on the fire pot at all times.{nl}
 QUEST_JOBSTEP_20150317_000549	Ask the equipment merchant over there since he said he saw it recently.
 QUEST_JOBSTEP_20150317_000550	Wizard is the magician who focus on the basics of all magics.{nl}If you seek a stronger magic, you should go back to the basics.{nl}
-QUEST_JOBSTEP_20150317_000551	Please defeat the violent golem at the west forest of Siaulai.{nl}I will decide whether I will continue to teach you based on the result of it.
+QUEST_JOBSTEP_20150317_000551	Please defeat the violent golem at the western forest of Siaulai.{nl}I will decide whether I will continue to teach you based on the result of it.
 QUEST_JOBSTEP_20150317_000552	Huhu.{nl}I remember when you were a probationary wizard.
-QUEST_JOBSTEP_20150317_000553	Yes. Well done.{nl}Let's start from the basics. I will help you with my best.
-QUEST_JOBSTEP_20150317_000554	The Poatas are threatening the villagers at the east forest of Siaulai.{nl}If you could defeat that monster in the name of Gabiya goddess, I will teach you my magics.{nl}{nl}
-QUEST_JOBSTEP_20150317_000555	One can say that he is strong when he shares it with others after learning something.
-QUEST_JOBSTEP_20150317_000556	Well done. The goddess, Gabiya must be very satisfied.{nl}As promised, I will take you to the next stage of Pyromancer.
-QUEST_JOBSTEP_20150317_000557	With the power of chilly air, you dream to reach to a higher stage.{nl}Mushcaria at the west forest of Siaulai will be a good assignment for you.
-QUEST_JOBSTEP_20150317_000558	It's not good to see an weak human is chasing after strongness.
-QUEST_JOBSTEP_20150317_000559	You did well without any shortages.{nl}As promised, I will train you harder.
-QUEST_JOBSTEP_20150317_000560	Psychokino shows his power by believing his own abilities.{nl}You gotta show how much you trust yourself to receive my lessons.
-QUEST_JOBSTEP_20150317_000561	The Red Vubbe Warriors in this forest are hard to fight against.{nl}But, if you trust yourself, you will be able to defeat it.
-QUEST_JOBSTEP_20150317_000562	How are you going to use the super natural power if you don't trust yourself?{nl}Don't you think so?
-QUEST_JOBSTEP_20150317_000563	Your abilities are way better than I expected.{nl}But, if you learn from me, you can reach to a higher stage.
-QUEST_JOBSTEP_20150317_000564	Before you learn magics from me, I want to see how you control mana.{nl}Defeat the Vubbe Warrior at the west forest of Siaulai using any magic you want.
-QUEST_JOBSTEP_20150317_000565	As you know more about Linker, it is very interesting.{nl}Don't you think so? Reading the string of mana..
-QUEST_JOBSTEP_20150317_000566	You possess great abilities indeed.{nl}As a linker, if I could lead you well, you will become a really powerful magician.
-QUEST_JOBSTEP_20150317_000567	Before you learn the magics of Thaumaturge, I need to test your magical skills.{nl}Defeat Burning Salamanders at Magicians' Tower.
-QUEST_JOBSTEP_20150317_000568	It is important to measure your skills.{nl}It will be more important if you don't pass the test.
+QUEST_JOBSTEP_20150317_000553	Yes. Well done.{nl}Let's start from the basics. I will help you to the best of my abilities.
+QUEST_JOBSTEP_20150317_000554	The Poatas are threatening the villagers at the eastern forest of Siaulai.{nl}If you could defeat those monsters in the name of Gabiya goddess, I will teach you my magics.{nl}{nl}
+QUEST_JOBSTEP_20150317_000555	One can say that he is stronger after he shares it with others after learning something.
+QUEST_JOBSTEP_20150317_000556	Well done. The goddess, Gabiya, must be very satisfied.{nl}As promised, I will take you to the next stage of Pyromancer.
+QUEST_JOBSTEP_20150317_000557	You dream to reach a higher stage with the power of chilly air.{nl}Mushcaria at the western forest of Siaulai will be a good assignment for you.
+QUEST_JOBSTEP_20150317_000558	It's not good to see a weak human chasing after strength.
+QUEST_JOBSTEP_20150317_000559	You did well without any faults.{nl}As promised, I will train you farther.
+QUEST_JOBSTEP_20150317_000560	Psychokino shows his power by believing in his own abilities.{nl}You gotta show how much you trust yourself to receive my lessons.
+QUEST_JOBSTEP_20150317_000561	The Red Vubbe Warriors in this forest are hard to fight against.{nl}But, if you trust yourself, you will be able to defeat them.
+QUEST_JOBSTEP_20150317_000562	How are you going to use this super natural power if you don't trust yourself?{nl}Don't you think so?
+QUEST_JOBSTEP_20150317_000563	Your abilities are way better than I expected.{nl}But, if you learn from me, you can reach a higher stage.
+QUEST_JOBSTEP_20150317_000564	Before you learn magic from me, I want to see how you control mana.{nl}Defeat the Vubbe Warrior at the western forest of Siaulai using any magic you want.
+QUEST_JOBSTEP_20150317_000565	As you know more about Linker, it is very interesting.{nl}Don't you think so? Reading the string of mana...
+QUEST_JOBSTEP_20150317_000566	You possess great abilities indeed.{nl}As a linker, if I can lead you well, you will become a really powerful magician.
+QUEST_JOBSTEP_20150317_000567	Before you learn the magics of Thaumaturge, I need to test your magical skills.{nl}Defeat the Burning Salamanders at Magicians' Tower.
+QUEST_JOBSTEP_20150317_000568	It is important to measure your skill.{nl}It will be more important if you don't pass the test.
 QUEST_JOBSTEP_20150317_000569	This is nice.{nl}I will help with my best efforts for your future development.{nl}{nl}
-QUEST_JOBSTEP_20150317_000570	Instead of bragging yourself in words, it's way better to show others that you are competent.{nl}I will give you a test. Defeat slimy Reaverpedes at Remaining Tree Dale.
+QUEST_JOBSTEP_20150317_000570	Instead of bragging about yourself in words, it's much better to show others that you are competent.{nl}I will give you a test. Defeat slimy Reaverpedes at Remaining Tree Dale.
 QUEST_JOBSTEP_20150317_000571	The Reaverpedes at Remaining Tree Dale would fit your reputation.{nl}I've heard your name enough, but I should check with my own eyes.
-QUEST_JOBSTEP_20150317_000572	Very nice.{nl}You obtained the right to become more stronger with this.{nl}
-QUEST_JOBSTEP_20150317_000573	You better give up if your will is not strong enough.{nl}If that's not it, Defeat Devil Gloves that are walking around here.
-QUEST_JOBSTEP_20150317_000574	Evil spirits are just tools.{nl}I won't do anything that would turn my back on the goddess.
-QUEST_JOBSTEP_20150317_000575	You really take every possible means.{nl}Well, we are the same about that. I will permit you learning magics from me.
-QUEST_JOBSTEP_20150317_000576	I prepared something nice down there for someone who may become my disciple.{nl}From there, pick up some fragments of corpses. 
+QUEST_JOBSTEP_20150317_000572	Very nice.{nl}You have obtained the right to become stronger with this.{nl}
+QUEST_JOBSTEP_20150317_000573	You better give up if your will is not strong enough.{nl}If that's not it, Defeat the Devil Gloves that are walking around here.
+QUEST_JOBSTEP_20150317_000574	Evil spirits are just tools.{nl}I will not do anything that would turn my back on the goddess.
+QUEST_JOBSTEP_20150317_000575	You really use every possible means.{nl}Well, we are the same about that. I will permit you to learn magic from me.
+QUEST_JOBSTEP_20150317_000576	I have prepared something nice down there for someone who may become my disciple.{nl}From there, pick up some fragments of corpses. 
 QUEST_JOBSTEP_20150317_000577	Being a Necromancer is really nice.{nl}But, using humans as ingredients is forbidden.
 QUEST_JOBSTEP_20150317_000578	Very nice indeed.{nl}You have no problem understanding my spells.
 QUEST_JOBSTEP_20150317_000579	Chronomancer Master
 QUEST_JOBSTEP_20150317_000580	If you want to learn my magic, I should first understand your skills.{nl}The Reaverpedes at Remaining Tree Dale would be enough.
-QUEST_JOBSTEP_20150317_000581	No matter how strong a magic is, no magic can stop the time from flowing.{nl}But, it could be possible by Agailla Flurry..
+QUEST_JOBSTEP_20150317_000581	No matter how strong a magic is, it can not stop time from flowing.{nl}But, it could be possible by Agailla Flurry..
 QUEST_JOBSTEP_20150317_000582	You did way better than I expected.{nl}I will acknowledge your skills. Please follow me well from now on.
 QUEST_JOBSTEP_20150317_000583	I don't know if those Masters really think about the safety of the goddess and the kingdom.{nl}Ironbaum is approaching Klaipeda, but no one is worried about it.
-QUEST_JOBSTEP_20150317_000584	That attitude is what I wanted.{nl}I will teach you the true magic if you defeat Ironbaum at the west forest of Siaulai.
-QUEST_JOBSTEP_20150317_000585	Especially the attitude of Cryomancer really...pisses me off.
+QUEST_JOBSTEP_20150317_000584	That attitude is what I wanted.{nl}I will teach you the true magic if you defeat Ironbaum at the western forest of Siaulai.
+QUEST_JOBSTEP_20150317_000585	Especially the attitude of the Cryomancer really...pisses me off.
 QUEST_JOBSTEP_20150317_000586	I remember when you first arrived at Klaipedas.{nl}If you want, you can start the training right away.
-QUEST_JOBSTEP_20150317_000587	Ironbaum is running around at the east forest of Siaulai rignt now.{nl}But, Chronomancer Master is not doing anything about it.{nl}
-QUEST_JOBSTEP_20150317_000588	I know it is little ridiculous to ask a favor to a person who has come to learn my magic, but I have no other choice.{nl}I want you to defeat Ironbaum to teach him a lesson.
-QUEST_JOBSTEP_20150317_000589	Klaipeda may fall into a danger, but he only cares about his safety. That's pathetic.
-QUEST_JOBSTEP_20150317_000590	Well done.{nl}Cryomancer Master woudn't stand and watch now since the Pyromancer trainee also stepped forward.{nl}Until then, let's talk about the fire magic slowly.
+QUEST_JOBSTEP_20150317_000587	Ironbaum is running around at the eastern forest of Siaulai rignt now.{nl}But, the Chronomancer Master is not doing anything about it.{nl}
+QUEST_JOBSTEP_20150317_000588	I know it is little ridiculous to ask a favor to a person whom has come to learn my magic, but I have no other choice.{nl}I want you to defeat Ironbaum to teach him a lesson.
+QUEST_JOBSTEP_20150317_000589	Klaipeda may fall into danger, but he only cares about his safety. That's pathetic.
+QUEST_JOBSTEP_20150317_000590	Well done.{nl}The Cryomancer Master woudn't stand and watch now since the Pyromancer trainee also stepped forward.{nl}Until then, let's talk about the fire magic throughly.
 QUEST_JOBSTEP_20150317_000591	The other masters are all blaming me.{nl}They told me that I am not doing anything even when those monsters are threatening Klaipeda.{nl}
-QUEST_JOBSTEP_20150317_000592	Do I have to face against those weak monsters?{nl}If you could take care of them, I will teach you the magic of Choronomancer.
-QUEST_JOBSTEP_20150317_000593	It's called an Ironbaum at the west forest of Siaulai.{nl}Even if I am not interested in it, I can't help resist listening since I also have ears.
-QUEST_JOBSTEP_20150317_000594	I wonder what Pyromancer Master would tell by looking at the laid down Ironbaum.{nl}I will teach you the magic of Chronomancer as I promised.
-QUEST_JOBSTEP_20150317_000595	I have a request that I don't want to lose to Linker Master.{nl}If you could take care of that request on behalf of me, I will teach you how to control the energy. How about it?
-QUEST_JOBSTEP_20150317_000596	It is not that hard.{nl}You just have to defeat Beowolf that is walking around this mine village.
-QUEST_JOBSTEP_20150317_000597	I had troubles for that a few times in the past.{nl}But if I have a disciple like you, I won't lose to Linker Master anymore.
-QUEST_JOBSTEP_20150317_000598	That's nice!{nl}Leave the Linker Master and let's talk about the energy in details.
-QUEST_JOBSTEP_20150317_000599	If you want to learn about my magic, there is something that you should do for me.{nl}Defeat the Beowolf that appeared in the mine village quicker than Psychokino Master.
+QUEST_JOBSTEP_20150317_000592	Do I have to face against those weak monsters?{nl}If you can take care of them, I will teach you the magic of the Choronomancer.
+QUEST_JOBSTEP_20150317_000593	It's called an Ironbaum, it is at the western forest of Siaulai.{nl}Even if I am not interested in it, I can't help listening since I also have ears.
+QUEST_JOBSTEP_20150317_000594	I wonder what the Pyromancer Master would think when looking at the laid down Ironbaum.{nl}I will teach you the magic of Chronomancer as I promised.
+QUEST_JOBSTEP_20150317_000595	I have a request that I don't want to lose to the Linker Master.{nl}If you could take care of that request on behalf of me, I will teach you how to control your energy. How about it?
+QUEST_JOBSTEP_20150317_000596	It is not that hard.{nl}You just have to defeat the Beowolf that is walking around this mine village.
+QUEST_JOBSTEP_20150317_000597	I had troubles with that a few times in the past.{nl}But if I have a disciple like you, I won't lose to the Linker Master anymore.
+QUEST_JOBSTEP_20150317_000598	That's nice!{nl}Leave the Linker Master and let's talk about energy in details.
+QUEST_JOBSTEP_20150317_000599	If you want to learn about my magic, there is something that you should do for me.{nl}Defeat the Beowolf that appeared in the mine village quicker than the Psychokino Master.
 QUEST_JOBSTEP_20150317_000600	Beowolf is not easy, but you would be able to defeat it.{nl}You applied to become a linker right?
 QUEST_JOBSTEP_20150317_000601	Well done. I wonder what Psychokino Master would feel after looking at the laid down Beowolf.{nl}I will teach you my magic as I promised to you.
 QUEST_JOBSTEP_20150317_000602	Monsters are making a chaos near Fedimian.{nl}As a result, masters are working together to defeat them.{nl}How about it, if you are an applicant to become a Thaumaturge, I think you should also help.

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -447,40 +447,40 @@ QUEST_JOBSTEP_20150317_000446	You want to learn Sapper skills from me? That's a 
 QUEST_JOBSTEP_20150317_000447	So you will need to help me with it. {nl}Can you defeat Rocktortuga in Ruklys Memorial and bring me Natural Mano Stones?
 QUEST_JOBSTEP_20150317_000448	It's Rocktortuga of Ruklys Memorial. {nl}Rocktortugas in other areas don't give Mano Stones.
 QUEST_JOBSTEP_20150317_000449	Alright. Got the Mano Stones..{nl}Come by anytime if you want to learn Sapper skills.
-QUEST_JOBSTEP_20150317_000450	You said you want to learn my skills?{nl}If you could bring well burnable stones from Yonazolems from the central district, then I will think about it.
+QUEST_JOBSTEP_20150317_000450	You said you want to learn my skills?{nl}If you could bring me some burnable stones from Yonazolems' central district, then I will think about it.
 QUEST_JOBSTEP_20150317_000451	In other words, it's impossible.
-QUEST_JOBSTEP_20150317_000452	You have unreasonably great skills. {nl}I'd welcome a disciple like you. I will teach you the skills.
-QUEST_JOBSTEP_20150317_000453	We enhance our immunity by controlling lots poisons.{nl}If you could survive from the poison of Rajatoads at the central district, then I will teach you how to control poisons well.
+QUEST_JOBSTEP_20150317_000452	You have unreasonably great skills. {nl}I'd welcome a disciple like you. I will teach you my skills.
+QUEST_JOBSTEP_20150317_000453	We enhance our immunity by experiencing lots of poisons.{nl}If you could survive from the poison of Rajatoads at the central district, then I will teach you how to control poisons as well.
 QUEST_JOBSTEP_20150317_000454	Would it make sense if Wugushi is poisoned and weak?
 QUEST_JOBSTEP_20150317_000455	Our teachings are harsh so I hope you understand. {nl}Anyway, you can come anytime if you want to learn.
-QUEST_JOBSTEP_20150317_000456	I'm so ashamed of my disciples ruining all the commissions. {nl}If you do a good job, I will teach you Quarrel Shooter skills.
-QUEST_JOBSTEP_20150317_000457	It's the Temple Shooter in Town Central. {nl}My disciples even ran away when it was right in front so prepare yourself for it.
+QUEST_JOBSTEP_20150317_000456	I'm so ashamed of my disciples ruining all the commissions. {nl}If you do a good job, I will teach you the Quarrel Shooter skills.
+QUEST_JOBSTEP_20150317_000457	It's the Temple Shooter in Town Central. {nl} Even my disciples ran away when it was right in front of them, so prepare yourself for it.
 QUEST_JOBSTEP_20150317_000458	You defeated it. Now I feel better. {nl}Come for lessons anytime. I'll teach you wholeheartedly.
 QUEST_JOBSTEP_20150317_000459	Schwarzer Reiter
 QUEST_JOBSTEP_20150317_000460	If you want to be a Schwarze Reiter, then answer this question.{nl}If you want to survive from the intense battles, what are the things that are needed?{nl}
-QUEST_JOBSTEP_20150317_000461	Allies? Support? Supply? No, A sword and a gun would be enough for me.{nl}The only things that I can trust are those things.
-QUEST_JOBSTEP_20150317_000462	And one more thing. The hatred against the enemies!{nl}If you wish to advance to Schwarze Reiter, you should remember that hatred.{nl}
+QUEST_JOBSTEP_20150317_000461	Allies? Support? Supply? No, a sword and a gun would be enough for me.{nl}They are the only things that I can trust.
+QUEST_JOBSTEP_20150317_000462	And one more thing. The hatred towards the enemies!{nl}If you wish to advance to Schwarze Reiter, you should remember that hatred.{nl}
 QUEST_JOBSTEP_20150317_000463	Because you won't be able to advance until you beat me.{nl}Come to me when you are prepared.
-QUEST_JOBSTEP_20150317_000464	It seems that you just missed your last luck. {nl}Let's get started.
-QUEST_JOBSTEP_20150317_000465	I feel like I am seeing my younger days in you. {nl}Now since you became Schwarze Reiter, we can now be mirrors to each other.
-QUEST_JOBSTEP_20150317_000466	I need to test if you are qualified to learn my skills. {nl}Sparnas Horn seems right enough for someone like you, what do you think?
-QUEST_JOBSTEP_20150317_000467	I heard Sparnas Horn is huge so it spends most of its time on the ground than on air.
+QUEST_JOBSTEP_20150317_000464	It seems that your luck has ran out. {nl}Let's get started.
+QUEST_JOBSTEP_20150317_000465	I feel like I am seeing my younger self in you. {nl}Now since you have become a Schwarze Reiter, we are now mirrors to each other.
+QUEST_JOBSTEP_20150317_000466	I need to test if you are qualified to learn my skills. {nl}Defeating a Sparnas Horn seems fair enough for someone like you, what do you think?
+QUEST_JOBSTEP_20150317_000467	I heard Sparnas Horn is huge, so it spends most of its time on the ground than on air.
 QUEST_JOBSTEP_20150317_000468	I didn't expect you to defeat it. That's pretty good. {nl}Alright. You can come anytime you want to learn skills.
-QUEST_JOBSTEP_20150317_000469	I heard Minotaurs has shown up at Lonesome Maketplace.{nl}Please bring me the proof of your victory.
-QUEST_JOBSTEP_20150317_000470	I don't know why, but from some point in time, lots of monsters are appearing from the petrified city.{nl}I heard other masters are having trouble because of that.
+QUEST_JOBSTEP_20150317_000469	I heard Minotaurs have shown up at Lonesome Maketplace.{nl}Please bring me the proof of your victory.
+QUEST_JOBSTEP_20150317_000470	I don't know why, but from some point in time, lots of monsters have started appearing from the petrified city.{nl}I heard other masters are having trouble because of that.
 QUEST_JOBSTEP_20150317_000471	You want to reach a higher level through the calling of Clerics. {nl}I will help you achieve it through service.
-QUEST_JOBSTEP_20150317_000472	There are many people waiting for treatment but there is not enough medicinal herbs. {nl}Please get Nicotia herbs from the Centurion Master in Pilgrim's Way.{nl}
-QUEST_JOBSTEP_20150317_000473	It's be a long journey. {nl}May the blessings of Goddess be with you always.
-QUEST_JOBSTEP_20150317_000474	Ah, the Cleric Master sent you. {nl}Nice to meet you. I'm Centurion Master.
+QUEST_JOBSTEP_20150317_000472	There are many people waiting for treatment, but there are not enough medicinal herbs. {nl}Please get Nicotia herbs from the Centurion Master in Pilgrim's Way.{nl}
+QUEST_JOBSTEP_20150317_000473	It will be a long journey. {nl}May the blessings of Goddess always be with you.
+QUEST_JOBSTEP_20150317_000474	Ah, the Cleric Master sent you. {nl}Nice to meet you. I'm the Centurion Master.
 QUEST_JOBSTEP_20150317_000475	Unfortunately, we're out of Nicotia that the Cleric Master is asking for. {nl}There was an urgent request so it had to be used.
 QUEST_JOBSTEP_20150317_000476	But don't worry. {nl}Nicotias grow all over the place so it'll be fine if you just take the young shoots.
 QUEST_JOBSTEP_20150317_000477	Nicotia is not far away from here. {nl}Send my regards to the Cleric Master.
-QUEST_JOBSTEP_20150317_000478	Thank you. This will help many people in pain. {nl}The Goddess will also be glad for your reaching higher level of Clerics.
+QUEST_JOBSTEP_20150317_000478	Thank you. This will help many people in pain. {nl}The Goddess will also be glad for your reaching of the higher level of Clerics.
 QUEST_JOBSTEP_20150317_000479	If you want to step up as Krivis, then go and worship the Goddess Statue in Fedimina. {nl}Pilgrimage is a sure way to fulfill duties to the Goddess.
-QUEST_JOBSTEP_20150317_000480	Take offering before you leave. {nl}The Priest Master and Cleric Master will give you the offering needed for worship.
-QUEST_JOBSTEP_20150317_000481	You're leaving for the pilgrimage. {nl}I can still remember my journey to pilgrimage when I was a young clergy.
+QUEST_JOBSTEP_20150317_000480	Take the offering before you leave. {nl}The Priest Master and Cleric Master will give you the offering needed for worship.
+QUEST_JOBSTEP_20150317_000481	You're leaving for the pilgrimage. {nl}I can still remember pilgrimage when I was a young clergy.
 QUEST_JOBSTEP_20150317_000482	You can feel your heart filling with faith when you look at the Goddess Statue in Fedimian.
-QUEST_JOBSTEP_20150317_000483	I can give you the offering materials.{nl}But before that, I have a favor to ask you. {nl}
+QUEST_JOBSTEP_20150317_000483	I can give you the offerings.{nl}But before that, I have a favor to ask you. {nl}
 QUEST_JOBSTEP_20150317_000484	Residents are complaining about the Rock Tortuga running wild in Siauliai Western Woods. {nl}I will give you the offerings if you get rid of that monster.
 QUEST_JOBSTEP_20150317_000485	The Goddess will also be happy for your mercy.{nl}Here, take the offerings. {nl}
 QUEST_JOBSTEP_20150317_000486	The Goddess will also be happy for your mercy.{nl}I also want to visit Fedimian again if I could.
@@ -491,8 +491,8 @@ QUEST_JOBSTEP_20150317_000490	I can feel that you are full of the Goddess's bles
 QUEST_JOBSTEP_20150317_000491	Are you coming from Fedimian? {nl}Krivis Master is waiting for you.
 QUEST_JOBSTEP_20150317_000492	Will you take on the vocation of Priest and follow the path of Goddess? {nl}You can do so by getting rid of evil.
 QUEST_JOBSTEP_20150317_000493	Evil forces are showing up in the Way of Big Starving Demon in Fedimian. {nl}Extract its identity from it and smudge it with the name of Goddess.
-QUEST_JOBSTEP_20150317_000494	Anyone who follows the words of the Goddess can receive her powers to drive out evil spirits. {nl} But its strength will depend on the depth of faith.
-QUEST_JOBSTEP_20150317_000495	Well done. {nl}In the name of the goddess, please judge those negative things so they can't put their feet on the ground.
+QUEST_JOBSTEP_20150317_000494	Anyone who follows the words of the Goddess can receive her powers to drive out evil spirits. {nl} But its strength will depend on the depth of your faith.
+QUEST_JOBSTEP_20150317_000495	Well done. {nl}In the name of the goddess, please judge the evil in this world so they are unable to get a foothold.
 QUEST_JOBSTEP_20150317_000496	If you want to research about the way of Bokor, you should do something for me.{nl}Please get the jewel from Krivis Master.
 QUEST_JOBSTEP_20150317_000497	Bokor Master sent you?{nl}So they have decided to dispose of that jewel.
 QUEST_JOBSTEP_20150317_000498	It will be very dangerous.{nl}You should get prepared.


### PR DESCRIPTION
General grammar, spelling, contextual, and phrasing fixes. From lines 450-599.

At one point there was an instance where "Fire Pot" was referred to as "Mostem."
