### PR TITLE
QUEST_JOBSTEP.tsv 18, 521, 1478, 1480, 2606, 2905 (Bokor Master gender fix)

### DIFF
--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -15,7 +15,7 @@ QUEST_JOBSTEP_20150317_000014	Good work. Thanks to you I can go on to the next s
 QUEST_JOBSTEP_20150317_000015	Good, you're here. I need you to defeat the evil spirits I summon. {nl}I will record the unique wavelength that is transmitted in the process. 
 QUEST_JOBSTEP_20150317_000016	I am doing research on the 4th state of matter. {nl}It is impossible without the cooperation of the Bokor Master who deals with the spirits. 
 QUEST_JOBSTEP_20150317_000017	Yes, that's great. {nl}Tell the Pyromancer Master that we have all the materials we need. 
-QUEST_JOBSTEP_20150317_000018	Good. {nl}That study is being done with the Bokor Master. So go pay her a visit and she'll tell you what to do. 
+QUEST_JOBSTEP_20150317_000018	Good. {nl}That study is being done together with the Bokor Master. So go pay her a visit and she'll tell you what to do. 
 QUEST_JOBSTEP_20150317_000019	Cryomancer Master
 QUEST_JOBSTEP_20150317_000020	You want to learn Cryomancer magic from me? {nl}Sure I'll teach you. If you take care of something first! 
 QUEST_JOBSTEP_20150317_000021	The Pyromancer Master is not around. {nl}Well, it's an easy task.
@@ -518,7 +518,7 @@ QUEST_JOBSTEP_20150317_000517	Please tell Tesla that I am okay.
 QUEST_JOBSTEP_20150317_000518	Go meet Priest Master too.{nl}The amount of perfumed oil you have may not be enough.
 QUEST_JOBSTEP_20150317_000519	That's the task we intrusted to you, so if you need it we will give to you. {nl}Here you go.
 QUEST_JOBSTEP_20150317_000520	Even if you receive perfumed oil from the Priest Master, it may not be enough.{nl}Since you should take care of it with the greatest care.
-QUEST_JOBSTEP_20150317_000521	The amount of perfumed oil you have seems a bit lacking.{nl}Since the Bokor Master also has some oil, why don't you go meet him?
+QUEST_JOBSTEP_20150317_000521	The amount of perfumed oil you have seems a bit lacking.{nl}Since the Bokor Master also has some oil, why don't you go meet her?
 QUEST_JOBSTEP_20150317_000522	Perfumed Oil? we will definitely give it to you.{nl}Tesla told us that he doesn't need any pay for that, so we felt sorry about it.
 QUEST_JOBSTEP_20150317_000523	Too bad I can't go with you since I don't have enough time.
 QUEST_JOBSTEP_20150317_000524	The statues that we intrusted to you is the statue in Fedimian and the statue in Klaipeda.{nl}Okay then, I am counting on you.
@@ -1475,9 +1475,9 @@ QUEST_JOBSTEP_20150317_001474	The bomb doesn't seem so powerful. Report the resu
 QUEST_JOBSTEP_20150317_001475	Talk to Bokor Master
 QUEST_JOBSTEP_20150317_001476	Go to Bokor Master in Klaipeda.
 QUEST_JOBSTEP_20150317_001477	Collect Mission or Field Boss Monster Card
-QUEST_JOBSTEP_20150317_001478	Bokor Master asked you bring a boss monster card. The card can be obtained from any boss monsters in field or mission.
+QUEST_JOBSTEP_20150317_001478	Bokor Master asked you to bring a boss monster card. The card can be obtained from any boss monsters in a field or a mission.
 QUEST_JOBSTEP_20150317_001479	Mission Zone/Crystal Mines Field Boss/Tenet Cathedral Field Boss/Mausoleum Field Boss (Except quest boss monsters)
-QUEST_JOBSTEP_20150317_001480	Give card to Bokor Master
+QUEST_JOBSTEP_20150317_001480	Give the card to Bokor Master
 QUEST_JOBSTEP_20150317_001481	Got the boss monster card. Give it to Bokor Master.
 QUEST_JOBSTEP_20150317_001482	Go meet Sculptor Tesla at Rhombuspaving Dale.
 QUEST_JOBSTEP_20150317_001483	Talk to Item Merchant in Klaipeda
@@ -2603,7 +2603,7 @@ QUEST_JOBSTEP_20150714_002602	I can see your passion to become a Pyromancer, but
 QUEST_JOBSTEP_20150714_002603	I can now move on to the next stage of the research because of you.{nl}You can always come to learn Magic. Well done.
 QUEST_JOBSTEP_20150714_002604	Welcome. You should eliminate the evil that I summoned.{nl}I should record the unique wavelength that would come out from the process.
 QUEST_JOBSTEP_20150714_002605	I am researching about the 4th state about the substance.{nl}It can't be done without support from Bokor Master who controls spirits.
-QUEST_JOBSTEP_20150714_002606	Good. {nl}Since that research is being progressed with Bokor Master, he will tell you what to do when you go meet him.
+QUEST_JOBSTEP_20150714_002606	Good. {nl}Since that research is being done together with Bokor Master, she will tell you what to do when you meet her.
 QUEST_JOBSTEP_20150714_002607	You want to learn magic from me?{nl}Of course I can teach you. If you could do me a favor.
 QUEST_JOBSTEP_20150714_002608	This will be enough.{nl}It will be hard from this stage so you should follow well.
 QUEST_JOBSTEP_20150714_002609	You want to be a Ranger? Then I will request something to you. {nl}I will decide whether I should teach you based on how well you complete the task.
@@ -2902,7 +2902,7 @@ QUEST_JOBSTEP_20150717_002901	Reception Error [Oracle]
 QUEST_JOBSTEP_20150717_002902	Give the stolen goods to Kalipeda Tools Merchant.
 QUEST_JOBSTEP_20150717_002903	Sapper Master want to return the stolen belongings to its owner and repent for the past. Return the stolen things to Tools Merchant in Klaipeda.
 QUEST_JOBSTEP_20150717_002904	Collect Boss Monster Card
-QUEST_JOBSTEP_20150717_002905	Bokor Master asked you bring the card obtained from boss monster.
+QUEST_JOBSTEP_20150717_002905	Bokor Master asked you to bring the card obtained from a boss monster.
 QUEST_JOBSTEP_20150717_002906	Talk to Klaipeda Tools Merchant
 QUEST_JOBSTEP_20150717_002907	Sculptor Tesla is looking for a cat to use as his model. Ask the Tools Merchant in Klaipeda if there is a cat he can use.
 QUEST_JOBSTEP_20150717_002908	Find the Tools Merchant's father in Sirdgela Forest

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -15,7 +15,7 @@ QUEST_JOBSTEP_20150317_000014	Good work. Thanks to you I can go on to the next s
 QUEST_JOBSTEP_20150317_000015	Good, you're here. I need you to defeat the evil spirits I summon. {nl}I will record the unique wavelength that is transmitted in the process. 
 QUEST_JOBSTEP_20150317_000016	I am doing research on the 4th state of matter. {nl}It is impossible without the cooperation of the Bokor Master who deals with the spirits. 
 QUEST_JOBSTEP_20150317_000017	Yes, that's great. {nl}Tell the Pyromancer Master that we have all the materials we need. 
-QUEST_JOBSTEP_20150317_000018	Good. {nl}That study is being done together with the Bokor Master. So go pay her a visit and she'll tell you what to do. 
+QUEST_JOBSTEP_20150317_000018	Good. {nl}This research is being done together with the Bokor Master. So go pay her a visit and she'll tell you what to do. 
 QUEST_JOBSTEP_20150317_000019	Cryomancer Master
 QUEST_JOBSTEP_20150317_000020	You want to learn Cryomancer magic from me? {nl}Sure I'll teach you. If you take care of something first! 
 QUEST_JOBSTEP_20150317_000021	The Pyromancer Master is not around. {nl}Well, it's an easy task.
@@ -2603,7 +2603,7 @@ QUEST_JOBSTEP_20150714_002602	I can see your passion to become a Pyromancer, but
 QUEST_JOBSTEP_20150714_002603	I can now move on to the next stage of the research because of you.{nl}You can always come to learn Magic. Well done.
 QUEST_JOBSTEP_20150714_002604	Welcome. You should eliminate the evil that I summoned.{nl}I should record the unique wavelength that would come out from the process.
 QUEST_JOBSTEP_20150714_002605	I am researching about the 4th state about the substance.{nl}It can't be done without support from Bokor Master who controls spirits.
-QUEST_JOBSTEP_20150714_002606	Good. {nl}Since that research is being done together with Bokor Master, she will tell you what to do when you meet her.
+QUEST_JOBSTEP_20150714_002606	Good. {nl}Since the research is being done together with Bokor Master, she will tell you what to do when you meet her.
 QUEST_JOBSTEP_20150714_002607	You want to learn magic from me?{nl}Of course I can teach you. If you could do me a favor.
 QUEST_JOBSTEP_20150714_002608	This will be enough.{nl}It will be hard from this stage so you should follow well.
 QUEST_JOBSTEP_20150714_002609	You want to be a Ranger? Then I will request something to you. {nl}I will decide whether I should teach you based on how well you complete the task.


### PR DESCRIPTION
Bokor Master was referred to as male multiple times. The NPC is female. Also fixed a few sentences I found while searching for the gender ones. Shouldn't interfere with other pull requests.
