### PR TITLE
[Grammar/Spelling/Punctuation] ETC.tsv 134, 138, 198, 247, 374, 438, 773, 778, 784, 876, 897, 907, 1004, 1583, 3463, 3807

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -1001,7 +1001,7 @@ ETC_20150317_001000	Summon of Glass Mole
 ETC_20150317_001001	Yognome
 ETC_20150317_001002	It is speculated whether this underground spirit has been deformed and corrupted.
 ETC_20150317_001003	Syaulrabe
-ETC_20150317_001004	Specter Master' Summon Post
+ETC_20150317_001004	Specter Master's Summon Post
 ETC_20150317_001005	Capria
 ETC_20150317_001006	Varistor
 ETC_20150317_001007	Summoned of Cyclops
@@ -1580,7 +1580,7 @@ ETC_20150317_001579	Failed to purchase item! An unknown error has occurred.
 ETC_20150317_001580	Too close
 ETC_20150317_001581	{S20}{ol}{#46ffc8} You do not have enough Stamina.
 ETC_20150317_001582	Object needed for the skill is not available.
-ETC_20150317_001583	You cannot equip secondary equipment while wearing a two-handed weapon.
+ETC_20150317_001583	You cannot equip secondary equipment while wielding a two-handed weapon.
 ETC_20150317_001584	You cannot use 'Return' during Rest Mode.
 ETC_20150317_001585	Another character has taken the request.
 ETC_20150317_001586	The previous game did not end.
@@ -3804,7 +3804,7 @@ ETC_20150317_003803	Failed to meet the conditions.
 ETC_20150317_003804	Force Start
 ETC_20150317_003805	You cannot restart the quest while it is still in progress. You have to complete it first.
 ETC_20150317_003806	If you need to restart quest standby complete, complete the quest first
-ETC_20150317_003807	Can only be used when the quest is still in progress
+ETC_20150317_003807	Can only be used while the quest is still in progress
 ETC_20150317_003808	Transaction error
 ETC_20150317_003809	This can only be used when the quest is progress or in standby mode. Current state:
 ETC_20150317_003810	Quest Starting Map:

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -775,7 +775,7 @@ ETC_20150317_000774	Blue Panto Warrior
 ETC_20150317_000775	Red Panto Warrior
 ETC_20150317_000776	Panto Assassin
 ETC_20150317_000777	Moglan
-ETC_20150317_000778	This beast once exclusively roamed in the Demon realm. Nowadays it is found all over the world, endangering humans and other wildlife.
+xETC_20150317_000778	This beast once exclusively roamed in the Demon realm. Nowadays it is found all over the world, endangering humans and other wildlife.
 ETC_20150317_000779	Denden
 ETC_20150317_000780	The demons have tamed Denden and uses it for their means.
 ETC_20150317_000781	Doyor

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -775,7 +775,7 @@ ETC_20150317_000774	Blue Panto Warrior
 ETC_20150317_000775	Red Panto Warrior
 ETC_20150317_000776	Panto Assassin
 ETC_20150317_000777	Moglan
-xETC_20150317_000778	This beast once exclusively roamed in the Demon realm. Nowadays it is found all over the world, endangering humans and other wildlife.
+xETC_20150317_000778	This beast once exclusively roamed in the Demon realm. Nowadays it is found all over the world, endangering humans and wildlife.
 ETC_20150317_000779	Denden
 ETC_20150317_000780	The demons have tamed Denden and uses it for their means.
 ETC_20150317_000781	Doyor

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -770,18 +770,18 @@ ETC_20150317_000769	When it comes to flight, Bavon would be better just floating
 ETC_20150317_000770	Tanu
 ETC_20150317_000771	A carnivorous plant that uses bait to catch food. It shred its food into pieces before swallowing.
 ETC_20150317_000772	Zignuts
-ETC_20150317_000773	A three headed monster. It is hard to tell whether the main body is just one head or all three.
+ETC_20150317_000773	A three-headed monster. It is hard to tell whether the main body is just one head or all three.
 ETC_20150317_000774	Blue Panto Warrior
 ETC_20150317_000775	Red Panto Warrior
 ETC_20150317_000776	Panto Assassin
 ETC_20150317_000777	Moglan
-ETC_20150317_000778	This beast that once exclusively roamed in the Demon realm. Nowadays it is found all over the world, endangering other wildlife and humans.
+ETC_20150317_000778	This beast once exclusively roamed in the Demon realm. Nowadays it is found all over the world, endangering humans and other wildlife.
 ETC_20150317_000779	Denden
 ETC_20150317_000780	The demons have tamed Denden and uses it for their means.
 ETC_20150317_000781	Doyor
 ETC_20150317_000782	If a moving poisonous mushroom makes you anxious, consider Doyor as an example.
 ETC_20150317_000783	Tipio
-ETC_20150317_000784	The yellow grass on its body looks supple. But if you touch it, it can be quite painful .
+ETC_20150317_000784	The yellow grass on its body looks supple. But if you touch it, it can be quite painful.
 ETC_20150317_000785	Rondo
 ETC_20150317_000786	The Rondo is not an animal found in our world, rather it is an animal that crossed from the demon realm.
 ETC_20150317_000787	Terra Nymph
@@ -3460,7 +3460,7 @@ ETC_20150317_003459	Comrade song
 ETC_20150317_003460	Welcome to the friendly Larry Marina!
 ETC_20150317_003461	Wow, this tree just won't budge!
 ETC_20150317_003462	Whew... when is the shift?
-ETC_20150317_003463	If I don't, then who would?!
+ETC_20150317_003463	If I don't, then who will?!
 ETC_20150317_003464	Collected the moss
 ETC_20150317_003465	Collecting
 ETC_20150317_003466	Collected discolored grass

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -3459,8 +3459,8 @@ ETC_20150317_003458	I would not go back to life
 ETC_20150317_003459	Comrade song
 ETC_20150317_003460	Welcome to the friendly Larry Marina!
 ETC_20150317_003461	Wow, this tree just won't budge!
-xETC_20150317_003462	Whew... when is the shift?
-ETC_20150317_003463	If I don't, then who will?!
+ETC_20150317_003462	Whew... when is the shift?
+xETC_20150317_003463	If I don't, then who will?!
 ETC_20150317_003464	Collected the moss
 ETC_20150317_003465	Collecting
 ETC_20150317_003466	Collected discolored grass

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -873,7 +873,7 @@ ETC_20150317_000872	A mutated mantis. It has gotten stronger and has developed t
 ETC_20150317_000873	Egnome
 ETC_20150317_000874	Egnomes carry a stern look. The more stern it looks, the more powerful it is.
 ETC_20150317_000875	Beetow
-ETC_20150317_000876	After mutating, Beetow has developed an unreasonable and venomous nature. Its aggression has also become more significant.
+xETC_20150317_000876	After mutating, Beetow have developed an unreasonable and venomous nature. Its aggression has also become more significant.
 ETC_20150317_000877	I'll have a big sickle with their bodies to pound sister.
 ETC_20150317_000878	Carcashu
 ETC_20150317_000879	Carcashu is a fungus. Its toxins are strong, but there are parts of it that can be eaten.
@@ -894,7 +894,7 @@ ETC_20150317_000893	This monster has evolved from a bird and has since lost its 
 ETC_20150317_000894	Dumaro
 ETC_20150317_000895	The Dumaro is a newly discovered monster, which developed its toxic abilities after the Great Plant Cataclysm.
 ETC_20150317_000896	Lichenclops
-ETC_20150317_000897	The Lichenclops doesn't only have good eye sight, their sense of smell is also exceptional.
+xETC_20150317_000897	The Lichenclops don't only have good eyesight, their sense of smell is also exceptional.
 ETC_20150317_000898	Rubblem
 ETC_20150317_000899	Loftlem
 ETC_20150317_000900	Blindlem
@@ -904,7 +904,7 @@ ETC_20150317_000903	Infroblood is a case where plant spores transform into monst
 ETC_20150317_000904	Ticen
 ETC_20150317_000905	Ticen wanders around with a spear, it tends to group with other Ticen variants.
 ETC_20150317_000906	Tucen
-ETC_20150317_000907	A tip of Tucen's tail is made out of minerals.
+xETC_20150317_000907	The tip of Tucen's tail is made out of minerals.
 ETC_20150317_000908	Colimen
 ETC_20150317_000909	Colitile
 ETC_20150317_000910	Colimenpru

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -131,11 +131,11 @@ ETC_20150317_000130	Orange Sakmoli
 ETC_20150317_000131	Black Sakmoli
 ETC_20150317_000132	Rikaus
 ETC_20150317_000133	Green Apparition
-ETC_20150317_000134	Ghost affected by the demons tend to change their appearances like this.
+xETC_20150317_000134	Ghosts affected by the demons tend to change their appearances like this.
 ETC_20150317_000135	Black Apparition
 ETC_20150317_000136	Spectre
 ETC_20150317_000137	Black Spectre
-ETC_20150317_000138	Unlike other monsters in Myan Leong Ryu, these monsters often were evil souls even when they were living.
+xETC_20150317_000138	Unlike other monsters in Myan Leong Ryu, these monsters were often evil souls even when they were living.
 ETC_20150317_000139	Giant Spectre
 ETC_20150317_000140	Specter of Dazzled
 ETC_20150317_000141	Green Rikaus
@@ -195,7 +195,7 @@ ETC_20150317_000194	Boowook
 ETC_20150317_000195	One of the defensive systems left in the king's tomb.
 ETC_20150317_000196	Bearkaras
 ETC_20150317_000197	Pino
-ETC_20150317_000198	Early pioneers came up with its name from its similarity to the Gepetto.
+xETC_20150317_000198	Early pioneers came up with its name from its similarity to the Geppetto.
 ETC_20150317_000199	Helmet Bug
 ETC_20150317_000200	Monsters that have simply grown in size and become more aggressive are rather relieving.
 ETC_20150317_000201	Cauliflower
@@ -244,7 +244,7 @@ ETC_20150317_000243	These lesser demons come in countless types due to their pop
 ETC_20150317_000244	Black Drake
 ETC_20150317_000245	These species were once fairly rare; however, in recent times their numbers have greatly increased.
 ETC_20150317_000246	Big Cockatrice
-ETC_20150317_000247	The Big Cockatrice is quite dangerous, as its glare and breath can petrify any opponents. Engaging this creature should not be taken lightly.
+xETC_20150317_000247	The Big Cockatrice is quite dangerous, as its glare and breath can petrify any opponent. Engaging this creature should not be taken lightly.
 ETC_20150317_000248	Green Kokateu
 ETC_20150317_000249	Red Kokateu
 ETC_20150317_000250	Sequoia
@@ -371,7 +371,7 @@ ETC_20150317_000370	Long-sleeved Tree
 ETC_20150317_000371	A shrub monster that attacks by either firing its twigs or striking with its branches.
 ETC_20150317_000372	Rakter
 ETC_20150317_000373	Venucelos
-ETC_20150317_000374	According to legend this watchdog is a creation that Zachariel the Great had planned to preserve.
+xETC_20150317_000374	According to legend, this watchdog is a creation that Zachariel the Great had planned to preserve.
 ETC_20150317_000375	Cemetery Golem
 ETC_20150317_000376	Kepa Chieftain
 ETC_20150317_000377	Poata
@@ -435,7 +435,7 @@ ETC_20150317_000434	Shardstatue
 ETC_20150317_000435	A possessed demonic statue in the image of the Goddess.
 ETC_20150317_000436	Deadborn Scap
 ETC_20150317_000437	Cire
-ETC_20150317_000438	This monster does not seem to transmute from typical plants but rather from rotten flora. However, there are no evidence to support this conclusion.
+xETC_20150317_000438	This monster does not seem to transmute from typical plants but rather from rotten flora. However, there is no evidence to support this conclusion.
 ETC_20150317_000439	Lithaspung
 ETC_20150317_000440	Teesbang
 ETC_20150317_000441	Mushpung
@@ -770,7 +770,7 @@ ETC_20150317_000769	When it comes to flight, Bavon would be better just floating
 ETC_20150317_000770	Tanu
 ETC_20150317_000771	A carnivorous plant that uses bait to catch food. It shred its food into pieces before swallowing.
 ETC_20150317_000772	Zignuts
-ETC_20150317_000773	A three-headed monster. It is hard to tell whether the main body is just one head or all three.
+xETC_20150317_000773	A three-headed monster. It is hard to tell whether the main body is just one head or all three.
 ETC_20150317_000774	Blue Panto Warrior
 ETC_20150317_000775	Red Panto Warrior
 ETC_20150317_000776	Panto Assassin
@@ -781,7 +781,7 @@ ETC_20150317_000780	The demons have tamed Denden and uses it for their means.
 ETC_20150317_000781	Doyor
 ETC_20150317_000782	If a moving poisonous mushroom makes you anxious, consider Doyor as an example.
 ETC_20150317_000783	Tipio
-ETC_20150317_000784	The yellow grass on its body looks supple. But if you touch it, it can be quite painful.
+xETC_20150317_000784	The yellow grass on its body looks supple. But if you touch it, it can be quite painful.
 ETC_20150317_000785	Rondo
 ETC_20150317_000786	The Rondo is not an animal found in our world, rather it is an animal that crossed from the demon realm.
 ETC_20150317_000787	Terra Nymph
@@ -1001,7 +1001,7 @@ ETC_20150317_001000	Summon of Glass Mole
 ETC_20150317_001001	Yognome
 ETC_20150317_001002	It is speculated whether this underground spirit has been deformed and corrupted.
 ETC_20150317_001003	Syaulrabe
-ETC_20150317_001004	Specter Master's Summon Post
+xETC_20150317_001004	Specter Master's Summon Post
 ETC_20150317_001005	Capria
 ETC_20150317_001006	Varistor
 ETC_20150317_001007	Summoned of Cyclops
@@ -1580,7 +1580,7 @@ ETC_20150317_001579	Failed to purchase item! An unknown error has occurred.
 ETC_20150317_001580	Too close
 ETC_20150317_001581	{S20}{ol}{#46ffc8} You do not have enough Stamina.
 ETC_20150317_001582	Object needed for the skill is not available.
-ETC_20150317_001583	You cannot equip secondary equipment while wielding a two-handed weapon.
+xETC_20150317_001583	You cannot equip secondary equipment while wielding a two-handed weapon.
 ETC_20150317_001584	You cannot use 'Return' during Rest Mode.
 ETC_20150317_001585	Another character has taken the request.
 ETC_20150317_001586	The previous game did not end.
@@ -3459,7 +3459,7 @@ ETC_20150317_003458	I would not go back to life
 ETC_20150317_003459	Comrade song
 ETC_20150317_003460	Welcome to the friendly Larry Marina!
 ETC_20150317_003461	Wow, this tree just won't budge!
-ETC_20150317_003462	Whew... when is the shift?
+xETC_20150317_003462	Whew... when is the shift?
 ETC_20150317_003463	If I don't, then who will?!
 ETC_20150317_003464	Collected the moss
 ETC_20150317_003465	Collecting
@@ -3804,7 +3804,7 @@ ETC_20150317_003803	Failed to meet the conditions.
 ETC_20150317_003804	Force Start
 ETC_20150317_003805	You cannot restart the quest while it is still in progress. You have to complete it first.
 ETC_20150317_003806	If you need to restart quest standby complete, complete the quest first
-ETC_20150317_003807	Can only be used while the quest is still in progress
+xETC_20150317_003807	Can only be used while the quest is still in progress
 ETC_20150317_003808	Transaction error
 ETC_20150317_003809	This can only be used when the quest is progress or in standby mode. Current state:
 ETC_20150317_003810	Quest Starting Map:


### PR DESCRIPTION
My apologies if I broke any guidelines, this is my first submission to further assist the translation effort. If this takes well, I will scrub these files even harder. Below is a comment for each change:

134 - Grammar - In reference to multiple ghosts types, the 's' was added. 
138 - Grammar - Adverb before the verb to make 'often' refer to the evil souls rather than the monsters.
198 - Spelling - In the other text, Geppetto is often mentioned with two 'P's.
247 - Grammar - No explanation needed here.
374 - Punctuation - I'm wary of these, as the structure for commas varies throughout the document.
438 - Grammar - Self-explanatory.
773 - Punctuation - Needs to be compounded.
778 - Grammar - Extra 'that' creates a fragment in the sentence.
784 - Punctuation - Simple. Moved the period.
876 - Grammar - Wrong tense.
897 - Grammar/Spelling - Wrong tense and spelling.
907 - Grammar - Subjective change, does the Tucen have more than one tail?
1004 - Spelling - I believe this is missing an 's'.
1583 - Grammar - While you can wear a weapon, say, on your back, I believe the context here is referring to a two-handed weapon already being wielded.
3463 - Grammar - Wrong tense to go with 'don't'.
3807 - Grammar - Hard to tell the context here. But the use of 'still' doesn't fit with the tense use of 'when'.

Thank you,
