### PR TITLE
QUEST_LV_100.tsv: change "move to" -> "go to" as appropriate, plus spelling fixes

### DIFF
--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -3023,7 +3023,7 @@ QUEST_LV_0100_20150317_003022	Goddess Gabija (3)
 QUEST_LV_0100_20150317_003023	Let's go start a fire.
 QUEST_LV_0100_20150317_003024	I'm not ready yet.
 QUEST_LV_0100_20150317_003025	Goddess Gabija (4)
-QUEST_LV_0100_20150317_003026	Move to magic teleportation circle.
+QUEST_LV_0100_20150317_003026	Go to the magic teleportation circle.
 QUEST_LV_0100_20150317_003027	Let's find a safer way. 
 QUEST_LV_0100_20150317_003028	Goddess Gabija (5)
 QUEST_LV_0100_20150317_003029	Go to another magic circle.
@@ -3221,9 +3221,9 @@ QUEST_LV_0100_20150317_003220	Go find the next inscription
 QUEST_LV_0100_20150317_003221	Research of Historian Rexipher (3)
 QUEST_LV_0100_20150317_003222	Go to where the inscription is
 QUEST_LV_0100_20150317_003223	Research of Historian Rexipher (4)
-QUEST_LV_0100_20150317_003224	Move to where the next inscription is located
+QUEST_LV_0100_20150317_003224	Go to where the next inscription is located
 QUEST_LV_0100_20150317_003225	Research of Historian Rexipher (5)
-QUEST_LV_0100_20150317_003226	Move to a where the last inscription is located
+QUEST_LV_0100_20150317_003226	Go to where the last inscription is located
 QUEST_LV_0100_20150317_003227	
 QUEST_LV_0100_20150317_003228	Trick of the Demon (2)
 QUEST_LV_0100_20150317_003229	I follow the whereabouts of Rexipher
@@ -3799,7 +3799,7 @@ QUEST_LV_0100_20150317_003798
 QUEST_LV_0100_20150317_003799	Bramble Strategy (2)
 QUEST_LV_0100_20150317_003800	Go to destroy
 QUEST_LV_0100_20150317_003801	Give me some time
-QUEST_LV_0100_20150317_003802	Notice/Move to Giliai Courtyard!#5
+QUEST_LV_0100_20150317_003802	Notice/Go to Giliai Courtyard!#5
 QUEST_LV_0100_20150317_003803	Bishop's Dream (2)
 QUEST_LV_0100_20150317_003804	Ok, I'll drop by
 QUEST_LV_0100_20150317_003805	To the Overlong Bridge Valley
@@ -3875,12 +3875,12 @@ QUEST_LV_0100_20150317_003874	Please be getting rid of lock torque Two moths tha
 QUEST_LV_0100_20150317_003875	Report to Guard Captain the defeat of Rocktortuga.
 QUEST_LV_0100_20150317_003876	Tell Battle Commander to return to camp
 QUEST_LV_0100_20150317_003877	You were asked to tell troops to assemble before going to Klaipeda. Tell the Battle Commander about it.
-QUEST_LV_0100_20150317_003878	Move to Hanaming infested area
-QUEST_LV_0100_20150317_003879	Move to area with Hanamings to complete the duty given by the Battle Commander.
+QUEST_LV_0100_20150317_003878	Go to the area infested with Hanamings
+QUEST_LV_0100_20150317_003879	Go to area with Hanamings to complete the duty given by the Battle Commander.
 QUEST_LV_0100_20150317_003880	Chase the Hanamings
 QUEST_LV_0100_20150317_003881	Defeat the surrounding Hanamings
-QUEST_LV_0100_20150317_003882	Move to Hanaming habitat
-QUEST_LV_0100_20150317_003883	Go to Hanaming habitat to quickly complete the Battle Commander's assignment.
+QUEST_LV_0100_20150317_003882	Go to the Hanaming habitat
+QUEST_LV_0100_20150317_003883	Go to the Hanaming habitat to complete the Battle Commander's assignment.
 QUEST_LV_0100_20150317_003884	Collect Hanaming Petals to investigate
 QUEST_LV_0100_20150317_003885	Collect Petals from Hanamings to complete the mission of the Battle Commander
 QUEST_LV_0100_20150317_003886	Give Petals to Battle Commander
@@ -3936,7 +3936,7 @@ QUEST_LV_0100_20150317_003935	Report to Supply Officer that you defeated the Lar
 QUEST_LV_0100_20150317_003936	Defeat the Large Gray Chupacabras that appeared when you defeated a Chupacabra 
 QUEST_LV_0100_20150317_003937	Talk to Supply Officer
 QUEST_LV_0100_20150317_003938	Seems like the Supply Officer is in trouble. Try to talk to him.
-QUEST_LV_0100_20150317_003939	Move to the marked location
+QUEST_LV_0100_20150317_003939	Go to the marked location
 QUEST_LV_0100_20150317_003940	Track the trails of the Weaver in the marked area.
 QUEST_LV_0100_20150317_003941	Defeat Weaver and report to the Supply Officer.
 QUEST_LV_0100_20150317_003942	Defeat Weaver
@@ -4006,13 +4006,13 @@ QUEST_LV_0100_20150317_004005	Find Pipoti's friend
 QUEST_LV_0100_20150317_004006	Stonemason Pipoti says his friend suddenly disappeared. Find him his colleagues around the Firefly Forest.
 QUEST_LV_0100_20150317_004007	Unfortuatnely, Pipoti's friend did not make it alive. Return to Pipoti.
 QUEST_LV_0100_20150317_004008	Defeatthe monsters that attacked
-QUEST_LV_0100_20150317_004009	Move to the area marked in Pipoti's map
+QUEST_LV_0100_20150317_004009	Go to the area marked in Pipoti's map
 QUEST_LV_0100_20150317_004010	There is a mark in Pipoti's map. Right click on the map and move to the marked area.
 QUEST_LV_0100_20150317_004011	Avoid the monsters and check the treasure box
 QUEST_LV_0100_20150317_004012	Something hidden is marked in Pipoti's map. Avoid Yonazolem and open the treasure box. 
 QUEST_LV_0100_20150317_004013	Obtain %s from Yonazolem
 QUEST_LV_0100_20150317_004014	Defeat Yonazolem
-QUEST_LV_0100_20150317_004015	Move to the marked area in Pipoti's map
+QUEST_LV_0100_20150317_004015	Go to the marked area in Pipoti's map
 QUEST_LV_0100_20150317_004016	There are other marked areas in Pipoti's map. Right click on the map and move to the marked area.
 QUEST_LV_0100_20150317_004017	Avoid the monsters and check the treasure box
 QUEST_LV_0100_20150317_004018	Something hidden is marked in Pipoti's map. Avoid the monsters and open the treasure box. 
@@ -4246,8 +4246,8 @@ QUEST_LV_0100_20150317_004245	The new researcher told you that he lost all the r
 QUEST_LV_0100_20150317_004246	Obtained %s by defeating Tontus at Dulkiu Hill
 QUEST_LV_0100_20150317_004247	Obtain Ripped research Records by defeating Tontus
 QUEST_LV_0100_20150317_004248	Talk to the new researcher
-QUEST_LV_0100_20150317_004249	Move to the Repository
-QUEST_LV_0100_20150317_004250	Move to the Repository which the new researcher told you about
+QUEST_LV_0100_20150317_004249	Go to the Repository
+QUEST_LV_0100_20150317_004250	Go to the Repository which the new researcher told you about
 QUEST_LV_0100_20150317_004251	It seems that the recorder Jonas went upto Dulkiu Hill. Persuade him to go back since it is dangerous.
 QUEST_LV_0100_20150317_004252	Protect the recorder Jonas
 QUEST_LV_0100_20150317_004253	You were attacked by monsters while you were persuading Jonas. Protect Jonas from the monsters.
@@ -4660,7 +4660,7 @@ QUEST_LV_0100_20150317_004659	Pass the third test
 QUEST_LV_0100_20150317_004660	Destroy the statue of the Goddess of the test
 QUEST_LV_0100_20150317_004661	Use the key
 QUEST_LV_0100_20150317_004662	Use the key to open the way to Thorny Forest
-QUEST_LV_0100_20150317_004663	Move to Thorny Forest
+QUEST_LV_0100_20150317_004663	Go to Thorny Forest
 QUEST_LV_0100_20150317_004664	Hanaming suddenly appeared
 QUEST_LV_0100_20150317_004665	Hanaming's appearance
 QUEST_LV_0100_20150317_004666	Defeat the herd of Hanamings that are rushing in
@@ -4730,8 +4730,8 @@ QUEST_LV_0100_20150317_004729	Give the pots to the protector of the secret
 QUEST_LV_0100_20150317_004730	Now is the time to avenge Rexipher and find the revelation of the Goddess. Install the pots with the wills of the protectors.
 QUEST_LV_0100_20150317_004731	Defeat Rexipher
 QUEST_LV_0100_20150317_004732	All the energies of the Mausoleum are restraining Rexipher. Defeat Rexipher.
-QUEST_LV_0100_20150317_004733	Move to the burial chamber of the Mausoleum
-QUEST_LV_0100_20150317_004734	You have defeated Rexipher! Move to the burian chamer which is the deepest area of the Mausoleum.
+QUEST_LV_0100_20150317_004733	Go to the burial chamber of the Mausoleum
+QUEST_LV_0100_20150317_004734	You have defeated Rexipher! Go to the burial chamber which is the deepest area of the Mausoleum.
 QUEST_LV_0100_20150317_004735	Listen to the advices of Zachariel
 QUEST_LV_0100_20150317_004736	Listen to the interpretations of the revelation from the will of the greatest king of humans, Zachariel.
 QUEST_LV_0100_20150317_004737	Obtain the Burning Stone from the protectors of the Mausoleum
@@ -4759,8 +4759,8 @@ QUEST_LV_0100_20150317_004758	Read the manual of the secret place
 QUEST_LV_0100_20150317_004759	You can see the manual of the secret place. Read it again.
 QUEST_LV_0100_20150317_004760	Obtained the energy of the protector
 QUEST_LV_0100_20150317_004761	The method of obtaining the secret letter of the Mausoleum is written on the manual of the secret place. Gain the power of the protectors first.
-QUEST_LV_0100_20150317_004762	Move to the secret place
-QUEST_LV_0100_20150317_004763	You've gained the power of the protectors. Move to the secret place to find the secret letter of the Mausoleum.
+QUEST_LV_0100_20150317_004762	Go to the secret place
+QUEST_LV_0100_20150317_004763	You've gained the power of the protectors. Go to the secret place to find the secret letter of the Mausoleum.
 QUEST_LV_0100_20150317_004764	Defeat Tomblord
 QUEST_LV_0100_20150317_004765	There is a monster blocking your way as you are about to find the secret letter of the Mausoleum. Defeat Tomblord.
 QUEST_LV_0100_20150317_004766	Find the secret letter of the Mausoleum
@@ -5047,7 +5047,7 @@ QUEST_LV_0100_20150317_005046	The Essence of Light is ready. Talk to Baidutis.
 QUEST_LV_0100_20150317_005047	Open the entrance of the cathedral
 QUEST_LV_0100_20150317_005048	Baidutis told you to deactivate the barriers of demons using the Essence of Light. Powerful monsters hat are pulled to the power of the essence may attack so he told you to be careful.
 QUEST_LV_0100_20150317_005049	Defeat Mummyghast
-QUEST_LV_0100_20150317_005050	Move to the entrace of Katyn Forest
+QUEST_LV_0100_20150317_005050	Go to the entrace of Katyn Forest
 QUEST_LV_0100_20150317_005051	
 QUEST_LV_0100_20150317_005052	The entrance of Katyn Forest
 QUEST_LV_0100_20150317_005053	Baidutis is looking for help from somebody at the 1st floor of Tenet Cathedral
@@ -6342,7 +6342,7 @@ QUEST_LV_0100_20150317_006341	The Accessory Merchant has given the Relevator an 
 QUEST_LV_0100_20150317_006342	Listen to Gustas Jonas for the next step.
 QUEST_LV_0100_20150317_006343	Meet Morcus Jonas in Long Bridge Valley.
 QUEST_LV_0100_20150317_006344	You'll know what to do next when you meet Morcus Jonas in Long Bridge Valley.
-QUEST_LV_0100_20150317_006345	Goddess Saule says the Bramble stole the revelation in Thorn Forest. Move to Thorn Forest.
+QUEST_LV_0100_20150317_006345	Goddess Saule says the Bramble stole the revelation in Thorn Forest. Go to Thorn Forest.
 QUEST_LV_0100_20150317_006346	
 QUEST_LV_0100_20150317_006347	
 QUEST_LV_0100_20150317_006348	Talk to Soldier Jace
@@ -6406,7 +6406,7 @@ QUEST_LV_0100_20150317_006405	Acquired Vubbe Thief's Leather! Bring it to Mr. Ju
 QUEST_LV_0100_20150323_006406	Now take the unsealing stone and go to Ramstis Ridge. {nl}Student of Gustas will teach you how to release the seal there. 
 QUEST_LV_0100_20150323_006407	Were you not guided yet?{nl}It's the student of Gustas in Ramstis Ridge.{nl}It is made to let only the chosen one enter.
 QUEST_LV_0100_20150323_006408	Ask the mayor for directions to Gele Plateau. {nl}I will sent the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
-QUEST_LV_0100_20150323_006409	The high gardens that the Goddess mentioned must be referring to the Gele Plateau. {nl}I heared the Paladin Master is there to keep a long term promise. 
+QUEST_LV_0100_20150323_006409	The high gardens that the Goddess mentioned must be referring to Gele Plateau. {nl}I heard the Paladin Master is there to keep a long term promise.
 QUEST_LV_0100_20150323_006410	
 QUEST_LV_0100_20150323_006411	
 QUEST_LV_0100_20150323_006412	If you ever fight against us Rodeleros, better be careful of your legs. {nl}Swords pop out from below the shield. {nl}
@@ -6509,7 +6509,7 @@ QUEST_LV_0100_20150323_006508	Install memorial stone at the entrance of Undergro
 QUEST_LV_0100_20150323_006509	The Mausoluem entrance is just the fit place to commemorate the lives lost in this area. Install the memorial stone at the Mausoleum entrance in Zachariel Corssroad. 
 QUEST_LV_0100_20150323_006510	Pick up and retrieve the purifier tube on the way to district 7.
 QUEST_LV_0100_20150323_006511	Arrive at Miner's Village
-QUEST_LV_0100_20150323_006512	You must enter the Crystal Mines but the Miner's Village where the  Crystal Mine is located in is under attack by the Vubbes. Move to Miner's Village Quickly!
+QUEST_LV_0100_20150323_006512	You must enter the Crystal Mines but the Miner's Village where the Crystal Mine is located in is under attack by the Vubbes. Go to Miner's Village quickly!
 QUEST_LV_0100_20150323_006513	Treasure Hunter Edang of Stele Road is looking for someone who can deliver the the stones.
 QUEST_LV_0100_20150323_006514	Talk to Grita in Fedimian Outskirts
 QUEST_LV_0100_20150323_006515	Grita is waiting in Karsta Battlefiield of Fedimian Outskirts. Go and talk to Grita.
@@ -6581,26 +6581,26 @@ QUEST_LV_0100_20150323_006580	Treasure Hunter of Stele Road is waiting for someo
 QUEST_LV_0100_20150323_006581	Talk to the wandering soldier of Escanciu Village.
 QUEST_LV_0100_20150323_006582	Found a written command while checking the military bag of wandering soul in Escanciu Village. Check the details of the command.
 QUEST_LV_0100_20150323_006583	Complete the Tree Dale mission for the wandering soul of Escanciu.
-QUEST_LV_0100_20150323_006584	Move to Kvailas Forest
+QUEST_LV_0100_20150323_006584	Go to Kvailas Forest
 QUEST_LV_0100_20150323_006585	Find the Followers of Goddess Saule in Sirdgela Forest and help them.
 QUEST_LV_0100_20150323_006586	Goddess Saule's follower Samantha is waiting for your help in Kvailas Forest.
 QUEST_LV_0100_20150323_006587	Villagers told you to go to the elderly of Andale Village. Go to the elderly of Andale Village in Vieta Gorge.
 QUEST_LV_0100_20150323_006588	Go to Ershike Altar
 QUEST_LV_0100_20150323_006589	Colleted all materials needed to restore the obelisk. Go to Ershike altar to combine it.
 QUEST_LV_0100_20150323_006590	Retrieve dye from Ershike Altar
-QUEST_LV_0100_20150323_006591	Move to Cobalt Forest
+QUEST_LV_0100_20150323_006591	Go to Cobalt Forest
 QUEST_LV_0100_20150323_006592	Check Ershike Altar
 QUEST_LV_0100_20150323_006593	Omnius force is felt from the Ershike altar. Check what is happening. 
 QUEST_LV_0100_20150323_006594	Priest of Vieta Gorge told you to go to the priest in Andale Village. To go the Andale Village of Cobalt Forest. 
 QUEST_LV_0100_20150323_006595	Check the portal of Veja Ravine
 QUEST_LV_0100_20150323_006596	The villagers were disguised as Demons. Run away to the portal in Veja Ravine.
 QUEST_LV_0100_20150323_006597	Check the old well in Coblat Forest.
-QUEST_LV_0100_20150323_006598	Move to Akmens Ridge
+QUEST_LV_0100_20150323_006598	Go to Akmens Ridge
 QUEST_LV_0100_20150323_006599	Morcus Jonas says you can listen to the next story from Rolandas Jonas in Akmens Ridge.
 QUEST_LV_0100_20150323_006600	Go and meet Rolandas Jonas in Akmens Ridge.
 QUEST_LV_0100_20150323_006601	Goddess Saule says Bramble of Kvailas Forest is in Thorn Forest. Pass through Gate Route and Spine Heart Dale to Kvailas Forest to find the revelation. 
 QUEST_LV_0100_20150323_006602	Kvailas Forest
-QUEST_LV_0100_20150323_006603	Move to Gele Plateau
+QUEST_LV_0100_20150323_006603	Go to Gele Plateau
 QUEST_LV_0100_20150323_006604	Gele Plateau
 QUEST_LV_0100_20150323_006605	The Ranger Master seems to know about the sword. Go and talk to them.
 QUEST_LV_0100_20150323_006606	The Ranger Master says this sword is Evoniphon's and tells you to ask the Hunter Master about the poison.
@@ -6853,16 +6853,16 @@ QUEST_LV_0100_20150428_006852	You found the luggage of the villager. Return the 
 QUEST_LV_0100_20150428_006853	Defeat Blue Woodspirits that appeared near Obelisk
 QUEST_LV_0100_20150428_006854	Siaulai Goddess lost the revelation from Brambles at the thorny forest of Kbailas forest. Help the priests at Gate Route and Spine Heart Dale and look for the revelation at Kbailas forest.
 QUEST_LV_0100_20150428_006855	Take the cable car from Srautas Canyon that will appear as you go down from the twin bridge of the crystal mine, and go up a bit to get to Gelly Plauteau.
-QUEST_LV_0100_20150428_006856	Move to Starving Demon's Road
-QUEST_LV_0100_20150428_006857	Move to Starving Demon's Road
-QUEST_LV_0100_20150428_006858	Move to Starving Demon's Road
+QUEST_LV_0100_20150428_006856	Go to Starving Demon's Road
+QUEST_LV_0100_20150428_006857	Go to Starving Demon's Road
+QUEST_LV_0100_20150428_006858	Go to Starving Demon's Road
 QUEST_LV_0100_20150428_006859	You should go past Starving Demon's Road in order to get to the great cathedral by following the revelation. Help the people having troubles at Starving Demon's Road after going past Fedimian.
 QUEST_LV_0100_20150428_006860	After going past Fedimian, in order to go to the great cathedral, you need to past Starving Demon's Road. Help the people having troubles at Starving Demon's Road.
 QUEST_LV_0100_20150428_006861	To the 1st zone of Demons' Prison
-QUEST_LV_0100_20150428_006862	Move to the 1st zone of Demons' Prison
-QUEST_LV_0100_20150428_006863	Move to the 1st zone of Demons' Prision
-QUEST_LV_0100_20150428_006864	In order to go to Demons' Prision, you should go past Gitise settlement area. Help the ones that are in trouble to go to Gitese settlement area past Klaipeda.
-QUEST_LV_0100_20150511_006865	Anyways, my guess is that those demons wake up again and control those Vubbes.(nl)The dream you had and the legend of Cunningham.. they may forecast something big.{nl}
+QUEST_LV_0100_20150428_006862	Go to the 1st zone of Demons' Prison
+QUEST_LV_0100_20150428_006863	Go to the 1st zone of Demons' Prison
+QUEST_LV_0100_20150428_006864	In order to go to Demons' Prison, you should go past Gitise settlement area. Help the ones that are in trouble to go to Gitese settlement area past Klaipeda.
+QUEST_LV_0100_20150511_006865	Anyway, my guess is that those demons have woken up again and control those Vubbes.{nl}The dream you had and the legend of Cunningham.. they may be foretelling something big.{nl}
 QUEST_LV_0100_20150511_006866	It's good to find the reason for the increase in the number of monsters in this forest.{nl}But, I am more worried about supplies being stopped to the mine village.
 QUEST_LV_0100_20150511_006867	Vubbe Warrior is hiding deep inside the felled area.{nl}I know that the order has come, but it may be safer to wait for the reinforcement here.
 QUEST_LV_0100_20150511_006868	If you face us as enemies, you should be careful not to lose your legs.{nl}Swords will come out from the lower part of the shields.{nl}
@@ -6901,7 +6901,7 @@ QUEST_LV_0100_20150511_006900	Retrieve the diary from the lost bag of Varkis
 QUEST_LV_0100_20150511_006901	The adventurer Varkis told you that monsters stole the bag and ran away. Retrieve his diary by finding the bag at way below the Shirnas Plateau.
 QUEST_LV_0100_20150511_006902	Go to the camp of adventurer, Varkis
 QUEST_LV_0100_20150511_006903	The gigantic monster was defeated, but Varkis passed away. Go back to his camp with the diary.
-QUEST_LV_0100_20150511_006904	Move to the camp of Varkis
+QUEST_LV_0100_20150511_006904	Go to the camp of Varkis
 QUEST_LV_0100_20150511_006905	Varkis passed away. Go back to the camp where Varkis used to reside and meet his spirit.
 QUEST_LV_0100_20150511_006906	Collect the research materials of Varkis at Dykyne Intersections.
 QUEST_LV_0100_20150511_006907	It seems that Varkis still has some regrets on the research that he used to do when he was alive. Collect his materials at Dykyne Intersections.
@@ -7269,7 +7269,7 @@ QUEST_LV_0100_20150714_007268	Notice/Collected all the tree sap.{nl}Go to Ershik
 QUEST_LV_0100_20150714_007269	Notice/Dye completed!{nl}Obtain the dye from the altar.#5
 QUEST_LV_0100_20150714_007270	Restoring Obelisk
 QUEST_LV_0100_20150714_007271	Setting the bombs
-QUEST_LV_0100_20150714_007272	Notice/Move to Giliai Courtyard!#5
+QUEST_LV_0100_20150714_007272	Notice/Go to Giliai Courtyard!#5
 QUEST_LV_0100_20150714_007273	Unseperable Spirit
 QUEST_LV_0100_20150714_007274	Ask him to tell you the story
 QUEST_LV_0100_20150714_007275	There is a way(1)
@@ -7821,7 +7821,7 @@ QUEST_LV_0100_20150803_007820	Check the keepstakes of the soldier/SITGROPE/1/TRA
 QUEST_LV_0100_20150803_007821	The spirit of the solider with resentment(2)
 QUEST_LV_0100_20150803_007822	Put down the ring
 QUEST_LV_0100_20150803_007823	The depesperate man
-QUEST_LV_0100_20150803_007824	Move to the lower side of the base
+QUEST_LV_0100_20150803_007824	Go to the lower side of the base
 QUEST_LV_0100_20150803_007825	Track the trails of the Weaver at the lower side of the base
 QUEST_LV_0100_20150803_007826	You've defeated Weavers. Go back to Supply Officer and report.
 QUEST_LV_0100_20150803_007827	Check the barrier stone in Closed Area


### PR DESCRIPTION
This shouldn't interfere with other pull requests. "Move to <area>" doesn't sound right, you usually use "go to <area>". There were also a couple of spelling mistakes on those lines, which I fixed.

Line 6865 has been edited within the context of the game, faulty newline replaced with correct tag.
