### PR TITLE
QUEST_JOBSTEP.tsv // 2098-2137

### DIFF
--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -2106,16 +2106,16 @@ QUEST_JOBSTEP_20150317_002105	You defeated Gaigalas. Report back to the Peltasta
 QUEST_JOBSTEP_20150317_002106	Defeat Gaigalas
 QUEST_JOBSTEP_20150317_002107	Go find the Highlander Master in Klaipeda.
 QUEST_JOBSTEP_20150317_002108	The Highlander Master wants you to gather more experience. He asks you to defeat Honeypin at Deep Indigo Forest. 
-QUEST_JOBSTEP_20150317_002109	You defeated enough Honeypin. Report back to the Highlander Master.
+QUEST_JOBSTEP_20150317_002109	You defeated Honeypin. Report back to the Highlander Master.
 QUEST_JOBSTEP_20150317_002110	The Hoplite Master possesses the skill which his colleagues can rely on. Defeat Collimencia in Forest of Incremental Rocks to prove your skills.
 QUEST_JOBSTEP_20150317_002111	You defeated Colimencia. Report back to the Hoplite Master.
 QUEST_JOBSTEP_20150317_002112	Go to the Barbarian Master in Siauliai Eastern Woods.
 QUEST_JOBSTEP_20150317_002113	Meet the Barbarian Master in Siauliai Eastern Woods
 QUEST_JOBSTEP_20150317_002114	The Barbarian Master wants other people to respect him by defeating the Poata that are known for attacking people. Defeat Poata in Forest of Incremental Rocks.
-QUEST_JOBSTEP_20150317_002115	You Defeated Poata. Report back to the Barbarian Master.
+QUEST_JOBSTEP_20150317_002115	You defeated Poata. Report back to the Barbarian Master.
 QUEST_JOBSTEP_20150317_002116	Meet the Rodelero Master in Fedimian.
-QUEST_JOBSTEP_20150317_002117	The Rodelero Master wants you to gather experience in real combat. Defeat Collimencia in Forest of Incremental Rocks to prove your skills.
-QUEST_JOBSTEP_20150317_002118	You Defeated enough Colimencia. Report back to the Rodeleo Master.
+QUEST_JOBSTEP_20150317_002117	The Rodelero Master wants you to gather experience in real combat. Defeat Colimencia in Forest of Incremental Rocks to prove your skills.
+QUEST_JOBSTEP_20150317_002118	You defeated Colimencia. Report back to the Rodeleo Master.
 QUEST_JOBSTEP_20150317_002119	Meet the Cataphract Master in High Crooked Road.
 QUEST_JOBSTEP_20150317_002120	The Cataphract Master tells you that it is important to break anything that disturbes your way. Defeat Gaigalas in Flowerless Forest to prove your skills.
 QUEST_JOBSTEP_20150317_002121	You defeated Gaigalas. Report back to the Cataphract Master.

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -2096,45 +2096,45 @@ QUEST_JOBSTEP_20150317_002095	Hand over the corpses to Necromancer Master
 QUEST_JOBSTEP_20150317_002096	You've collected some parts of the corpses. Go back to Necromancer.
 QUEST_JOBSTEP_20150317_002097	Obtain %s
 QUEST_JOBSTEP_20150317_002098	Go to the Swordsman Master in Klaipeda.
-QUEST_JOBSTEP_20150317_002099	Defeat Honeypins at Deep Indigo Forest
-QUEST_JOBSTEP_20150317_002100	The Swordsman Master is emphasizing the importance of training in actual combat. Defeat Honeypins at Deep Indigo Forest and gather combat experience.
-QUEST_JOBSTEP_20150317_002101	You defeated enough Honeypins. Report back to the Swordsman Master.
+QUEST_JOBSTEP_20150317_002099	Defeat Honeypin at Deep Indigo Forest
+QUEST_JOBSTEP_20150317_002100	The Swordsman Master is emphasizing the importance of training in actual combat. Defeat Honeypin at Deep Indigo Forest and gather combat experience.
+QUEST_JOBSTEP_20150317_002101	You defeated Honeypin. Report back to the Swordsman Master.
 QUEST_JOBSTEP_20150317_002102	Go to the Peltasta Master in Klaipeda.
 QUEST_JOBSTEP_20150317_002103	Defeat Gaigalas in Flowerless Forest
 QUEST_JOBSTEP_20150317_002104	The Peltasta Master wants you to prove your skills. Defeat Gaigalas in Flowerless Forest to demonstrate your skills.
-QUEST_JOBSTEP_20150317_002105	You defeated enough Gaigalas. Report back to the Peltasta Master.
+QUEST_JOBSTEP_20150317_002105	You defeated Gaigalas. Report back to the Peltasta Master.
 QUEST_JOBSTEP_20150317_002106	Defeat Gaigalas
 QUEST_JOBSTEP_20150317_002107	Go find the Highlander Master in Klaipeda.
-QUEST_JOBSTEP_20150317_002108	The Highlander Master wants you to gather more experience. He asks you to defeat Honeypins at Deep Indigo Forest. 
-QUEST_JOBSTEP_20150317_002109	You defeated enough Honeypins. Report back to the Highlander Master.
-QUEST_JOBSTEP_20150317_002110	The Hoplite Master possesses the skill which his colleagues can rely on. Defeat Collimencias in Forest of Incremental Rocks to prove your skills.
-QUEST_JOBSTEP_20150317_002111	You defeated enough Colimencias. Report back to the Hoplite Master.
+QUEST_JOBSTEP_20150317_002108	The Highlander Master wants you to gather more experience. He asks you to defeat Honeypin at Deep Indigo Forest. 
+QUEST_JOBSTEP_20150317_002109	You defeated enough Honeypin. Report back to the Highlander Master.
+QUEST_JOBSTEP_20150317_002110	The Hoplite Master possesses the skill which his colleagues can rely on. Defeat Collimencia in Forest of Incremental Rocks to prove your skills.
+QUEST_JOBSTEP_20150317_002111	You defeated Colimencia. Report back to the Hoplite Master.
 QUEST_JOBSTEP_20150317_002112	Go to the Barbarian Master in Siauliai Eastern Woods.
 QUEST_JOBSTEP_20150317_002113	Meet the Barbarian Master in Siauliai Eastern Woods
-QUEST_JOBSTEP_20150317_002114	The Barbarian Master wants other people to respect him for defeating Poatas that are known for attacking people. Defeat Poatas in Forest of Incremental Rocks.
-QUEST_JOBSTEP_20150317_002115	You Defeated enough Poatas. Report back to the Barbarian Master.
+QUEST_JOBSTEP_20150317_002114	The Barbarian Master wants other people to respect him by defeating the Poata that are known for attacking people. Defeat Poata in Forest of Incremental Rocks.
+QUEST_JOBSTEP_20150317_002115	You Defeated Poata. Report back to the Barbarian Master.
 QUEST_JOBSTEP_20150317_002116	Meet the Rodelero Master in Fedimian.
-QUEST_JOBSTEP_20150317_002117	The Rodelero Master wants you to gather experience in real combat. Defeat Collimencias in Forest of Incremental Rocks to prove your skills.
-QUEST_JOBSTEP_20150317_002118	You Defeated enough Colimencias. Report back to the Rodeleo Master.
+QUEST_JOBSTEP_20150317_002117	The Rodelero Master wants you to gather experience in real combat. Defeat Collimencia in Forest of Incremental Rocks to prove your skills.
+QUEST_JOBSTEP_20150317_002118	You Defeated enough Colimencia. Report back to the Rodeleo Master.
 QUEST_JOBSTEP_20150317_002119	Meet the Cataphract Master in High Crooked Road.
 QUEST_JOBSTEP_20150317_002120	The Cataphract Master tells you that it is important to break anything that disturbes your way. Defeat Gaigalas in Flowerless Forest to prove your skills.
-QUEST_JOBSTEP_20150317_002121	You Defeated enough Gaigalas. Report to the Cataphract Master.
+QUEST_JOBSTEP_20150317_002121	You defeated Gaigalas. Report back to the Cataphract Master.
 QUEST_JOBSTEP_20150317_002122	Go to the Squire Master in Fedimian.
-QUEST_JOBSTEP_20150317_002123	Defeat Poatas and find the Symbol of Legwyn Family
-QUEST_JOBSTEP_20150317_002124	The Squire Master wants the Symbol of Legwyn Family. Defeat Poatas in Forest of Incremental Rocks to find the symbol.
+QUEST_JOBSTEP_20150317_002123	Defeat Poata and find the Symbol of Legwyn Family
+QUEST_JOBSTEP_20150317_002124	The Squire Master wants the Symbol of Legwyn Family. Defeat Poata in Forest of Incremental Rocks to find the symbol.
 QUEST_JOBSTEP_20150317_002125	Report back to the Squire Master
 QUEST_JOBSTEP_20150317_002126	You found the Ornament of Legwyin Family. Report back to the Squire Master.
 QUEST_JOBSTEP_20150317_002127	Retrieve the Ornament of Legwyin Family
 QUEST_JOBSTEP_20150317_002128	Talk to the Corsair Master
 QUEST_JOBSTEP_20150317_002129	Meet the Squire Master in Starving Demon's Road
-QUEST_JOBSTEP_20150317_002130	The Corsair Master wants you to prove your skills. Defeat Honeypins in Deep Indigo Forest to demonstrate your skills.
+QUEST_JOBSTEP_20150317_002130	The Corsair Master wants you to prove your skills. Defeat Honeypin in Deep Indigo Forest to demonstrate your skills.
 QUEST_JOBSTEP_20150317_002131	Report back to the Corsair Master
-QUEST_JOBSTEP_20150317_002132	You defeated enough Honeypins. Report back to the Corsair Master.
+QUEST_JOBSTEP_20150317_002132	You defeated Honeypin. Report back to the Corsair Master.
 QUEST_JOBSTEP_20150317_002133	Talk to the Doppelsoeldner Master
 QUEST_JOBSTEP_20150317_002134	Meet the Doppelsoeldner Master in Forgotten Port.
 QUEST_JOBSTEP_20150317_002135	The Doppelsoeldner Master wants you to prove your skills by defeating Gaigalas in Flowerless Forest. 
 QUEST_JOBSTEP_20150317_002136	Report back to the Doppelsoeldner Master
-QUEST_JOBSTEP_20150317_002137	You defeated enough Gaigalas. Report back to the Doppelsoeldner Master.
+QUEST_JOBSTEP_20150317_002137	You defeated Gaigalas. Report back to the Doppelsoeldner Master.
 QUEST_JOBSTEP_20150317_002138	Talk to Cronomancer Master
 QUEST_JOBSTEP_20150317_002139	Talk to Chronomancer Master in High Crooked Road.
 QUEST_JOBSTEP_20150317_002140	Defeat Reaverpedes in Remaining Tree Dale

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -2095,46 +2095,46 @@ QUEST_JOBSTEP_20150317_002094	Necromancer told you to bring the corpses of the m
 QUEST_JOBSTEP_20150317_002095	Hand over the corpses to Necromancer Master
 QUEST_JOBSTEP_20150317_002096	You've collected some parts of the corpses. Go back to Necromancer.
 QUEST_JOBSTEP_20150317_002097	Obtain %s
-QUEST_JOBSTEP_20150317_002098	Go to Swordsman Master in Klaipeda.
+QUEST_JOBSTEP_20150317_002098	Go to the Swordsman Master in Klaipeda.
 QUEST_JOBSTEP_20150317_002099	Defeat Honeypins at Deep Indigo Forest
-QUEST_JOBSTEP_20150317_002100	Swordsman Master is emphasizing the importance of training with actual fights. Defeat Honeypins at Deep Indigo Forest and accumulate the experiences.
-QUEST_JOBSTEP_20150317_002101	Defeated Honeypins. Report to Swordsman Master.
-QUEST_JOBSTEP_20150317_002102	Go to Peltasta Master in Klaipeda.
+QUEST_JOBSTEP_20150317_002100	The Swordsman Master is emphasizing the importance of training in actual combat. Defeat Honeypins at Deep Indigo Forest and gather combat experience.
+QUEST_JOBSTEP_20150317_002101	You defeated enough Honeypins. Report back to the Swordsman Master.
+QUEST_JOBSTEP_20150317_002102	Go to the Peltasta Master in Klaipeda.
 QUEST_JOBSTEP_20150317_002103	Defeat Gaigalas in Flowerless Forest
-QUEST_JOBSTEP_20150317_002104	Peltasta Master wants you to prove your skills. Defeat Gaigalas in Flowerless Forest and prove your skills.
-QUEST_JOBSTEP_20150317_002105	Defeated Gaigalas. Report to Peltasta Master.
+QUEST_JOBSTEP_20150317_002104	The Peltasta Master wants you to prove your skills. Defeat Gaigalas in Flowerless Forest to demonstrate your skills.
+QUEST_JOBSTEP_20150317_002105	You defeated enough Gaigalas. Report back to the Peltasta Master.
 QUEST_JOBSTEP_20150317_002106	Defeat Gaigalas
-QUEST_JOBSTEP_20150317_002107	Go find Highlander Master in Klaipeda.
-QUEST_JOBSTEP_20150317_002108	Highlander Master wants you to accumulate more experiences. Defeat Honeypin at Deep Indigo Forest. 
-QUEST_JOBSTEP_20150317_002109	Defeated Honeypins. Report to Highlander Master.
-QUEST_JOBSTEP_20150317_002110	Hoplite Master possesses the skill which his colleagues can rely on. Defeat Collimencia in Forest of Incremental Rocks to prove your skills.
-QUEST_JOBSTEP_20150317_002111	Defeated Colimencia. Report to Hoplite Master.
-QUEST_JOBSTEP_20150317_002112	Go to Barbarian Master in Siauliai Eastern Woods.
-QUEST_JOBSTEP_20150317_002113	Go meet Barbarian Master in the East Forest of Siaulai
-QUEST_JOBSTEP_20150317_002114	Barbarian Master wants to make other people to respect him by defeating Poatas that are known for attacking people. Defeat Poatas in Forest of Incremental Rocks.
-QUEST_JOBSTEP_20150317_002115	Defeated Poatas. Report to Barbarian Master.
-QUEST_JOBSTEP_20150317_002116	Go meet Rodelero Master in Fedimian.
-QUEST_JOBSTEP_20150317_002117	Rodelero Master wants to accumulate real experiences. Defeat Collimencia in Forest of Incremental Rocks to prove your skills.
-QUEST_JOBSTEP_20150317_002118	Defeated Colimencia. Report to Rodeleo Master.
-QUEST_JOBSTEP_20150317_002119	Go meet Cataphract Master in High Crooked Road.
-QUEST_JOBSTEP_20150317_002120	Cataphract Master told you that it is important to break anything that disturbes your way. Defeat Gaigalas in Flowerless Forest to prove your skills.
-QUEST_JOBSTEP_20150317_002121	Defeated Gaigalas. Report to Cataphract Master.
-QUEST_JOBSTEP_20150317_002122	Go to Squire Master in Fedimian.
-QUEST_JOBSTEP_20150317_002123	Defeate Poatas and find the seal of family
-QUEST_JOBSTEP_20150317_002124	Squire Master has the symbol of Legwyn Family. Defeat Poatas in Forest of Incremental Rocks to find the symbol.
-QUEST_JOBSTEP_20150317_002125	Report to Squire Master
-QUEST_JOBSTEP_20150317_002126	Found the family's ornament. Report to Squire Master.
-QUEST_JOBSTEP_20150317_002127	Get the ornament of Legwyin Family
-QUEST_JOBSTEP_20150317_002128	Talk to Corsair Master
-QUEST_JOBSTEP_20150317_002129	Go meet Squire Master in Starving Demon's Road
-QUEST_JOBSTEP_20150317_002130	Cursoir Master wants you to prove your skills. Defeat Honeypins in Deep Indigo Forest to prove your skills.
-QUEST_JOBSTEP_20150317_002131	Report to Corsair Master
-QUEST_JOBSTEP_20150317_002132	Defeated Honeypins. Report to Corsair Master.
-QUEST_JOBSTEP_20150317_002133	Talk to Doppelsoeldner Master
-QUEST_JOBSTEP_20150317_002134	Go meet Doppelsoeldner Master in Forgotten Port.
-QUEST_JOBSTEP_20150317_002135	Doppelsoeldner Master wants you to prove your skills by defeating Gaigalas in Flowerless Forest.
-QUEST_JOBSTEP_20150317_002136	Report to Doppelsoeldner Master
-QUEST_JOBSTEP_20150317_002137	Defeated Gaigalas. Report to Doppelsoeldner Master.
+QUEST_JOBSTEP_20150317_002107	Go find the Highlander Master in Klaipeda.
+QUEST_JOBSTEP_20150317_002108	The Highlander Master wants you to gather more experience. He asks you to defeat Honeypins at Deep Indigo Forest. 
+QUEST_JOBSTEP_20150317_002109	You defeated enough Honeypins. Report back to the Highlander Master.
+QUEST_JOBSTEP_20150317_002110	The Hoplite Master possesses the skill which his colleagues can rely on. Defeat Collimencias in Forest of Incremental Rocks to prove your skills.
+QUEST_JOBSTEP_20150317_002111	You defeated enough Colimencias. Report back to the Hoplite Master.
+QUEST_JOBSTEP_20150317_002112	Go to the Barbarian Master in Siauliai Eastern Woods.
+QUEST_JOBSTEP_20150317_002113	Meet the Barbarian Master in Siauliai Eastern Woods
+QUEST_JOBSTEP_20150317_002114	The Barbarian Master wants other people to respect him for defeating Poatas that are known for attacking people. Defeat Poatas in Forest of Incremental Rocks.
+QUEST_JOBSTEP_20150317_002115	You Defeated enough Poatas. Report back to the Barbarian Master.
+QUEST_JOBSTEP_20150317_002116	Meet the Rodelero Master in Fedimian.
+QUEST_JOBSTEP_20150317_002117	The Rodelero Master wants you to gather experience in real combat. Defeat Collimencias in Forest of Incremental Rocks to prove your skills.
+QUEST_JOBSTEP_20150317_002118	You Defeated enough Colimencias. Report back to the Rodeleo Master.
+QUEST_JOBSTEP_20150317_002119	Meet the Cataphract Master in High Crooked Road.
+QUEST_JOBSTEP_20150317_002120	The Cataphract Master tells you that it is important to break anything that disturbes your way. Defeat Gaigalas in Flowerless Forest to prove your skills.
+QUEST_JOBSTEP_20150317_002121	You Defeated enough Gaigalas. Report to the Cataphract Master.
+QUEST_JOBSTEP_20150317_002122	Go to the Squire Master in Fedimian.
+QUEST_JOBSTEP_20150317_002123	Defeat Poatas and find the Symbol of Legwyn Family
+QUEST_JOBSTEP_20150317_002124	The Squire Master wants the Symbol of Legwyn Family. Defeat Poatas in Forest of Incremental Rocks to find the symbol.
+QUEST_JOBSTEP_20150317_002125	Report back to the Squire Master
+QUEST_JOBSTEP_20150317_002126	You found the Ornament of Legwyin Family. Report back to the Squire Master.
+QUEST_JOBSTEP_20150317_002127	Retrieve the Ornament of Legwyin Family
+QUEST_JOBSTEP_20150317_002128	Talk to the Corsair Master
+QUEST_JOBSTEP_20150317_002129	Meet the Squire Master in Starving Demon's Road
+QUEST_JOBSTEP_20150317_002130	The Corsair Master wants you to prove your skills. Defeat Honeypins in Deep Indigo Forest to demonstrate your skills.
+QUEST_JOBSTEP_20150317_002131	Report back to the Corsair Master
+QUEST_JOBSTEP_20150317_002132	You defeated enough Honeypins. Report back to the Corsair Master.
+QUEST_JOBSTEP_20150317_002133	Talk to the Doppelsoeldner Master
+QUEST_JOBSTEP_20150317_002134	Meet the Doppelsoeldner Master in Forgotten Port.
+QUEST_JOBSTEP_20150317_002135	The Doppelsoeldner Master wants you to prove your skills by defeating Gaigalas in Flowerless Forest. 
+QUEST_JOBSTEP_20150317_002136	Report back to the Doppelsoeldner Master
+QUEST_JOBSTEP_20150317_002137	You defeated enough Gaigalas. Report back to the Doppelsoeldner Master.
 QUEST_JOBSTEP_20150317_002138	Talk to Cronomancer Master
 QUEST_JOBSTEP_20150317_002139	Talk to Chronomancer Master in High Crooked Road.
 QUEST_JOBSTEP_20150317_002140	Defeat Reaverpedes in Remaining Tree Dale


### PR DESCRIPTION
those are mainly the same repeating for all class masters. initial
translation was differing a bit between class masters but the context is
also the same (prove your skill)..

tryed to remove some word repition
added articles
put monster types into plural
and changed some mere word groups to full sentences - reads less half
assed imo.

theres still many classes to go here
