### PR TITLE
Update ETC 7800-7837.tsv

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -7801,21 +7801,21 @@ ETC_20150317_007801	Activate the sealed device
 ETC_20150317_007802	Check the royal device
 ETC_20150317_007803 Unleash Gedulla's infantry seal before Rexipher 
 ETC_20150317_007804	Unseal Sviesa altar
-ETC_20150317_007805	Ruklys memorial(2)
+ETC_20150317_007805	Ruklys' memorial(2)
 ETC_20150317_007806	Acquire the first tombstone piece
 ETC_20150317_007807	Collect a dusty ruin fragment
 ETC_20150317_007808	Ruklys re-evaluation (1)
 ETC_20150317_007809	Ruklys re-evaluation (2)
 ETC_20150317_007810	Tap a stubby tree
 ETC_20150317_007811	Obtain a buried remnant shard
-ETC_20150317_007812	Lydia Schaffen is leaving zeolite (2)
+ETC_20150317_007812	Lydia Schaffen's Tombstone (2)
 ETC_20150317_007813	Collect the charcoal with Long arm tree
 ETC_20150317_007814	The third rub 
-ETC_20150317_007815	Lydia Schaffen's tombstone (4)
-ETC_20150317_007816	Lydia Schaffen's tombstone (5)
+ETC_20150317_007815	Lydia Schaffen's Tombstone (4)
+ETC_20150317_007816	Lydia Schaffen's Tombstone (5)
 ETC_20150317_007817	Flurry's epitaph (7)
 ETC_20150317_007818	Solicitor Edam's Request
-ETC_20150317_007819 Tower of Mage 42 interactive session
+ETC_20150317_007819 N/A
 ETC_20150317_007820	Open the Cathedral gate (4)
 ETC_20150317_007821	Release the barrier
 ETC_20150317_007822	Move to experimental place

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -7818,23 +7818,23 @@ ETC_20150317_007818	Solicitor Edam's Request
 ETC_20150317_007819 N/A
 ETC_20150317_007820	Open the Cathedral gate (4)
 ETC_20150317_007821	Release the barrier
-ETC_20150317_007822	Move to experimental place
-ETC_20150317_007823	Find related army person in Fedimian
-ETC_20150317_007824	Enter to petrified city
-ETC_20150317_007825	Plaza Check
-ETC_20150317_007826	Check B area
-ETC_20150317_007827	Check C area
-ETC_20150317_007828	Check collapsed plaza walls
-ETC_20150317_007829	Check blacksmith distance
-ETC_20150317_007830	Remove the weakened petrifaction frost
-ETC_20150317_007831	Petrification Frost Forecast (3)
-ETC_20150317_007832	Defeat the Dico Tomb robber
+ETC_20150317_007822	Go to the test site
+ETC_20150317_007823	Find the military associate in Fedimian
+ETC_20150317_007824	Enter the petrified city
+ETC_20150317_007825	Check grand plaza
+ETC_20150317_007826	Check area B
+ETC_20150317_007827	Check area C
+ETC_20150317_007828	Check the exterior wall of the collapsed plaza
+ETC_20150317_007829	Check the blacksmith's distance
+ETC_20150317_007830	Remove weakened petrification frost
+ETC_20150317_007831	Petrification frost Forecast (3)
+ETC_20150317_007832	Defeat the Dico Tomb Raider
 ETC_20150317_007833	Retrieve stolen supplies
-ETC_20150317_007834	Past Monitoring
-ETC_20150317_007835	Check a portal of army district
-ETC_20150317_007836	Check a portal of novle district
-ETC_20150317_007837	Check a portal of Drasa high place demolition
-ETC_20150317_007838	Ruklys Check the large square of portal
+ETC_20150317_007834	Retrospection
+ETC_20150317_007835	Check the army district's portal
+ETC_20150317_007836	Check the noble district's portal
+ETC_20150317_007837	Check Drasa temple ruin's portal
+ETC_20150317_007838	Check Ruklys grand plaza's portal
 ETC_20150317_007839	Deliver supplies covered with body odor
 ETC_20150317_007840	Coat the monster's body odor
 ETC_20150317_007841	Destroy drifted petrifaction documents

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -7799,7 +7799,7 @@ ETC_20150317_007799	Position saw in dream
 ETC_20150317_007800	Collect the antidote from people of Stone Pole Platform
 ETC_20150317_007801	Activate the sealed device
 ETC_20150317_007802	Check the royal device
-ETC_20150317_007803 Unleash Gedulla's infantry seal before Rexipher 
+ETC_20150317_007803	Unleash Gedulla's infantry seal before Rexipher 
 ETC_20150317_007804	Unseal Sviesa altar
 ETC_20150317_007805	Ruklys' memorial(2)
 ETC_20150317_007806	Acquire the first tombstone piece

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -7815,7 +7815,7 @@ ETC_20150317_007815	Lydia Schaffen's tombstone (4)
 ETC_20150317_007816	Lydia Schaffen's tombstone (5)
 ETC_20150317_007817	Flurry's epitaph (7)
 ETC_20150317_007818	Solicitor Edam's Request
-ETC_20150317_007819 Tower of Mage 42 interactive seession
+ETC_20150317_007819 Tower of Mage 42 interactive session
 ETC_20150317_007820	Open the Cathedral gate (4)
 ETC_20150317_007821	Release the barrier
 ETC_20150317_007822	Move to experimental place

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -7815,7 +7815,7 @@ ETC_20150317_007815	Lydia Schaffen's Tombstone (4)
 ETC_20150317_007816	Lydia Schaffen's Tombstone (5)
 ETC_20150317_007817	Flurry's epitaph (7)
 ETC_20150317_007818	Solicitor Edam's Request
-ETC_20150317_007819 N/A
+ETC_20150317_007819	N/A
 ETC_20150317_007820	Open the Cathedral gate (4)
 ETC_20150317_007821	Release the barrier
 ETC_20150317_007822	Go to the test site

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -7799,24 +7799,24 @@ ETC_20150317_007799	Position saw in dream
 ETC_20150317_007800	Collect the antidote from people of Stone Pole Platform
 ETC_20150317_007801	Activate the sealed device
 ETC_20150317_007802	Check the royal device
-ETC_20150317_007803	The discharge seal release of Dzurura in earlier than Rexipher
-ETC_20150317_007804	Release a seal of Sviesa's altar
-ETC_20150317_007805	Ruklys of memorial (2)
-ETC_20150317_007806	Obtain a first tombstone part
-ETC_20150317_007807	Collect the fragment covered with dust
+ETC_20150317_007803 Unleash Gedulla's infantry seal before Rexipher 
+ETC_20150317_007804	Unseal Sviesa altar
+ETC_20150317_007805	Ruklys memorial(2)
+ETC_20150317_007806	Acquire the first tombstone piece
+ETC_20150317_007807	Collect a dusty ruin fragment
 ETC_20150317_007808	Ruklys re-evaluation (1)
 ETC_20150317_007809	Ruklys re-evaluation (2)
-ETC_20150317_007810	Sap a short tree
-ETC_20150317_007811	Obtain a part of buried remains
+ETC_20150317_007810	Tap a stubby tree
+ETC_20150317_007811	Obtain a buried remnant shard
 ETC_20150317_007812	Lydia Schaffen is leaving zeolite (2)
 ETC_20150317_007813	Collect the charcoal with Long arm tree
-ETC_20150317_007814	Third time rubbing work
-ETC_20150317_007815	Lydia Schaffen is leaving zeolite (4)
-ETC_20150317_007816	Lydia Schaffen is leaving zeolite (5)
+ETC_20150317_007814	The third rub 
+ETC_20150317_007815	Lydia Schaffen's tombstone (4)
+ETC_20150317_007816	Lydia Schaffen's tombstone (5)
 ETC_20150317_007817	Flurry's epitaph (7)
-ETC_20150317_007818	Request of solicitor Eedang
-ETC_20150317_007819	N/A
-ETC_20150317_007820	Open the front gate of Sanctum (4)
+ETC_20150317_007818	Solicitor Edam's Request
+ETC_20150317_007819 Tower of Mage 42 interactive seession
+ETC_20150317_007820	Open the Cathedral gate (4)
 ETC_20150317_007821	Release the barrier
 ETC_20150317_007822	Move to experimental place
 ETC_20150317_007823	Find related army person in Fedimian


### PR DESCRIPTION
My preference would be to change:
Rexipher to Lexipher

(Things I need to see in game to know+ matters of style):
Remnant vs ruin (remains would refer to the decaying body...)
fragment vs shard
Tombstone vs memorial (more general term) vs epitaph (the writing on the stone)

Line 7809:
몽당 can describe pencil stubs (adj: diminutive or dwarf).
Tap vs sap. Tap is used in the context of collecting sap (maple syrup eh).
Line 7813: 
탁본 can refer to the rubbing of inscriptions

8/11--------------

7834 과거 관찰 - Retrospection vs Past Monitoring vs. Past Observation vs. Observing the Past
7832 도굴단: Tomb robber => Tomb Raider
7825 대광장: Prefix = great, large
7838-39 채취 body odor/musk.

예배소: a place of worship, like an altar, chapel or temple. It can be in a high place like a mountain.

석화된 도시 진입:
진입 is  a noun. In cases like this, the imperative is preferable to the gerund form, right? The former sounds better in English, as it is active writing, but the latter might be truer to the original form.

석화서리: Is this frost that petrifies or frost that is petrified? petrified frost vs petrification frost

Note: need to see places in game to differentiate articles of nouns and proper nouns. If anyone knows, please correct my capitalization and usage of a/the.
