### PR TITLE
Update QUEST_LV_0100.tsv

### DIFF
--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -26,7 +26,7 @@ QUEST_LV_0100_20150317_000025	Soldier York
 QUEST_LV_0100_20150317_000026	Siaulambs are breaking the norms.{nl}I am in a panic myself, so I don't know what to do.{nl}Luders will not stand for this... What should we do?
 QUEST_LV_0100_20150317_000027	Do you think the problem would be resolved by just defeating Sparnas?
 QUEST_LV_0100_20150317_000028	Thanks to your help, I think I can get myself together.{nl}But... this kind of thing will happen again right? Then what should I do...?
-QUEST_LV_0100_20150317_000029	Sparnas? We don't have an answer for that.{nl}It just appears from the sky without any signs, destroys all supplies and then dissappears.{nl}I get a headache just hearing its cries.
+xQUEST_LV_0100_20150317_000029	Sparnas? We don't have an answer for that.{nl}It just appears from the sky without any signs, destroys all supplies and then disappears.{nl}I get a headache just hearing its cries.
 QUEST_LV_0100_20150317_000030	The place I just talked about is the 2nd supply warehouse.{nl}It is depressing to think how these kinds of things will be recurring in the future.
 QUEST_LV_0100_20150317_000031	Take it. I made some bait from old grains in the supplies.{nl}I will lure him up there, so you stay here.{nl}Sparnas will definitely appear at one of these two places. Do not miss it, and destroy it for sure.{nl}
 QUEST_LV_0100_20150317_000032	We may not get a second chance if we don't defeat it this time.{nl}They're not idiots.
@@ -68,7 +68,7 @@ QUEST_LV_0100_20150317_000067	You won't know how eagerly we have waited for this
 QUEST_LV_0100_20150317_000068	Gustas Jonas
 QUEST_LV_0100_20150317_000069	So it's you.{nl}You are much more of a man compared to what I had imagined.
 QUEST_LV_0100_20150317_000070	Soldier Alan
-QUEST_LV_0100_20150317_000071	You are a new soldier right?{nl}I received a patrolling order, but I guess you can go my behalf.
+xQUEST_LV_0100_20150317_000071	You are a new soldier right?{nl}I received a patrolling order, but I guess you can go on my behalf.
 QUEST_LV_0100_20150317_000072	You're good.{nl}I don't want to go there. I had a horrible experience once.
 QUEST_LV_0100_20150317_000073	I'm remembering something...
 QUEST_LV_0100_20150317_000074	You know that we are dispatched here to destroy Gaigalas right?{nl}Hey newcomer. Can you take this report to Commander Wallis?
@@ -382,13 +382,13 @@ QUEST_LV_0100_20150317_000381	The Miners' Village is under siege and entrance is
 QUEST_LV_0100_20150317_000382	You have to cheer up.{nl} Even Sir Aras is holding on.
 QUEST_LV_0100_20150317_000383	Goddess Zemyna overlooks the earth.{nl}There are rumors that the Goddess has abandoned us but that's nonsense.{nl}Her statue still shines beautifully when you pray to it.
 QUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods.{nl}That's why the Mining Village located in the middle of it turned to a battlefield.{nl}
-QUEST_LV_0100_20150317_000385	And that's why I can't permit entrance to the Miners Village. For safety reasons.{nl}Of course it will be a different story if your skill are good enough to ensure{nl} your safety even without the protection of guards.
+xQUEST_LV_0100_20150317_000385	And that's why I can't permit entrance to the Miners Village. For safety reasons.{nl}Of course it will be a different story if your skills are good enough to ensure{nl} your safety even without the protection of guards.
 QUEST_LV_0100_20150317_000386	Gosh, it could have been really dangerous.{nl}That huge thing was hiding so well.
 QUEST_LV_0100_20150317_000387	It's very important to study monsters at times like this.{nl}It's like weather forecasts where you try to find out the cause and see what would happen.
 QUEST_LV_0100_20150317_000388	I'm sure the Leaf Bugs in Uoros farm stole it.{nl}They did steal from us once before.
 QUEST_LV_0100_20150317_000389	Send my regards to the Guard Captain when you meet him.
 QUEST_LV_0100_20150317_000390	In order to test if your skills are good enough to enter the Miners Village,{nl}I need you to help us solve a problem we have.{nl}
-QUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus.{nl}I believe this would be a fairly easy task
+xQUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus.{nl}I believe this would be a fairly easy task.
 QUEST_LV_0100_20150317_000392	There seems to be a gap in the rock where you can insert something.
 QUEST_LV_0100_20150317_000393	Let's search the Bulvjes farm first.{nl}But don't chase them or something as it can be dangerous.
 QUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess.{nl}Anyway, the supply camp is located further below the farm.
@@ -749,7 +749,7 @@ QUEST_LV_0100_20150317_000748	Welcome, I'm glad to see that you've had a safe jo
 QUEST_LV_0100_20150317_000749	My old friend, Algis, will explain. Please listen to him.
 QUEST_LV_0100_20150317_000750	I can see the monsters cleary from up here.{nl}He may get surrounded by them soon.
 QUEST_LV_0100_20150317_000751	The broken barrier pieces are scattered in the Mazas shelter. {nl} Collect it and give it to sir Kayetonas in flower hill. {nl}
-QUEST_LV_0100_20150317_000752	My poor father must be happy if he know I became a guard.{nl}But, I already made a mistake.
+xQUEST_LV_0100_20150317_000752	My poor father must be happy if he knows I became a guard.{nl}But, I already made a mistake.
 QUEST_LV_0100_20150317_000753	We can say it's peaceful for now.{nl}For now.
 QUEST_LV_0100_20150317_000754	
 QUEST_LV_0100_20150317_000755	That's why if there are guards struggling with the barrier, I want you to help.
@@ -903,7 +903,7 @@ QUEST_LV_0100_20150317_000902	But the enemy is the Demon King. Even the Paladin 
 QUEST_LV_0100_20150317_000903	We can't do anything about the destroyed altar but the fragments still have power. {nl} Gather the pieces and insert it in the 8 pillars of the Sventove Central Hall.
 QUEST_LV_0100_20150317_000904	When you are done, I will be able to tie up Gesti through the power of the divine crystal and the church. {nl} It may be for a short while but that's the best option we have.
 QUEST_LV_0100_20150317_000905	So you activated the Malda altar? {nl} Now it will be safe to stay here for the time being. Good work.
-QUEST_LV_0100_20150317_000906	Demon are going around the second floor searching every corner. {nl} Activating the Auka altar will be able to turn their attention.
+xQUEST_LV_0100_20150317_000906	Demons are going around the second floor searching every corner. {nl} Activating the Auka altar will be able to turn their attention.
 QUEST_LV_0100_20150317_000907	I'm relieved you're beside me. {nl} I think it was a good thing that Laima chose you.
 QUEST_LV_0100_20150317_000908	Good job. {nl} When this is over, I should gather all brothers and drive them away at once.
 QUEST_LV_0100_20150317_000909	I'll ring the bell and let you know when the Gesti show up so have a safe trip on your way.
@@ -925,7 +925,7 @@ QUEST_LV_0100_20150317_000924
 QUEST_LV_0100_20150317_000925	In the kingdom, there are several valuable weapons aside from this divine sphere. {nl} Those weapons saved many lives on the Medis Diena four years ago.
 QUEST_LV_0100_20150317_000926	From now on, I will focus on the divine crystal. {nl} In the meanwhile, please use your skills so that I won't be disturbed.
 QUEST_LV_0100_20150317_000927	I'm sorry. It's all my fault. {nl}The Gesti found out the divine heal is not the revelation so it will head straight to the church. {nl}
-QUEST_LV_0100_20150317_000928	But his old body of mine does not follow my will anymore. {nl} Now I can only trust my old friend Algis and you. {nl}
+xQUEST_LV_0100_20150317_000928	But this old body of mine does not follow my will anymore. {nl} Now I can only trust my old friend Algis and you. {nl}
 QUEST_LV_0100_20150317_000929	
 QUEST_LV_0100_20150317_000930	It is too much for me to handle alone without any help from other brothers. {nl} I'd better run the Malda Altar. {nl}
 QUEST_LV_0100_20150317_000931	
@@ -946,7 +946,7 @@ QUEST_LV_0100_20150317_000945	Those Sidmias want me to put my head on that flowe
 QUEST_LV_0100_20150317_000946	We received the charm from the elders that will brainwash Pantos to stand on our side.{nl}Do you want to take up the challenge?{nl}
 QUEST_LV_0100_20150317_000947	According to the elders, we are done with those Pantos.{nl}We can't continue the relationship anymore.
 QUEST_LV_0100_20150317_000948	This barrier is impossible to open from the inside. {nl} Fortunately, the entrance to the basement looks safe. {nl}
-QUEST_LV_0100_20150317_000949	However, it's too dangerous to in the basement with the divine sphere. {nl} I'll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
+xQUEST_LV_0100_20150317_000949	However, it's too dangerous to go into the basement with the divine sphere. {nl} I'll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
 QUEST_LV_0100_20150317_000950	You have done what other can't easily do.{nl}The Goddess must be proud of you.
 QUEST_LV_0100_20150317_000951	My faith in religion is strong enough to destroy those demons, but the reality isn't that simple.{nl}I hope you help us a bit.
 QUEST_LV_0100_20150317_000952	
@@ -1238,7 +1238,7 @@ QUEST_LV_0100_20150317_001237	I would have fled long time ago if it wasn't for t
 QUEST_LV_0100_20150317_001238	We should somehow block those demons.{nl}I can't pass this danger to our brothers in the cathedral.
 QUEST_LV_0100_20150317_001239	We can't go in due to the barrier.{nl}To open the door, we should go through 1st floor of the basement.
 QUEST_LV_0100_20150317_001240	When I meet you again, is this world going to be peaceful.. I hope it is.
-QUEST_LV_0100_20150317_001241	I never expected those demons will come down this far.{nl}I hope our brothers stand still against them.
+xQUEST_LV_0100_20150317_001241	I never expected those demons would come down this far.{nl}I hope our brothers stand still against them.
 QUEST_LV_0100_20150317_001242	We have lots of things to protect so we should rather defeat those demons quietly than excitng them.{nl}I feel much more safe with you.
 QUEST_LV_0100_20150317_001243	Honestly, I thought it would be hard to stand still with only Paladins.{nl}I guess my belief in them wasn't that much.
 QUEST_LV_0100_20150317_001244	It will be better to fight them face to face instead of hiding.{nl}It will be even better if the opponents are the demons.
@@ -2001,7 +2001,7 @@ QUEST_LV_0100_20150317_002000	So you're the one who wanted to meet Goddess Saule
 QUEST_LV_0100_20150317_002001	The priest is located in Cerpe crossroads. {nl}I heard he needed the venom of Black Maize so try to get him that as a present.
 QUEST_LV_0100_20150317_002002	We wouldn't have dreamed about the portal if it wasn't for you. {nl} You truly are the blessing of God.
 QUEST_LV_0100_20150317_002003	Andail's village Priest
-QUEST_LV_0100_20150317_002004	Isn't this the venom of the black maize? {nl} Thank you very much. {nl}
+xQUEST_LV_0100_20150317_002004	Isn't this the venom of the Black Maize? {nl} Thank you very much. {nl}
 QUEST_LV_0100_20150317_002005	You can leave meeting Goddess Saule with me. {nl} Now that the diving pond is purified, we just need to solve the Obelisk.
 QUEST_LV_0100_20150317_002006	Magic letters are carved on the Obelisk. {nl} But some letters were erased as the divine pond became contaminated. {nl}
 QUEST_LV_0100_20150317_002007	If the letters are gone, we just need to write it back on. {nl} Now that you've collected the venom of Black Maize, we just need the sap of the oak tree.
@@ -2012,7 +2012,7 @@ QUEST_LV_0100_20150317_002011	The Obelisk is in the Slepingas stream.
 QUEST_LV_0100_20150317_002012	I'm sure God will be satisfied with you.
 QUEST_LV_0100_20150317_002013	It's almost done. {nl} After completing the rituals to cleanse your body, you will be able to meet the Goddess soon. {nl}
 QUEST_LV_0100_20150317_002014	
-QUEST_LV_0100_20150317_002015	Use this tranquilizer on the black maize and extract its poison. {nl} The Maize should be weakened for the tranquilizer to work.
+xQUEST_LV_0100_20150317_002015	Use this tranquilizer on the Black Maize and extract its poison. {nl} The Maize should be weakened for the tranquilizer to work.
 QUEST_LV_0100_20150317_002016	Thank you so much! {nl}By the way, what was that vibration?
 QUEST_LV_0100_20150317_002017	The disciple of Andail Village
 QUEST_LV_0100_20150317_002018	You're the Revelator right? {nl}Upent is preying on the village so we can't hold the ritual right away. {nl}
@@ -2130,13 +2130,13 @@ QUEST_LV_0100_20150317_002129	Let's go to the fusion machine.{nl}We just have to
 QUEST_LV_0100_20150317_002130	We should succeed..
 QUEST_LV_0100_20150317_002131	So this is the Jewel of Prominence.. I can feel it's great energy.{nl}Let's quickly give this to Gabija. There's stairs to go up on the right side.
 QUEST_LV_0100_20150317_002132	To find the Jewel of Prominence, just use this detector.{nl}When you use this detector near the place where the jewel is located, the jewel will come out.
-QUEST_LV_0100_20150317_002133	The portal that you tried to open is the gate of lies.{nl}The villagers hear are the tricks of Demons' lord, Bramble.
+xQUEST_LV_0100_20150317_002133	The portal that you tried to open is the gate of lies.{nl}The villagers here are the tricks of Demons' lord, Bramble.
 QUEST_LV_0100_20150317_002134	It's embarrassing but I am also tricked and captured, losing all my strength. {nl} Please destroy the magic circle imprisoning me.
 QUEST_LV_0100_20150317_002135	The magic circle of confinement is located in Drugys Courtyard and Vapsva lot. {nl}Please hurry.
 QUEST_LV_0100_20150317_002136	Thank you for saving me. {nl}
 QUEST_LV_0100_20150317_002137	I am Saule, the Goddess of the sun. {nl} Everything is just like how Laima has forseen.
-QUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here. {nl} We've got to find the inspetor, Clymen, hiding in between the gap of dimensions.
-QUEST_LV_0100_20150317_002139	Please bring me the sacrifice tools in the Grand Corridor. {nl} I will try to use the divine power that dwell in the tool.
+xQUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here. {nl} We've got to find the inspetor, Clymen, hiding in between the gap of dimensions.
+xQUEST_LV_0100_20150317_002139	Please bring me the sacrifice tools in the Grand Corridor. {nl} I will try to use the divine power that dwells in the tool.
 QUEST_LV_0100_20150317_002140	Thank you. {nl} This much divine power would be enough.
 QUEST_LV_0100_20150317_002141	
 QUEST_LV_0100_20150317_002142	Just a bit more. Please suppress the Magi.
@@ -2154,7 +2154,7 @@ QUEST_LV_0100_20150317_002153
 QUEST_LV_0100_20150317_002154	I just feel sorry to my brother.
 QUEST_LV_0100_20150317_002155	Old man of Andail village
 QUEST_LV_0100_20150317_002156	God is looking after our village so our village has clear water and air. And there are no disasters here.
-QUEST_LV_0100_20150317_002157	So finally the revelator has come.{nl}Very healthy and reliable. I gues we can do it this time.
+xQUEST_LV_0100_20150317_002157	So finally the revelator has come.{nl}Very healthy and reliable. I guess we can do it this time.
 QUEST_LV_0100_20150317_002158	Aren't you the Revelator? {nl} So, what brings you to our village? {nl}
 QUEST_LV_0100_20150317_002159	Goddess Saule? {nl} We haven't seen her for a long time. {nl}
 QUEST_LV_0100_20150317_002160	The portal leading to Goddess Saule just won't open. {nl}I think it's all because the diving pond is contaminated.
@@ -2348,7 +2348,7 @@ QUEST_LV_0100_20150317_002347	Found a letter in the sack
 QUEST_LV_0100_20150317_002348	The letter in the sack
 QUEST_LV_0100_20150317_002349	Receiver: Drashoes{nl}Address: Virdului Cabin{nl}I am sending you the head of the tree with long branches that you ordered.
 QUEST_LV_0100_20150317_002350	400 years would have passed by when this revelation reaches you. {nl} Thank you in advance for your continued pursuit of finding the revelation. . {nl}
-QUEST_LV_0100_20150317_002351	As I'm sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin. {nl} if you find this revelation, it would mean that he had done an excellent job in fulfilling his mission. {nl}
+xQUEST_LV_0100_20150317_002351	As I'm sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin. {nl} If you find this revelation, it would mean that he had done an excellent job in fulfilling his mission. {nl}
 QUEST_LV_0100_20150317_002352	The demons have been chasing the revelation before I made this revelation. {nl} Gesti, the leader of the demons whom you have met is one of them. {nl}
 QUEST_LV_0100_20150317_002353	Three demon Kings and the demon leaders who follow them. {nl}Giltine is the one who controls all of them. {nl}
 QUEST_LV_0100_20150317_002354	All these catastrophes are her plans. {nl} The disasters will continue and at the end of it will be the end of human race. {nl}
@@ -6012,9 +6012,9 @@ QUEST_LV_0100_20150317_006011	Hilda asked you to guard her while she observes th
 QUEST_LV_0100_20150317_006012	Hilda is done observing the pillars. Talk to her again. 
 QUEST_LV_0100_20150317_006013	Talk to Hilda who has sparkling eyes looking  at the pillars. 
 QUEST_LV_0100_20150317_006014	Protect Sculptor Hilda
-QUEST_LV_0100_20150317_006015	Hilda want to observe the pillar longer. Protect her from the monsters while she observes the pillars. 
-QUEST_LV_0100_20150317_006016	Seem like Hilda is done checking the pillars. Talk to her. 
-QUEST_LV_0100_20150317_006017	You have to block the demons attaking the mausoleum while chasing Rexipher. Talk to the Statue of guardian. 
+xQUEST_LV_0100_20150317_006015	Hilda wants to observe the pillar longer. Protect her from the monsters while she observes the pillars. 
+xQUEST_LV_0100_20150317_006016	Seems like Hilda is done checking the pillars. Talk to her. 
+xQUEST_LV_0100_20150317_006017	You have to block the demons attacking the mausoleum while chasing Rexipher. Talk to the statue of guardian. 
 QUEST_LV_0100_20150317_006018	Get piece of Royal Slate
 QUEST_LV_0100_20150317_006019	Mausoleum guardians are protecting the stones that Rexipher destroyed. Collect the pieces of slate from the Mausolem guardians. 
 QUEST_LV_0100_20150317_006020	Collected all pieces of the slate. Talk to the statue of guardian.
@@ -6271,7 +6271,7 @@ QUEST_LV_0100_20150317_006270	You need to go back to Goddess Saule to ask for th
 QUEST_LV_0100_20150317_006271	Talk to Andale's elder
 QUEST_LV_0100_20150317_006272	
 QUEST_LV_0100_20150317_006273	Collect the venom of Black Maize
-QUEST_LV_0100_20150317_006274	Collect the venom of Maize for gift to Village Priest. It is only able to obtain the venom of black Maize to use the paralysis powder while black Maize's hp has reduced by half.
+xQUEST_LV_0100_20150317_006274	Collect the venom of Maize for gift to Village Priest. It is only able to obtain the venom of Black Maize to use the paralysis powder while Black Maize's hp has reduced by half.
 QUEST_LV_0100_20150317_006275	Go to Andale's village priest
 QUEST_LV_0100_20150317_006276	Collected Black Maize's venom. Go to Andale Priest in Cerpe Crossroad.
 QUEST_LV_0100_20150317_006277	Kill Black Maize to get %s
@@ -6405,7 +6405,7 @@ QUEST_LV_0100_20150317_006404	Mr. Juan asked you to bring him Vubbe Theif's Leat
 QUEST_LV_0100_20150317_006405	Acquired Vubbe Thief's Leather! Bring it to Mr. Juan.
 QUEST_LV_0100_20150323_006406	Now take the unsealing stone and go to Ramstis Ridge. {nl}Student of Gustas will teach you how to release the seal there. 
 QUEST_LV_0100_20150323_006407	Were you not guided yet?{nl}It's the student of Gustas in Ramstis Ridge.{nl}It is made to let only the chosen one enter.
-QUEST_LV_0100_20150323_006408	Ask the mayor for directions to Gele Plateau. {nl}I will sent the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
+xQUEST_LV_0100_20150323_006408	Ask the mayor for directions to Gele Plateau. {nl}I will send the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
 QUEST_LV_0100_20150323_006409	The high gardens that the Goddess mentioned must be referring to the Gele Plateau. {nl}I heared the Paladin Master is there to keep a long term promise. 
 QUEST_LV_0100_20150323_006410	
 QUEST_LV_0100_20150323_006411	
@@ -6919,7 +6919,7 @@ QUEST_LV_0100_20150714_006918	The golds that the monsters have in this town will
 QUEST_LV_0100_20150714_006919	I feel dizzy.{nl}What am I doing here?
 QUEST_LV_0100_20150714_006920	I wish the Goddesses were here.{nl}I don't want to see anything sad anymore.
 QUEST_LV_0100_20150714_006921	The proof of the salvation is this Slate?{nl}It just looks like an old slate to me.{nl} 
-QUEST_LV_0100_20150714_006922	Use the time efficiently 
+xQUEST_LV_0100_20150714_006922	Use the time efficiently.
 QUEST_LV_0100_20150714_006923	Of course, you should first show your skills.{nl}Defeat Sand Chupacabras and Zinutes.
 QUEST_LV_0100_20150714_006924	If you are going to help me, please also take care of the gigantic gray Chupakabras.{nl}They often steal the supplies.
 QUEST_LV_0100_20150714_006925	When you defeat Chupakabras, the gigantic gray Chupakabra would appear.{nl}Okay, then I am counting on you.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -308,17 +308,17 @@ QUEST_LV_0100_20150317_000307	But the Miners' Village is at war with the Vubbes 
 QUEST_LV_0100_20150317_000308	Monsters have been around for a long time, but they only started becoming violent four years ago.{nl}The ones that were affected the most would be the plant types. They did not exist before.{nl}
 QUEST_LV_0100_20150317_000309	Of course, beasts were no exception.{nl}When the monster that seemed like it was fused with a demon appeared, I thought it was all over.
 QUEST_LV_0100_20150317_000310	Knight Aras
-QUEST_LV_0100_20150317_000311	Aren't you hurt?{nl}Thank you for getting rid of the Poatas but you're too reckless.
+xQUEST_LV_0100_20150317_000311	Aren't you hurt?{nl}Thank you for getting rid of the Poatas, but you're too reckless.
 QUEST_LV_0100_20150317_000312	You want to get into the Crystal Mine?{nl}The Miners' Village is currently at war with the Vubbes and it's very dangerous,{nl}so I cannot permit that.
-QUEST_LV_0100_20150317_000313	And our troops are in no condition to guard you.{nl}I'm sorry but you have to go back.
+xQUEST_LV_0100_20150317_000313	And our troops are in no condition to guard you.{nl}I'm sorry, but you have to go back.
 QUEST_LV_0100_20150317_000314	If you can't get rid of the Pokubus, you'll have to give up going into the Miners' Village.
 QUEST_LV_0100_20150317_000315	Thank you.{nl}Do not worry, I'll keep my promise.
 QUEST_LV_0100_20150317_000316	Outpost Sentinel
 QUEST_LV_0100_20150317_000317	
-QUEST_LV_0100_20150317_000318	Other monsters also show up when there are Chupacabras.{nl}Miners' Village is a problem on its own but there are just too many things to pay attention to.
+xQUEST_LV_0100_20150317_000318	Other monsters also show up when there are Chupacabras.{nl}Miners' Village is a problem on its own, but there are just too many things to pay attention to.
 QUEST_LV_0100_20150317_000319	Thank you.{nl}It really helps lift our spirits.
 QUEST_LV_0100_20150317_000320	With your abilities, I have one more favor to ask.{nl}Can you help us drive out the Chupacabras in the supply camp too?
-QUEST_LV_0100_20150317_000321	The Miners' Village is a problem but out situation here is not so good either. {nl}We have to prepare some measures before the number of monsters increase even more.
+xQUEST_LV_0100_20150317_000321	The Miners' Village is a problem, but our situation here is not so good either. {nl}We have to prepare some measures before the number of monsters increase even more.
 QUEST_LV_0100_20150317_000322	Are you done already?{nl}Never seen anyone as fast as you before.
 QUEST_LV_0100_20150317_000323	I'm on a mission to find out why the number of monsters in the East woods suddenly increased.{nl}Also, I act as the intermediary in supplying the Miners' Village.{nl}
 QUEST_LV_0100_20150317_000324	There are other knights out in Miners' Village but...{nl}To be honest, the battle is taking longer than expected. It would have ended sooner if Sir Aras was there.
@@ -328,22 +328,22 @@ QUEST_LV_0100_20150317_000327	Thank you.{nl}Now we can finally get to work easil
 QUEST_LV_0100_20150317_000328	Finding the cause of the monsters is important,{nl}but I'm more worried about supplies not making it to the Miners' Village.
 QUEST_LV_0100_20150317_000329	The movement of weavers in the lower area of the stream seems suspicious.{nl}Seems like they're trying to interfere with supplying the Miners' Village.
 QUEST_LV_0100_20150317_000330	We might have to give up our current supplies and support ourselves until the next batch of supplies arrive.
-QUEST_LV_0100_20150317_000331	Thank you.{nl}With you helping us out like this, we will not be defeated.
+xQUEST_LV_0100_20150317_000331	Thank you.{nl}With you helping us out like this we will not be defeated.
 QUEST_LV_0100_20150317_000332	The next mission is to find the cause of the increasing number of monsters.{nl}Popolions have a big appetite so I hope we can find a clue.
-QUEST_LV_0100_20150317_000333	Miners' Village is already in trouble and if the East Woods is in this situation, {nl}we can't assure the safety of Klaipeda.{nl}We can just hope that Klaipeda is doing well.
+xQUEST_LV_0100_20150317_000333	Miners' Village is already in trouble and if the East Woods is in this situation {nl}we can't assure the safety of Klaipeda.{nl}We can only hope that Klaipeda is doing well.
 QUEST_LV_0100_20150317_000334	Operations officer
 QUEST_LV_0100_20150317_000335	Were you sent by Aras?{nl}It's a piece of Vubbe clothing. Hmm... Is that so...
 QUEST_LV_0100_20150317_000336	I think the Vubbes of the Miners' Village have made their way into the woods.{nl}Maybe that's the reason behind the sudden increase in monsters too.{nl}
 QUEST_LV_0100_20150317_000337	I better ask Sir Aras to search for Vubbes in other areas too.{nl}In the meantime, please take a look at the upper side.
-QUEST_LV_0100_20150317_000338	We haven't searched the upper side yet.{nl}Of course, we should be sending troops but I ask for your help as this is an urgent matter.
-QUEST_LV_0100_20150317_000339	You saw the Vubbe Fighter, but missed it?{nl}We also got a report that the Vubbe fighter appeared in the area below.{nl}
-QUEST_LV_0100_20150317_000340	First, talk to the Search Scout in the lower bridge of Bulvjes.{nl}This will become a tedious long term war if we miss the Vubbe fighter.
+xQUEST_LV_0100_20150317_000338	We haven't searched the upper side yet.{nl}Of course, we should be sending troops, but I ask for your help as this is an urgent matter.
+xQUEST_LV_0100_20150317_000339	You saw the Vubbe Fighter, but missed it?{nl}We also got a report that the Vubbe Fighter appeared in the area below.{nl}
+xQUEST_LV_0100_20150317_000340	First, talk to the Search Scout in the lower bridge of Bulvjes.{nl}This will become a tedious long term war if we miss the Vubbe Fighter.
 QUEST_LV_0100_20150317_000341	So the Vubbe Fighter was the reason behind the increase of monsters.{nl}Please find out how many Vubbe Fighters there are.{nl}
 QUEST_LV_0100_20150317_000342	Under the circumstances, it makes sense that the monsters are controlled by Vubbe Fighters.{nl}But deep down, you just don't want to believe it.
-QUEST_LV_0100_20150317_000343	Following your report, there are no more Vubbe Fighters in these woods.{nl}
+xQUEST_LV_0100_20150317_000343	Following your report there are no more Vubbe Fighters in these woods.{nl}
 QUEST_LV_0100_20150317_000344	
 QUEST_LV_0100_20150317_000345	Supply Soldier
-QUEST_LV_0100_20150317_000346	We need Weaver Claws as a part of supplies to be sent to Miners' Village {nl}but we just don't have time to look for them.{nl}What do we do?
+xQUEST_LV_0100_20150317_000346	We need Weaver Claws as a part of supplies to be sent to Miners' Village, {nl}but we just don't have time to look for them.{nl}What do we do?
 QUEST_LV_0100_20150317_000347	Actually, it doesn't make sense for the supply soldier to get the supplies.{nl}It should have come from Klaipeda.
 QUEST_LV_0100_20150317_000348	Thank you.{nl}Unexpected help always feels good.
 QUEST_LV_0100_20150317_000349	In fact, everything would have been fine if the Pokubus weren't around.{nl}The Pokubus were running wild and that's why were weren't able to retrieve all the supplies.
@@ -352,28 +352,28 @@ QUEST_LV_0100_20150317_000351	Thank you.{nl}I envy your ability.
 QUEST_LV_0100_20150317_000352	Eastern Woods Search Scout
 QUEST_LV_0100_20150317_000353	Oh, it's you.{nl}I have heard from the operations officer.{nl}
 QUEST_LV_0100_20150317_000354	A Vubbe Fighter is hiding deep in the Nudegi Felled Area.{nl}We got the orders to kill it, but it may be safer to wait for additional troops.
-QUEST_LV_0100_20150317_000355	I'm just a Search Scout but it was my first time to see a Vubbe Fighter up close.
+xQUEST_LV_0100_20150317_000355	I'm just a Search Scout, but it was my first time to see a Vubbe Fighter up close.
 QUEST_LV_0100_20150317_000356	Awesome. You got rid of it by yourself.{nl}Go ahead and report to Sir Aras. He'll be very pleased.
 QUEST_LV_0100_20150317_000357	You mean you really killed the Vubbe Fighter?{nl}Well then, now we can be relieved since the number of monsters will no longer grow.
-QUEST_LV_0100_20150317_000358	Of course. As promised, I will grant your access to the Miners' Village.{nl}Please wait.
-QUEST_LV_0100_20150317_000359	If you find any clues, let the Operations Officer in the northern area know about it.
+xQUEST_LV_0100_20150317_000358	Of course. As promised, I will grant you access to the Miners' Village.{nl}Please wait.
+xQUEST_LV_0100_20150317_000359	If you find any clues let the Operations Officer in the northern area know about it.
 QUEST_LV_0100_20150317_000360	I think the Miners' Village is not in a good situation.{nl}It's too late to move the troops so you go first to support the Miners' Village.
-QUEST_LV_0100_20150317_000361	They have low IQ but these monsters build groups and live as a community.{nl}They used to appear only occasionally in the deeper areas of the mines... Could they be expanding their forces?{nl}
+xQUEST_LV_0100_20150317_000361	They have low IQ, but these monsters form groups and live as a community.{nl}They used to appear only occasionally in the deeper areas of the mines... Could they be expanding their forces?{nl}
 QUEST_LV_0100_20150317_000362	Whatever the reason is, Vubbes expanding their territory is a big problem.{nl}Monsters that lose their territory to Vubbes will be forced to make their way into our base.
 QUEST_LV_0100_20150317_000363	It's a single road from here on so you'll be able to find the people easily.{nl}
 QUEST_LV_0100_20150317_000364	Oh, let me give you some helpful information in return for your your help.{nl}The evidence of salvation that the Revelators are looking for can be found in the Closed Area.
 QUEST_LV_0100_20150317_000365	One thing, there's something that keeps bothering me.{nl}A vague feeling of something alien.
 QUEST_LV_0100_20150317_000366	Miner
-QUEST_LV_0100_20150317_000367	Thank you for saving me.{nl}The revelator has come to save us. It's like a dream.{nl}
-QUEST_LV_0100_20150317_000368	The Closed Area?{nl}If you insist on getting in, gather the mysterious stones the Vubbes have.{nl}The walls just open when you touch the crystal clogged wall with it.
+xQUEST_LV_0100_20150317_000367	Thank you for saving me.{nl}The Revelator has come to save us. It's like a dream.{nl}
+xQUEST_LV_0100_20150317_000368	The Closed Area?{nl}If you insist on getting in, gather the mysterious stones the Vubbes have.{nl}The walls just open when you touch the crystal-clogged wall with them.
 QUEST_LV_0100_20150317_000369	I was collecting the supplies to be sent to the Miners' Village, but the monsters stole it all.{nl}
 QUEST_LV_0100_20150317_000370	The supply boxes contain dangerous explosives and collecting them is not an easy task.
 QUEST_LV_0100_20150317_000371	They couldn't have gone far.{nl}It would have been better if it just exploded on the way.
 QUEST_LV_0100_20150317_000372	Mercenary Lint
 QUEST_LV_0100_20150317_000373	Thank you again.{nl}I should return to my commander soon. I think I can return to him after I get some more rest.
 QUEST_LV_0100_20150317_000374	I knew you would.{nl}One more thing, the ground near the Closed Area is weak so the entrance has been blocked for a long time.{nl}
-QUEST_LV_0100_20150317_000375	The kidnapped people are veteran miners so they may know how to get in.{nl}Well then, may the blessings of the Goddess be with you.
-QUEST_LV_0100_20150317_000376	It wasn't long ago.{nl}I felt a strange power while performing experiments in the Closed Area.{nl}It was different from the mana that we know but it was very warm.{nl}
+xQUEST_LV_0100_20150317_000375	The kidnapped people are veteran miners, so they may know how to get in.{nl}Well then, may the blessings of the Goddess be with you.
+xQUEST_LV_0100_20150317_000376	It wasn't long ago.{nl}I felt a strange power while performing experiments in the Closed Area.{nl}It was different from the mana that we know, but it was very warm.{nl}
 QUEST_LV_0100_20150317_000377	But some force did not allow me to approach, as if it had an owner already.{nl}A few days after the incident, the bishop dreamed about the evidence of salvation.{nl}
 QUEST_LV_0100_20150317_000378	Perhaps the evidence of salvation is the force I felt...{nl}That's what I think.
 QUEST_LV_0100_20150317_000379	All I see are monsters and we're out of supplies.{nl}I'm also curious how the battle situation is in Miners' Village.
@@ -381,23 +381,23 @@ QUEST_LV_0100_20150317_000380	Until I'm assigned a new task, I'm thinking of goi
 QUEST_LV_0100_20150317_000381	The Miners' Village is under siege and entrance is prohibited for civilians.{nl}Remember that we can't guarantee your safety if you do not get my permission.
 QUEST_LV_0100_20150317_000382	You have to cheer up.{nl} Even Sir Aras is holding on.
 QUEST_LV_0100_20150317_000383	Goddess Zemyna overlooks the earth.{nl}There are rumors that the Goddess has abandoned us but that's nonsense.{nl}Her statue still shines beautifully when you pray to it.
-QUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods.{nl}That's why the Mining Village located in the middle of it turned to a battlefield.{nl}
+xQUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods.{nl}That's why the Miners' Village located in the middle of it turned into a battlefield.{nl}
 xQUEST_LV_0100_20150317_000385	And that's why I can't permit entrance to the Miners Village. For safety reasons.{nl}Of course it will be a different story if your skills are good enough to ensure{nl} your safety even without the protection of guards.
 QUEST_LV_0100_20150317_000386	Gosh, it could have been really dangerous.{nl}That huge thing was hiding so well.
 QUEST_LV_0100_20150317_000387	It's very important to study monsters at times like this.{nl}It's like weather forecasts where you try to find out the cause and see what would happen.
 QUEST_LV_0100_20150317_000388	I'm sure the Leaf Bugs in Uoros farm stole it.{nl}They did steal from us once before.
 QUEST_LV_0100_20150317_000389	Send my regards to the Guard Captain when you meet him.
-QUEST_LV_0100_20150317_000390	In order to test if your skills are good enough to enter the Miners Village,{nl}I need you to help us solve a problem we have.{nl}
+xQUEST_LV_0100_20150317_000390	In order to test if your skills are good enough to enter the Miners' Village,{nl}I need you to help us solve a problem we have.{nl}
 xQUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus.{nl}I believe this would be a fairly easy task.
 QUEST_LV_0100_20150317_000392	There seems to be a gap in the rock where you can insert something.
 QUEST_LV_0100_20150317_000393	Let's search the Bulvjes farm first.{nl}But don't chase them or something as it can be dangerous.
-QUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess.{nl}Anyway, the supply camp is located further below the farm.
+xQUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess.{nl}Anyway, the supply camp is located further down the farm.
 QUEST_LV_0100_20150317_000395	
 QUEST_LV_0100_20150317_000396	Vubbes are emerging inside the Mine Gallery so be sure to stay together in groups of five.
 QUEST_LV_0100_20150317_000397	Equipment Merchant
 QUEST_LV_0100_20150317_000398	Even at times like this, I struggle to find the best items I can. You can't go easy in terms of dealing with your customers.
 QUEST_LV_0100_20150317_000399	Monsters attack and steal from people who buy items from me. I think they know I can tell which items are good.{nl}I feel sorry for those who were attacked but it also proves that the items are worth it.
-QUEST_LV_0100_20150317_000400	The monsters never raided into Klaipeda but with Sir Uska gone, it's hard to be at ease.{nl}You have you watch out for yourself at times like this.
+xQUEST_LV_0100_20150317_000400	The monsters never raided into Klaipeda, but with Sir Uska gone it's hard to be at ease.{nl}You have you watch out for yourself at times like this.
 QUEST_LV_0100_20150317_000401	I want to travel with a single weapon in hand like an adventurer... But it's not that easy.
 QUEST_LV_0100_20150317_000402	If you listen to the soldiers, they'll use terms only they can understand and make it sound difficult.{nl}But when I ask a friend who's a soldier, he says it's not like they are talking about anything important.
 QUEST_LV_0100_20150317_000403	Be cautious of people who sell weapons from monsters without permit.{nl}They'll try and scam you into to buying useless things or sell you things at ridiculously high prices.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -145,12 +145,12 @@ QUEST_LV_0100_20150317_000144	I should go see Dezik.{nl}I hope to see you again 
 QUEST_LV_0100_20150317_000145	Someone must have done something strange to the monsters protecting the Mausoleum.{nl}What were they thinking?
 QUEST_LV_0100_20150317_000146	Sir, recover your consciousness. Sir!
 QUEST_LV_0100_20150317_000147	New Mausoleum Researcher
-QUEST_LV_0100_20150317_000148	I lost my important research materials at the Abondoned Old Workplace.{nl}The monsters must have taken them... Should I just give up?
+xQUEST_LV_0100_20150317_000148	I lost my important research materials at the Abandoned Old Workplace.{nl}The monsters must have taken them... Should I just give up?
 QUEST_LV_0100_20150317_000149	I am so glad I get to see the Mausoleum myself, but the monsters... They are scary.
 QUEST_LV_0100_20150317_000150	Thank you so much.{nl}But you should also check the Records Repository.
 QUEST_LV_0100_20150317_000151	The entrace to the Mausoleum is hidden somewhere in this gigantic canyon.{nl}And this place is the start of the canyon.
 QUEST_LV_0100_20150317_000152	Many experts have come here to conduct research on the Mausoleum.{nl}Maybe we can find some clues about the Medis Diena here.
-QUEST_LV_0100_20150317_000153	Why are there so many monsters at the Canyon when there is such little plant life?
+xQUEST_LV_0100_20150317_000153	Why are there so many monsters at the canyon when there is such little plant life?
 QUEST_LV_0100_20150317_000154	What happened to my request? Is it not done yet?
 QUEST_LV_0100_20150317_000155	Look closely at the ground.{nl}It may have fallen down.
 QUEST_LV_0100_20150317_000156	Only these?{nl}Well, thank you for finding this much at least.{nl}I can just copy again from the beginning.
@@ -181,20 +181,20 @@ QUEST_LV_0100_20150317_000180	Alright, it's done.{nl}Take this to Davio.
 QUEST_LV_0100_20150317_000181	Merchant Davio
 QUEST_LV_0100_20150317_000182	We brought that old man's medicine. {nl}But we spent a long time getting it. I should charge you more.{nl}
 QUEST_LV_0100_20150317_000183	The gold that Lichenclops have in this town will be enough.{nl}Bring those to the pharmacist at Kapas.
-QUEST_LV_0100_20150317_000184	This will be enough. Davio sent you right?{nl}To make the medicine effective I need one more ingredient.
+xQUEST_LV_0100_20150317_000184	This will be enough. Davio sent you, right?{nl}To make the medicine effective I need one more ingredient.
 QUEST_LV_0100_20150317_000185	To make the medicine, I needed find the cause and it drove me crazy.{nl}The funny thing is that it was the same thing as the magic that was used long ago.{nl}
 QUEST_LV_0100_20150317_000186	I heard a rumor that Zachariel erased the memories of all workers after building the Mausoleum.{nl}That's the magic cast on Jonas, though he is also a bit senile.
 QUEST_LV_0100_20150317_000187	It was so hard to get that old man's medicine.{nl}But, there's nothing that I cannot get.
 QUEST_LV_0100_20150317_000188	It will be completed when you melt it in the honey that you brought. Take it.
 QUEST_LV_0100_20150317_000189	That medicine works well. Make him swallow it somehow.
 QUEST_LV_0100_20150317_000190	It's late.{nl}Did you bring my records?
-QUEST_LV_0100_20150317_000191	Go to the Abondoned Workplace.{nl}Some old man is wandering around there. I think it's Jonas.
+QUEST_LV_0100_20150317_000191	Go to the Abandoned Old Workplace.{nl}Some old man is wandering around there. I think it's Jonas.
 QUEST_LV_0100_20150317_000192	What is that? It smells like honey alcohol.
 QUEST_LV_0100_20150317_000193	I feel dizzy.{nl}What am I doing here anyway?
 QUEST_LV_0100_20150317_000194	It's good to hear that they are searching for it.{nl}I left all the supplies and my belogings since monsters were chasing after me.{nl}Can you go find the scattered supplies first?
 QUEST_LV_0100_20150317_000195	I don't have anything to tell you as a humble mercenary.{nl}I was okay even on the Medis Diena, I am sure this place is cursed.{nl}
 QUEST_LV_0100_20150317_000196	Why do you come here now after such a long time?{nl}Where is Mirta and who are you?
-QUEST_LV_0100_20150317_000197	I'm trying to remember something but it keeps fading whenever I get close.
+xQUEST_LV_0100_20150317_000197	I'm trying to remember something, but it keeps fading whenever I get close.
 QUEST_LV_0100_20150317_000198	Vaidotas
 QUEST_LV_0100_20150317_000199	The smell.. I think the purifying device in the mine is broken.{nl}We better repair it quickly. The people taken away might suffocate.
 QUEST_LV_0100_20150317_000200	Do you know the legend of Cunningham?{nl}It's a legend about the great demon sealed here in the Crystal Mine.{nl}For more details, there is a book about it in the miners lounge of 2nd Gallery.{nl}
@@ -202,15 +202,15 @@ QUEST_LV_0100_20150317_000201	Anyway, my guess is that the demon is re-awakening
 QUEST_LV_0100_20150317_000202	Only the Goddess would know if it is hope or despair.{nl}
 QUEST_LV_0100_20150317_000203	The purifier can be easily fixed by anyone but it may be hard to find the parts.{nl}In that case, use the compass that I gave you.{nl}
 QUEST_LV_0100_20150317_000204	Well then, I have some things to do so I will meet you in the 3rd Gallery.{nl}I wish for your fortune of war in the name of the Goddess.
-QUEST_LV_0100_20150317_000205	If you can't repair the purifier, use the compass I gave you.{nl}You'll be able to find a way.
+xQUEST_LV_0100_20150317_000205	If you can't repair the purifier use the compass I gave you.{nl}You'll be able to find a way.
 QUEST_LV_0100_20150317_000206	Village Aunt
 QUEST_LV_0100_20150317_000207	Did you come to save us? Did you?
 QUEST_LV_0100_20150317_000208	Okay! We are going to be okay now!
 QUEST_LV_0100_20150317_000209	Village Girl
-QUEST_LV_0100_20150317_000210	Please save us. Please..
-QUEST_LV_0100_20150317_000211	Please release me. Please..
+xQUEST_LV_0100_20150317_000210	Please save us. Please...
+xQUEST_LV_0100_20150317_000211	Please release me. Please...
 QUEST_LV_0100_20150317_000212	Mr. Juan
-QUEST_LV_0100_20150317_000213	I feel mad whenever I see those Vubbes that ruined my hometown.{nl}That's why I want to help people like you who fight againt the Vubbes.
+xQUEST_LV_0100_20150317_000213	I feel mad whenever I see those Vubbes that ruined my hometown.{nl}That's why I want to help people like you who fight against the Vubbes.
 QUEST_LV_0100_20150317_000214	I would have left already if this wasn't my hometown.{nl}Where on earth have all the Vubbes been hiding before they crawled out?
 QUEST_LV_0100_20150317_000215	Pharmacist lady
 QUEST_LV_0100_20150317_000216	Thanks for the last time.{nl}Without you, I would have never gotten those ingredients.
@@ -228,7 +228,7 @@ QUEST_LV_0100_20150317_000227	You better ask the Bokor Master about this slate.{
 QUEST_LV_0100_20150317_000228	Use your time wisely.{nl}No one can know everything about one's own future.
 QUEST_LV_0100_20150317_000229	So you finally came.{nl}What did the Bokor Master tell you?
 QUEST_LV_0100_20150317_000230	I'm also curious about the girl who cracked the seal.{nl}This is not a seal that can easily be broken.
-QUEST_LV_0100_20150317_000231	If the Bokor Master told you that I would know it..{nl}I can think of a place.{nl}
+xQUEST_LV_0100_20150317_000231	If the Bokor Master told you that I would know it...{nl}I can think of a place.{nl}
 QUEST_LV_0100_20150317_000232	
 QUEST_LV_0100_20150317_000233	Miners' Village Mayor
 QUEST_LV_0100_20150317_000234	Welcome. Aren't you our town's savior?{nl}
@@ -236,9 +236,9 @@ QUEST_LV_0100_20150317_000235
 QUEST_LV_0100_20150317_000236	So this revelation is Goddess Laima and we have to collect all these for the Goddess to regain her powers?{nl}That is amazing.
 QUEST_LV_0100_20150317_000237	Oh, please do not reveal the fact that the Revelator has been found unless absolutely necessary.{nl}It may only create confusion if the rumors spread.
 QUEST_LV_0100_20150317_000238	Ah, you mean the report.{nl}At first, those Siaulagos did something strange to the supplies, but they ran away after a while when Sparnas came.{nl}
-QUEST_LV_0100_20150317_000239	I was spotted by those Siaulagos when they were running away, so I engaged in a battle..{nl}Yes.. And as you can see, I lost it. The report, I mean.{nl}Aren't they bastards?
+xQUEST_LV_0100_20150317_000239	I was spotted by those Siaulagos when they were running away, so I engaged in a battle...{nl}Yes... And as you can see, I lost it. The report, I mean.{nl}Aren't they bastards?
 QUEST_LV_0100_20150317_000240	When you find the report, please hand it over to Luders right away.{nl}I feel terrified to think what those bastards did to our supplies.
-QUEST_LV_0100_20150317_000241	Yes. After seeing Moody's report, I am confident that they put something in our supplies to lure Sparnas.{nl}Such as Old Grains that birds go crazy on.
+xQUEST_LV_0100_20150317_000241	Yes. After seeing Moody's report, I am confident that they put something in our supplies to lure Sparnas.{nl}Such as old grains that birds go crazy on.
 QUEST_LV_0100_20150317_000242	The soldiers on patrol found the place where Siaulambs' stolen goods are packed.{nl}How about we steal them for ourselves?{nl}Let's make it known that we're not as weak as they think.{nl}
 QUEST_LV_0100_20150317_000243	You should fight fire with fire.{nl}We will keep attacking until they fully realize that they've made a mistake.
 QUEST_LV_0100_20150317_000244	We're not going to suffer anymore.{nl}Thanks for your efforts.
@@ -266,16 +266,16 @@ QUEST_LV_0100_20150317_000265	Oh, you're the Revelator.{nl}It must be fate that 
 QUEST_LV_0100_20150317_000266	You mentioned that we need to assemble, right?{nl}Help me find the missing luggage and I'll go as soon as I can.
 QUEST_LV_0100_20150317_000267	You haven't found the luggage yet? I can't go back without it.
 QUEST_LV_0100_20150317_000268	Thank you. You found it sooner than I expected.{nl}
-QUEST_LV_0100_20150317_000269	If you follow the road to the north, you will find the Search Scout.{nl}Good luck.
+xQUEST_LV_0100_20150317_000269	If you follow the road to the north you will find the Search Scout.{nl}Good luck.
 QUEST_LV_0100_20150317_000270	Laimonas
 QUEST_LV_0100_20150317_000271	Have you ever offered worship to the Statue?{nl}If not, I'd really recommend it.
 QUEST_LV_0100_20150317_000272	That depends on which Goddess it is.{nl}If you follow the road to the right you will find the Statue of Goddess Zemyna. 
 QUEST_LV_0100_20150317_000273	I do worry that the monsters might harm the Goddess Statue.
 QUEST_LV_0100_20150317_000274	Good thing to hear that the Statue is fine.{nl}The monsters know to fear the Goddess.{nl}
-QUEST_LV_0100_20150317_000275	Go down the Shadow Forest Road and you should arrive at Klaipeda shortly.{nl}Well then, may be blessings of the Goddess be with you.
+xQUEST_LV_0100_20150317_000275	Go down the Shadow Forest Road and you should arrive at Klaipeda shortly.{nl}Well then, may the blessings of the Goddess be with you.
 QUEST_LV_0100_20150317_000276	Please do me a favor if you are headed to Klaipeda.{nl}It's not easy to go back and forth from Klaipeda because of the Infro Rocktors nowadays.
 QUEST_LV_0100_20150317_000277	Maybe taking care of the Statues will make the Goddesses return sooner...
-QUEST_LV_0100_20150317_000278	Follow the road on the left at the camp crossroads.{nl}{-scp SCR_DIALOG_NPC_ANIM(
+xQUEST_LV_0100_20150317_000278	Follow the road on the left at the camp crossroads.{nl}{-scp SCR_DIALOG_NPC_ANIM(
 QUEST_LV_0100_20150317_000279	)} You'll meet the troops right away.
 QUEST_LV_0100_20150317_000280	)} Alright, good job.{nl}You'll arrive at Klaipeda shortly if you follow the Shadow Forest Road.{nl}Don't forget to drop by Sir Uska.
 QUEST_LV_0100_20150317_000281	Battle Commander

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -382,7 +382,7 @@ QUEST_LV_0100_20150317_000381	The Miners' Village is under siege and entrance is
 QUEST_LV_0100_20150317_000382	You have to cheer up.{nl} Even Sir Aras is holding on.
 QUEST_LV_0100_20150317_000383	Goddess Zemyna overlooks the earth.{nl}There are rumors that the Goddess has abandoned us but that's nonsense.{nl}Her statue still shines beautifully when you pray to it.
 QUEST_LV_0100_20150317_000384	Vubbes suddenly came pouring in from outside of the Siaulai Woods.{nl}That's why the Mining Village located in the middle of it turned to a battlefield.{nl}
-QUEST_LV_0100_20150317_000385	And that's why I can't permit entrance to the Miners Village. For safety reasons.{nl}Of course it will be a different story if your skill are good enough to ensure{nl} your safety even without the protection of guards.
+xQUEST_LV_0100_20150317_000385	And that's why I can't permit entrance to the Miners Village. For safety reasons.{nl}Of course it will be a different story if your skills are good enough to ensure{nl} your safety even without the protection of guards.
 QUEST_LV_0100_20150317_000386	Gosh, it could have been really dangerous.{nl}That huge thing was hiding so well.
 QUEST_LV_0100_20150317_000387	It's very important to study monsters at times like this.{nl}It's like weather forecasts where you try to find out the cause and see what would happen.
 QUEST_LV_0100_20150317_000388	I'm sure the Leaf Bugs in Uoros farm stole it.{nl}They did steal from us once before.
@@ -749,7 +749,7 @@ QUEST_LV_0100_20150317_000748	Welcome, I'm glad to see that you've had a safe jo
 QUEST_LV_0100_20150317_000749	My old friend, Algis, will explain. Please listen to him.
 QUEST_LV_0100_20150317_000750	I can see the monsters cleary from up here.{nl}He may get surrounded by them soon.
 QUEST_LV_0100_20150317_000751	The broken barrier pieces are scattered in the Mazas shelter. {nl} Collect it and give it to sir Kayetonas in flower hill. {nl}
-QUEST_LV_0100_20150317_000752	My poor father must be happy if he know I became a guard.{nl}But, I already made a mistake.
+xQUEST_LV_0100_20150317_000752	My poor father must be happy if he knows I became a guard.{nl}But, I already made a mistake.
 QUEST_LV_0100_20150317_000753	We can say it's peaceful for now.{nl}For now.
 QUEST_LV_0100_20150317_000754	
 QUEST_LV_0100_20150317_000755	That's why if there are guards struggling with the barrier, I want you to help.
@@ -903,7 +903,7 @@ QUEST_LV_0100_20150317_000902	But the enemy is the Demon King. Even the Paladin 
 QUEST_LV_0100_20150317_000903	We can't do anything about the destroyed altar but the fragments still have power. {nl} Gather the pieces and insert it in the 8 pillars of the Sventove Central Hall.
 QUEST_LV_0100_20150317_000904	When you are done, I will be able to tie up Gesti through the power of the divine crystal and the church. {nl} It may be for a short while but that's the best option we have.
 QUEST_LV_0100_20150317_000905	So you activated the Malda altar? {nl} Now it will be safe to stay here for the time being. Good work.
-QUEST_LV_0100_20150317_000906	Demon are going around the second floor searching every corner. {nl} Activating the Auka altar will be able to turn their attention.
+xQUEST_LV_0100_20150317_000906	Demons are going around the second floor searching every corner. {nl} Activating the Auka altar will be able to turn their attention.
 QUEST_LV_0100_20150317_000907	I'm relieved you're beside me. {nl} I think it was a good thing that Laima chose you.
 QUEST_LV_0100_20150317_000908	Good job. {nl} When this is over, I should gather all brothers and drive them away at once.
 QUEST_LV_0100_20150317_000909	I'll ring the bell and let you know when the Gesti show up so have a safe trip on your way.
@@ -925,7 +925,7 @@ QUEST_LV_0100_20150317_000924
 QUEST_LV_0100_20150317_000925	In the kingdom, there are several valuable weapons aside from this divine sphere. {nl} Those weapons saved many lives on the Medis Diena four years ago.
 QUEST_LV_0100_20150317_000926	From now on, I will focus on the divine crystal. {nl} In the meanwhile, please use your skills so that I won't be disturbed.
 QUEST_LV_0100_20150317_000927	I'm sorry. It's all my fault. {nl}The Gesti found out the divine heal is not the revelation so it will head straight to the church. {nl}
-QUEST_LV_0100_20150317_000928	But his old body of mine does not follow my will anymore. {nl} Now I can only trust my old friend Algis and you. {nl}
+xQUEST_LV_0100_20150317_000928	But this old body of mine does not follow my will anymore. {nl} Now I can only trust my old friend Algis and you. {nl}
 QUEST_LV_0100_20150317_000929	
 QUEST_LV_0100_20150317_000930	It is too much for me to handle alone without any help from other brothers. {nl} I'd better run the Malda Altar. {nl}
 QUEST_LV_0100_20150317_000931	
@@ -946,7 +946,7 @@ QUEST_LV_0100_20150317_000945	Those Sidmias want me to put my head on that flowe
 QUEST_LV_0100_20150317_000946	We received the charm from the elders that will brainwash Pantos to stand on our side.{nl}Do you want to take up the challenge?{nl}
 QUEST_LV_0100_20150317_000947	According to the elders, we are done with those Pantos.{nl}We can't continue the relationship anymore.
 QUEST_LV_0100_20150317_000948	This barrier is impossible to open from the inside. {nl} Fortunately, the entrance to the basement looks safe. {nl}
-QUEST_LV_0100_20150317_000949	However, it's too dangerous to in the basement with the divine sphere. {nl} I'll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
+xQUEST_LV_0100_20150317_000949	However, it's too dangerous to go into the basement with the divine sphere. {nl} I'll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
 QUEST_LV_0100_20150317_000950	You have done what other can't easily do.{nl}The Goddess must be proud of you.
 QUEST_LV_0100_20150317_000951	My faith in religion is strong enough to destroy those demons, but the reality isn't that simple.{nl}I hope you help us a bit.
 QUEST_LV_0100_20150317_000952	
@@ -1238,7 +1238,7 @@ QUEST_LV_0100_20150317_001237	I would have fled long time ago if it wasn't for t
 QUEST_LV_0100_20150317_001238	We should somehow block those demons.{nl}I can't pass this danger to our brothers in the cathedral.
 QUEST_LV_0100_20150317_001239	We can't go in due to the barrier.{nl}To open the door, we should go through 1st floor of the basement.
 QUEST_LV_0100_20150317_001240	When I meet you again, is this world going to be peaceful.. I hope it is.
-QUEST_LV_0100_20150317_001241	I never expected those demons will come down this far.{nl}I hope our brothers stand still against them.
+xQUEST_LV_0100_20150317_001241	I never expected those demons would come down this far.{nl}I hope our brothers stand still against them.
 QUEST_LV_0100_20150317_001242	We have lots of things to protect so we should rather defeat those demons quietly than excitng them.{nl}I feel much more safe with you.
 QUEST_LV_0100_20150317_001243	Honestly, I thought it would be hard to stand still with only Paladins.{nl}I guess my belief in them wasn't that much.
 QUEST_LV_0100_20150317_001244	It will be better to fight them face to face instead of hiding.{nl}It will be even better if the opponents are the demons.
@@ -2001,7 +2001,7 @@ QUEST_LV_0100_20150317_002000	So you're the one who wanted to meet Goddess Saule
 QUEST_LV_0100_20150317_002001	The priest is located in Cerpe crossroads. {nl}I heard he needed the venom of Black Maize so try to get him that as a present.
 QUEST_LV_0100_20150317_002002	We wouldn't have dreamed about the portal if it wasn't for you. {nl} You truly are the blessing of God.
 QUEST_LV_0100_20150317_002003	Andail's village Priest
-QUEST_LV_0100_20150317_002004	Isn't this the venom of the black maize? {nl} Thank you very much. {nl}
+xQUEST_LV_0100_20150317_002004	Isn't this the venom of the Black Maize? {nl} Thank you very much. {nl}
 QUEST_LV_0100_20150317_002005	You can leave meeting Goddess Saule with me. {nl} Now that the diving pond is purified, we just need to solve the Obelisk.
 QUEST_LV_0100_20150317_002006	Magic letters are carved on the Obelisk. {nl} But some letters were erased as the divine pond became contaminated. {nl}
 QUEST_LV_0100_20150317_002007	If the letters are gone, we just need to write it back on. {nl} Now that you've collected the venom of Black Maize, we just need the sap of the oak tree.
@@ -2012,7 +2012,7 @@ QUEST_LV_0100_20150317_002011	The Obelisk is in the Slepingas stream.
 QUEST_LV_0100_20150317_002012	I'm sure God will be satisfied with you.
 QUEST_LV_0100_20150317_002013	It's almost done. {nl} After completing the rituals to cleanse your body, you will be able to meet the Goddess soon. {nl}
 QUEST_LV_0100_20150317_002014	
-QUEST_LV_0100_20150317_002015	Use this tranquilizer on the black maize and extract its poison. {nl} The Maize should be weakened for the tranquilizer to work.
+xQUEST_LV_0100_20150317_002015	Use this tranquilizer on the Black Maize and extract its poison. {nl} The Maize should be weakened for the tranquilizer to work.
 QUEST_LV_0100_20150317_002016	Thank you so much! {nl}By the way, what was that vibration?
 QUEST_LV_0100_20150317_002017	The disciple of Andail Village
 QUEST_LV_0100_20150317_002018	You're the Revelator right? {nl}Upent is preying on the village so we can't hold the ritual right away. {nl}
@@ -2130,13 +2130,13 @@ QUEST_LV_0100_20150317_002129	Let's go to the fusion machine.{nl}We just have to
 QUEST_LV_0100_20150317_002130	We should succeed..
 QUEST_LV_0100_20150317_002131	So this is the Jewel of Prominence.. I can feel it's great energy.{nl}Let's quickly give this to Gabija. There's stairs to go up on the right side.
 QUEST_LV_0100_20150317_002132	To find the Jewel of Prominence, just use this detector.{nl}When you use this detector near the place where the jewel is located, the jewel will come out.
-QUEST_LV_0100_20150317_002133	The portal that you tried to open is the gate of lies.{nl}The villagers hear are the tricks of Demons' lord, Bramble.
+xQUEST_LV_0100_20150317_002133	The portal that you tried to open is the gate of lies.{nl}The villagers here are the tricks of Demons' lord, Bramble.
 QUEST_LV_0100_20150317_002134	It's embarrassing but I am also tricked and captured, losing all my strength. {nl} Please destroy the magic circle imprisoning me.
 QUEST_LV_0100_20150317_002135	The magic circle of confinement is located in Drugys Courtyard and Vapsva lot. {nl}Please hurry.
 QUEST_LV_0100_20150317_002136	Thank you for saving me. {nl}
 QUEST_LV_0100_20150317_002137	I am Saule, the Goddess of the sun. {nl} Everything is just like how Laima has forseen.
-QUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here. {nl} We've got to find the inspetor, Clymen, hiding in between the gap of dimensions.
-QUEST_LV_0100_20150317_002139	Please bring me the sacrifice tools in the Grand Corridor. {nl} I will try to use the divine power that dwell in the tool.
+xQUEST_LV_0100_20150317_002138	Thank you. But this is not the only barrier imprisoning me in here. {nl} We've got to find the inspetor, Clymen, hiding in between the gap of dimensions.
+xQUEST_LV_0100_20150317_002139	Please bring me the sacrifice tools in the Grand Corridor. {nl} I will try to use the divine power that dwells in the tool.
 QUEST_LV_0100_20150317_002140	Thank you. {nl} This much divine power would be enough.
 QUEST_LV_0100_20150317_002141	
 QUEST_LV_0100_20150317_002142	Just a bit more. Please suppress the Magi.
@@ -2154,7 +2154,7 @@ QUEST_LV_0100_20150317_002153
 QUEST_LV_0100_20150317_002154	I just feel sorry to my brother.
 QUEST_LV_0100_20150317_002155	Old man of Andail village
 QUEST_LV_0100_20150317_002156	God is looking after our village so our village has clear water and air. And there are no disasters here.
-QUEST_LV_0100_20150317_002157	So finally the revelator has come.{nl}Very healthy and reliable. I gues we can do it this time.
+xQUEST_LV_0100_20150317_002157	So finally the revelator has come.{nl}Very healthy and reliable. I guess we can do it this time.
 QUEST_LV_0100_20150317_002158	Aren't you the Revelator? {nl} So, what brings you to our village? {nl}
 QUEST_LV_0100_20150317_002159	Goddess Saule? {nl} We haven't seen her for a long time. {nl}
 QUEST_LV_0100_20150317_002160	The portal leading to Goddess Saule just won't open. {nl}I think it's all because the diving pond is contaminated.
@@ -2348,7 +2348,7 @@ QUEST_LV_0100_20150317_002347	Found a letter in the sack
 QUEST_LV_0100_20150317_002348	The letter in the sack
 QUEST_LV_0100_20150317_002349	Receiver: Drashoes{nl}Address: Virdului Cabin{nl}I am sending you the head of the tree with long branches that you ordered.
 QUEST_LV_0100_20150317_002350	400 years would have passed by when this revelation reaches you. {nl} Thank you in advance for your continued pursuit of finding the revelation. . {nl}
-QUEST_LV_0100_20150317_002351	As I'm sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin. {nl} if you find this revelation, it would mean that he had done an excellent job in fulfilling his mission. {nl}
+xQUEST_LV_0100_20150317_002351	As I'm sure the demons will prey on the revelation, I will leave this revelation in the hands of Rimgaudis, the first Paladin. {nl} If you find this revelation, it would mean that he had done an excellent job in fulfilling his mission. {nl}
 QUEST_LV_0100_20150317_002352	The demons have been chasing the revelation before I made this revelation. {nl} Gesti, the leader of the demons whom you have met is one of them. {nl}
 QUEST_LV_0100_20150317_002353	Three demon Kings and the demon leaders who follow them. {nl}Giltine is the one who controls all of them. {nl}
 QUEST_LV_0100_20150317_002354	All these catastrophes are her plans. {nl} The disasters will continue and at the end of it will be the end of human race. {nl}
@@ -6271,7 +6271,7 @@ QUEST_LV_0100_20150317_006270	You need to go back to Goddess Saule to ask for th
 QUEST_LV_0100_20150317_006271	Talk to Andale's elder
 QUEST_LV_0100_20150317_006272	
 QUEST_LV_0100_20150317_006273	Collect the venom of Black Maize
-QUEST_LV_0100_20150317_006274	Collect the venom of Maize for gift to Village Priest. It is only able to obtain the venom of black Maize to use the paralysis powder while black Maize's hp has reduced by half.
+xQUEST_LV_0100_20150317_006274	Collect the venom of Maize for gift to Village Priest. It is only able to obtain the venom of Black Maize to use the paralysis powder while Black Maize's hp has reduced by half.
 QUEST_LV_0100_20150317_006275	Go to Andale's village priest
 QUEST_LV_0100_20150317_006276	Collected Black Maize's venom. Go to Andale Priest in Cerpe Crossroad.
 QUEST_LV_0100_20150317_006277	Kill Black Maize to get %s
@@ -6405,7 +6405,7 @@ QUEST_LV_0100_20150317_006404	Mr. Juan asked you to bring him Vubbe Theif's Leat
 QUEST_LV_0100_20150317_006405	Acquired Vubbe Thief's Leather! Bring it to Mr. Juan.
 QUEST_LV_0100_20150323_006406	Now take the unsealing stone and go to Ramstis Ridge. {nl}Student of Gustas will teach you how to release the seal there. 
 QUEST_LV_0100_20150323_006407	Were you not guided yet?{nl}It's the student of Gustas in Ramstis Ridge.{nl}It is made to let only the chosen one enter.
-QUEST_LV_0100_20150323_006408	Ask the mayor for directions to Gele Plateau. {nl}I will sent the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
+xQUEST_LV_0100_20150323_006408	Ask the mayor for directions to Gele Plateau. {nl}I will send the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
 QUEST_LV_0100_20150323_006409	The high gardens that the Goddess mentioned must be referring to the Gele Plateau. {nl}I heared the Paladin Master is there to keep a long term promise. 
 QUEST_LV_0100_20150323_006410	
 QUEST_LV_0100_20150323_006411	
@@ -6919,7 +6919,7 @@ QUEST_LV_0100_20150714_006918	The golds that the monsters have in this town will
 QUEST_LV_0100_20150714_006919	I feel dizzy.{nl}What am I doing here?
 QUEST_LV_0100_20150714_006920	I wish the Goddesses were here.{nl}I don't want to see anything sad anymore.
 QUEST_LV_0100_20150714_006921	The proof of the salvation is this Slate?{nl}It just looks like an old slate to me.{nl} 
-QUEST_LV_0100_20150714_006922	Use the time efficiently 
+xQUEST_LV_0100_20150714_006922	Use the time efficiently.
 QUEST_LV_0100_20150714_006923	Of course, you should first show your skills.{nl}Defeat Sand Chupacabras and Zinutes.
 QUEST_LV_0100_20150714_006924	If you are going to help me, please also take care of the gigantic gray Chupakabras.{nl}They often steal the supplies.
 QUEST_LV_0100_20150714_006925	When you defeat Chupakabras, the gigantic gray Chupakabra would appear.{nl}Okay, then I am counting on you.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -26,7 +26,7 @@ QUEST_LV_0100_20150317_000025	Soldier York
 QUEST_LV_0100_20150317_000026	Siaulambs are breaking the norms.{nl}I am in a panic myself, so I don't know what to do.{nl}Luders will not stand for this... What should we do?
 QUEST_LV_0100_20150317_000027	Do you think the problem would be resolved by just defeating Sparnas?
 QUEST_LV_0100_20150317_000028	Thanks to your help, I think I can get myself together.{nl}But... this kind of thing will happen again right? Then what should I do...?
-QUEST_LV_0100_20150317_000029	Sparnas? We don't have an answer for that.{nl}It just appears from the sky without any signs, destroys all supplies and then dissappears.{nl}I get a headache just hearing its cries.
+xQUEST_LV_0100_20150317_000029	Sparnas? We don't have an answer for that.{nl}It just appears from the sky without any signs, destroys all supplies and then disappears.{nl}I get a headache just hearing its cries.
 QUEST_LV_0100_20150317_000030	The place I just talked about is the 2nd supply warehouse.{nl}It is depressing to think how these kinds of things will be recurring in the future.
 QUEST_LV_0100_20150317_000031	Take it. I made some bait from old grains in the supplies.{nl}I will lure him up there, so you stay here.{nl}Sparnas will definitely appear at one of these two places. Do not miss it, and destroy it for sure.{nl}
 QUEST_LV_0100_20150317_000032	We may not get a second chance if we don't defeat it this time.{nl}They're not idiots.
@@ -68,7 +68,7 @@ QUEST_LV_0100_20150317_000067	You won't know how eagerly we have waited for this
 QUEST_LV_0100_20150317_000068	Gustas Jonas
 QUEST_LV_0100_20150317_000069	So it's you.{nl}You are much more of a man compared to what I had imagined.
 QUEST_LV_0100_20150317_000070	Soldier Alan
-QUEST_LV_0100_20150317_000071	You are a new soldier right?{nl}I received a patrolling order, but I guess you can go my behalf.
+xQUEST_LV_0100_20150317_000071	You are a new soldier right?{nl}I received a patrolling order, but I guess you can go on my behalf.
 QUEST_LV_0100_20150317_000072	You're good.{nl}I don't want to go there. I had a horrible experience once.
 QUEST_LV_0100_20150317_000073	I'm remembering something...
 QUEST_LV_0100_20150317_000074	You know that we are dispatched here to destroy Gaigalas right?{nl}Hey newcomer. Can you take this report to Commander Wallis?
@@ -388,7 +388,7 @@ QUEST_LV_0100_20150317_000387	It's very important to study monsters at times lik
 QUEST_LV_0100_20150317_000388	I'm sure the Leaf Bugs in Uoros farm stole it.{nl}They did steal from us once before.
 QUEST_LV_0100_20150317_000389	Send my regards to the Guard Captain when you meet him.
 QUEST_LV_0100_20150317_000390	In order to test if your skills are good enough to enter the Miners Village,{nl}I need you to help us solve a problem we have.{nl}
-QUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus.{nl}I believe this would be a fairly easy task
+xQUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus.{nl}I believe this would be a fairly easy task.
 QUEST_LV_0100_20150317_000392	There seems to be a gap in the rock where you can insert something.
 QUEST_LV_0100_20150317_000393	Let's search the Bulvjes farm first.{nl}But don't chase them or something as it can be dangerous.
 QUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess.{nl}Anyway, the supply camp is located further below the farm.
@@ -6012,9 +6012,9 @@ QUEST_LV_0100_20150317_006011	Hilda asked you to guard her while she observes th
 QUEST_LV_0100_20150317_006012	Hilda is done observing the pillars. Talk to her again. 
 QUEST_LV_0100_20150317_006013	Talk to Hilda who has sparkling eyes looking  at the pillars. 
 QUEST_LV_0100_20150317_006014	Protect Sculptor Hilda
-QUEST_LV_0100_20150317_006015	Hilda want to observe the pillar longer. Protect her from the monsters while she observes the pillars. 
-QUEST_LV_0100_20150317_006016	Seem like Hilda is done checking the pillars. Talk to her. 
-QUEST_LV_0100_20150317_006017	You have to block the demons attaking the mausoleum while chasing Rexipher. Talk to the Statue of guardian. 
+xQUEST_LV_0100_20150317_006015	Hilda wants to observe the pillar longer. Protect her from the monsters while she observes the pillars. 
+xQUEST_LV_0100_20150317_006016	Seems like Hilda is done checking the pillars. Talk to her. 
+xQUEST_LV_0100_20150317_006017	You have to block the demons attacking the mausoleum while chasing Rexipher. Talk to the statue of guardian. 
 QUEST_LV_0100_20150317_006018	Get piece of Royal Slate
 QUEST_LV_0100_20150317_006019	Mausoleum guardians are protecting the stones that Rexipher destroyed. Collect the pieces of slate from the Mausolem guardians. 
 QUEST_LV_0100_20150317_006020	Collected all pieces of the slate. Talk to the statue of guardian.


### PR DESCRIPTION
I wanted to correct some errors that I read while playing the beta test. Here are some that I found:

QUEST_LV_0100_20150317_000385 - The word "skill" should be in plural here.
QUEST_LV_0100_20150317_000752 - Changed the word "know" to "knows".
QUEST_LV_0100_20150317_000906 - "Demon" needed to be in plural.
QUEST_LV_0100_20150317_000928 - I believe he is talking about his own body and not someone else's.
QUEST_LV_0100_20150317_000949 - Inserted in the word "go" and changed the word from "in" to "into" for context.
QUEST_LV_0100_20150317_001241 - I believe "would" is the correct word in this sentence.

QUEST_LV_0100_20150317_002004
QUEST_LV_0100_20150317_002015
QUEST_LV_0100_20150317_006274

In other sentences it refers to Black Maize as a proper name. Tree of Savior has Black Maize as the name of a monster in its database so I capitalized the name in every mention of it.

QUEST_LV_0100_20150317_002133 - It is referring to a location and not "to hear" something.
QUEST_LV_0100_20150317_002138 - I did not edit this sentence, but it should be reviewed. The word "inspetor" does not exist in the English vocabulary, so I leave that to judgement if you want to replace it or remove it completely.
QUEST_LV_0100_20150317_002139 - I believe it should be "dwells".
QUEST_LV_0100_20150317_002157 - Corrected a grammatical error here.
QUEST_LV_0100_20150317_002351 - Grammatical error on first word of the sentence not capitalized.
QUEST_LV_0100_20150323_006408 - It is referring to the present and not the past.
QUEST_LV_0100_20150714_006922 - Missing period.
