### PR TITLE
Proper translation for SKILL_20150317_002344 (bow mastery related)

### DIFF
--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -2341,7 +2341,7 @@ SKILL_20150317_002340	Turn Undead: spirit
 SKILL_20150317_002341	Instant death probability of skill [Turn Undead] also affects your spirit.
 SKILL_20150317_002342	Conversion: Increase Strength
 SKILL_20150317_002343	Strength of monsters converted with Conversion] increase by 10%.
-SKILL_20150317_002344	[Both hands bow] to the public type monster when mounted I will give a 20% additional damage of Physical attack.
+SKILL_20150317_002344	[Bow] Gives 20% additional physical damage to aerial-type monster when equipped
 SKILL_20150317_002345	Oblique shot: Slow
 SKILL_20150317_002346	When the skill [Swift step] is enabled, enemies attacked with [Oblique shot] falls under [Slow] at 5% rate per attribute level.
 SKILL_20150317_002347	Multi-shot -SP recovery

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -2341,7 +2341,7 @@ SKILL_20150317_002340	Turn Undead: spirit
 SKILL_20150317_002341	Instant death probability of skill [Turn Undead] also affects your spirit.
 SKILL_20150317_002342	Conversion: Increase Strength
 SKILL_20150317_002343	Strength of monsters converted with Conversion] increase by 10%.
-SKILL_20150317_002344	[Bow] Gives 20% additional physical damage to aerial-type monster when equipped
+SKILL_20150317_002344	[Bow] Gives 20% additional physical damage to flying-type monster when equipped
 SKILL_20150317_002345	Oblique shot: Slow
 SKILL_20150317_002346	When the skill [Swift step] is enabled, enemies attacked with [Oblique shot] falls under [Slow] at 5% rate per attribute level.
 SKILL_20150317_002347	Multi-shot -SP recovery
@@ -4801,7 +4801,7 @@ SKILL_20150717_004800	The range of [Disinter] will be increased by 10.
 SKILL_20150717_004801	Cooldown time of [Dig] will be reduced by 10 secs.
 SKILL_20150717_004802	Physical ATK and Magic ATK will be increased for 30 mins for the allies that participated in [Item Awakening] dungeon. ATK will increase by 20% per Attribute level.
 SKILL_20150717_004803	Fulldraw : Knockback increase
-SKILL_20150717_004804	[Two-Handed Bow] to the public type monster when mounted I will give a 20% additional damage of Physical attack.
+SKILL_20150717_004804	[Bow] Gives 20% additional physical damage to flying-type monster when equipped
 SKILL_20150717_004805	When [Swift Steps] is being activated, the enemies that got shot by [Oblique Shot] will fall into [Slow] with 5% probability per Attribute level for 7 secs.
 SKILL_20150717_004806	Physical DEF of the enemies that are threaded with [Full Draw] will decrease by 10% per Attribute level.
 SKILL_20150717_004807	Tumbleweed of [Broom Trap] will be reduced by 0.5 secs per Attribute level and the number of rotations will decrease by 0.5 per Attribute level.


### PR DESCRIPTION
Change from machine translate to proper translate and no need to put [two handed bow] since bow is already two handed in game, while crossbow are 1 handed
