### PR TITLE
Typo/grammar fix for wizard/linker/pyro skill descriptions

### DIFF
--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1142,7 +1142,7 @@ SKILL_20150317_001141	Gravity Pole
 SKILL_20150317_001142	Create a stright gravitational field and pull in target.
 SKILL_20150317_001143	Target #{CaptionRatio}#{nl}Max. duration 5 seconds
 SKILL_20150317_001144	Unbind
-SKILL_20150317_001145	Release all links connected.
+SKILL_20150317_001145	Release all connected links.
 SKILL_20150317_001146	Cut all links at once {nl} Level 1 master
 SKILL_20150317_001147	Physical link
 SKILL_20150317_001148	Link party members and divide damage.
@@ -3674,11 +3674,11 @@ SKILL_20150414_003673	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Use centrifugal
 SKILL_20150414_003674	{#993399}{ol}[Magic]{/}{/}{nl}Gather magical energy and shoot to enemy. Inflicted damage increases depending on the energy gathered.
 SKILL_20150414_003675	Make enemy lethargic.
 SKILL_20150414_003676	Make enemy fall asleep. Enemy wakes up when reaching attack limit.
-SKILL_20150414_003677	Create defese sreen that reflects certain amound of enemy's attacks.
+SKILL_20150414_003677	Create a defensive screen that reflects a certain amount of enemy attacks.
 SKILL_20150414_003678	{#993399}{ol}[Magic]{/}{/}{nl}Continuously attack enemies with magic bullets.
 SKILL_20150414_003679	Skill cast time decerases.
 SKILL_20150414_003680	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Summon fire ball. Enemies touching the fire ball receives continuous fire damage.
-SKILL_20150414_003681	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Create wall of fire and continuously damage approaching enemies.
+SKILL_20150414_003681	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Create a wall of fire that continuously damages approaching enemies.
 SKILL_20150414_003682	Temporarily add Fire Attribute to your and party member's attacks.
 SKILL_20150414_003683	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Blast burning enemy and inflict damage.
 SKILL_20150414_003684	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Summon fire pillar and inflict damage to enemy.


### PR DESCRIPTION
Wizard "Reflect Shield"
Linker "Unbind"
Pyromancer "Fire Ball", "Fire Wall"
