### PR TITLE
Fixed up lines (loosely) related to Kvailas Forest

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2552,7 +2552,7 @@ ETC_20150317_002551	Naktis' subordinates are being too disrupting!
 ETC_20150317_002552	Using a key of Mayvern..
 ETC_20150317_002553	Experimental Mesyum
 ETC_20150317_002554	Acidic solution Maki
-ETC_20150317_002555	Using the Refined Spell Crystal
+ETC_20150317_002555	Using the Refined Magic Crystal
 ETC_20150317_002556	Things that were recovered
 ETC_20150317_002557	Labor was not detected
 ETC_20150317_002558	Labor has been detected
@@ -7889,7 +7889,7 @@ ETC_20150317_007889	Capture the suspicious movement (4)
 ETC_20150317_007890	Capture the suspicious movement (5)
 ETC_20150317_007891	Surprise Attack of Maegro
 ETC_20150317_007892	Load of Bramble, Gaigalas
-ETC_20150317_007893	Create an enhanced thorn pollen stimulant by mixing it with a Merog's saliva and a pollen stimulant
+ETC_20150317_007893	Create an enhanced thorn pollen stimulant by mixing it with Merog saliva and a pollen stimulant
 ETC_20150317_007894	Load of Bramble, Molich
 ETC_20150317_007895	Bramble punished
 ETC_20150317_007896	Activate a Obelisk

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2552,7 +2552,7 @@ ETC_20150317_002551	Naktis' subordinates are being too disrupting!
 ETC_20150317_002552	Using a key of Mayvern..
 ETC_20150317_002553	Experimental Mesyum
 ETC_20150317_002554	Acidic solution Maki
-ETC_20150317_002555	Using the Refined Soul Crystal
+ETC_20150317_002555	Using the Refined Spell Crystal
 ETC_20150317_002556	Things that were recovered
 ETC_20150317_002557	Labor was not detected
 ETC_20150317_002558	Labor has been detected

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -590,9 +590,9 @@ ETC_20150317_000589	It is said that they receive their powers from human souls b
 ETC_20150317_000590	Green Ellom
 ETC_20150317_000591	This type of Ellom is toxic.
 ETC_20150317_000592	Yellow Ellom
-ETC_20150317_000593	Merlog Shaman
-ETC_20150317_000594	Merlog variant. Slight differences in the mutation process differentiates the variety of Merlogs.
-ETC_20150317_000595	Merlog Stinger
+ETC_20150317_000593	Merog Shaman
+ETC_20150317_000594	Merog variant. Slight differences in the mutation process differentiates the variety of Merogs.
+ETC_20150317_000595	Merog Stinger
 ETC_20150317_000596	This reptile monster attacks instinctively but shows as much abilities as its intelligence.
 ETC_20150317_000597	Hogam Captain
 ETC_20150317_000598	A Hogma whose intelligence and instinct give them leadership in the fight against humans.
@@ -2552,7 +2552,7 @@ ETC_20150317_002551	Naktis' subordinates are being too disrupting!
 ETC_20150317_002552	Using a key of Mayvern..
 ETC_20150317_002553	Experimental Mesyum
 ETC_20150317_002554	Acidic solution Maki
-ETC_20150317_002555	While using to change the horsepower
+ETC_20150317_002555	Using the Refined Soul Crystal
 ETC_20150317_002556	Things that were recovered
 ETC_20150317_002557	Labor was not detected
 ETC_20150317_002558	Labor has been detected
@@ -7889,7 +7889,7 @@ ETC_20150317_007889	Capture the suspicious movement (4)
 ETC_20150317_007890	Capture the suspicious movement (5)
 ETC_20150317_007891	Surprise Attack of Maegro
 ETC_20150317_007892	Load of Bramble, Gaigalas
-ETC_20150317_007893	Create a enhanced thorn pollen stimulant to mix with a Maegro's Mspittle and a Pollen stimulant
+ETC_20150317_007893	Create an enhanced thorn pollen stimulant by mixing it with a Merog's saliva and a pollen stimulant
 ETC_20150317_007894	Load of Bramble, Molich
 ETC_20150317_007895	Bramble punished
 ETC_20150317_007896	Activate a Obelisk
@@ -7935,7 +7935,7 @@ ETC_20150317_007935	Find the cathedral's things (1)
 ETC_20150317_007936	Find the cathedral's things
 ETC_20150317_007937	Petrified Book Rubbing
 ETC_20150317_007938	Quest Buff
-ETC_20150317_007939	Move to Fallen Worry Forest through Gate Route and Spine Heart Dale
+ETC_20150317_007939	Move to the Fallen Worry forest via Gate Route and Spine Heart Dale
 ETC_20150317_007940	Move to Leaf Veil Plateau
 ETC_20150317_007941	I will move to Fedimian
 ETC_20150317_007942	Get leather from Jukopus
@@ -9965,7 +9965,7 @@ ETC_20150323_009966	This is also purification
 ETC_20150323_009967	Block the Underground Tunnel
 ETC_20150323_009968	Culprit of the Underground Maze
 ETC_20150323_009969	Escort Farm Soldier Upham to Chief Vuros
-ETC_20150323_009970	Move to Kvailas Forest through Gate Route and Sirdgela Forest.
+ETC_20150323_009970	Move to Kvailas Forest via Gate Route and Sirdgela Forest.
 ETC_20150323_009971	Move to Gele Plauteau
 ETC_20150323_009972	Gitis Settlement Area Phenomenon(1)	
 ETC_20150323_009973	Gitis Settlement Area Phenomenon(2)	
@@ -12394,8 +12394,8 @@ ETC_20150714_012395	Don't move
 ETC_20150714_012396	Impure energy is about to pour over! Run away!
 ETC_20150714_012397	You've defeated Gaigalas!{nl}Cut down the root of Bramble
 ETC_20150714_012398	You've defeated Molek!{nl}Cut down the root of Bramble
-ETC_20150714_012399	You've removed the roots of Brambles!{nl}Defeat Gaigalas
-ETC_20150714_012400	You've removed the roots of Brambles!{nl}Defeat Molek
+ETC_20150714_012399	You've removed the roots of Bramble!{nl}Defeat Gaigalas
+ETC_20150714_012400	You've removed the roots of Bramble!{nl}Defeat Molek
 ETC_20150714_012401	The contaminated Vikaras has exploded!
 ETC_20150714_012402	The contaminated Vikaras is about to explode!
 ETC_20150714_012403	You can't insert the Holy Relic

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -2956,7 +2956,7 @@ ITEM_20150317_002955	(Temporary) Enlarged Sample
 ITEM_20150317_002956	Commander Julian's Order 
 ITEM_20150317_002957	A detailed tactic is explained alongside the map. 
 ITEM_20150317_002958	Mersium Sample 
-ITEM_20150317_002959	Merlog Sample 
+ITEM_20150317_002959	Merog Sample 
 ITEM_20150317_002960	Merleech Sample 
 ITEM_20150317_002961	Mersumma Thorn 
 ITEM_20150317_002962	Thronball Thorn 
@@ -3299,7 +3299,7 @@ ITEM_20150317_003298	Adele treasures this ring. Let's get it back to Adele.
 ITEM_20150317_003299	Poisonous Mushroom of Truffle 
 ITEM_20150317_003300	A Treepelli's poisonous mushroom. Most people think it's a horn. 
 ITEM_20150317_003301	A strong acidic solution that can melt through thorny stems. 
-ITEM_20150317_003302	Operer Spit 
+ITEM_20150317_003302	Operer Saliva 
 ITEM_20150317_003303	An Operor's saliva that has the power to purify corrupted magical crystals. 
 ITEM_20150317_003304	Refined Spell Crystal 
 ITEM_20150317_003305	A completely purified magical crystal. It can remove the thorny vines blocking the path. 
@@ -3353,12 +3353,12 @@ ITEM_20150317_003352	Revelator's Proof
 ITEM_20150317_003353	An index describing how to obtain the Legendary Key from the West Barrier. 
 ITEM_20150317_003354	Spatial Crest 
 ITEM_20150317_003355	A special key for finding revelations and hidden places. 
-ITEM_20150317_003356	Merog Spittle 
+ITEM_20150317_003356	Merog Saliva 
 ITEM_20150317_003357	It creates an awakening effect if it is mixed with Thorn Flower Powder Stimulant. 
 ITEM_20150317_003358	Enhanced Thorn Flower Stimulant 
 ITEM_20150317_003359	It has a better effect than the Thorn Flower Powder  
 ITEM_20150317_003360	Thorn Flower Fluid 
-ITEM_20150317_003361	It has an awakening effect if mixed with a Merog's spit. 
+ITEM_20150317_003361	It has an awakening effect if mixed with a Merog's saliva. 
 ITEM_20150317_003362	Slime's Body Liquid 
 ITEM_20150317_003363	Material requested by the Elementalist Master to prove your qualification 
 ITEM_20150317_003364	Hallowventer Bone Piece 
@@ -3373,7 +3373,7 @@ ITEM_20150317_003372	A pot filled with the magical energy that flows through the
 ITEM_20150317_003373	Black Maize Poison  
 ITEM_20150317_003374	Ingredient necessary to redecorate the Obelisk. It has a high level of acidity. 
 ITEM_20150317_003375	Paralysis Powder 
-ITEM_20150317_003376	Paralysis Powder that can stun the Black Maize in Rhombuspaving Dale. 
+ITEM_20150317_003376	Paralysis Powder that can stun the Black Maize in Rhombuspaving Dale. I 
 ITEM_20150317_003377	White Oak Essence  
 ITEM_20150317_003378	Ingredient necessary for the paint used in painting inscriptions onto the Obelisk. It's black in color. 
 ITEM_20150317_003379	Adhesive Coating  

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -3301,7 +3301,7 @@ ITEM_20150317_003300	A Treepelli's poisonous mushroom. Most people think it's a 
 ITEM_20150317_003301	A strong acidic solution that can melt through thorny stems. 
 ITEM_20150317_003302	Operer Saliva 
 ITEM_20150317_003303	An Operor's saliva that has the power to purify corrupted magical crystals. 
-ITEM_20150317_003304	Refined Spell Crystal 
+ITEM_20150317_003304	Refined Magic Crystal 
 ITEM_20150317_003305	A completely purified magical crystal. It can remove the thorny vines blocking the path. 
 ITEM_20150317_003306	Cauliflower Sap 
 ITEM_20150317_003307	Highly volatile sap. Essential for burning away wet thorny vines. 
@@ -3358,7 +3358,7 @@ ITEM_20150317_003357	It creates an awakening effect if it is mixed with Thorn Fl
 ITEM_20150317_003358	Enhanced Thorn Flower Stimulant 
 ITEM_20150317_003359	It has a better effect than the Thorn Flower Powder  
 ITEM_20150317_003360	Thorn Flower Fluid 
-ITEM_20150317_003361	It has an awakening effect if mixed with a Merog's saliva. 
+ITEM_20150317_003361	It has an awakening effect if mixed with Merog Saliva. 
 ITEM_20150317_003362	Slime's Body Liquid 
 ITEM_20150317_003363	Material requested by the Elementalist Master to prove your qualification 
 ITEM_20150317_003364	Hallowventer Bone Piece 
@@ -3373,7 +3373,7 @@ ITEM_20150317_003372	A pot filled with the magical energy that flows through the
 ITEM_20150317_003373	Black Maize Poison  
 ITEM_20150317_003374	Ingredient necessary to redecorate the Obelisk. It has a high level of acidity. 
 ITEM_20150317_003375	Paralysis Powder 
-ITEM_20150317_003376	Paralysis Powder that can stun the Black Maize in Rhombuspaving Dale. I 
+ITEM_20150317_003376	Paralysis Powder that can stun the Black Maize in Rhombuspaving Dale.
 ITEM_20150317_003377	White Oak Essence  
 ITEM_20150317_003378	Ingredient necessary for the paint used in painting inscriptions onto the Obelisk. It's black in color. 
 ITEM_20150317_003379	Adhesive Coating  

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -15,7 +15,7 @@ QUEST_20150317_000014	Goddess Laima
 QUEST_20150317_000015	Much time will have drifted between us when you see this message. {nl}I am the Goddess of Fate and Wisdom - Laima.
 QUEST_20150317_000016	600 years ago - at the time I am sending this revelation - I saw a great deal of death and grief. {nl}Your seeing of this message likely means that all that I foresaw has come to pass.
 QUEST_20150317_000017	The Demons have started the first cataclysms, and the goddesses have vanished. {nl}I knew all of this in advance and spent great effort to interfere with fate, but my power alone was not enough.
-QUEST_20150317_000018	I have wandered through many far-seeing dreams to find an answer. {nl}You were at the end of them…a Savior.
+QUEST_20150317_000018	I have wandered through many far-seeing dreams to find an answer. {nl}You were at the end of them… a Savior.
 QUEST_20150317_000019	However, I knew the Demons would never rest while I kept my power. {nl}I was forced to hide away, until the time of your appearance.
 QUEST_20150317_000020	I resolved to divide my being and subsist inside many of these messages. {nl}I continued to secretly create them, even as the kingdoms flew by over the millennia. 
 QUEST_20150317_000021	Savior. These messages are hidden across axes of time. {nl}Once they are brought together, I will regain my complete form and help against the Demons.
@@ -1452,7 +1452,7 @@ QUEST_20150323_001452	Thanks to the medicine, Witas' curse is not working.
 QUEST_20150323_001453	If you ever see the Devout Tree, please bring it back to life. {nl}I heard that tree blocks the power of the curse.
 QUEST_20150323_001454	I believe that the evil will eventually fall and the Goddess will be victorious. {nl}The mark of victory is right in front of me.
 QUEST_20150323_001455	Anyway, I will go to the battlefield first so please help the guards and my followers. {nl}I will meet you in Nefritas Cliff.
-QUEST_20150323_001456	Do not think this is over. {nl}I will be watching from Kvailas Forest. 
+QUEST_20150323_001456	Do not think this is over. {nl}I'll be watching you from Kvailas Forest. 
 QUEST_20150323_001457	Catacomb 1st Floor internal warp
 QUEST_20150323_001458	It needs to be purified more…
 QUEST_20150323_001459	Blurry spirit of Catacomb 1st Floor

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -67,8 +67,8 @@ QUEST_JOBSTEP_20150317_000066	Anyway, you did a good job. {nl}Let's get along we
 QUEST_JOBSTEP_20150317_000067	I'm looking for a book. Four books of Lydia Schaffen. {nl}If you help me find the books, I will teach you my skills. 
 QUEST_JOBSTEP_20150317_000068	The book used to be in Miner's town but it was lost when the Vubbes raided. {nl} Try going to the Vubbe Outpost.
 QUEST_JOBSTEP_20150317_000069	It's this book. You will need this book if you dream to be the best Archer. {nl}I will make you a copy if you can gather all the books. 
-QUEST_JOBSTEP_20150317_000070	The Quarrel Shooter Master holds the next book. {nl}He was looking for Merog Leather before. Maybe you can make a deal with him using those.
-QUEST_JOBSTEP_20150317_000071	Do you have the Merog Leather yet from the Hunter Master?
+QUEST_JOBSTEP_20150317_000070	The Quarrel Shooter Master holds the next book. {nl}He was looking for some Merog leather before. Maybe you can make a trade with him using those.
+QUEST_JOBSTEP_20150317_000071	Do you have the Merog leather yet for the Hunter Master?
 QUEST_JOBSTEP_20150317_000072	This is of good quality. The Hunter Master will be pleased. {nl}You can take the book. {nl}
 QUEST_JOBSTEP_20150317_000073	Merogs are in the Fallen Worry forest and the Quarrel Shooter Master is in Klaipeda. {nl}Someone might get ahead of you, so you better hurry.
 QUEST_JOBSTEP_20150317_000074	The Archer Master in Klaipeda has the next book. {nl}He's not a mean person so he will give you the book if you ask nicely. {nl}
@@ -117,7 +117,7 @@ QUEST_JOBSTEP_20150317_000116	Oh, that's pretty good. {nl}It will he helpful for
 QUEST_JOBSTEP_20150317_000117	The problem is the Hunter Master. I really don't want to see her face. {nl}So you go and get the next book from her. 
 QUEST_JOBSTEP_20150317_000118	You mean the book I have? {nl}Well, okay. I'll hand it over for 5000 silver. 
 QUEST_JOBSTEP_20150317_000119	I think around 5000 silver will do. {nl}Can you spare that much? 
-QUEST_JOBSTEP_20150317_000120	You came at the right time.{nl}Quarrel Shooter Master told you that if you could bring the leathers of Merogs, he will make you a copy of the next volume.
+QUEST_JOBSTEP_20150317_000120	You came at the right time.{nl}The Quarrel Shooter Master told you that if you could bring Merog leather, he'll make you a copy of the next volume.
 QUEST_JOBSTEP_20150317_000121	Didn't the Ranger Master tell you anything?{nl}I asked him for Merog leather.
 QUEST_JOBSTEP_20150317_000122	Merogs are at the Fallen Worry forest and the Quarrel Shooter Master is at Klaipeda. {nl}Someone may go there and get the book faster than you, so please hurry.
 QUEST_JOBSTEP_20150317_000123	The book is in good condition.{nl}Now, bring the book to the Archer Master. {nl}
@@ -1275,10 +1275,10 @@ QUEST_JOBSTEP_20150317_001274	Give the book to Hunter Master
 QUEST_JOBSTEP_20150317_001275	Foudn the book Hunter Master is looking for. Give it to Hunter Master.
 QUEST_JOBSTEP_20150317_001276	Killed Vubbe Fighter and acquired %s
 QUEST_JOBSTEP_20150317_001277	This isn't the only book the Hunter Master is looking for. Talk to him again.
-QUEST_JOBSTEP_20150317_001278	Collect the leathers of Merog
-QUEST_JOBSTEP_20150317_001279	Hunter Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Merog you have for the book. Obtain the leather of Merogs from the Fallen Worry forest.
-QUEST_JOBSTEP_20150317_001280	Hand over the leathers of Merog to Quarrel Shooter Master
-QUEST_JOBSTEP_20150317_001281	You've obtained enough Leathers of Merogs that are needed by Quarrel Shooter Master. Hand over the leathers of Merogs to Quarrel Shooter Master at Klaipeda.
+QUEST_JOBSTEP_20150317_001278	Collect Merog Leather
+QUEST_JOBSTEP_20150317_001279	The Hunter Master told you that you may be able to trade with the Quarrel Shooter Master with the Merog leather you have for the book. Obtain the Merog leather from the Fallen Worry forest.
+QUEST_JOBSTEP_20150317_001280	Hand over the Merog leather to the Quarrel Shooter Master
+QUEST_JOBSTEP_20150317_001281	You've obtained enough Merog leather for the Quarrel Shooter Master. Hand it over to the Quarrel Shooter Master at Klaipeda.
 QUEST_JOBSTEP_20150317_001282	Obtain %s by defeating Merogs
 QUEST_JOBSTEP_20150317_001283	Hunter Master doesn't express it much but he seems happy to have found the book. Talk to him about the next book to find.
 QUEST_JOBSTEP_20150317_001284	Collect rocks from the Crystal Mines entrance in Miners' Village
@@ -1316,8 +1316,8 @@ QUEST_JOBSTEP_20150317_001315	This isn't the only book Archer Master is looking 
 QUEST_JOBSTEP_20150317_001316	Hunter Master has the book Archer Master wants. Prepare 5000 silvers to get the book from Hunter Master.
 QUEST_JOBSTEP_20150317_001317	Gathered enough money for the book. Give 5000 silvers to Hunter Master in exchange for the book and take the book to Archer Master.
 QUEST_JOBSTEP_20150317_001318	Archer Master looks very happy to have found the book. Talk to him to find the next book.
-QUEST_JOBSTEP_20150317_001319	Collect the leathers of Merogs
-QUEST_JOBSTEP_20150317_001320	Archer Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Merogs you have for the book. Obtain the leather of Merogs from the Fallen Worry forest.
+QUEST_JOBSTEP_20150317_001319	Collect Merog Leather
+QUEST_JOBSTEP_20150317_001320	The Archer Master told you that you may be able trade the Quarrel Shooter Master some Merog leather you have for the book. Obtain Merog leather from Merogs in the Fallen Worry forest.
 QUEST_JOBSTEP_20150317_001321	There is one last book left. Talk to the Archer Master on how you can get the last book.
 QUEST_JOBSTEP_20150317_001322	Archer Master asked you to give the pouch to Ranger Master. Deliver it to Ranger Master in Klaipeda and exchange it for the book.
 QUEST_JOBSTEP_20150317_001323	Gave the pouch to Ranger Master in exchange for the book. Take the book to Archer Master.
@@ -1407,7 +1407,7 @@ QUEST_JOBSTEP_20150317_001406	Give the materials to Wizard Master
 QUEST_JOBSTEP_20150317_001407	Collected the materials for Wizard Master. Give it to him.
 QUEST_JOBSTEP_20150317_001408	Collect %s from Spine Heart Dale
 QUEST_JOBSTEP_20150317_001409	Collect %s from the Fallen Worry forest
-QUEST_JOBSTEP_20150317_001410	Collect %s from Siaulai Mine Village
+QUEST_JOBSTEP_20150317_001410	Collect %s from Miners' Village
 QUEST_JOBSTEP_20150317_001411	Wizard Master's research starts from now. Talk to wizard Master again.
 QUEST_JOBSTEP_20150317_001412	Use the Scroll for data around town
 QUEST_JOBSTEP_20150317_001413	Wizard Master is studying Klaipeda which has less attacks from the monsters. Help Wizard Master by going to the marked areas in the map and using the Scroll for collecting data.

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -67,10 +67,10 @@ QUEST_JOBSTEP_20150317_000066	Anyway, you did a good job. {nl}Let's get along we
 QUEST_JOBSTEP_20150317_000067	I'm looking for a book. Four books of Lydia Schaffen. {nl}If you help me find the books, I will teach you my skills. 
 QUEST_JOBSTEP_20150317_000068	The book used to be in Miner's town but it was lost when the Vubbes raided. {nl} Try going to the Vubbe Outpost.
 QUEST_JOBSTEP_20150317_000069	It's this book. You will need this book if you dream to be the best Archer. {nl}I will make you a copy if you can gather all the books. 
-QUEST_JOBSTEP_20150317_000070	Quarrel Shooter Master holds the next book. {nl}He was looking for Merlog Leather before. Maybe you can try a deal with him using that.
-QUEST_JOBSTEP_20150317_000071	Do you have the Merlog Leather yet from the Hunter Master?
+QUEST_JOBSTEP_20150317_000070	The Quarrel Shooter Master holds the next book. {nl}He was looking for Merog Leather before. Maybe you can make a deal with him using those.
+QUEST_JOBSTEP_20150317_000071	Do you have the Merog Leather yet from the Hunter Master?
 QUEST_JOBSTEP_20150317_000072	This is of good quality. The Hunter Master will be pleased. {nl}You can take the book. {nl}
-QUEST_JOBSTEP_20150317_000073	Merlog is in Fallen Worry Forest, and Quarrel Shooter Master is in Klaipeda. {nl}Someone might get ahead of you so better hurry.
+QUEST_JOBSTEP_20150317_000073	Merogs are in the Fallen Worry forest and the Quarrel Shooter Master is in Klaipeda. {nl}Someone might get ahead of you, so you better hurry.
 QUEST_JOBSTEP_20150317_000074	The Archer Master in Klaipeda has the next book. {nl}He's not a mean person so he will give you the book if you ask nicely. {nl}
 QUEST_JOBSTEP_20150317_000075	He is helping with the repair of the damaged city wall. {nl}I heard there are rocks moved to Miner's Village, so bringing him that rock can be a way to ask. 
 QUEST_JOBSTEP_20150317_000076	Did the Hunter Master sent this rock? {nl}If it's Lydia Schaffen's book, you could have just asked. But thank you anyway. 
@@ -103,9 +103,9 @@ QUEST_JOBSTEP_20150317_000102	I'm surprised you found it so fast! {nl}And it's i
 QUEST_JOBSTEP_20150317_000103	I think you might be able to buy the next book from the Hunter Master..{nl}I'm broke after fixing the wall with my money. Haha..
 QUEST_JOBSTEP_20150317_000104	You mean the second book of Lydia Schaffen? {nl}I'll hand it over for 5000 silver. 
 QUEST_JOBSTEP_20150317_000105	I think around 5000 silver will do. {nl}I heard that's the book's value. 
-QUEST_JOBSTEP_20150317_000106	Ah, you came at the right time.{nl}If you could take the leathers of Meroggs to Quarrel Shooter Master, he will make you a copy of the next volume.
-QUEST_JOBSTEP_20150317_000107	Did the leathers of Merogg come from Archer Master?
-QUEST_JOBSTEP_20150317_000108	You will see Meroggs easily at Fallen Worry Forest.{nl}Take those to Quarrel Shooter Master in Klaipeda.
+QUEST_JOBSTEP_20150317_000106	Ah, you came at the right time.{nl}If you could take this Merog leather to the Quarrel Shooter Master, he will make you a copy of the next volume.
+QUEST_JOBSTEP_20150317_000107	Did this Merog leather come from the Archer Master?
+QUEST_JOBSTEP_20150317_000108	You will find plenty of Merogs at the Fallen Worry forest.{nl}Take those to Quarrel Shooter Master in Klaipeda.
 QUEST_JOBSTEP_20150317_000109	The quality is fine enough. The Archer Master must also be pleased. {nl}Here, I've prepared a copy, so take it. 
 QUEST_JOBSTEP_20150317_000110	Now there is one book left. {nl}Give this pouch to the Ranger Master and get the book. {nl}
 QUEST_JOBSTEP_20150317_000111	Did the Archer Master send you? {nl}Well, good work. I'll give you the book as promised. 
@@ -117,9 +117,9 @@ QUEST_JOBSTEP_20150317_000116	Oh, that's pretty good. {nl}It will he helpful for
 QUEST_JOBSTEP_20150317_000117	The problem is the Hunter Master. I really don't want to see her face. {nl}So you go and get the next book from her. 
 QUEST_JOBSTEP_20150317_000118	You mean the book I have? {nl}Well, okay. I'll hand it over for 5000 silver. 
 QUEST_JOBSTEP_20150317_000119	I think around 5000 silver will do. {nl}Can you spare that much? 
-QUEST_JOBSTEP_20150317_000120	You came at the right time.{nl}Quarrel Shooter Master told you that if you could bring the leathers of Meroggs, he will make you a copy of the next volume.
-QUEST_JOBSTEP_20150317_000121	Didn't Ranger Master tell you anything?{nl}I asked him for Meroggs' leathers.
-QUEST_JOBSTEP_20150317_000122	Meroggs are at Fallen Worry Forest and Quarrel Shooter Master is at Klaipeda. {nl}Someone may go there and get the book faster than you so please hurry.
+QUEST_JOBSTEP_20150317_000120	You came at the right time.{nl}Quarrel Shooter Master told you that if you could bring the leathers of Merogs, he will make you a copy of the next volume.
+QUEST_JOBSTEP_20150317_000121	Didn't the Ranger Master tell you anything?{nl}I asked him for Merog leather.
+QUEST_JOBSTEP_20150317_000122	Merogs are at the Fallen Worry forest and the Quarrel Shooter Master is at Klaipeda. {nl}Someone may go there and get the book faster than you, so please hurry.
 QUEST_JOBSTEP_20150317_000123	The book is in good condition.{nl}Now, bring the book to the Archer Master. {nl}
 QUEST_JOBSTEP_20150317_000124	The Archer Master in Klaipeda has the last book. {nl}I heard he is repairing the wall so this might help you get the book? 
 QUEST_JOBSTEP_20150317_000125	I heard there is a rock useful for repairing the wall in Miner's Village. {nl}Bring that to the Archer Master as a present. 
@@ -166,13 +166,13 @@ QUEST_JOBSTEP_20150317_000165	I can feel that you are full of the Goddess' bless
 QUEST_JOBSTEP_20150317_000166	Swordsman Master
 QUEST_JOBSTEP_20150317_000167	An old saying goes, fight to death and you will survive. {nl}I will be able to teach you if you come to realize what it means. 
 QUEST_JOBSTEP_20150317_000168	You haven't realized what it means. {nl}Fight a bit more. 
-QUEST_JOBSTEP_20150317_000169	Right...Now do you understand. {nl}Remember that you're a Swordsman and devote yourself to being one. 
+QUEST_JOBSTEP_20150317_000169	Right... Now do you understand. {nl}Remember that you're a Swordsman and devote yourself to being one. 
 QUEST_JOBSTEP_20150317_000170	Then fight against Mentiwoods at Seven Hues Mesa.{nl}You may learn something from it.
 QUEST_JOBSTEP_20150317_000171	The most important thing for Priests is to belief in the Goddess, and to prove it. {nl}Exorcise the soldiers possessed with evil spirits in the name of Goddess. 
 QUEST_JOBSTEP_20150317_000172	That soldier is being taken care of in Miner's Village. {nl}Your sincerity will become your strength. 
 QUEST_JOBSTEP_20150317_000173	Your sincerity has been proven. {nl}We will walk together in the name of the Goddess. 
 QUEST_JOBSTEP_20150317_000174	Learning magic from me comes after helping my research. {nl}Let's talk about the talent problem afterwards. 
-QUEST_JOBSTEP_20150317_000175	First get me Skins of Grolls from Spine Heart Dale, Feelers of Chafperors from Fallen Worry Forest, {nl}And lastly the nuclueses from Jukopus. I am counting on you.
+QUEST_JOBSTEP_20150317_000175	First get me Skins of Grolls from Spine Heart Dale, Feelers of Chafperors from the Fallen Worry forest, {nl}And lastly the nuclueses from Jukopus. I am counting on you.
 QUEST_JOBSTEP_20150317_000176	You've gathered everything. {nl}Now let's move on to the next step. 
 QUEST_JOBSTEP_20150317_000177	Klaipeda is far from the capital and was barely attacked by the monsters. {nl}I paid attention to that point and I am studying to make a great magic circle. {nl}
 QUEST_JOBSTEP_20150317_000178	And for that, I need to accumulate data. {nl}Can you use this scroll around the city? 
@@ -1224,7 +1224,7 @@ QUEST_JOBSTEP_20150317_001223	Recognition of Barbarian Master
 QUEST_JOBSTEP_20150317_001224	Talk to Hoplite Master
 QUEST_JOBSTEP_20150317_001225	Go find Hoplite Master in West Siauliai Woods.
 QUEST_JOBSTEP_20150317_001226	Prove your will for determination
-QUEST_JOBSTEP_20150317_001227	Hopelite explained to us about the mind of strongness. To prove the determination to become stronger, please bring Leathers of Grolls from Spine Heart Dale, Poisonous Needles of Chafperors from Fallen Worry Forest, and Black Powders of Blue Yukopuses from Siaulai Mine Village. 
+QUEST_JOBSTEP_20150317_001227	Hopelite explained to us about the mind of strongness. To prove the determination to become stronger, {nl}please bring Groll Leather from Spine Heart Dale, Poisonous Needles of Chafperors from the Fallen Worry forest {nl}and Black Powder of Blue Yukopuses from Siaulai Mine Village. 
 QUEST_JOBSTEP_20150317_001228	Gathered all the materials needed to prove your determination to become stronger. Go back to Hoplite Master.
 QUEST_JOBSTEP_20150317_001229	Talk to Psychokino Master
 QUEST_JOBSTEP_20150317_001230	Go find Psychokino Master in Siauliai Miner's Village.
@@ -1275,11 +1275,11 @@ QUEST_JOBSTEP_20150317_001274	Give the book to Hunter Master
 QUEST_JOBSTEP_20150317_001275	Foudn the book Hunter Master is looking for. Give it to Hunter Master.
 QUEST_JOBSTEP_20150317_001276	Killed Vubbe Fighter and acquired %s
 QUEST_JOBSTEP_20150317_001277	This isn't the only book the Hunter Master is looking for. Talk to him again.
-QUEST_JOBSTEP_20150317_001278	Collect the leathers of Merogg
-QUEST_JOBSTEP_20150317_001279	Hunter Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Merogg you have for the book. Obtain the leathers of Meroggs from Fallen Worry Forest.
-QUEST_JOBSTEP_20150317_001280	Hand over the leathers of Merogg to Quarrel Shooter Master
-QUEST_JOBSTEP_20150317_001281	You've obtained enough Leathers of Meroggs that are needed by Quarrel Shooter Master. Hand over the leathers of Meroggs to Quarrel Shooter Master at Klaipeda.
-QUEST_JOBSTEP_20150317_001282	Obtain %s by defeating Meroggs
+QUEST_JOBSTEP_20150317_001278	Collect the leathers of Merog
+QUEST_JOBSTEP_20150317_001279	Hunter Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Merog you have for the book. Obtain the leather of Merogs from the Fallen Worry forest.
+QUEST_JOBSTEP_20150317_001280	Hand over the leathers of Merog to Quarrel Shooter Master
+QUEST_JOBSTEP_20150317_001281	You've obtained enough Leathers of Merogs that are needed by Quarrel Shooter Master. Hand over the leathers of Merogs to Quarrel Shooter Master at Klaipeda.
+QUEST_JOBSTEP_20150317_001282	Obtain %s by defeating Merogs
 QUEST_JOBSTEP_20150317_001283	Hunter Master doesn't express it much but he seems happy to have found the book. Talk to him about the next book to find.
 QUEST_JOBSTEP_20150317_001284	Collect rocks from the Crystal Mines entrance in Miners' Village
 QUEST_JOBSTEP_20150317_001285	Archer master has the next book. Collect rocks from the Crystal Mines entrance in Miners' Village for Archer Master.
@@ -1316,8 +1316,8 @@ QUEST_JOBSTEP_20150317_001315	This isn't the only book Archer Master is looking 
 QUEST_JOBSTEP_20150317_001316	Hunter Master has the book Archer Master wants. Prepare 5000 silvers to get the book from Hunter Master.
 QUEST_JOBSTEP_20150317_001317	Gathered enough money for the book. Give 5000 silvers to Hunter Master in exchange for the book and take the book to Archer Master.
 QUEST_JOBSTEP_20150317_001318	Archer Master looks very happy to have found the book. Talk to him to find the next book.
-QUEST_JOBSTEP_20150317_001319	Collect the leathers of Meroggs
-QUEST_JOBSTEP_20150317_001320	Archer Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Meroggs you have for the book. Obtain the leathers of Meroggs from Fallen Worry Forest.
+QUEST_JOBSTEP_20150317_001319	Collect the leathers of Merogs
+QUEST_JOBSTEP_20150317_001320	Archer Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Merogs you have for the book. Obtain the leather of Merogs from the Fallen Worry forest.
 QUEST_JOBSTEP_20150317_001321	There is one last book left. Talk to the Archer Master on how you can get the last book.
 QUEST_JOBSTEP_20150317_001322	Archer Master asked you to give the pouch to Ranger Master. Deliver it to Ranger Master in Klaipeda and exchange it for the book.
 QUEST_JOBSTEP_20150317_001323	Gave the pouch to Ranger Master in exchange for the book. Take the book to Archer Master.
@@ -1331,7 +1331,7 @@ QUEST_JOBSTEP_20150317_001330	Get Lydia Schaffen's book from Vubbe Fighter
 QUEST_JOBSTEP_20150317_001331	This isn't the only book Ranger Master is looking for. Talk to the Ranger Master again.
 QUEST_JOBSTEP_20150317_001332	Hunter Master has the book Ranger Master wants. Prepare 5000 silvers to get the book from Hunter Master.
 QUEST_JOBSTEP_20150317_001333	Archer Master doesn't express it much but he seems happy to have found the book. Talk to him about the next book to find.
-QUEST_JOBSTEP_20150317_001334	Ranger Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Meroggs for the book. Obtain the leathers of Meroggs from Fallen Worry Forest.
+QUEST_JOBSTEP_20150317_001334	Ranger Master told you that you may be able to trade with Quarrel Shooter Master with the leathers of Merogs for the book. Obtain the leathers of Merogs from the Fallen Worry forest.
 QUEST_JOBSTEP_20150317_001335	Ranger Master looks very happy to have found the book. Talk to him to find the next book.
 QUEST_JOBSTEP_20150317_001336	Collect rocks from the area Ranger Master mentioned
 QUEST_JOBSTEP_20150317_001337	Collected all the books for Ranger Master. Talk to Ranger Master to be acknowledged as a Ranger.
@@ -1402,12 +1402,12 @@ QUEST_JOBSTEP_20150317_001401	Defeat the body of evil spirit
 QUEST_JOBSTEP_20150317_001402	Talk to Wizard Master
 QUEST_JOBSTEP_20150317_001403	Go to Wizard Master in Klaipeda
 QUEST_JOBSTEP_20150317_001404	Collect the materials for Wizard Master
-QUEST_JOBSTEP_20150317_001405	Collect the Skins of Grolls in Spine Heart Dale, Feelers of Chafperors in Fallen Worry Forest, and the nucleuses of Yukopuses from Siaulai Mine Village.
+QUEST_JOBSTEP_20150317_001405	Collect the Skins of Grolls in Spine Heart Dale, Feelers of Chafperors in the Fallen Worry forest, and the nucleuses of Yukopuses from Siaulai Mine Village.
 QUEST_JOBSTEP_20150317_001406	Give the materials to Wizard Master
 QUEST_JOBSTEP_20150317_001407	Collected the materials for Wizard Master. Give it to him.
 QUEST_JOBSTEP_20150317_001408	Collect %s from Spine Heart Dale
-QUEST_JOBSTEP_20150317_001409	Collect %s from Fallen Worry Forest
-QUEST_JOBSTEP_20150317_001410	Collect %s from Mine Village
+QUEST_JOBSTEP_20150317_001409	Collect %s from the Fallen Worry forest
+QUEST_JOBSTEP_20150317_001410	Collect %s from Siaulai Mine Village
 QUEST_JOBSTEP_20150317_001411	Wizard Master's research starts from now. Talk to wizard Master again.
 QUEST_JOBSTEP_20150317_001412	Use the Scroll for data around town
 QUEST_JOBSTEP_20150317_001413	Wizard Master is studying Klaipeda which has less attacks from the monsters. Help Wizard Master by going to the marked areas in the map and using the Scroll for collecting data.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -2047,7 +2047,7 @@ QUEST_LV_0100_20150317_002046	Have you seen my ring?{nl}If you see that ring, pl
 QUEST_LV_0100_20150317_002047	That ring is full of divine energy so it will be hard for monsters to swallow it.{nl}Unless the monster is big.
 QUEST_LV_0100_20150317_002048	You found the ring! {nl}Thanks. Thank you so much!
 QUEST_LV_0100_20150317_002049	The priests are having hard time due to thorny bushes.{nl}How about you help them?
-QUEST_LV_0100_20150317_002050	I will write down all the processes for you.{nl}How about you start by recharging mana of magic crystal?
+QUEST_LV_0100_20150317_002050	I will write down the process for you.{nl}How about you start by recharging the mana of this magic crystal?
 QUEST_LV_0100_20150317_002051	Okay, show me that you can stand against those thorny bushes with your religious faith.{nl}You can't say you are the follower when you are weak like now.
 QUEST_LV_0100_20150317_002052	
 QUEST_LV_0100_20150317_002053	I don't know if it's due to the thorny bushes or the vicious atmosphere, but {nl}this forest makes people depressed.
@@ -2083,7 +2083,7 @@ QUEST_LV_0100_20150317_002082	Whenever I tried to purify the Thorny Trees founta
 QUEST_LV_0100_20150317_002083	Monsters are becoming more violent as they enter deeper into the thorny forest.{nl}Maybe that's due to the vicious energy.
 QUEST_LV_0100_20150317_002084	I can relax now and purify the fountain.{nl}Thank you so much.
 QUEST_LV_0100_20150317_002085	I can rely on you.{nl}Please protect the altar until the fountain gets purified.
-QUEST_LV_0100_20150317_002086	Put Merog's saliva in this potion and shake it.{nl}It will help you withstand the muddy aura of Bramble.
+QUEST_LV_0100_20150317_002086	Put Merog saliva in this potion and shake it.{nl}It will help you withstand the muddy aura of Bramble.
 QUEST_LV_0100_20150317_002087	Bramble is recovering by embedding roots around the Thorn Forest.{nl}Cutting those roots will hurt him.
 QUEST_LV_0100_20150317_002088	You can't let your guards down even if Bramble is weakened.{nl}They are one the leader of the demons after all.
 QUEST_LV_0100_20150317_002089	Now we'll make a full-scale attack on Bramble. {nl} I'll go in the Giliaii courtyard and scout out Bramble first so follow me.
@@ -3702,8 +3702,8 @@ QUEST_LV_0100_20150317_003701	I have nothing to do with it
 QUEST_LV_0100_20150317_003702	About the evil forces of the Thorn Forest
 QUEST_LV_0100_20150317_003703	In the Name of Faith (2)
 QUEST_LV_0100_20150317_003704	In the Name of Faith (3)
-QUEST_LV_0100_20150317_003705	Purifying../MAKING/2/TRACK_BEFORE/None
-QUEST_LV_0100_20150317_003706	Retrieving Spell Crystals/MAKING/3/TRACK_BEFORE/None
+QUEST_LV_0100_20150317_003705	Purifying…/MAKING/2/TRACK_BEFORE/None
+QUEST_LV_0100_20150317_003706	Retrieving Magic Crystal/MAKING/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003707	In the Name of Faith (4)
 QUEST_LV_0100_20150317_003708	Last Warning of the Watcher
 QUEST_LV_0100_20150317_003709	It will be fine
@@ -6172,17 +6172,17 @@ QUEST_LV_0100_20150317_006171	Melt the Thorn vines using acid solution.
 QUEST_LV_0100_20150317_006172	Adelle made acid solution with the mix solution you brought. Bring the solution to Gate Route and melt the Thorn vines. 
 QUEST_LV_0100_20150317_006173	Talk to Follower Virgis
 QUEST_LV_0100_20150317_006174	Virgis wants your help.
-QUEST_LV_0100_20150317_006175	Charge spell crystal in the condensed spell area. 
-QUEST_LV_0100_20150317_006176	Memo of Virgis: First, charge the spell crystal I gave you. Look for the condensed spell area in Pavydo Woodland. 
-QUEST_LV_0100_20150317_006177	Collect Operor's sting to refine the spell crystal.
-QUEST_LV_0100_20150317_006178	Memo of Virgis : Great. But you can't use the spell crystal right away because it has absorbed foul energy together. So collect the Operor's stingers that have purifying effects. 
+QUEST_LV_0100_20150317_006175	Charge the magic crystal in the condensed magic areas. 
+QUEST_LV_0100_20150317_006176	Memo of Virgis: First, charge the magic crystal I gave you. Look for the condensed magic areas in Pavydo Woodland. 
+QUEST_LV_0100_20150317_006177	Collect Operor stingers to refine the magic crystal with.
+QUEST_LV_0100_20150317_006178	Memo of Virgis: Great. But we can't use the crystal right away because it accumulated foul energy. So collect Operor stingers for their purifying effects. 
 QUEST_LV_0100_20150317_006179	Kill Operor and get %s
-QUEST_LV_0100_20150317_006180	Refine the spell of spell crystal
-QUEST_LV_0100_20150317_006181	Memo of Vargis : Did you collect all the stingers? The Purifying Altar is in Lenistwo Wasteland. Go there and use the Operor's stingers to refine the spell crystals. 
-QUEST_LV_0100_20150317_006182	Get refined spell crystals
-QUEST_LV_0100_20150317_006183	Use spell crystals to remove Thorn vines
-QUEST_LV_0100_20150317_006184	Memo of Vargis : Very good. Now use the clean spell crystal and show those Thorn vines the power of Goddess Saule's Followers.
-QUEST_LV_0100_20150317_006185	Memo of Vargis : Very good. Now use the clean spell crystal and show those Thorn vines the power of Goddess Saule's Followers.
+QUEST_LV_0100_20150317_006180	Refine the magic of the magic crystal
+QUEST_LV_0100_20150317_006181	Memo of Vargis: Did you collect all the stingers? The Purifying Altar is in Lenistwo Wasteland. Go there and use the Operor stingers to refine the magic crystal. 
+QUEST_LV_0100_20150317_006182	Get refined magic crystal
+QUEST_LV_0100_20150317_006183	Use the refined magic crystal to remove Thorn vines
+QUEST_LV_0100_20150317_006184	Memo of Vargis: Very good. Now use the refined magic crystal and show those thorn vines the power of Goddess Saule's Followers.
+QUEST_LV_0100_20150317_006185	Memo of Vargis: Very good. Now use the refined magic crystal and show those thorn vines the power of Goddess Saule's Followers.
 QUEST_LV_0100_20150317_006186	Talk to Follower Nojus
 QUEST_LV_0100_20150317_006187	Goddess Saule Follower Nojus is anxiously waiting for you.
 QUEST_LV_0100_20150317_006188	Find the ominous voice

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -584,7 +584,7 @@ QUEST_LV_0100_20150317_000583	Well then, see you in the mines.
 QUEST_LV_0100_20150317_000584	Miner's village Mayor
 QUEST_LV_0100_20150317_000585	
 QUEST_LV_0100_20150317_000586	Goddess Saule
-QUEST_LV_0100_20150317_000587	To retrieve the revelation, please go to Fallen Worry Forest.{nl}Now is the chance when the Demons' Lord, Bramble recovers his power.
+QUEST_LV_0100_20150317_000587	To retrieve the revelation, go to the Fallen Worry forest.{nl}Now is your chance while the Demon Lord Bramble recovers his power.
 QUEST_LV_0100_20150317_000588	Mausoleum Foundation Stone
 QUEST_LV_0100_20150317_000589	I pass my words to the revelator who comes here.{nl}I, Zachariel, sleep here to protect the goal of the Goddess. 
 QUEST_LV_0100_20150317_000590	If something vicious comes here, protect here from it by waking the sleeping protector.{nl}{nl}
@@ -2050,15 +2050,15 @@ QUEST_LV_0100_20150317_002049	The priests are having hard time due to thorny bus
 QUEST_LV_0100_20150317_002050	I will write down all the processes for you.{nl}How about you start by recharging mana of magic crystal?
 QUEST_LV_0100_20150317_002051	Okay, show me that you can stand against those thorny bushes with your religious faith.{nl}You can't say you are the follower when you are weak like now.
 QUEST_LV_0100_20150317_002052	
-QUEST_LV_0100_20150317_002053	I don't know if it's due to thorny bushes or vicious atmosphere, but.. {nl}This forest make people too depressed.
+QUEST_LV_0100_20150317_002053	I don't know if it's due to the thorny bushes or the vicious atmosphere, but {nl}this forest makes people depressed.
 QUEST_LV_0100_20150317_002054	I believe in myself that one day this forest will be okay again.
 QUEST_LV_0100_20150317_002055	Are you okay?{nl}I almost lost my conciousness due to that voice.{nl}Who is he anyways..
 QUEST_LV_0100_20150317_002056	
-QUEST_LV_0100_20150317_002057	The atmosphere is becoming stronger and the priests are getting tired. It's bad.
-QUEST_LV_0100_20150317_002058	Thanks.{nl}I wonder what would have happened without you.
-QUEST_LV_0100_20150317_002059	As Merogg sorcerers are undertaking their rituals, I will give it a try.{nl}Can you take care of those sorcerers?
+QUEST_LV_0100_20150317_002057	This is bad, the atmosphere is becoming stronger and the priests are getting tired.
+QUEST_LV_0100_20150317_002058	Thanks.{nl}I'm not sure what would've happened without you.
+QUEST_LV_0100_20150317_002059	Merog shamans are undertaking a ritual.{nl}Can you take care of them?
 QUEST_LV_0100_20150317_002060	Thanks for your help.{nl}Now the demons won't be able to act freely.
-QUEST_LV_0100_20150317_002061	I didn't know those demons would use Summon crystal.{nl}They may surround us.
+QUEST_LV_0100_20150317_002061	I didn't think those demons would use a Summon crystal.{nl}They may overwhelm us.
 QUEST_LV_0100_20150317_002062	I want to receive all the information about that magic field.{nl}Please be careful not to break the precious sample.
 QUEST_LV_0100_20150317_002063	We would be able to find a way to use it.{nl}Those demons used our altar so we can use it too.
 QUEST_LV_0100_20150317_002064	Believer Onute
@@ -2070,23 +2070,23 @@ QUEST_LV_0100_20150317_002069
 QUEST_LV_0100_20150317_002070	Saule Goddess Quezon evil aura it is not willing to spread in the other forest. {nl} Therefore, thing we're here.
 QUEST_LV_0100_20150317_002071	I am so angry to see those filthy demons walking around.
 QUEST_LV_0100_20150317_002072	I gave up long time ago since I can't see an end to that vicious atmosphere.{nl}I just think of it as my destiny.
-QUEST_LV_0100_20150317_002073	Now we just need to find out the plan of those Meroggs.{nl}Until then, please face that magician.
+QUEST_LV_0100_20150317_002073	Now we just need to find out the plan of those Merogs.{nl}Until then, please face that magician.
 QUEST_LV_0100_20150317_002074	Saule Goddess was so do not speak the absolute their presence. {nl} Ramyonsoyo that give me the world of confusion only without any reason.
 QUEST_LV_0100_20150317_002075	This is all my fault. I shouldn't have underestimated it.
 QUEST_LV_0100_20150317_002076	
 QUEST_LV_0100_20150317_002077	I am okay about the sample so just break it so that it won't activate.{nl}I am gonna take a look at it myself.
 QUEST_LV_0100_20150317_002078	I get angry everytime I enter that Thorny Foresst.{nl}How could these dirty things happen in this divine forest of the Goddess?
-QUEST_LV_0100_20150317_002079	Help me. Meroggs are after me.{nl}When they are moving in a herd like that, I can't face them.
+QUEST_LV_0100_20150317_002079	Help me. Merogs are after me.{nl}When they are moving in a herd like that, I can't face them.
 QUEST_LV_0100_20150317_002080	Good. {nl} Now, we're going to destroy the roots of Bramble.
 QUEST_LV_0100_20150317_002081	Believer Samanta
 QUEST_LV_0100_20150317_002082	Whenever I tried to purify the Thorny Trees fountain, those monsters attack.{nl}Is there some way to avoid them?
 QUEST_LV_0100_20150317_002083	Monsters are becoming more violent as they enter deeper into the thorny forest.{nl}Maybe that's due to the vicious energy.
 QUEST_LV_0100_20150317_002084	I can relax now and purify the fountain.{nl}Thank you so much.
 QUEST_LV_0100_20150317_002085	I can rely on you.{nl}Please protect the altar until the fountain gets purified.
-QUEST_LV_0100_20150317_002086	Put Merlog's saliva in this potion and shake it. {nl} It will help you withstand the muddy aura of Bramble.
-QUEST_LV_0100_20150317_002087	Bramble is recovering by embedding roots around the Thorn Forest . {nl} Cutting those roots will be very painful.
-QUEST_LV_0100_20150317_002088	You can't let your guards down even if the Brambles weakened. {nl} It is the leader of the demons no matter how injured it is.
-QUEST_LV_0100_20150317_002089	Now we'll make a full-scale attack on Bramble. {nl} I'll go in the Giliaii courtyard and watch on the Brambles first so follow me.
+QUEST_LV_0100_20150317_002086	Put Merog's saliva in this potion and shake it.{nl}It will help you withstand the muddy aura of Bramble.
+QUEST_LV_0100_20150317_002087	Bramble is recovering by embedding roots around the Thorn Forest.{nl}Cutting those roots will hurt him.
+QUEST_LV_0100_20150317_002088	You can't let your guards down even if Bramble is weakened.{nl}They are one the leader of the demons after all.
+QUEST_LV_0100_20150317_002089	Now we'll make a full-scale attack on Bramble. {nl} I'll go in the Giliaii courtyard and scout out Bramble first so follow me.
 QUEST_LV_0100_20150317_002090	The most important roots in the Sviesa hills and Tankinta lot. {nl} Cut them both.
 QUEST_LV_0100_20150317_002091	Even when all vicious energy is removed, this forest will be as it is.{nl}But, we will an end someday.
 QUEST_LV_0100_20150317_002092	Believer Kazis
@@ -2280,7 +2280,7 @@ QUEST_LV_0100_20150317_002279	I came to pray in the distance Klaipeda. {nl} agai
 QUEST_LV_0100_20150317_002280	Each time you come here along the husband on the Klaipeda, it is always prayer to come here. {nl} I was either God Beast of the day also defended to me was one wishes excluded get to.
 QUEST_LV_0100_20150317_002281	Don't you ever think about going to the great cathedral.{nl}Besides the dangers due to it's breakages..
 QUEST_LV_0100_20150317_002282	Yes. The Pilgrim's Way that must be passed when you wanna go to the great cathedral.{nl}Ah well.. the spirits of 
-QUEST_LV_0100_20150317_002283	Seal of Vubbe Tribe, Horn of Pantos, Heart of Merlog, HTeeth of Hogma. {nl} That is a lot! {nl}
+QUEST_LV_0100_20150317_002283	Seal of Vubbe Tribe, Horn of Pantos, Heart of Merog, HTeeth of Hogma. {nl} That is a lot! {nl}
 QUEST_LV_0100_20150317_002284	The bootys that you've obtained are not to be boasted about.{nl}How about we bet?
 QUEST_LV_0100_20150317_002285	
 QUEST_LV_0100_20150317_002286	Haha, I lost.{nl}You are great as I heard so. Here, it's your reward as promised/
@@ -3714,7 +3714,7 @@ QUEST_LV_0100_20150317_003713
 QUEST_LV_0100_20150317_003714	Can't do anything
 QUEST_LV_0100_20150317_003715	I'll take care of it right away
 QUEST_LV_0100_20150317_003716	It will be safer to let the other believers know 
-QUEST_LV_0100_20150317_003717	Skill of Interference
+QUEST_LV_0100_20150317_003717	The Art of Interference
 QUEST_LV_0100_20150317_003718	I can give it a try
 QUEST_LV_0100_20150317_003719	I don't feel it
 QUEST_LV_0100_20150317_003720	Don't panic
@@ -3804,7 +3804,7 @@ QUEST_LV_0100_20150317_003803	Bishop's Dream (2)
 QUEST_LV_0100_20150317_003804	Ok, I'll drop by
 QUEST_LV_0100_20150317_003805	To the Overlong Bridge Valley
 QUEST_LV_0100_20150317_003806	
-QUEST_LV_0100_20150317_003807	Notice/Arrived at the Fallen Worry Forest where the Brambles are hiding.#3
+QUEST_LV_0100_20150317_003807	Notice/Arrived at the Fallen Worry forest where the Bramble is hiding.#3
 QUEST_LV_0100_20150317_003808	A Soldier's Favor
 QUEST_LV_0100_20150317_003809	I'll gather the keepsakes
 QUEST_LV_0100_20150317_003810	Stolen Food Supplies
@@ -5659,7 +5659,7 @@ QUEST_LV_0100_20150317_005658	Guard Mathew asked for your felp to find cable car
 QUEST_LV_0100_20150317_005659	Found all the cable car parts as Mathew asked. Give it to Mathew. 
 QUEST_LV_0100_20150317_005660	Retrieve parts swallowed by Zignuts %s 
 QUEST_LV_0100_20150317_005661	Kill Poatas that threaten the cable car
-QUEST_LV_0100_20150317_005662	Mathew asked you to get rid of the Pantos that might destroy the cable car again. Soil Poata's habitat in Margas Hills and lure them to get rid of them. 
+QUEST_LV_0100_20150317_005662	Mathew asked you to get rid of the Poatas that might destroy the cable car again. Soil Poata's habitat in Margas Hills and lure them to get rid of them. 
 QUEST_LV_0100_20150317_005663	Got rid of Poatas as Mathew requested. Tell the good news to Mathew. 
 QUEST_LV_0100_20150317_005664	Get rid of Poata
 QUEST_LV_0100_20150317_005665	Talk to Molly
@@ -6185,11 +6185,11 @@ QUEST_LV_0100_20150317_006184	Memo of Vargis : Very good. Now use the clean spel
 QUEST_LV_0100_20150317_006185	Memo of Vargis : Very good. Now use the clean spell crystal and show those Thorn vines the power of Goddess Saule's Followers.
 QUEST_LV_0100_20150317_006186	Talk to Follower Nojus
 QUEST_LV_0100_20150317_006187	Goddess Saule Follower Nojus is anxiously waiting for you.
-QUEST_LV_0100_20150317_006188	Trace the omnious voice
-QUEST_LV_0100_20150317_006189	Nojus told you where the omnious voice is coming from. Go and find it. 
+QUEST_LV_0100_20150317_006188	Find the ominous voice
+QUEST_LV_0100_20150317_006189	Nojus told you where the ominous voice is coming from. Go and find it. 
 QUEST_LV_0100_20150317_006190	
-QUEST_LV_0100_20150317_006191	Defeated the poatas summoned by the watcher. Go deep into the Thorn Forest to find Bramble.
-QUEST_LV_0100_20150317_006192	Kill the summoned Poatas
+QUEST_LV_0100_20150317_006191	Defeated the Poata summoned by the watcher. Go deep into the Thorn Forest to find Bramble.
+QUEST_LV_0100_20150317_006192	Kill the summoned Poata
 QUEST_LV_0100_20150317_006193	Talk to Follower Alvidas
 QUEST_LV_0100_20150317_006194	Saule Goddess Follower Alvidas is watching you.
 QUEST_LV_0100_20150317_006195	Look for Goddess Saule Followers
@@ -6204,11 +6204,11 @@ QUEST_LV_0100_20150317_006203	Killed Rikaus that was spreading evil aura. Report
 QUEST_LV_0100_20150317_006204	Kill Rikaus
 QUEST_LV_0100_20150317_006205	Talk to Follower Evaldas
 QUEST_LV_0100_20150317_006206	Saule Goddess Follower Evaldas needs your help.
-QUEST_LV_0100_20150317_006207	Get rid of the Merog Shaman
-QUEST_LV_0100_20150317_006208	Evaldas asked you to get rid of the Shaman. Break into the Merog Shamans in their rituals and get rid of them.
+QUEST_LV_0100_20150317_006207	Get rid of the Merog Shamans
+QUEST_LV_0100_20150317_006208	Evaldas asked you to get rid of some Merog. Stop their ritual and get rid of them.
 QUEST_LV_0100_20150317_006209	Report to Evaldas
-QUEST_LV_0100_20150317_006210	Get rid of the Merog Shaman. Tell Evaldas about it. 
-QUEST_LV_0100_20150317_006211	Kill the Merog Shaman installing magic circle
+QUEST_LV_0100_20150317_006210	You got rid of the Merog Shamans. Tell Evaldas about it. 
+QUEST_LV_0100_20150317_006211	Kill the Merog Shaman performing the ritual
 QUEST_LV_0100_20150317_006212	Talk to Follower Zaneta
 QUEST_LV_0100_20150317_006213	Saule Goddess Follower Zaneta needs your help.
 QUEST_LV_0100_20150317_006214	Destroy the demon summoning crystal
@@ -6452,8 +6452,8 @@ QUEST_LV_0100_20150323_006451	I had no idea about Rukas Plateau. {nl}What are th
 QUEST_LV_0100_20150323_006452	Follow the road on the right and go to Cobalt Forest. {nl}Our town priest is waiting for you.
 QUEST_LV_0100_20150323_006453	When you have all materials ready, combine it in Ershike altar.
 QUEST_LV_0100_20150323_006454	The evil force was first felt in Kvailas Forest. {nl}The force was very strong so it will remain this way for a while even if you get rid of Bramble.
-QUEST_LV_0100_20150323_006455	The evil force of Kvailas Forest is becomeing stronger but our followers are becoming weak. {nl}I hope you can help us. {nl}
-QUEST_LV_0100_20150323_006456	Maybe the source of evil of Kavilas Forest has become the forest itself. {nl}Though I hope this is just an idel fear. 
+QUEST_LV_0100_20150323_006455	The evil force in Kvailas Forest is becoming stronger, but our followers are becoming weak. {nl}I hope you can help us. {nl}
+QUEST_LV_0100_20150323_006456	Maybe the source of the evil in Kavilas Forest has become the forest itself. {nl}Though I hope this is just an idle fear. 
 QUEST_LV_0100_20150323_006457	It will come to and end when the evil force deep inside Kavailas Forest is removed. {nl}It's a pity everyone is chasing only what's right in front of them.
 QUEST_LV_0100_20150323_006458	Kvailas Forest is the worst. {nl}The evil force is at high and even your lives are at stake. 
 QUEST_LV_0100_20150323_006459	I miss my family in Cobalt Forest. {nl}And.. I want to apologize to my brother for the fight we had.
@@ -6851,7 +6851,7 @@ QUEST_LV_0100_20150428_006850	The assistant commander Volda asked you to get rid
 QUEST_LV_0100_20150428_006851	Find the person who knows about the epitaph of Gailla Flurry and listen to his request.
 QUEST_LV_0100_20150428_006852	You found the luggage of the villager. Return the luggage to the villager and ask him about the contents in the epitaph.
 QUEST_LV_0100_20150428_006853	Defeat Blue Woodspirits that appeared near Obelisk
-QUEST_LV_0100_20150428_006854	Siaulai Goddess lost the revelation from Brambles at the thorny forest of Kbailas forest. Help the priests at Gate Route and Spine Heart Dale and look for the revelation at Kbailas forest.
+QUEST_LV_0100_20150428_006854	Siaulai Goddess lost the revelation from Bramble at the thorny forest of Kbailas forest. {nl}Help the priests at Gate Route and Spine Heart Dale and look for the revelation at Kbailas forest.
 QUEST_LV_0100_20150428_006855	Take the cable car from Srautas Canyon that will appear as you go down from the twin bridge of the crystal mine, and go up a bit to get to Gelly Plauteau.
 QUEST_LV_0100_20150428_006856	Move to Starving Demon's Road
 QUEST_LV_0100_20150428_006857	Move to Starving Demon's Road
@@ -6946,26 +6946,26 @@ QUEST_LV_0100_20150714_006945	A monster in disguise as a Goddess Statue. I pity 
 QUEST_LV_0100_20150714_006946	We didn't just stay put when we were sieged by the mosnters. {nl}We sent out Scouts to get away from here but no one came back. {nl}
 QUEST_LV_0100_20150714_006947	If you are okay, I want you to search for them.{nl}
 QUEST_LV_0100_20150714_006948	It's gonna be hard.{nl}The Thorny Forest keeps enlarging.
-QUEST_LV_0100_20150714_006949	A dark aura similar to the voice a while ago is covering the Thorny Forest. {nl}Especially the Kavilas Forest... Please be careful...
+QUEST_LV_0100_20150714_006949	A dark aura similar to the voice a while ago is covering the Thorny Forest. {nl}Especially the Kavilas Forest… Please be careful…
 QUEST_LV_0100_20150714_006950	Good. {nl}First, defeat the Big Blue Grivas up the hills.
 QUEST_LV_0100_20150714_006951	When you throw this bomb to the long branch trees, they will burn.{nl}When you feel they are burnt enough, destroy those tress to get wood coals.{nl}
 QUEST_LV_0100_20150714_006952	Be careful. This place is full of the evil energy from Bramble.{nl}You better go back to be safe.
 QUEST_LV_0100_20150714_006953	Ah, it was you revelator! Could you help me little more?{nl}I am trying to burn down the thorny bushes that are full of evil energy.
 QUEST_LV_0100_20150714_006954	There's a demon that I want you to defeat.{nl}The monster is called Likaous at Thorny Pole Garden. It brings vicious atmosphere with him.
-QUEST_LV_0100_20150714_006955	A very ominous voice is looking for you.{nl}Please be careful...
+QUEST_LV_0100_20150714_006955	I heard a very ominous voice looking for you.{nl}Please be careful…
 QUEST_LV_0100_20150714_006956	I never thought I would meet someone other than a believer here which is full of thorny bushes and the monsters.{nl}It would be hard without the protection of the Goddess. Don't you think so, Revelator?{nl}
-QUEST_LV_0100_20150714_006957	So you are the revelator. The believers are having a hard time due to the thorny bushes.{nl}How about you help them...
-QUEST_LV_0100_20150714_006958	The evil force was first felt in Kvailas Forest. {nl}The force was very strong so it will remain this way for a while even if you get rid of Bramble.
-QUEST_LV_0100_20150714_006959	The evil force of Kvailas Forest is becomeing stronger but our followers are becoming weak. {nl}I am worried that we may lose to the evil. I hope the revelator was with us...
-QUEST_LV_0100_20150714_006960	Really?{nl}I will let the believers know that you are helping them.
+QUEST_LV_0100_20150714_006957	So you are the revelator. The believers are having a hard time due to the thorny bushes.{nl}How about you help them…
+QUEST_LV_0100_20150714_006958	The evil force was first felt in Kvailas Forest. {nl}The force is very strong so it'll remain this way for a while, even if you get rid of Bramble.
+QUEST_LV_0100_20150714_006959	The evil force in Kvailas Forest is becoming stronger, but our followers are becoming weak.{nl}I'm worried that we may lose to the evil. If only the Revelator was with us…
+QUEST_LV_0100_20150714_006960	Really?{nl}I'll let the other believers know that you are helping them.
 QUEST_LV_0100_20150714_006961	Help me. Infroholders are chasing after me.{nl}I will lose when they move in a herd like that.
 QUEST_LV_0100_20150714_006962	Put Matsum's flower alcohol in this potion and shake it. {nl} It will help you withstand the muddy aura of Bramble.
 QUEST_LV_0100_20150714_006963	This place is too dangerous. {nl}Please go to a safe area.
 QUEST_LV_0100_20150714_006964	I can feel Clymen in Ishpirki Entrance. {nl}Hurry and get rid of it.
-QUEST_LV_0100_20150714_006965	Bramble...{nl}It is so pity that it denys its fate.{nl}
+QUEST_LV_0100_20150714_006965	Bramble…{nl}It is so pity that it denys its fate.{nl}
 QUEST_LV_0100_20150714_006966	When I gained my conciousness, a few hundreds of years have passed.
 QUEST_LV_0100_20150714_006967	Jane's spirit
-QUEST_LV_0100_20150714_006968	I saved nothing.{nl}Master, Magicians' Tower, and my peace...{nl}
+QUEST_LV_0100_20150714_006968	I saved nothing.{nl}Master, Magicians' Tower, and my peace…{nl}
 QUEST_LV_0100_20150714_006969	You have no reason to help me, but it's been such a long time that I saw a man alive.{nl}Can you listen to my story if you are okay?
 QUEST_LV_0100_20150714_006970	Thanks. It's going to be a long story.
 QUEST_LV_0100_20150714_006971	It's too selfish to seek for the salvation now.{nl}Exhausted. It may be better to eliminate Akorn with me.
@@ -7263,7 +7263,7 @@ QUEST_LV_0100_20150714_007262	Combining
 QUEST_LV_0100_20150714_007263	Purifying/MAKING/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150714_007264	I am the revelator and will help
 QUEST_LV_0100_20150714_007265	The attack of Infroholder Speller
-QUEST_LV_0100_20150714_007266	Notice/Defeat the Merogg and Chaferer that followed Bronews!
+QUEST_LV_0100_20150714_007266	Notice/Defeat the Merog and Chaferer that followed Bronews!
 QUEST_LV_0100_20150714_007267	Notice/Succesfully activated the altar of purification!#3
 QUEST_LV_0100_20150714_007268	Notice/Collected all the tree sap.{nl}Go to Ershike Altar and combine the materials!#5
 QUEST_LV_0100_20150714_007269	Notice/Dye completed!{nl}Obtain the dye from the altar.#5
@@ -7344,7 +7344,7 @@ QUEST_LV_0100_20150714_007343	Notice/!/Use the detection stick to find the place
 QUEST_LV_0100_20150714_007344	I will collect all the researches
 QUEST_LV_0100_20150714_007345	and hand them over to Yustas
 QUEST_LV_0100_20150714_007346	I will leave since there's nothing you could help anymore
-QUEST_LV_0100_20150714_007347	Notice/Arrived at the Fallen Worry Forest where the Brambles are hiding.#3
+QUEST_LV_0100_20150714_007347	Notice/Arrived at the Fallen Worry forest where Bramble is hiding.#3
 QUEST_LV_0100_20150714_007348	The remaining danger(1)
 QUEST_LV_0100_20150714_007349	I don't have time for that now
 QUEST_LV_0100_20150714_007350	The remaining danger(2)
@@ -7791,7 +7791,7 @@ QUEST_LV_0100_20150803_007790	{nl}That's impossible... Maybe it was really the s
 QUEST_LV_0100_20150803_007791	To express my apology, I want to help the grave guard.{nl}But, I am shy to say directly to him myself.{nl}Can you pass my apology to him?
 QUEST_LV_0100_20150803_007792	Barrier stone of the Closed Area
 QUEST_LV_0100_20150803_007793	Notice/The barrier blocking the Closed Area is falling down!#5
-QUEST_LV_0100_20150803_007794	Notice/Arrived at the Sirudgellar Forest where the Brambles are hiding!#3
+QUEST_LV_0100_20150803_007794	Notice/Arrived at the Sirudgellar Forest where Bramble is hiding!#3
 QUEST_LV_0100_20150803_007795	The special power that was detected by Monocle(1)
 QUEST_LV_0100_20150803_007796	Wait until you use Monocle
 QUEST_LV_0100_20150803_007797	I can't wait anymore

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -304,12 +304,12 @@ SKILL_20150317_000303	[Hogma Warrior] Physical Slash Fire Property Attack
 SKILL_20150317_000304	[Hogma Archer] Range Stab Lightning Property Attack
 SKILL_20150317_000305	[Hogma Shaman] Magic, Magic, Fire Property Attack
 SKILL_20150317_000306	[Merog Shaman] Magic, Magic, Ice Property, Range Force Attack
-SKILL_20150317_000307	[Merog Poison Accupunturist] Range, Stab, Poison Property, Shoot poison
+SKILL_20150317_000307	[Merog Needler] Range, Stab, Poison Property, Shoot Poison Dart
 SKILL_20150317_000308	[Hogma Shaman] Magic, Magic, Fire Property Firewall Attack,
 SKILL_20150317_000309	[Merog Shaman] Magic, Hit, Ice Property, with Rod
 SKILL_20150317_000310	[Hogma Warrior] Physical Strike Fire Property Shield Knockback Attack
 SKILL_20150317_000311	[Hogma Warrior] Buff, Magic Fire Property Block increase
-SKILL_20150317_000312	[Merog Poison Accupunturist] Range, Stab, Poison Property, Jump and Shoot poison needle
+SKILL_20150317_000312	[Merog Needler] Range, Stab, Poison Property, Jump and Shoot Poison Needle
 SKILL_20150317_000313	[Hogma Battle Commander] Physical Slash Dark Property Attack
 SKILL_20150317_000314	[Hogma Battle Commander] Physical Stab Dark Property Attack
 SKILL_20150317_000315	[Hogma Battle Commander] Monster Summon

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -304,7 +304,7 @@ SKILL_20150317_000303	[Hogma Warrior] Physical Slash Fire Property Attack
 SKILL_20150317_000304	[Hogma Archer] Range Stab Lightning Property Attack
 SKILL_20150317_000305	[Hogma Shaman] Magic, Magic, Fire Property Attack
 SKILL_20150317_000306	[Merog Shaman] Magic, Magic, Ice Property, Range Force Attack
-SKILL_20150317_000307	[Merog Needler] Range, Stab, Poison Property, Shoot Poison Dart
+SKILL_20150317_000307	[Merog Needler] Range, Stab, Poison Property, Shoot Poison Needle
 SKILL_20150317_000308	[Hogma Shaman] Magic, Magic, Fire Property Firewall Attack,
 SKILL_20150317_000309	[Merog Shaman] Magic, Hit, Ice Property, with Rod
 SKILL_20150317_000310	[Hogma Warrior] Physical Strike Fire Property Shield Knockback Attack


### PR DESCRIPTION
Corrected a severely mistranslated line
Adjusted several dialogue lines based around the Kvailas Forest quest chain.
Unified monster race identifier to Merog
Edited dialogue using Merog in its lines.
Changed all entries referring to "Fallen Worry Forest" to "the Fallen Worry Forest"
Edited dialogue using Fallen Worry Forest in its lines.
Edited lines containing Bramble to indicate he is a single entity.
