### PR TITLE
Update QUEST_JOBSTEP.tsv [Lines 51-100]

### DIFF
--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -67,10 +67,10 @@ QUEST_JOBSTEP_20150317_000066	Anyway, you did a good job. {nl}Let's get along we
 QUEST_JOBSTEP_20150317_000067	I'm looking for books. Four books of Lydia Schaffen. {nl}If you help me find these books, I will teach you my skills. 
 QUEST_JOBSTEP_20150317_000068	The books used to be in Miners' Village but they were lost when the Vubbes raided. {nl} Try going to the Vubbe Outpost.
 QUEST_JOBSTEP_20150317_000069	It's this book. You will need this book if you dream to be the best Archer. {nl}I'll make you a copy if you can gather all the books. 
-QUEST_JOBSTEP_20150317_000070	Quarrelshooter Master holds the next book. {nl}He was looking for Merlog Leather before. Maybe you can make a deal with him using that.
+QUEST_JOBSTEP_20150317_000070	The Quarrelshooter Master holds the next book. {nl}He was looking for Merlog Leather before. Maybe you can make a deal with him using that.
 QUEST_JOBSTEP_20150317_000071	Do you have the Merlog Leather yet from the Hunter Master?
 QUEST_JOBSTEP_20150317_000072	This is of exceptional quality. The Hunter Master will be pleased. {nl}You can take the book. {nl}
-QUEST_JOBSTEP_20150317_000073	Merlog is in Fallen Worry Forest, and Quarrelshooter Master is in Klaipeda. {nl}Someone might get ahead of you so better hurry.
+QUEST_JOBSTEP_20150317_000073	Merlog is in Fallen Worry Forest, and the Quarrelshooter Master is in Klaipeda. {nl}Someone might get ahead of you so better hurry.
 QUEST_JOBSTEP_20150317_000074	The Archer Master in Klaipeda has the next book. {nl}He's not a mean person so he'll give you it if you ask nicely. {nl}
 QUEST_JOBSTEP_20150317_000075	He's helping with the repair of the damaged city wall. {nl}I heard there are rocks moved to Miners' Village, so bringing him that rock can be a way to ask. 
 QUEST_JOBSTEP_20150317_000076	Did the Hunter Master send this rock? {nl}If it's Lydia Schaffen's book, you could have just asked. But thank you anyway. 

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -48,56 +48,56 @@ QUEST_JOBSTEP_20150317_000047	Good work. {nl}You've done a good job as my assist
 QUEST_JOBSTEP_20150317_000048	My research is about the methods of shifting psychokinesis to the substance of matter. {nl}In other words...It's a method of brainwashing by using medicine. 
 QUEST_JOBSTEP_20150317_000049	Linker Master
 QUEST_JOBSTEP_20150317_000050	Talent is very important for Linkers. {nl}Closing one's heart is easy but opening others' requires special talents. {nl}
-QUEST_JOBSTEP_20150317_000051	I will test you to see if you have such talent. 
+QUEST_JOBSTEP_20150317_000051	I will test you to see if you have such talents. 
 QUEST_JOBSTEP_20150317_000052	Good. However, you must prepare some materials before taking the test.{nl}Bring me a Dunball’s thorn and Velwriggler’s carving at Gate Route.{nl} [?]
 QUEST_JOBSTEP_20150317_000053	Great job! {nl}But this is only a preparation for the test. {nl}
 QUEST_JOBSTEP_20150317_000054	I will start the test now. {nl}Behind the Gate Route is a rip in the space of the world.{nl}
-QUEST_JOBSTEP_20150317_000055	It's just reality for normal people, but if you have the talent of a Linker, {nl}you will be able to find the hidden world. {nl}Find the book from there and bring it to me. 
-QUEST_JOBSTEP_20150317_000056	Have you gone there yet? {nl}Just go to Gate Route and check. I’ve marked the location on the map.{nl}
-QUEST_JOBSTEP_20150317_000057	You brought the book. You have passed the test. {nl}Please read that book as your determination as a Linker. 
+QUEST_JOBSTEP_20150317_000055	It's just reality for normal people, but if you truly have the talents of a Linker, {nl}you'll be able to find the hidden world. {nl}Find the book from there and bring it to me. 
+QUEST_JOBSTEP_20150317_000056	Have you gone there yet? {nl}Just go to Gate Route and check. I’ve marked the location on your map.{nl}
+QUEST_JOBSTEP_20150317_000057	You brought the book. You've passed the test. {nl}Please read that book as your determination as a Linker. 
 QUEST_JOBSTEP_20150317_000058	Skills of a Sapper...Then surely you must pay for it. {nl}Not to me. Instead, I want you to give a donation to the Cleric Master in Klaipeda. {nl}Around 5000 silver? 
-QUEST_JOBSTEP_20150317_000059	Wait, there’s one more thing. {nl}I hid some objects at Flude Island of Siaulai Western Woods.{nl}Before you go to Klaipeda, find the object first and return them to their original owners in Klaipeda.{nl}{nl} 
-QUEST_JOBSTEP_20150317_000060	Oh, this. I saw it somewhere...hmm...looks familiar...{nl}Well I'll take it with thanks since you're giving it to me.
-QUEST_JOBSTEP_20150317_000061	Huh, this is the tool I lost. {nl}Thank you. Where has it been?
+QUEST_JOBSTEP_20150317_000059	Wait, there’s one more thing. {nl}I hid some objects at Flude Island of Siaulai Western Woods.{nl}Before you go to Klaipeda, find the objects first and return them to their original owners in Klaipeda.{nl}{nl} 
+QUEST_JOBSTEP_20150317_000060	Oh, this. I saw it somewhere...hmm...looks familiar...{nl}Well, I'll take it with thanks since you're giving it to me.
+QUEST_JOBSTEP_20150317_000061	Huh, this is the tool I lost. {nl}Thank you. Where'd you find it?
 QUEST_JOBSTEP_20150317_000062	Did you forget about the donation? {nl}It's 5000 silver.
 QUEST_JOBSTEP_20150317_000063	Cleric Master
-QUEST_JOBSTEP_20150317_000064	Thank you in the name of Goddess.{nl}I promise the donations will be used for those injured by monsters. {nl}
+QUEST_JOBSTEP_20150317_000064	Thank you in the name of the Goddesses.{nl}I promise the donations will be used to help those injured by monsters. {nl}
 QUEST_JOBSTEP_20150317_000065	I used to be a thief, but I came to realize certain things and I stopped my life of crime. {nl}But there is a little load left on my mind...and I will really end it this time {nl}
 QUEST_JOBSTEP_20150317_000066	Anyway, you did a good job. {nl}Let's get along well from now on, teaching and learning from each other. 
-QUEST_JOBSTEP_20150317_000067	I'm looking for a book. Four books of Lydia Schaffen. {nl}If you help me find the books, I will teach you my skills. 
-QUEST_JOBSTEP_20150317_000068	The book used to be in Miner's town but it was lost when the Vubbes raided. {nl} Try going to the Vubbe Outpost.
-QUEST_JOBSTEP_20150317_000069	It's this book. You will need this book if you dream to be the best Archer. {nl}I will make you a copy if you can gather all the books. 
-QUEST_JOBSTEP_20150317_000070	Quarrel Shooter Master holds the next book. {nl}He was looking for Merlog Leather before. Maybe you can try a deal with him using that.
+QUEST_JOBSTEP_20150317_000067	I'm looking for books. Four books of Lydia Schaffen. {nl}If you help me find these books, I will teach you my skills. 
+QUEST_JOBSTEP_20150317_000068	The books used to be in Miners' Village but they were lost when the Vubbes raided. {nl} Try going to the Vubbe Outpost.
+QUEST_JOBSTEP_20150317_000069	It's this book. You will need this book if you dream to be the best Archer. {nl}I'll make you a copy if you can gather all the books. 
+QUEST_JOBSTEP_20150317_000070	Quarrelshooter Master holds the next book. {nl}He was looking for Merlog Leather before. Maybe you can make a deal with him using that.
 QUEST_JOBSTEP_20150317_000071	Do you have the Merlog Leather yet from the Hunter Master?
-QUEST_JOBSTEP_20150317_000072	This is of good quality. The Hunter Master will be pleased. {nl}You can take the book. {nl}
-QUEST_JOBSTEP_20150317_000073	Merlog is in Fallen Worry Forest, and Quarrel Shooter Master is in Klaipeda. {nl}Someone might get ahead of you so better hurry.
-QUEST_JOBSTEP_20150317_000074	The Archer Master in Klaipeda has the next book. {nl}He's not a mean person so he will give you the book if you ask nicely. {nl}
-QUEST_JOBSTEP_20150317_000075	He is helping with the repair of the damaged city wall. {nl}I heard there are rocks moved to Miner's Village, so bringing him that rock can be a way to ask. 
-QUEST_JOBSTEP_20150317_000076	Did the Hunter Master sent this rock? {nl}If it's Lydia Schaffen's book, you could have just asked. But thank you anyway. 
-QUEST_JOBSTEP_20150317_000077	The last book is with the Ranger Master in Klaipeda. {nl}Give her this pouch. {nl}I could go myself but we're not really comfortable seeing each other. 
+QUEST_JOBSTEP_20150317_000072	This is of exceptional quality. The Hunter Master will be pleased. {nl}You can take the book. {nl}
+QUEST_JOBSTEP_20150317_000073	Merlog is in Fallen Worry Forest, and Quarrelshooter Master is in Klaipeda. {nl}Someone might get ahead of you so better hurry.
+QUEST_JOBSTEP_20150317_000074	The Archer Master in Klaipeda has the next book. {nl}He's not a mean person so he'll give you it if you ask nicely. {nl}
+QUEST_JOBSTEP_20150317_000075	He's helping with the repair of the damaged city wall. {nl}I heard there are rocks moved to Miners' Village, so bringing him that rock can be a way to ask. 
+QUEST_JOBSTEP_20150317_000076	Did the Hunter Master send this rock? {nl}If it's Lydia Schaffen's book, you could have just asked. But thank you anyway. 
+QUEST_JOBSTEP_20150317_000077	The last book is with the Ranger Master in Klaipeda. {nl}Give her this pouch. {nl}I would go myself but we're not really comfortable seeing each other. 
 QUEST_JOBSTEP_20150317_000078	Don't ask why. Work is work, and it's a fact that we don't want to face each other. 
 QUEST_JOBSTEP_20150317_000079	This pouch...Did you come for the Hunter Master? {nl}Here. Give her this book. 
-QUEST_JOBSTEP_20150317_000080	I don't want to act mean when she's acting humble. 
-QUEST_JOBSTEP_20150317_000081	This leather will be enough. {nl}Go to the Quarrel Shooter Master before someone else takes it. 
+QUEST_JOBSTEP_20150317_000080	I don't want to be mean when she's acting humble. 
+QUEST_JOBSTEP_20150317_000081	This leather will be enough. {nl}Go to the Quarrelshooter Master before someone else takes it. 
 QUEST_JOBSTEP_20150317_000082	This rock will be useful in repairing the wall. {nl}Bring it to the Archer Master quickly. 
 QUEST_JOBSTEP_20150317_000083	Are you the one who wants to learn my skills? {nl}Great, I was just looking for someone to help me find Lydia Shaffen's book. {nl}You're going to help right? 
-QUEST_JOBSTEP_20150317_000084	There is one in Miner's Village but it was lost when the Vubbes raided. {nl} I'm sure it's in the Vubbe Outpost.
-QUEST_JOBSTEP_20150317_000085	Oh yes, this is it. {nl}This will be helpful for people like you, who dream of becoming a Quarrel Shooter. {nl}I will give you a copy if you collect all the books. 
-QUEST_JOBSTEP_20150317_000086	Three more left. {nl}I think you can get one of it by handing some money to the Hunter Master..
+QUEST_JOBSTEP_20150317_000084	There is one in Miners' Village but it was lost when the Vubbes raided. {nl} I'm positive it's in the Vubbe Outpost.
+QUEST_JOBSTEP_20150317_000085	Oh yes, this is it. {nl}This will be helpful for people like you, who dream of becoming a Quarrelshooter. {nl}I'll give you a copy if you collect all the books. 
+QUEST_JOBSTEP_20150317_000086	Three more left. {nl}I think you can get one of them by offering some money to the Hunter Master..
 QUEST_JOBSTEP_20150317_000087	The problem is, I'm broke. 
-QUEST_JOBSTEP_20150317_000088	You mean Lydia Schaffen's book that I have? {nl}I'll hand it over for 5000 silvers.
+QUEST_JOBSTEP_20150317_000088	You mean Lydia Schaffen's book, that I have? {nl}I'll hand it over for 5000 silver.
 QUEST_JOBSTEP_20150317_000089	Well then, thanks for your help. {nl}Around 5000 silver will do. {nl}
 QUEST_JOBSTEP_20150317_000090	5000 silver...Yup, that's right. {nl}I'll give you the book as promised. 
-QUEST_JOBSTEP_20150317_000091	Well...the Archer Master must have the next book. {nl}He's still helping repair the wall so wouldn't he like it if you got him some stones? {nl}I could take it to him myself but...owwww...my back.
+QUEST_JOBSTEP_20150317_000091	Well...the Archer Master must have the next book. {nl}He's still helping to repair the wall, so wouldn't he like it if you brought him some stones? {nl}I could take it to him myself but...owwww...my back.
 QUEST_JOBSTEP_20150317_000092	The Archer Master has the next book. {nl}He's not a mean person so he will give you the book if you ask nicely. {nl}
-QUEST_JOBSTEP_20150317_000093	I heard he is helping repair the damaged city wall. {nl}There are rocks moved to Miner's Village so he'll be moved if you bring him that rock. 
+QUEST_JOBSTEP_20150317_000093	I heard he is helping repair the damaged city wall. {nl}There are rocks moved to Miners' Village, so he'll be pleased if you bring him that rock. 
 QUEST_JOBSTEP_20150317_000094	Did the Hunter Master send this rock? {nl}If it's Lydia Schaffen's book, you could have just asked. But thank you anyway. 
-QUEST_JOBSTEP_20150317_000095	Now, for the last book. {nl}Give this pouch to the Ranger Master and get the book. 
-QUEST_JOBSTEP_20150317_000096	Did the Quarrel Shooter send this? {nl}Thanks. I'll hand over the book as promised. 
-QUEST_JOBSTEP_20150317_000097	Bring the book quickly. {nl}I can't hold it. 
-QUEST_JOBSTEP_20150317_000098	Great, it's this one! {nl}I'll teach you the skills of Quarrel Shooter as promised. {nl}
+QUEST_JOBSTEP_20150317_000095	Now, for the last book. {nl}Give this pouch to the Ranger Master and get the last book. 
+QUEST_JOBSTEP_20150317_000096	Did the Quarrelshooter Master send this? {nl}Thanks. I'll hand over the book as promised. 
+QUEST_JOBSTEP_20150317_000097	Take the book quickly. {nl}I can't hold it. 
+QUEST_JOBSTEP_20150317_000098	Great, it's this one! {nl}I'll teach you the skills of a Quarrelshooter, as promised. {nl}
 QUEST_JOBSTEP_20150317_000099	This rock will be useful in repairing the wall. {nl}Bring it to the Archer Master quickly. 
-QUEST_JOBSTEP_20150317_000100	If you want to learn more of my skills, there is a condition. {nl}I want you to help me find the four books of Lydia Schaffen. 
+QUEST_JOBSTEP_20150317_000100	If you wish to learn more of my skills, there is a condition. {nl}I want you to help me find the four books of Lydia Schaffen. 
 QUEST_JOBSTEP_20150317_000101	I heard the first book was with a resident in Miner's Village before the Vubbes attacked. {nl}So I think it could be in the Vubbe Outpost. 
 QUEST_JOBSTEP_20150317_000102	I'm surprised you found it so fast! {nl}And it's in a good state. {nl}
 QUEST_JOBSTEP_20150317_000103	I think you might be able to buy the next book from the Hunter Master..{nl}I'm broke after fixing the wall with my money. Haha..


### PR DESCRIPTION
This pull is for the lines 51-100.
More thorough analysis of grammar, punctuation, and sentence structure.

Changed a few instances of "Miner's Village" to "Miners' Village" as per the Wiki.
Also changed a few instances of "Quarrel Shooter" to "Quarrelshooter".
