### PR TITLE
Update SKILL.tsv Problem with Two-Handed being Dual-Wield/Dual-Handed

### DIFF
--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -4259,10 +4259,10 @@ SKILL_20150714_004258	Magic Amplification Increase
 SKILL_20150714_004259	Armorr Penetration
 SKILL_20150714_004260	Decrease Physical Defense
 SKILL_20150714_004261	You can change weapons.
-SKILL_20150714_004262	You can equip [One-handed sword] type weapon.
-SKILL_20150714_004263	You can equip [Two-Handed sword] type weapon.
-SKILL_20150714_004264	You can equip [One-handed spear] type weapon.
-SKILL_20150714_004265	You can equip [Two-Handed spear] type weapon.
+xSKILL_20150714_004262	You can equip [One-Handed sword] type weapon.
+xSKILL_20150714_004263	You can equip [Two-Handed sword] type weapon.
+xSKILL_20150714_004264	You can equip [One-Handed spear] type weapon.
+xSKILL_20150714_004265	You can equip [Two-Handed spear] type weapon.
 SKILL_20150714_004266	You can equip [Bow] type weapon.
 SKILL_20150714_004267	You can equip [Crossbow] type weapon.
 SKILL_20150714_004268	You can equip [Rod] type weapon.
@@ -4316,7 +4316,7 @@ SKILL_20150714_004315	Skull Swing: Enhancement
 SKILL_20150714_004316	The damage that will be dealt on an enemy with [Skull Swing] will increase by 1% per Attribute level.
 SKILL_20150714_004317	The pushing power of the skill [Catastroke] will increase by 50 per Attribute level.
 SKILL_20150714_004318	The amount that will reduce an enemy's INT and SPR with the skill [Crown] will increase by 2% per Attribute level.
-SKILL_20150714_004319	When equipped with [Two-Handed Swords], Critical ATK rate will increase by 10% per Attribute level.
+xSKILL_20150714_004319	When equipped with [Two-Handed Sword], Critical ATK rate will increase by 10% per Attribute level.
 SKILL_20150714_004320	Critical ATK rate of the skill [Moulinet] will increase by 10% per Attribute level.
 SKILL_20150714_004321	The duration of time that will stiffen the enemy that is blocked by [Crossguard] will be increased. It will increase by 1 sec per Attribute level.
 SKILL_20150714_004322	The enemy pushed by [Catastroke] will be damaged additionally by 50% per Physical ATK.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -8,14 +8,14 @@ SKILL_20150317_000007	[Puragi] Physical, Hit, Poison Property, Normal Attack 1 t
 SKILL_20150317_000008	[Puragi] Physical, Strike, Poison Property, Attack 1 time
 SKILL_20150317_000009	[Puragi] Physical, Strike, Poison Property, Stomp 1 time
 SKILL_20150317_000010	[Zigri] Normal Attack, Conical AoE
-SKILL_20150317_000011	[Zigri] Spinning Attack
-SKILL_20150317_000012	[Zigri] Jump and Stomping shock
+SKILL_20150317_000011	[Zigri] Spinning Strike
+SKILL_20150317_000012	[Zigri] Jump and Stomping Shock
 SKILL_20150317_000013	[Fisherman] Physical, Strike, Ice Property, Strike with Fishing Rod
 SKILL_20150317_000014	[Fisherman] Magic, Buff, Magic, Buff Skill
 SKILL_20150317_000015	[Green Pokuborn] Physical, Stab, Lightning Property, Horn Attack 1 time
 SKILL_20150317_000016	[Bushspider] Physical, Strike, Earth Property, Attack 1 time
 SKILL_20150317_000017	[Fragaras] Quick bite
-SKILL_20150317_000018	[Fragaras] Large Bite
+SKILL_20150317_000018	[Fragaras] Large Chomp
 SKILL_20150317_000019	[Fragaras] Normal Attack, Conical AoE
 SKILL_20150317_000020	Basic Normal Attack
 SKILL_20150317_000021	[Meduja] Magic, Magic, Lightning Property Attack 1 time
@@ -4260,9 +4260,9 @@ SKILL_20150714_004259	Armorr Penetration
 SKILL_20150714_004260	Decrease Physical Defense
 SKILL_20150714_004261	You can change weapons.
 SKILL_20150714_004262	You can equip [One-handed sword] type weapon.
-SKILL_20150714_004263	You can equip [Dual handed sword] type weapon.
+SKILL_20150714_004263	You can equip [Two-Handed sword] type weapon.
 SKILL_20150714_004264	You can equip [One-handed spear] type weapon.
-SKILL_20150714_004265	You can equip [Dual handed spear] type weapon.
+SKILL_20150714_004265	You can equip [Two-Handed spear] type weapon.
 SKILL_20150714_004266	You can equip [Bow] type weapon.
 SKILL_20150714_004267	You can equip [Crossbow] type weapon.
 SKILL_20150714_004268	You can equip [Rod] type weapon.
@@ -4316,7 +4316,7 @@ SKILL_20150714_004315	Skull Swing: Enhancement
 SKILL_20150714_004316	The damage that will be dealt on an enemy with [Skull Swing] will increase by 1% per Attribute level.
 SKILL_20150714_004317	The pushing power of the skill [Catastroke] will increase by 50 per Attribute level.
 SKILL_20150714_004318	The amount that will reduce an enemy's INT and SPR with the skill [Crown] will increase by 2% per Attribute level.
-SKILL_20150714_004319	When equipped with [Dual Wield Swords], Critical ATK rate will increase by 10% per Attribute level.
+SKILL_20150714_004319	When equipped with [Two-Handed Swords], Critical ATK rate will increase by 10% per Attribute level.
 SKILL_20150714_004320	Critical ATK rate of the skill [Moulinet] will increase by 10% per Attribute level.
 SKILL_20150714_004321	The duration of time that will stiffen the enemy that is blocked by [Crossguard] will be increased. It will increase by 1 sec per Attribute level.
 SKILL_20150714_004322	The enemy pushed by [Catastroke] will be damaged additionally by 50% per Physical ATK.


### PR DESCRIPTION
Dual-Wield/Dual-Handed changed to Two-Handed (Use Two-Handed Sword/ Two-Handed Sword Mastery)
Lines edited :
4263,4265,4319 skills for two-handed sword confusing for players.
two-handed sword is not dual-wielding swords.
