### PR TITLE
ETC.tsv: changed "Use <class> Attribute" to "Learn <class> Attributes"

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -4200,7 +4200,7 @@ ETC_20150317_004199	 minutes required
 ETC_20150317_004200	 seconds required
 ETC_20150317_004201	{@st42b} Silver
 ETC_20150317_004202	{@st42_yellow}{s16} Top Level Master!
-ETC_20150317_004203	{@st42_yellow}{s16} Studying Attribute..
+ETC_20150317_004203	{@st42_yellow}{s16} Learning Attribute..
 ETC_20150317_004204	You have obtained the [{Auto_1}] achievement.
 ETC_20150317_004205	Auction List
 ETC_20150317_004206	Cabinet
@@ -7301,52 +7301,52 @@ ETC_20150317_007301	Hoglan
 ETC_20150317_007302	Accessory Shop
 ETC_20150317_007303	Miscellaneous Items
 ETC_20150317_007304	Skip Tutorial
-ETC_20150317_007305	Use Druid Attributes
-ETC_20150317_007306	Use Sadhu Attributes
-ETC_20150317_007307	Use Wugushi Attributes
-ETC_20150317_007308	Use Rodelero Attributes
-ETC_20150317_007309	Use Squire Attributes
-ETC_20150317_007310	Use Thaumaturge Attributes
-ETC_20150317_007311	Use Elementalist Attributes
-ETC_20150317_007312	Use Scout Attributes
-ETC_20150317_007313	Use Barbarian Attributes
-ETC_20150317_007314	Use Hoplite Attributes
-ETC_20150317_007315	Use Psychokino Attributes
+ETC_20150317_007305	Learn Druid Attributes
+ETC_20150317_007306	Learn Sadhu Attributes
+ETC_20150317_007307	Learn Wugushi Attributes
+ETC_20150317_007308	Learn Rodelero Attributes
+ETC_20150317_007309	Learn Squire Attributes
+ETC_20150317_007310	Learn Thaumaturge Attributes
+ETC_20150317_007311	Learn Elementalist Attributes
+ETC_20150317_007312	Learn Scout Attributes
+ETC_20150317_007313	Learn Barbarian Attributes
+ETC_20150317_007314	Learn Hoplite Attributes
+ETC_20150317_007315	Learn Psychokino Attributes
 ETC_20150317_007316	The Linker Attributes
-ETC_20150317_007317	Use Sapper Attributes
-ETC_20150317_007318	Use Hunter Attributes
-ETC_20150317_007319	Use Dievdirbys Attributes
+ETC_20150317_007317	Learn Sapper Attributes
+ETC_20150317_007318	Learn Hunter Attributes
+ETC_20150317_007319	Learn Dievdirbys Attributes
 ETC_20150317_007320	Buy Dievdirbys Items
-ETC_20150317_007321	Use Alchemist Attributes
-ETC_20150317_007322	Use Priest Attributes
+ETC_20150317_007321	Learn Alchemist Attributes
+ETC_20150317_007322	Learn Priest Attributes
 ETC_20150317_007323	Buy Priest Items
-ETC_20150317_007324	Use Krivis Attributes
-ETC_20150317_007325	Use Cleric Attributes
-ETC_20150317_007326	Use Paladin Attributes
-ETC_20150317_007327	Use Fletcher Attributes
-ETC_20150317_007328	Use Corsair Attributes
-ETC_20150317_007329	Use Rogue Attributes
-ETC_20150317_007330	Use Schwarzer Reiter Attributes
-ETC_20150317_007331	Use Hackapell Attributes
-ETC_20150317_007332	Use Oracle Attributes
-ETC_20150317_007333	Use Bokor Attributes
-ETC_20150317_007334	Use Peltasta Attributes
-ETC_20150317_007335	Use Highlander Attributes
-ETC_20150317_007336	Use Pyromancer Attributes
+ETC_20150317_007324	Learn Krivis Attributes
+ETC_20150317_007325	Learn Cleric Attributes
+ETC_20150317_007326	Learn Paladin Attributes
+ETC_20150317_007327	Learn Fletcher Attributes
+ETC_20150317_007328	Learn Corsair Attributes
+ETC_20150317_007329	Learn Rogue Attributes
+ETC_20150317_007330	Learn Schwarzer Reiter Attributes
+ETC_20150317_007331	Learn Hackapell Attributes
+ETC_20150317_007332	Learn Oracle Attributes
+ETC_20150317_007333	Learn Bokor Attributes
+ETC_20150317_007334	Learn Peltasta Attributes
+ETC_20150317_007335	Learn Highlander Attributes
+ETC_20150317_007336	Learn Pyromancer Attributes
 ETC_20150317_007337	Buy Pyromancer Items
-ETC_20150317_007338	Use Cryomancer Attributes
-ETC_20150317_007339	Use Swordsman Attributes
-ETC_20150317_007340	Use Wizard Attributes
-ETC_20150317_007341	Use Archer Attributes
-ETC_20150317_007342	Use Quarrel Shooter Attributes
-ETC_20150317_007343	Use Ranger Attributes
-ETC_20150317_007344	Use Monk Attributes
-ETC_20150317_007345	Use Pardoner Attributes
+ETC_20150317_007338	Learn Cryomancer Attributes
+ETC_20150317_007339	Learn Swordsman Attributes
+ETC_20150317_007340	Learn Wizard Attributes
+ETC_20150317_007341	Learn Archer Attributes
+ETC_20150317_007342	Learn Quarrel Shooter Attributes
+ETC_20150317_007343	Learn Ranger Attributes
+ETC_20150317_007344	Learn Monk Attributes
+ETC_20150317_007345	Learn Pardoner Attributes
 ETC_20150317_007346	Buy Pardoner Items
-ETC_20150317_007347	Use Sorcerer Attributes
-ETC_20150317_007348	Use Necromancer Attributes
-ETC_20150317_007349	Use Doppelsoeldner Attributes
-ETC_20150317_007350	Use Chronomancer Attributes
+ETC_20150317_007347	Learn Sorcerer Attributes
+ETC_20150317_007348	Learn Necromancer Attributes
+ETC_20150317_007349	Learn Doppelsoeldner Attributes
+ETC_20150317_007350	Learn Chronomancer Attributes
 ETC_20150317_007351	Attack +%d
 ETC_20150317_007352	Improves Critical Hit Rating by +%d
 ETC_20150317_007353	Strength +%d
@@ -9885,7 +9885,7 @@ ETC_20150323_009886	Contaminated Altar
 ETC_20150323_009887	Pilgrim Statue
 ETC_20150323_009888	Offered flower
 ETC_20150323_009889	Crystal Processing Device
-ETC_20150323_009890	Use Elementalist Attributes
+ETC_20150323_009890	Learn Elementalist Attributes
 ETC_20150323_009891	Hunt boss monsters with party members.
 ETC_20150323_009892	DoTimeAction:Collecting Woods:3#SITGROPESET2:None
 ETC_20150323_009893	Property:1/PropertyAdd:1/GiveItem:SIAULIAI50_WOOD_PIECE:1:0/NPCKill/EffectNPC:Local:F_pc_making_finish_white:2:BOT/Notice:NOTICE_Dm_Clear:Acquired wood!:3
@@ -10696,7 +10696,7 @@ ETC_20150406_010697	Outer World Mentiken
 ETC_20150406_010698	Outer World Mushwort
 ETC_20150406_010699	Statue of the Goddess Ausrine D
 ETC_20150406_010700	Statue of the Goddess Ausrine E
-ETC_20150406_010701	Pyromancer Room
+ETC_20150406_010701	Pyromancer's Room
 ETC_20150406_010702	Banquet Hall
 ETC_20150406_010703	Get kindlings from Orange Dandel and keep the fire alive!
 ETC_20150406_010704	The monsters seem to have smelled the purifying liquid. They are attacking!
@@ -10974,11 +10974,11 @@ ETC_20150414_010975	Druid Female
 ETC_20150414_010976	Hawk
 ETC_20150414_010977	Buy Wugushi Items
 ETC_20150414_010978	Buy Squire Items
-ETC_20150414_010979	Use Alchemist Attribute
+ETC_20150414_010979	Learn Alchemist Attributes
 ETC_20150414_010980	Buy Alchemist Items
 ETC_20150414_010981	Buy Fletcher Items
 ETC_20150414_010982	World Formation
-ETC_20150414_010983	Use Falconer Attribute
+ETC_20150414_010983	Learn Falconer Attributes
 ETC_20150414_010984	IvnItem:FARM47_1_SQ_060_ITEM_1:1/DoTimeAction:Making meat jerky:3:MAKING:None
 ETC_20150414_010985	AnimNPC:Local:OPEN:0/Notice:NOTICE_Dm_!:Made jerky!:3/Sleep:5000/AnimNPC:Local:CLOSE:0/EffectNPC:Local:F_smoke135_dark:2:BOT/GiveItem:FARM47_1_SQ_060_ITEM_2:1/TakeItem:FARM47_1_SQ_060_ITEM_1:1/Property:2/PropertyAdd:1
 ETC_20150414_010986	Stop Rexipher
@@ -12064,7 +12064,7 @@ ETC_20150714_012065	Noble man
 ETC_20150714_012066	Temporal Grave
 ETC_20150714_012067	Normal Husband Down
 ETC_20150714_012068	Village LadA3 Down
-ETC_20150714_012069	Use Centurion's Attribute
+ETC_20150714_012069	Learn Centurion Attributes
 ETC_20150714_012070	Found a player who is most suitable for the party. Invite this person to the party!
 ETC_20150714_012071	There's a party that requested for your participation. Join the party!
 ETC_20150714_012072	There's a similar player who is nearby. Invite this person to the party!


### PR DESCRIPTION
- "use attributes" didn't make sense, this is a learning NPC
- consistency fix: some classes had "Attribute", some had "Attributes"
- consistency fix: NPC talks about learning attributes, but dialog was saying "Studying attribute..". Changed to "learning attribute"
