### PR TITLE
Update SKILL.tsv Complete readability overhaul for all skills and attributes.

### DIFF
--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1168,7 +1168,7 @@ SKILL_20150317_001167	Swell Body
 SKILL_20150317_001168	Enlarge size of target. Target's HP, EXP, and drop rate are doubled.
 SKILL_20150317_001169	Small -> Medium -> Large {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001170	Transpose
-SKILL_20150317_001171	Swaps INT and CON for a limited period of time.
+SKILL_20150317_001171	Temporarily Swaps INT and CON.
 SKILL_20150317_001172	Reversi
 SKILL_20150317_001173	Gain control of enemy magic circles.
 SKILL_20150317_001174	Change enemy's magic circles to friendly ones in target area. {nl}Level 1 Master

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -657,8 +657,8 @@ SKILL_20150317_000656	[Kirmelich] Physical Non-Property Stab
 SKILL_20150317_000657	[Naktis] Magic Non-Property Magic
 SKILL_20150317_000658	[Devilglove] Physical Non-Property Strike
 SKILL_20150317_000659	[Devilglove] Magic Non-Property Strike
-SKILL_20150317_000660	[Kelberos] Physical Non-Property Strike
-SKILL_20150317_000661	[Kelberos] Physical Non-Property Magic
+SKILL_20150317_000660	[Kerberos] Physical Non-Property Strike
+SKILL_20150317_000661	[Kerberos] Physical Non-Property Magic
 SKILL_20150317_000662	[Minotaurs] Physical Fire Property Strike
 SKILL_20150317_000663	[Minotaurs] Magic Fire Property Magic
 SKILL_20150317_000664	[Minotaurs] Physical Fire Property Magic
@@ -758,8 +758,8 @@ SKILL_20150317_000757	[Netherbovine] Magic Dark Property Magic
 SKILL_20150317_000758	[Yonazolem Monster Summon]
 SKILL_20150317_000759	[Field Chaparition]Basic Normal Dark
 SKILL_20150317_000760	[Field Chaparition]Magic Normal Dark
-SKILL_20150317_000761	[Field Kelberos]Basic Normal Fire
-SKILL_20150317_000762	[Field Kelberos]Magic Magic Fire
+SKILL_20150317_000761	[Field Kerberos]Basic Normal Fire
+SKILL_20150317_000762	[Field Kerberos]Magic Magic Fire
 SKILL_20150317_000763	[Poata] Physical Poison Property Strike
 SKILL_20150317_000764	[Poata] Physical Poison Property Monster Summon
 SKILL_20150317_000765	[Red Vubbe Fighter] Physical Fire Property Strike
@@ -1946,7 +1946,7 @@ SKILL_20150317_001945	Sparnas card activated
 SKILL_20150317_001946	Critical damage will increase.
 SKILL_20150317_001947	Rikaus Card activated
 SKILL_20150317_001948	SP continuously recover.
-SKILL_20150317_001949	Kelberos Card activated
+SKILL_20150317_001949	Kerberos Card activated
 SKILL_20150317_001950	Fire Property attack will increase.
 SKILL_20150317_001951	Carapace card activated
 SKILL_20150317_001952	Yonazolem card activated
@@ -2060,141 +2060,141 @@ SKILL_20150317_002059	Remaining defense after using [Gung Ho] is increased by 5%
 SKILL_20150317_002060	Bash: Knock Down
 SKILL_20150317_002061	Monsters attacked with [Bash] are knocked down.
 SKILL_20150317_002062	Concentrate: Stun
-SKILL_20150317_002063	While the [Astral Projection] is enabled, enemy falls under [Stun] at 2% per attribute level when attacked.
+SKILL_20150317_002063	While [Concentrate] is active, There is a 2% per attribute level of inflicting [Stun] on the enemy when attacking.
 SKILL_20150317_002064	Restrain: Duration
-SKILL_20150317_002065	Duration of [Retrain] will increase by 5 seconds per level
+SKILL_20150317_002065	The duration of [Retrain] increases by 5 seconds per level
 SKILL_20150317_002066	Thrust: Chance of Critical
-SKILL_20150317_002067	Critical probability of [Thrust] is increased by 10% per attribute level.
+SKILL_20150317_002067	Critical probability of [Thrust] increases by 10% per attribute level.
 SKILL_20150317_002068	Swash Buckling: Max. HP
 SKILL_20150317_002069	Max. HP of character increases by 5% per attribute level while [Swash Buckling] is enabled.
 SKILL_20150317_002070	Swash Buckling: Range
-SKILL_20150317_002071	Provocation range of [Swash Buckling] increase by 0.2m per level.
+SKILL_20150317_002071	Provocation range of [Swash Buckling] increases by 0.2m per level.
 SKILL_20150317_002072	Umbo Blow: Stun
-SKILL_20150317_002073	Enemies attacked with [Umbo Blow] fall under [Stun] by a chance of 5% per attribute level.
+SKILL_20150317_002073	Enemies attacked with [Umbo Blow] have a  5% per attribute level chance of gaining the status [Stun].
 SKILL_20150317_002074	Shield Lob: Splash
 SKILL_20150317_002075	Splash of [Shield Lob] increases by 1 per attribute level.
 SKILL_20150317_002076	Shield Mastery
-SKILL_20150317_002077	[Shield] wear when block is increased by 5% per level features.
+SKILL_20150317_002077	When [Shield] is equipped block is increased by 5% per attribute level.
 SKILL_20150317_002078	Peltasta: Guard
-SKILL_20150317_002079	Press C button to use [Guard] after wearing shield.
+SKILL_20150317_002079	Press C button to use [Guard] while wearing shield.
 SKILL_20150317_002080	Block: Counter Attack
-SKILL_20150317_002081	[Block] After a successful, if you attack in the Omuboburo] to the enemy, will be added to 200% of the damage. In addition critical damage is increased by 5% per level 5 seconds
+SKILL_20150317_002081	After a successful [Block] [Umbo blow] will do 200% extra damage of the damage. Critical damage is also increased by 5% per level for 5 seconds
 SKILL_20150317_002082	[Umbo Blow]: Add a knockdown
-SKILL_20150317_002083	Enemies hit with [Umbo Blow] fall down and knock down power increases by 40% per level.
+SKILL_20150317_002083	Enemies hit with [Umbo Blow] are knocked down. Knock down power increases by 40% per level.
 SKILL_20150317_002084	Rim Blow: Frozen Stone
 SKILL_20150317_002085	Use [Rim Blow] on frozen or petrified enemies to inflict additional 20% damage per level.
 SKILL_20150317_002086	Guard: Defense
 SKILL_20150317_002087	Defense of character is increased by 10% while [Guard] is enabled.
 SKILL_20150317_002088	Cartar Stroke: Collision Damage
-SKILL_20150317_002089	When enemies knocked back by [Catar Stroke] hit the wall, they receive an additional physical damage of 50%.
+SKILL_20150317_002089	When enemies knocked back by [Catar Stroke] hit a wall, they take an additional 50% physical damage.
 SKILL_20150317_002090	Cartar Stroke: Knockback Distance
-SKILL_20150317_002091	Pushing force of [Cartar Stroke] increases by 50% per attribute level.
+SKILL_20150317_002091	The knock back power of [Cartar Stroke] increases by 50% per attribute level.
 SKILL_20150317_002092	Crown: Decrease
-SKILL_20150317_002093	Amount of INT and SPR consumption is reduced by 2% per attribute level when using [Crown].
+SKILL_20150317_002093	Increases the amount of INT and SPR the enemy loses by 2% per attribute level when using [Crown].
 SKILL_20150317_002094	Wagon Wheel: Fall Damage
-SKILL_20150317_002095	Enemies in the air by [Wagon Wheel] receive damage of 50% of character's Physical damage.
+SKILL_20150317_002095	Enemies launched in the air by [Wagon Wheel] receive damage of 50% of character's Physical damage.
 SKILL_20150317_002096	Wagon Wheel: Splash
 SKILL_20150317_002097	Splash is increased by 1 in [Wagon Wheel].
 SKILL_20150317_002098	Cross Guard: Counterattack
-SKILL_20150317_002099	Skills when a successful block in the cross guard], giving you the damage about 10% for each level of character Physical damage
+SKILL_20150317_002099	Whe an attack is succesfully blocked by [Cross Guard] You inflict 10% per attribute level of your physical attack on your attack as damage.
 SKILL_20150317_002100	Cross Guard: Defense
 SKILL_20150317_002101	If at least 3 monsters are provoked when using [Cross Guard], damage received decreases by 10% per level.
 SKILL_20150317_002102	Two-handed Sword Mastery
-SKILL_20150317_002103	[Both hands sword] wearing critical attack is increased by 10% per level of features.
-SKILL_20150317_002104	Moulinet: Critical occurs
-SKILL_20150317_002105	Critical probability of skill [Moulinet] is increased by 10% per Attribute level.
+SKILL_20150317_002103	[Two-handed Sword] wearing critical attack is increased by 10% per level of features.
+SKILL_20150317_002104	Moulinet: Critical occurrece
+SKILL_20150317_002105	Critical rate for [Moulinet] is increased by 10% per Attribute level.
 SKILL_20150317_002106	Stabbing: Evasion
 SKILL_20150317_002107	Evasion increase by 5% per Attribute level when attacking enemy with [Stabbing].
 SKILL_20150317_002108	Pierce: Continuous hit
 SKILL_20150317_002109	[Pierce] makes 4 continuous attacks on boss monster.
 SKILL_20150317_002110	Pierce: Bleed
-SKILL_20150317_002111	5 seconds with 2% probability per attribute level of that it has been attacked by skill [Pierce] it takes to [bleeding].
+SKILL_20150317_002111	Gain a 2% probability per attribute level that an enemy hit by [Pierce] gains the status [Bleeding] for 5 seconds.
 SKILL_20150317_002112	Finestra: Physical Damage
 SKILL_20150317_002113	10% of character's INT is added to Physical damage while [Finestra] is enabled.
 SKILL_20150317_002114	Synchro Thrusting: Critical occurrence
-SKILL_20150317_002115	When the counter-attack skills [Synchro Thrusting] is successful, chance of critical increases by 5% per level for 5 seconds
+SKILL_20150317_002115	Critical chance increases by 5% per attribute level for 5 seconds if [Synchro Thrusting] is successfully used as a counter attack. 
 SKILL_20150317_002116	Synchro Thrusting: Stab
-SKILL_20150317_002117	Hit damage of [Two-handed Thrust] decrease by 10% per attribute level and Stab damage increase by 20% per attribute level.
+SKILL_20150317_002117	Hit damage of the shield attack decrease by 10% per attribute level while the  Stab damage increase by 20% per attribute level.
 SKILL_20150317_002118	Finestra: Splash
-SKILL_20150317_002119	Spash increase by 2 and evasion decrease twice as much when [Finestra] is enabled.
+SKILL_20150317_002119	Spash increase by 3 while the evasion loss is doubled whiel [Finestra] is enabled.
 SKILL_20150317_002120	Warcry: defense decrease
-SKILL_20150317_002121	Number of enemies losing defense by [Warcry] increases by 1 per level.
+SKILL_20150317_002121	Number of enemies that lose defese when [Warcry] is used increases by 1 per level.
 SKILL_20150317_002122	Warcry: duration
-SKILL_20150317_002123	Duration of [Warcry] will increase by 2 seconds per level
+SKILL_20150317_002123	Duration of [Warcry] increases by 2 seconds per level
 SKILL_20150317_002124	Aggressor: Critical occurrence
 SKILL_20150317_002125	Accuracy added is lowered to half but chance of critical increases as much as evasion decreases when [Aggressor] is enabled.
 SKILL_20150317_002126	Aggressor: Additional Accuracy
-SKILL_20150317_002127	Additional Accuracy is increased by 2% per level and Evasion is decreased further by 2% per level when using [Aggressor]
+SKILL_20150317_002127	Accuracy is increased by 2% per level and Evasion is decreased further by 2% per level when using [Aggressor]
 SKILL_20150317_002128	Savagery: Critical occurrence
-SKILL_20150317_002129	Critical probability of skill [Savagery] is increased by 5% per Attribute level.
+SKILL_20150317_002129	Critical rate for [Savagery] is increased by 5% per Attribute level.
 SKILL_20150317_002130	Savagery: Slash repeat
-SKILL_20150317_002131	Continuous hit bonus is also applied to Slash attack for [Savagery].
+SKILL_20150317_002131	Slash attacks also become multihit attacks while [Savagery] is active.
 SKILL_20150317_002132	Targe Smash: Frozen Stone
-SKILL_20150317_002133	[Freezing], gives the attack at the time, 20% of additional damage per attribute level in the petrochemical] have been enemies [Targe Smash].
+SKILL_20150317_002133	Attacking [Frozen] or [Petrified] enemies deals 20% more damage per attribute level.
 SKILL_20150317_002134	Montano: Size slow
 SKILL_20150317_002135	[Slow] is inflicted on small, medium, large monsters for 3, 2, 1 second(s) when using [Montano].
 SKILL_20150317_002136	Shield Charge: Knockback
-SKILL_20150317_002137	Knockback distance of [Shield Charge] increase by 1m per level.
+SKILL_20150317_002137	Knockback distance of [Shield Charge] increases by 1m per level.
 SKILL_20150317_002138	Counter Thrust: Deprotect
-SKILL_20150317_002139	Skills across the state of 5 seconds in the counter thrust] to attack during each level to 10% of the probability of [di Protect] - Remove the existing functionality
+SKILL_20150317_002139	Counter Thrust has a 10% chance per attribute level of inflicted [Deprotect] for 5 seconds, negating all active buffs on the target.
 SKILL_20150317_002140	Shield Push: Unbalance
-SKILL_20150317_002141	Making knock down attacks on enemies under [Unbalance] with [Shield Push] gives additional damage of 20% of Physical damage.
+SKILL_20150317_002141	Knocking down enemies under [Unbalance] with [Shield Push] deals an additional 20% damage.
 SKILL_20150317_002142	Targe Smash: Flame
-SKILL_20150317_002143	Spreads [Flame] equal to amount of attribute level when killing enemy under [Flame] with [Targe Smash].
+SKILL_20150317_002143	Spreads [Flame] to a number of eemies equal to the attribute level when an enemy sufferig from [Flame] is killed with [Targe Smash].
 SKILL_20150317_002144	Cyclone: Moving
 SKILL_20150317_002145	Can move while using [Cyclone].
 SKILL_20150317_002146	Double Pay Earn: Attack damage
-SKILL_20150317_002147	Damage is reduced to 2x from 3x when skill [Double Pay Earn] is enabled.
+SKILL_20150317_002147	Damage taken is reduced to 2x from 3x when skill [Double Pay Earn] is enabled.
 SKILL_20150317_002148	Disqualification: Cloth Armor
-SKILL_20150317_002149	Apply effects of [Mordschlag] on enemies with leather armor also to choth armor.
+SKILL_20150317_002149	Apply effects of [Mordschlag] on enemies with leather armor to choth armor as well.
 SKILL_20150317_002150	Painbarrier: movement speed
-SKILL_20150317_002151	Movement speed increase by 5% per attribute level and evasion decrease by 10% per attribute level when using [Pain Barrier].
+SKILL_20150317_002151	Movement speed increases by 5% per attribute level and evasion decreases by 10% per attribute level when using [Pain Barrier].
 SKILL_20150317_002152	Cyclone: Arrow flick
-SKILL_20150317_002153	Basic arrow attack of enemy bounces by chance of 10% per attribute level when using [Cyclone].
-SKILL_20150317_002154	Sleep:maintain debuff
-SKILL_20150317_002155	Enemy under [Sleep] will not wake up even if attacked by 1% chance per attribute elvel but dauration will decreaseby 0.5 seconds per attribute level.
+SKILL_20150317_002153	Whe using [Cyclone] basic arrow attacks have a 10% chance per attribute level of bouncing off the character.
+SKILL_20150317_002154	Sleep: Maintain Debuff
+SKILL_20150317_002155	Enemy under [Sleep] will not wake up even if attacked at a 1% chance per attribute level but the duration will decrease by 0.5 seconds per attribute level.
 SKILL_20150317_002156	Reflect Shield: Reflect Damage
 SKILL_20150317_002157	Reflection damage of [Reflect shield] is added per attribute level, and hit damage is reduced.
 SKILL_20150317_002158	Reflect Shield: Defense
-SKILL_20150317_002159	Defense increase by 5% per level while the skill [Reflect Shield] is enabled
+SKILL_20150317_002159	Defense increase by 5% per level while [Reflect Shield] is active.
 SKILL_20150317_002160	Energy Bolt: Additional sleep damage
-SKILL_20150317_002161	Attack monster in [sleep] state with [Energy Bolt] to give additional damage of 50% of Magic attack.
+SKILL_20150317_002161	Attack monster in the [sleep] state with [Energy Bolt] to do 50% more damage.
 SKILL_20150317_002162	Lethargy : Duration
-SKILL_20150317_002163	Duration of [Lethargy] will increase by 2 seconds per level
+SKILL_20150317_002163	Duration of [Lethargy] increases by 2 seconds per level
 SKILL_20150317_002164	Lethargy: Strike
-SKILL_20150317_002165	Enemies under [Lethargy] receive additional damage of 20% of hit attack.
+SKILL_20150317_002165	Hit type attacks do 20% more damage to enemies suffering from [Lethargy].
 SKILL_20150317_002166	Quick Cast: Magic Damage
-SKILL_20150317_002167	Magic damage of next attack increases by 10% per attribute level when [Quick Cast] is enabled.
+SKILL_20150317_002167	Magic damage of next attack increases by 10% per attribute level when [Quick Cast] is active.
 SKILL_20150317_002168	Fireball: Flame debuff
-SKILL_20150317_002169	Enemy receives Fire damage for 5 seconds at 10% chance per attribute level when attacked with [Fire Ball].
+SKILL_20150317_002169	Enemies hit by[Fire Ball] have a 10% chance per attribute level of suffering from [Flame] for 5 seconds.
 SKILL_20150317_002170	Fire Wall: Increase Fire resistance
-SKILL_20150317_002171	Fire Property attack increases by 5 per Attribute level for 5 seconds when allies step on [Fire Wall].
+SKILL_20150317_002171	Fire Element attack increases by 5 per Attribute level for 5 seconds when allies step on [Fire Wall].
 SKILL_20150317_002172	Hell Breath: Rotate direction
-SKILL_20150317_002173	Can change direction when using [Hell Breathe]
+SKILL_20150317_002173	Can change direction when using [Hell Breath]
 SKILL_20150317_002174	Hell Breath: Knockback
-SKILL_20150317_002175	Enemies hit with [Hell Breathe] is pushed away at 10% chance per Attribute level.
-SKILL_20150317_002176	Enchanted Fire: Fire attribute resistance increase
-SKILL_20150317_002177	Character's Fire resistnace increase by 5 per level and Ice reistance decrease by 5 per level when using [Enchant Fire]
-SKILL_20150317_002178	Enchanted Fire: Fire attribute resistance decrease
-SKILL_20150317_002179	Fire Resistance of enemy within range of [Enchant Fire] decrease by 10% per attribute level for 5 seconds.
+SKILL_20150317_002175	Enemies hit with [Hell Breath] is pushed away at a 10% chance per Attribute level.
+SKILL_20150317_002176	Enchant Fire: Fire attribute resistance increase
+SKILL_20150317_002177	Character's Fire resistance increases by 5 per level and Ice resistance decreases by 5 per level when using [Enchant Fire]
+SKILL_20150317_002178	Enchant Fire: Fire attribute resistance decrease
+SKILL_20150317_002179	Fire Resistance of enemies within range of [Enchant Fire] decreases by 10% per attribute level for 5 seconds.
 SKILL_20150317_002180	Fire pillar: Pull
 SKILL_20150317_002181	[Fire Pillar] pulls enemy nearby. Higher attribute level increases range of enemies pulled.
 SKILL_20150317_002182	Staff Mastery : Fire
-SKILL_20150317_002183	[Staff] when worn the series weapon, Fire Property attack force of character will increase 5 for each level of features.
+SKILL_20150317_002183	When equipped with a [Staff], the character's fire element attack increases by 5 per attribute level.
 SKILL_20150317_002184	Ice Bolt: Chance of Freeze
-SKILL_20150317_002185	Chance of enemy hit by [Ice Bolt] to [Freeze] incerase by 10% per attribute level.
+SKILL_20150317_002185	Chance of enemy hit by [Ice Bolt] to [Freeze] increases by 10% per attribute level.
 SKILL_20150317_002186	Gust: Collision damage
 SKILL_20150317_002187	Enemy receive 50% of magic attack as damage when hitting wall after being pushed away with [Gust].
 SKILL_20150317_002188	Ice Blast: Splash freeze
-SKILL_20150317_002189	Enemies attacked with [Ice Blast] falls under [Freeze] by chance of 10% per attribute level.
+SKILL_20150317_002189	Enemies attacked with [Ice Blast] falls under [Freeze] at a 10% chance per attribute level.
 SKILL_20150317_002190	Telekinesis: Forced move
 SKILL_20150317_002191	Inflict damage of 20% of magic attack to enemies nearby when teleporting through [Telekinesis]
 SKILL_20150317_002192	Psychic Pressure: Stun
-SKILL_20150317_002193	Enemy falls under [Stun] for 1 second by 10% chance per Attribute level when hit with [Psychic Pressure].
+SKILL_20150317_002193	Enemy falls under [Stun] for 1 second at a 10% chance per Attribute level when hit with [Psychic Pressure].
 SKILL_20150317_002194	Gravity Pole: Evasion
 SKILL_20150317_002195	Evasion increases by 10 per attribute level when using [Gravity Pull].
 SKILL_20150317_002196	Magnetic Force: Stun
-SKILL_20150317_002197	Enemies attacked with [Magnetic Force] falls under [Stun] for 1 seconds at chance of 5% per attribute level.
+SKILL_20150317_002197	Enemies attacked with [Magnetic Force] falls under [Stun] for 1 second at chance of 5% per attribute level.
 SKILL_20150317_002198	Gravity Pole: Decrease Defense
 SKILL_20150317_002199	Physical Defense of enemy drawn in skill [Gravity Pole] is reduced by 5% per attribute level.
 SKILL_20150317_002200	Raise: Large monster
@@ -2206,7 +2206,7 @@ SKILL_20150317_002205	Enemies receive 20% of magic damage per attribute level wh
 SKILL_20150317_002206	Umbilical cord: Remaining defense
 SKILL_20150317_002207	Physical defense remains by 10% per attribute level when using [Umbilical Cord]
 SKILL_20150317_002208	Spiritual Chain: Duration
-SKILL_20150317_002209	Duration of [Spiritual Chain] increase by 2 seconds per attribute level.
+SKILL_20150317_002209	Duration of [Spiritual Chain] increases by 2 seconds per attribute level.
 SKILL_20150317_002210	Joint penalty: Additional damage
 SKILL_20150317_002211	Enemies touching [Joint Penalty] receives additional damage of 20% of Magic damage.
 SKILL_20150317_002212	Hangman's Knot: Splash defense
@@ -2214,35 +2214,35 @@ SKILL_20150317_002213	Spash defense of enemies gathered through [Hangman's Knot]
 SKILL_20150317_002214	Swell Body: Movement speed decrease
 SKILL_20150317_002215	Movement speed of enemy enlarged by [Swell Body] decrease by 10% per attribute level and Physical, Magic attack increase by 5% per attribute level.
 SKILL_20150317_002216	Shrink Body: Increase movement speed
-SKILL_20150317_002217	Movement of enemy shrinked with [Shrink Body] increase by 5% per attribute level and Physical, magic attack increase by 10% per attribute level.
+SKILL_20150317_002217	Movement of enemy shrunk with [Shrink Body] increase by 5% per attribute level and Physical, magic attack increase by 10% per attribute level.
 SKILL_20150317_002218	Swell Body: Add Damage
-SKILL_20150317_002219	Give damage of 30% of magic attack per Attribute level when size is changed by skill [Size Enlarge].
+SKILL_20150317_002219	Damage an enemy with 30% of your magic attack per Attribute level when its size is changed by [Size Enlarge].
 SKILL_20150317_002220	Shrink Body: Add damage
-SKILL_20150317_002221	Give damage of 30% of magic attack per Attribute level when size is changed by skill [Size Shrink].
+SKILL_20150317_002221	Damage an enemy with 30% of your magic attack per Attribute level when its size is changed by [Size Shrink].
 SKILL_20150317_002222	Swell Right Arm: Duration
-SKILL_20150317_002223	Duration of [Swell Right Arm] increase by 1 second per attribute level.
+SKILL_20150317_002223	Duration of [Swell Right Arm] increases by 1 second per attribute level.
 SKILL_20150317_002224	Electrocute: Freezing magic damage
-SKILL_20150317_002225	Give additional damage of 50% of magic attack per attribute level when using [Electrocute] on enemies under [Freeze].
-SKILL_20150317_002226	Stone Curse: Increase numebr os stone
+SKILL_20150317_002225	Deals an additional 50% damage per attribute level when using [Electrocute] on enemies under [Freeze].
+SKILL_20150317_002226	Stone Curse: Increase number of petrifications
 SKILL_20150317_002227	Number of [Petrify] using [Stone Curse] increase by attribute level.
 SKILL_20150317_002228	Prominence: Prominence wandering
 SKILL_20150317_002229	Prominence [Prominence] wanders in a smaller range.
 SKILL_20150317_002230	Hail: Freeze
-SKILL_20150317_002231	Enemies attacked with [Hail] falls under [Freeze] at 5% chance per Attribute level.
+SKILL_20150317_002231	Enemies attacked with [Hail] falls under [Freeze] at a 5% chance per Attribute level.
 SKILL_20150317_002232	Meteor: Evasion
 SKILL_20150317_002233	Evasion increase by 10 per attribute level when charging [Meteor].
 SKILL_20150317_002234	Elementalist: Resistance
-SKILL_20150317_002235	Fire, Ice, Lightning Resistance increase by 5 per attribute level.
+SKILL_20150317_002235	Fire, Ice, and Lightning Resistances increase by 5 per attribute level.
 SKILL_20150317_002236	Quicken: Critical occurrence
-SKILL_20150317_002237	Chance of critical for skill [Quicken]increase by 5% per attribute level, while evasion is reduced by 2%per attribute level.
+SKILL_20150317_002237	Critical chance for [Quicken] increases by 5% per attribute level, while evasion is reduced by 2% per attribute level.
 SKILL_20150317_002238	Slow : Critical defense
-SKILL_20150317_002239	Critical resistance of enemy under [Slow] decrease by the amount of character's intelligence.
+SKILL_20150317_002239	Critical resistance of enemy under [Slow] decreases by the amount of character's intelligence.
 SKILL_20150317_002240	Samsara : Two
-SKILL_20150317_002241	When enemies revives after [Samsara], two appear by 1% chance per attribute level.
+SKILL_20150317_002241	When enemies revives after [Samsara], two appear at a 1% chance per attribute level.
 SKILL_20150317_002242	Stop : Control Boss Monster
-SKILL_20150317_002243	[Stop] can also stop boss monsters but once released, it will not be stopped again.
+SKILL_20150317_002243	[Stop] can also stop boss monsters but once stop ends, the boss cannot be stopped again.
 SKILL_20150317_002244	Back Masking : Panic
-SKILL_20150317_002245	Enemies provoked after using [Back Masking] wil fall under [Panic] for 2 seconds per attribute level.
+SKILL_20150317_002245	Enemies provoked after using [Back Masking] will fall under [Panic] for 2 seconds per attribute level.
 SKILL_20150317_002246	Multi Shot : Critical Chance
 SKILL_20150317_002247	Critical probability of skill [multi-shot] is increased by 1% per Attribute level.
 SKILL_20150317_002248	Fulldraw : Knockback Distance
@@ -2250,23 +2250,23 @@ SKILL_20150317_002249	The pushing force of the skill [Fulldraw] is increased by 
 SKILL_20150317_002250	Fulldraw : Charging Speed
 SKILL_20150317_002251	The charging speed of [Fulldraw] skill will be decreased by 0.5 sec per level.
 SKILL_20150317_002252	Kneeling Shot : Critical Chance
-SKILL_20150317_002253	Chance of critical will increase by 2% per attribute level in [Kneeling Shot].
+SKILL_20150317_002253	Critical chance increases by 2% per attribute level while in [Kneeling Shot].
 SKILL_20150317_002254	Cure : Make Damage
-SKILL_20150317_002255	Magic circle period of [Cure] decrease by 0.2 seconds.
+SKILL_20150317_002255	Magic circle period of [Cure] decreases by 0.2 seconds.
 SKILL_20150317_002256	Divine
-SKILL_20150317_002257	[Heel] 1 only sacred attack for each level of 5 seconds when I stepped on the skills to ally increases
+SKILL_20150317_002257	[Heal] 1 only sacred attack for each level of 5 seconds when I stepped on the skills to ally increases
 SKILL_20150317_002258	Heal: Generate additional
-SKILL_20150317_002259	Receive [Heal] at 2% chance per attribute level when using [Heal].
+SKILL_20150317_002259	Receive [Heal] at a 2% chance per attribute level when using [Heal].
 SKILL_20150317_002260	Deprotected Zone: Follow enemy
 SKILL_20150317_002261	Magic circle of [Deprotected Zone] follows the monsters nearby.
 SKILL_20150317_002262	Deprotected Zone: Retention time
 SKILL_20150317_002263	Magic circle duration of [Deprotected zone] increase by 1 second per attribute level.
 SKILL_20150317_002264	Divine Might: Demon Type Damage
-SKILL_20150317_002265	Give damage of 100% of magic attack when demon type monster enters magic circle of [Divine Might].
+SKILL_20150317_002265	Deals 100% of magic attack as damage when demon type monster enters magic circle of [Divine Might].
 SKILL_20150317_002266	Aspersion : Decrease DEF
-SKILL_20150317_002267	[Aspersion] reduce defense of monster by 8% per attribute level. Holy water consumed increases to 2.
+SKILL_20150317_002267	[Aspersion] reduce defense of monster by 8% per attribute level. Uses 2 holy water.
 SKILL_20150317_002268	Monstrance: Follow enenmy
-SKILL_20150317_002269	Magic circle of [Monstrance] follows monsters nearby.
+SKILL_20150317_002269	Magic circle of [Monstrance] follows nearby monsters.
 SKILL_20150317_002270	Monstrance: Evasion Defense
 SKILL_20150317_002271	When allies are within [Monstrance] magic circle, evasion and Physical defense of target increase by 2% per attribute level.
 SKILL_20150317_002272	Blessing: Number of attacks
@@ -2276,204 +2276,204 @@ SKILL_20150317_002275	Number of targets of [Blessing] increases by 1 per Attribu
 SKILL_20150317_002276	Sacrament: Dark Property resistance
 SKILL_20150317_002277	Dark Resistance increases by 5 per attribute levvel while [Sacrament] is activated.
 SKILL_20150317_002278	Resurrection: HP recovery
-SKILL_20150317_002279	Character was revived through skill [Resurrection] will recover 10% of max. HP per level.
+SKILL_20150317_002279	A Character revived by[Resurrection] will recover 10% of max. HP per attribute level.
 SKILL_20150317_002280	Resurrection: Resurrection count
 SKILL_20150317_002281	Number of targets revived by [Resurrection] increases by 1 per Attribute level.
 SKILL_20150317_002282	Blunt Mastery: Stun
-SKILL_20150317_002283	Enemies attacked using [Blunt] type basic attacks has 2% chance per Attribute level of being Stunned.
-SKILL_20150317_002284	Krivi: Fire attribute resistance
-SKILL_20150317_002285	Character's Fire Resistance increases by 5 per attribute level while Dark Resistance decrease by 3 per attribute level.
+SKILL_20150317_002283	Enemies attacked with [Blunt] type basic attacks have a 2% chance per Attribute level of being Stunned.
+SKILL_20150317_002284	Krivis: Fire attribute resistance
+SKILL_20150317_002285	Character's Fire Resistance increases by 5 per attribute level while Dark Resistance decreases by 3 per attribute level.
 SKILL_20150317_002286	Zalciai: Intelligence
 SKILL_20150317_002287	Effect of [Zalciai] to clerics is changed from STR to INT.
 SKILL_20150317_002288	Divine Stigma: intelligence
-SKILL_20150317_002289	Strength increase but intelligence decrease by 20% per level when using [Divine Stigma].
+SKILL_20150317_002289	Strength increases by 20% per attribute level while Intelligence decreases by 20% per level when using [Divine Stigma].
 SKILL_20150317_002290	Zaibas: Splash
-SKILL_20150317_002291	[Zaibas] is affected by splash and inflicts damage on multiple targets at once. (total count does not change)
+SKILL_20150317_002291	[Zaibas] gains AoE and inflicts damage to multiple targets at once. (total number of hits does not change)
 SKILL_20150317_002292	Daino: duration
-SKILL_20150317_002293	Duration of skill [Daino] will increase by 40 seconds per attribute level.
+SKILL_20150317_002293	Duration of [Daino] increases by 40 seconds per attribute level.
 SKILL_20150317_002294	Hexing: Splash
 SKILL_20150317_002295	Splash is increased by 1 per attribute level in [Hexing].
 SKILL_20150317_002296	Effigy: Blind
-SKILL_20150317_002297	Enemies attacked with [Effigy] falls under [Blind] state at chance of 5% per Attribute level.
+SKILL_20150317_002297	Enemies attacked with [Effigy] fall under [Blind] state at a 5% chance per Attribute level.
 SKILL_20150317_002298	Ogouveve: Decrease Strength
 SKILL_20150317_002299	Strength of enemies within [Ogouveve] decreases by 2 per attribute level.
 SKILL_20150317_002300	Damballa: Probability of zombie appearance
-SKILL_20150317_002301	Chance of new zombie appearing increase by 2% per attribute level when using [Damballa].
+SKILL_20150317_002301	Chance of a new zombie appearing increase by 2% per attribute level when using [Damballa].
 SKILL_20150317_002302	Bwa Kayiman: zombie defense
-SKILL_20150317_002303	Physical defese of zombies in [Bwa Kayiman] increases by 3 per Attribute level.
+SKILL_20150317_002303	Physical defense of zombies in [Bwa Kayiman] increases by 3 per Attribute level.
 SKILL_20150317_002304	Mackangdal: Cumulative Damage
-SKILL_20150317_002305	Damage accumulated decreases by 10% per level while [Madangkal] is enabled.
+SKILL_20150317_002305	Damage taken decreases by 10% per attribute level while [Madangkal] is enabled.
 SKILL_20150317_002306	Creating zombie: zombify
-SKILL_20150317_002307	Max. number of zomebies in [Zombify] increases by 1 per Attribute level.
+SKILL_20150317_002307	Max. number of zombies in [Zombify] increases by 1 per Attribute level.
 SKILL_20150317_002308	Carve: acquisition probability
-SKILL_20150317_002309	Chance of acquiring materials through [Carve] increase by 5% per attribute level.
+SKILL_20150317_002309	Chance of acquiring materials through [Carve] increases by 5% per attribute level.
 SKILL_20150317_002310	Sculptor
-SKILL_20150317_002311	[Carve] skills gives the additional damage of 5% for each level in the plant type monster
+SKILL_20150317_002311	[Carve] deals 5% more damage per attribute level to plant monsters.
 SKILL_20150317_002312	Owl image: Number maintained
 SKILL_20150317_002313	Number of skill [Owl Image] maintained increases by 1 per level.
 SKILL_20150317_002314	Owl image: Flame
-SKILL_20150317_002315	According to the skill about 5% of magic damage of characters of 5 seconds at 5% of probability for each level each time it is the enemy attacked in the owl image] skills of attack of state [flame]
-SKILL_20150317_002316	Piece of Big tree: Pull
-SKILL_20150317_002317	Pull enemies within range of skill [Piece of Big Tree].
+SKILL_20150317_002315	Enemies hit by the [Owl Image] have a 5% chance per attribute level of being inflicted with [Flame], taking 5% of your magic damage as damage for 5 seconds.
+SKILL_20150317_002316	Carve Austras Koks: Pull
+SKILL_20150317_002317	Pulls enemies within range of [Carve Austras Koks].
 SKILL_20150317_002318	Dievdirbys : Damage of Plant Type
-SKILL_20150317_002319	[Blunt object] gives additional damage about 10% of the Physical attack of each attribute level to plant type monsters when worn.
+SKILL_20150317_002319	[Blunt object] do 10% extra damage per attribute level to plant type monsters.
 SKILL_20150317_002320	Zemyna Statue: Duration
-SKILL_20150317_002321	Duration of [Zemyna Statue] increase by 2 seconds per attribute level.
+SKILL_20150317_002321	Duration of [Zemyna Statue] increases by 2 seconds per attribute level.
 SKILL_20150317_002322	Out of Body: Moving distance
-SKILL_20150317_002323	Maximum distance that can be moved using [Astral Projection] increase by 1m per level
+SKILL_20150317_002323	Maximum distance that can be moved using [Astral Projection] increases by 1m per level
 SKILL_20150317_002324	Out of Body: Avoidance
 SKILL_20150317_002325	While the [Astral Projection] is enabled, evasion of body increases by 10% per attribute level.
 SKILL_20150317_002326	Astral Body Explosion : Knock down
-SKILL_20150317_002327	Enemy hit by [Astral Body Explosion] falls down.
+SKILL_20150317_002327	Enemies hit by [Astral Body Explosion] are knocked down.
 SKILL_20150317_002328	Prakriti: HP recovery
-SKILL_20150317_002329	Recovers up 5% of max. HP per attribute level when using [Prakriti].
+SKILL_20150317_002329	Recovers 5% of max. HP per attribute level when using [Prakriti].
 SKILL_20150317_002330	Body Basic Attack : Enemy DEF decrease
-SKILL_20150317_002331	Enemies hit with normal attack in spirit state falls under [Defense Weakening] by 5% chance per attribute level.
+SKILL_20150317_002331	Enemies hit with normal attack in spirit state falls under [Defense Weakening] at a 5% chance per attribute level.
 SKILL_20150317_002332	Resist Elements: Resist
-SKILL_20150317_002333	Fire, Ice, Eletric resistance increase by 5 and Poison, Earth resistance decrease by 5 per attribute level when using [Resists Elements]
+SKILL_20150317_002333	Fire, Ice, and Electric resistances increase by 5 and Poison, Earth resistance decreases by 5 per attribute level when using [Resists Elements]
 SKILL_20150317_002334	Barrier: Stab damage
 SKILL_20150317_002335	Stab damage of allies within [Barrier] increases by 10%
 SKILL_20150317_002336	Barrier: Holy damage
-SKILL_20150317_002337	Enemies hit by skill [Barrier] received 20% of Magic attack as Holy damage per attribute level.
+SKILL_20150317_002337	Enemies hit by skill [Barrier] received 20% of Magic attack per attribute level as Holy damage.
 SKILL_20150317_002338	Smite : Falling damage
-SKILL_20150317_002339	Inflict damage of 50% of Physical attack when enemy flown in air by [Smite] falls on the ground.
+SKILL_20150317_002339	Inflict damage of 50% extra damage when knocking flying enemies out of the air.
 SKILL_20150317_002340	Turn Undead: spirit
-SKILL_20150317_002341	Instant death probability of skill [Turn Undead] also affects your spirit.
+SKILL_20150317_002341	Instant death probability of skill [Turn Undead] is also affected by your spirit.
 SKILL_20150317_002342	Conversion: Increase Strength
-SKILL_20150317_002343	Strength of monsters converted with Conversion] increase by 10%.
-SKILL_20150317_002344	[Both hands bow] to the public type monster when mounted I will give a 20% additional damage of Physical attack.
+SKILL_20150317_002343	Strength of monsters converted with [Conversion] increase by 10%.
+SKILL_20150317_002344	[Two-handed Bow] Deals 20% more damage to Flying type monsters.
 SKILL_20150317_002345	Oblique shot: Slow
-SKILL_20150317_002346	When the skill [Swift step] is enabled, enemies attacked with [Oblique shot] falls under [Slow] at 5% rate per attribute level.
+SKILL_20150317_002346	When [Swift step] is active, enemies attacked with [Oblique shot] are inflicted with [Slow] at a rate of 5% per attribute level.
 SKILL_20150317_002347	Multi-shot -SP recovery
 SKILL_20150317_002348	[Multi-shot] is characteristic Lv x 5% SP recovery when hit in the critical
 SKILL_20150317_002349	Swift step: Critical
-SKILL_20150317_002350	When the skill [Swift step] is enabled, rate of critical increase by 10% per attribute level.
+SKILL_20150317_002350	When the skill [Swift step] is active, criticl rate increases by 10% per attribute level.
 SKILL_20150317_002351	Fulldraw: Defense decrease
-SKILL_20150317_002352	Physical Defense of the enemy skewed in [Fulldraw] decrease by 2% per attribute level.
+SKILL_20150317_002352	Physical Defense of the enemy skewered by [Fulldraw] decreases by 2% per attribute level.
 SKILL_20150317_002353	Barrage: Knockback
-SKILL_20150317_002354	Enemies hit by [Barrage] is pushed away by chance of 10% per attribute level.
+SKILL_20150317_002354	Enemies hit by [Barrage] are pushed away by at a 10% chance per attribute level.
 SKILL_20150317_002355	High anchoring: rotation
-SKILL_20150317_002356	Can change direction while charging [High Anchoring]
+SKILL_20150317_002356	Can change directions while charging [High Anchoring]
 SKILL_20150317_002357	Bounce shot: Slow
-SKILL_20150317_002358	Enemy attacked with [Bounce shot] falls under [Slow] by change of 3% per attribute level.
+SKILL_20150317_002358	Enemy attacked with [Bounce shot] are inflicted with [Slow] at a 3% chance per attribute level.
 SKILL_20150317_002359	Steady Aim: Attack speed remaining
-SKILL_20150317_002360	Skills [Steady Aim] attack speed of slower character in [certain to steady] is about 5% per level
+SKILL_20150317_002360	Attack speed lost while under[Steady Aim] decreases 5% per attribute level.
 SKILL_20150317_002361	[Arrow Sprinkle]
-SKILL_20150317_002362	Deploy Pavise: Qty
-SKILL_20150317_002363	Bumber of Pavise in [Deploy Pavise] increase to 2 but its HP decrease by half.
+SKILL_20150317_002362	Deploy Pavise: Quantity
+SKILL_20150317_002363	Number of Pavises deployable with [Deploy Pavise] increases to 2 but their HP are halved.
 SKILL_20150317_002364	Scatter Caltrop: Duration
-SKILL_20150317_002365	Caldrop duration of [Scatter Caldrop] increase by 1 second per attribute level.
+SKILL_20150317_002365	Durations of caltrops scattered by [Scatter Caldrop] increases by 1 second per attribute level.
 SKILL_20150317_002366	Scatter Caltrop: Bleed
-SKILL_20150317_002367	Enemies fall under [Bleed] at 8% chance per attribute level when stepping on [Scatter Caltrop].
+SKILL_20150317_002367	Enemies are inflicted with [Bleed] at an 8% chance per attribute level when stepping on caltrops.
 SKILL_20150317_002368	Stone shot: Stun
-SKILL_20150317_002369	Stun probability of skill [Stone shot] is increased by 5% per level
-SKILL_20150317_002370	Rapid Fire: rotation of the
+SKILL_20150317_002369	Stun probability of [Stone shot] increases by 5% per level
+SKILL_20150317_002370	Rapid Fire: rotation
 SKILL_20150317_002371	Can change direction while charging [Rapid Fire] (Impossible when shooting starts)
-SKILL_20150317_002372	Stone Picking: Qty
-SKILL_20150317_002373	The number of stone bullet picked by [Stone Picking] becomes [skill level].
-SKILL_20150317_002374	Bloom Trap: Rotation speed
-SKILL_20150317_002375	Rotation time of [Broom Trap] decrease by 0.2 seconds per attribute level and number of rotations decrease by 1 per attribute level.
+SKILL_20150317_002372	Stone Picking: Quantity
+SKILL_20150317_002373	The number of stone bullets picked by [Stone Picking] becomes [attribute level].
+SKILL_20150317_002374	Broom Trap: Rotation speed
+SKILL_20150317_002375	Rotation time of [Broom Trap] decreases by 0.2 seconds per attribute level and number of rotations decreases by 1 per attribute level.
 SKILL_20150317_002376	Claymore: Splash
-SKILL_20150317_002377	Number of Splash of [Claymore] increases by 1 per Attribute level.
+SKILL_20150317_002377	Number of enemies hit by [Claymore] increases by 1 per Attribute level.
 SKILL_20150317_002378	Punji Stake: Fall damage
-SKILL_20150317_002379	Enemies blown away with [Punji Steak] receive damage of 50% of character's Physical attack.
+SKILL_20150317_002379	Enemies blown away with [Punji Steak] receive fall damage equal to 50% of character's Physical attack.
 SKILL_20150317_002380	Detonate Traps: Party trap
-SKILL_20150317_002381	Number of magic circles that can be blown with [Detonate Traps] increases by 1 per level.
+SKILL_20150317_002381	Number of magic circles that can be detonated with [Detonate Traps] increases by 1 per attribute level.
 SKILL_20150317_002382	Pointing: fear
-SKILL_20150317_002383	Monster affected by [Pointing] fall under [fear] by 10% chance per attribute level.
-SKILL_20150317_002384	Coursing: Agro
-SKILL_20150317_002385	Enemies bitten with [Coursing] attacks the companion.
+SKILL_20150317_002383	Monster affected by [Pointing] are inflicted with [fear] with a 10% chance per attribute level.
+SKILL_20150317_002384	Coursing: Aggro
+SKILL_20150317_002385	Enemies bitten with [Coursing] attack the companion.
 SKILL_20150317_002386	Retrieve: Defense decrease
-SKILL_20150317_002387	Defense of enemies attacked with [Retrieve] decrease by 5 per attribute level.
+SKILL_20150317_002387	Defense of enemies attacked with [Retrieve] decreases by 5 per attribute level.
 SKILL_20150317_002388	Snatching: Flight type damage
-SKILL_20150317_002389	Flight type monsters that fall on ground by [Snatching] receive additional 20% damage on Slash, strike type attacks.
+SKILL_20150317_002389	Flight type monsters grounded by [Snatching] receive 20% more damage oby Slash and Strike type attacks.
 SKILL_20150317_002390	Praise: Movement speed
-SKILL_20150317_002391	Movement speed of companion added by [Praise] is increased by 5% per attribute level.
+SKILL_20150317_002391	Movement speed of companion affected by [Praise] is increased by 5% per attribute level.
 SKILL_20150317_002392	Hounding: Panic
-SKILL_20150317_002393	Enemy found using [Houngind] falls under [Confusion] by 10% chance per attribute level.
+SKILL_20150317_002393	Enemy found using [Hounding] is inflicted wtih [Confusion] with a 10% chance per attribute level.
 SKILL_20150317_002394	Detoxifiy: Poison immunity
-SKILL_20150317_002395	Character becomes immune to [Poison] for two seconds after being released from [Poison] by skill [Detoxifiy].
+SKILL_20150317_002395	Character becomes immune to [Poison] for two seconds after being cured of [Poison] by [Detoxifiy].
 SKILL_20150317_002396	Needle Blow - use poison
 SKILL_20150317_002397	[Needle Blow] decrease usage characteristics Lv x 5% of skills of poison
 SKILL_20150317_002398	Bewitch: Keep the poison
-SKILL_20150317_002399	Enemies under [Confusion] by [Bewith] will not be released from [Poison] by chance of 5% per level.
+SKILL_20150317_002399	Enemies inflicted with [Confusion] by [Bewitch] will not be cured of [Poison] at a 5% chance per attribute level.
 SKILL_20150317_002400	Wugong Gu: Host duration
-SKILL_20150317_002401	Host state of the skill [Wugong Gu] increase by 2 seconds per attribute level.
+SKILL_20150317_002401	The duration of the poison aura surrounding the monster hit by[Wugong Gu] increases by 2 seconds per attribute level.
 SKILL_20150317_002402	Throw Gu Pot: Poison remaining
-SKILL_20150317_002403	[Poison] is maintained for 2 seconds per attribute level even when enemy leaves range of [Throw Gu Pot].
+SKILL_20150317_002403	Enemy continues to suffer from[Poison] for 2 seconds per attribute level after leaving the puddle created by [Throw Gu Pot].
 SKILL_20150317_002404	Jincan Gu: Duration
-SKILL_20150317_002405	Duration of venom insect summoned by [Jincan Gu] increase by 2 seconds per level.
+SKILL_20150317_002405	Duration of venom insect summoned by [Jincan Gu] increases by 2 seconds per level.
 SKILL_20150317_002406	Poison pot: stocked amount
 SKILL_20150317_002407	Poison reserves of [poison pot] increase by 20%
 SKILL_20150317_002408	Cloaking: Physical Damage
-SKILL_20150317_002409	Attack skills following skills [Cloaking] will inflict additional damage of 50% of the Physical attack.
+SKILL_20150317_002409	The first attack made after using [Cloaking] will inflict 50% more physical damage.
 SKILL_20150317_002410	Camouflage: movement speed
-SKILL_20150317_002411	Movement speed increase by 10% per attribute level when using [Camouflage].
+SKILL_20150317_002411	Movement speed increases by 10% per attribute level while using [Camouflage].
 SKILL_20150317_002412	Undistance: Physical Damage
-SKILL_20150317_002413	Physical attack of allies within [Undistance] increase by 5% per attribute level.
+SKILL_20150317_002413	Physical attack of allies within [Undistance] increases by 5% per attribute level.
 SKILL_20150317_002414	Reconnaissance: Stab damage
-SKILL_20150317_002415	Monsters revealed with [Reconaissance] receive 10% more dadmage per level while skill is enabled.
-SKILL_20150317_002416	Be Prepared: Reset agro
+SKILL_20150317_002415	Monsters revealed with [Reconaissance] receive 10% more stab damage per level while the skill is enabled.
+SKILL_20150317_002416	Be Prepared: Reset aggro
 SKILL_20150317_002417	Character's aggro value held by enemy resets when using [Be Prepared]
 SKILL_20150317_002418	Sneak Hit: Duration
-SKILL_20150317_002419	Duration of [Sneak Hit] increase by 2 seconds per attribute level.
+SKILL_20150317_002419	Duration of [Sneak Hit] increases by 2 seconds per attribute level.
 SKILL_20150317_002420	Feint: Evasion increase
-SKILL_20150317_002421	Evasion of allies within range of [Feint] increase as much the amount of evasion of enemy decreased.
+SKILL_20150317_002421	Evasion of allies within range of [Feint] increase by the amount the enemy's evasion decreased.
 SKILL_20150317_002422	Burrow: SP
 SKILL_20150317_002423	Skill [Burrow] to hide dug the ground with the SP recovery features Lv x 5 increase -> Delete
 SKILL_20150317_002424	Brandish Bow: Knockback
-SKILL_20150317_002425	Knockback distance of [Brandish Bow] increase by 1m per attribute level.
+SKILL_20150317_002425	The Knockback distance of [Brandish Bow] increases by 1m per attribute level.
 SKILL_20150317_002426	Unlock Chest: movement speed
-SKILL_20150317_002427	Movement increase by 10% per attribute level for 5 seconds when opening treasure chest with [Unlock Chest]
+SKILL_20150317_002427	Movement speed increases by 10% per attribute level for 5 seconds after opening a treasure chest with [Unlock Chest]
 SKILL_20150317_002428	Arrow production
 SKILL_20150317_002429	[Fletcher] arrow production
 SKILL_20150317_002430	Broad head: Bleed
-SKILL_20150317_002431	Duration of [Bleed] of enemies attacked with [Broadhead] increases by 2 seconds per attribute level.
+SKILL_20150317_002431	Duration of the [Bleed] inflicted by [Broadhead] increases by 2 seconds per attribute level.
 SKILL_20150317_002432	Bodkin Point: Decrease defense
-SKILL_20150317_002433	[Defense Decrease] of [Bodkin Point] is decreased further by 2% per attribute level.
+SKILL_20150317_002433	[Defense Decrease] of [Bodkin Point] is increased by 2% per attribute level.
 SKILL_20150317_002434	Flu Flu: Cross Fire
 SKILL_20150317_002435	If enemy hit with [Flu Flu] is killed with [Cross Fire], [Flu Flu] attack is made again.
 SKILL_20150317_002436	Flu Flu: Number of Debuff
-SKILL_20150317_002437	Number of enemies affected by [Flu Flu] increase by 1 per attribute level.
+SKILL_20150317_002437	Number of enemies affected by [Flu Flu] increases by 1 per attribute level.
 SKILL_20150317_002438	Cross Fire: image
-SKILL_20150317_002439	According to skill 5 seconds at MakuTaro bursts was 10% of probability for each level of that was attacked in the attack of [Crossfire], about 5% of the Physical damage of state [image]
+SKILL_20150317_002439	There is a 10% chance per attribute level of any monster hit by [Crossfire] being inflicted with [image] and taking 5% of your Physical attack for 5 seconds.
 SKILL_20150317_002440	Rod Mastery: Ice
-SKILL_20150317_002441	[Load] when worn, Ice Property attack force of character will increase 5 for each level of features.
+SKILL_20150317_002441	When wearig a [Rod], Ice element attack is increased by 5 per attribute level.
 SKILL_20150317_002442	Rush: Stun
-SKILL_20150317_002443	Enemies pushed away by [Rush] falls under [Stun] for 2 seconds at 5% chance.
+SKILL_20150317_002443	Enemies pushed away by [Rush] are inflicted with [Stun] for 2 seconds at a 5% chance per attribute level.
 SKILL_20150317_002444	Impaler: Damage 2x
-SKILL_20150317_002445	Skill [Impaler] in beating the attack has been that, to receive twice the damage the original of the subject -> skills, existing feature this
-SKILL_20150317_002446	Dragging Death: Contol ally trap
-SKILL_20150317_002447	Can bring around trap and statue installed by allied with [Dragging Death]
-SKILL_20150317_002448	Stead Charge: Additional damage for Large size
-SKILL_20150317_002449	Skill [Stead Charge] is large monster, gives additional damage about 25% for each level in the character Physical damage to the enemy took to state [Slow] -> skills, the existing function this
-SKILL_20150317_002450	Arrest: No. of arrest
-SKILL_20150317_002451	Mumber of monsters for [Arrest] increase by (small: 2 per level)(medium 1 per level)
-SKILL_20150317_002452	Repair: Number of time repaired
-SKILL_20150317_002453	Use of [Repair] increase by 1 per level.
+SKILL_20150317_002445	The original monster hit by[Impaler] receives double damage.
+SKILL_20150317_002446	Dragging Death: Control ally trap
+SKILL_20150317_002447	[Dragging Death] can drag traps and statues installed by allies.
+SKILL_20150317_002448	Stead Charge: Additional damage against Large monsters
+SKILL_20150317_002449	When [Stead Charge] is used against a large monster, deals 25% more damage per attribute level
+SKILL_20150317_002450	Arrest: Number arrested
+SKILL_20150317_002451	Number of monsters hit by[Arrest] increases by (small: 2 per level)(medium 1 per level)
+SKILL_20150317_002452	Repair: Number of times repaired
+SKILL_20150317_002453	Use of [Repair] increases by 1 per attribute level.
 SKILL_20150317_002454	Weapon TouchUp: retention time
-SKILL_20150317_002455	Retention time of [Weapon TouchUp] increase by 10 minutes per level
+SKILL_20150317_002455	Retention time of [Weapon TouchUp] increases by 10 minutes per attribute level
 SKILL_20150317_002456	Armor Touch Up: Retention time
-SKILL_20150317_002457	Retention time of [Armor TouchUp] increase by 10 minutes per level
+SKILL_20150317_002457	Retention time of [Armor TouchUp] increases by 10 minutes per attribute level
 SKILL_20150317_002458	Iron Hook: Large monster
-SKILL_20150317_002459	[Iron Hook] blocks large monsters from moving for 0.5 seconds per level.
-SKILL_20150317_002460	Two-handed force: Sub-Weapon damage
-SKILL_20150317_002461	Physical damage of the sub-weapon used in [Two-handed Force] incerase by 10 per level.
+SKILL_20150317_002459	[Iron Hook] prevets large monsters from moving for 0.5 seconds per attribute level.
+SKILL_20150317_002460	Double Weapon Assault: Sub-Weapon damage
+SKILL_20150317_002461	Physical damage of the sub-weapon used in [Double Weapon Assault] increases by 10 per level.
 SKILL_20150317_002462	Jolly Roger: Pirate Flag Defense
-SKILL_20150317_002463	Pirate flag defense of [Jolly Roger] increase by 5 per level.
+SKILL_20150317_002463	Pirate flag defense of [Jolly Roger] increases by 5 per level.
 SKILL_20150317_002464	Keel Hauling: Stun
-SKILL_20150317_002465	Chance of [Stun] in [Keel Hauling] is increased by 5% per level
+SKILL_20150317_002465	Chance of [Keel Hauling] inflicting [Stun] increases by 5% per level.
 SKILL_20150317_002466	Movement increase by 10% per attribute level for 5 seconds when opening treasure chest with [Unlock Chest]
 SKILL_20150317_002467	Form Pirates
-SKILL_20150317_002468	Can for [Pirates] party with 1 member per level.
+SKILL_20150317_002468	Can form [Pirates] party with 1 member per attribute level.
 SKILL_20150317_002469	Palm Strike: Hit
-SKILL_20150317_002470	Enemies receive 50% of Physical damage when attacked with [Palm Strike] and hitting the wall.
+SKILL_20150317_002470	Enemies receive 50% of Physical damage when launched into a wall by [Palm Strike].
 SKILL_20150317_002471	Iron Skin: Additional damage
-SKILL_20150317_002472	Reflected damage of [Iron Skin] will inflict additional damage of 10% of Physical damage per level.
+SKILL_20150317_002472	Reflected damage of [Iron Skin] increases by 10% of your Physical damage per attribute level.
 SKILL_20150317_002473	Energy Blast: Rotate direction
 SKILL_20150317_002474	Can turn directions while using [Energy Blast] (Impossible if shooting starts)
 SKILL_20150317_002475	Ballista: Duration
-SKILL_20150317_002476	Duration of [Ballista] will increase by 2 seconds per level
+SKILL_20150317_002476	Duration of [Ballista] increases by 2 seconds per level
 SKILL_20150317_002477	Bash: Enhance
 SKILL_20150317_002478	Damage of [Bash] increases per attribute level
 SKILL_20150317_002479	Thrust: Enhance
@@ -2520,7 +2520,7 @@ SKILL_20150317_002519	Fire Wall: Enhance
 SKILL_20150317_002520	Damage of [Firewall] increases per attribute level
 SKILL_20150317_002521	Flare: Enhance
 SKILL_20150317_002522	Damage of [Flare] increases per attribute level
-SKILL_20150317_002523	Heruburesu: Enhance
+SKILL_20150317_002523	Hell Breath: Enhance
 SKILL_20150317_002524	Damage of [Hell Breath] increases per attribute level
 SKILL_20150317_002525	Fire pillar: Enhance
 SKILL_20150317_002526	Damage of [Fire Pillar] increases per attribute level
@@ -2552,7 +2552,7 @@ SKILL_20150317_002551	Magnetic Force: Enhance
 SKILL_20150317_002552	Damage of [Magnetic Force] increases per attribute level
 SKILL_20150317_002553	Aspersion: Enhance
 SKILL_20150317_002554	Damage of [Aspersion] increases per attribute level
-SKILL_20150317_002555	Bloom Trap: Enhance
+SKILL_20150317_002555	Broom Trap: Enhance
 SKILL_20150317_002556	Damage of [Broom Trap] increases per attribute level
 SKILL_20150317_002557	Claymore: Enhance
 SKILL_20150317_002558	Damage of [Claymore] increases per attribute level
@@ -2573,12 +2573,12 @@ SKILL_20150317_002572	Damage of [Effigy] increases per attribute level
 SKILL_20150317_002573	Damballa: Enhance
 SKILL_20150317_002574	Damage of [Damballa] increases per attribute level
 SKILL_20150317_002575	Carve: Enhance
-SKILL_20150317_002576	Damage of [Carve] increases per attribute level. Additional damage to plant type monsters also increase.
+SKILL_20150317_002576	Damage of [Carve] increases per attribute level. Additional damage to plant type monsters also increases.
 SKILL_20150317_002577	Owl image: Enhance
 SKILL_20150317_002578	Damage of [Carve Owl] increases per attribute level
 SKILL_20150317_002579	Cross Guard: Enhance
 SKILL_20150317_002580	Defense increase effect of [Cross Guard] increases per attribute level
-SKILL_20150317_002581	Enchanted Fire: Enhance
+SKILL_20150317_002581	Enchant Fire: Enhance
 SKILL_20150317_002582	Fire Property attack of [Enchant Fire] increases per attribute level
 SKILL_20150317_002583	Kneeling Shot: Enhance
 SKILL_20150317_002584	Physical damage of [Kneeling Shot] increases per attribute level
@@ -2795,9 +2795,9 @@ SKILL_20150317_002794	Psychic Pressure : Enhance 2
 SKILL_20150317_002795	[Psychic pressure] damage is enhanced to Psychokino Circle 2.
 SKILL_20150317_002796	Psychic Pressure : Enhance 3
 SKILL_20150317_002797	[Psychic pressure] damage is enhanced to Psychokino Circle 3.
-SKILL_20150317_002798	Magnetic Force : Enhance_
+SKILL_20150317_002798	Magnetic Force : Enhance 2
 SKILL_20150317_002799	[Magnetic Force] damage is enhanced to Psychokino Circle 2.
-SKILL_20150317_002800	Magnetic Force : Enhance 2
+SKILL_20150317_002800	Magnetic Force : Enhance 3
 SKILL_20150317_002801	[Magnetic Force] damage is enhanced to Psychokino Circle 3.
 SKILL_20150317_002802	Broom Trap : Enhance 2
 SKILL_20150317_002803	Damage of [Broom Trap] is enhanced to Sapper Circle 2.
@@ -2819,9 +2819,9 @@ SKILL_20150317_002818	Carve : Enhance 2
 SKILL_20150317_002819	Damage of [Carve] is enhanced to Dievdirbys Circle 2.
 SKILL_20150317_002820	Carve : Enhance 3
 SKILL_20150317_002821	Damage of [Carve] is enhanced to Dievdirbys Circle 3.
-SKILL_20150317_002822	Carve Owl : Enhance_
+SKILL_20150317_002822	Carve Owl : Enhance 2
 SKILL_20150317_002823	Damage of [Owl image] is enhanced to Dievdirbys Circle 2.
-SKILL_20150317_002824	Carve Owl : Enhance 2
+SKILL_20150317_002824	Carve Owl : Enhance 3
 SKILL_20150317_002825	Damage of [Owl image] is enhanced to Dievdirbys Circle 2.
 SKILL_20150317_002826	Effigy : Enhance 2
 SKILL_20150317_002827	Damage of [Effigy] is enhanced to Bokor Circle 2.
@@ -2877,9 +2877,9 @@ SKILL_20150317_002876	Impaler : Enhance 3
 SKILL_20150317_002877	[Impaler] damage is enhanced to food Tafurakuto Circle 3.
 SKILL_20150317_002878	Meteor : Enhance
 SKILL_20150317_002879	Damage of [Meteor] increases per attribute level
-SKILL_20150317_002880	Meteor : Enhance_
+SKILL_20150317_002880	Meteor : Enhance 2
 SKILL_20150317_002881	Damage of [Meteor] increases to Elementalist Circle 2
-SKILL_20150317_002882	Meteor: Enhance 2
+SKILL_20150317_002882	Meteor: Enhance 3
 SKILL_20150317_002883	Damage of [Meteor] increases to Elementalist Circle 2
 SKILL_20150317_002884	Prominence: Enhance
 SKILL_20150317_002885	Damage of [Prominence] increases per attribute level
@@ -2921,7 +2921,7 @@ SKILL_20150317_002920	Time Bomb Arrow: Enhance 2
 SKILL_20150317_002921	Damage of the Time Spring Arrow] is enhanced to Ranger Circle 3.
 SKILL_20150317_002922	Ballista: Damage
 SKILL_20150317_002923	Damage of [Ballista] increases per attribute level
-SKILL_20150317_002924	Ballistar: Damage to Circle
+SKILL_20150317_002924	Ballista: Damage to Circle 2
 SKILL_20150317_002925	Damage of [Ballista] is enhanced to Sapper Circle 2.
 SKILL_20150317_002926	Ballista: Damage to Circle 3
 SKILL_20150317_002927	Damage of [Ballista] is enhanced to Sapper Circle 3.
@@ -2939,7 +2939,7 @@ SKILL_20150317_002938	Wugong Gu : Enhance 3
 SKILL_20150317_002939	[Wugong Gu] damage is enhanced in the Wugushi Circle 3.
 SKILL_20150317_002940	Throw Gu Pot: Enhance
 SKILL_20150317_002941	Damage of [Throw Gu Pot] increases per attribute level
-SKILL_20150317_002942	Throw Gu Pot: Enhance _
+SKILL_20150317_002942	Throw Gu Pot: Enhance 2
 SKILL_20150317_002943	[Throw Gu Pot] damage is enhanced in the Wugushi Circle 2.
 SKILL_20150317_002944	Throw Gu Pot: Enhance 2
 SKILL_20150317_002945	[Throw Gu Pot] damage is enhanced in the Wugushi Circle 3.
@@ -2955,21 +2955,21 @@ SKILL_20150317_002954	Flare shot: Enhance 2
 SKILL_20150317_002955	Damage of [Flare shot] will be enhanced to Scout Circle 2.
 SKILL_20150317_002956	Bwa Kayiman: Enhance
 SKILL_20150317_002957	Damage of [Bwa Kayiman] increases per attribute level
-SKILL_20150317_002958	Bwa Kayiman: Enhance _
+SKILL_20150317_002958	Bwa Kayiman: Enhance 2
 SKILL_20150317_002959	Damage of [Bwa Kayiman] is enhanced to Bokor Circle 2.
-SKILL_20150317_002960	Bwa Kayiman: Enhance 2
+SKILL_20150317_002960	Bwa Kayiman: Enhance 3
 SKILL_20150317_002961	Damage of [Bwa Kayiman] is enhanced to Bokor Circle 3.
 SKILL_20150317_002962	Astral Body Explosion : Enhance
 SKILL_20150317_002963	Damage of [Astral Body Explosion] increases per attribute level
 SKILL_20150317_002964	Possession: Enhance
 SKILL_20150317_002965	Damage of [Possession] increases per attribute level
-SKILL_20150317_002966	Possession: Enhance 2
+SKILL_20150317_002966	Possession: Enhance 3
 SKILL_20150317_002967	Damage of [Possession] is enhanced to Sadhu Circle 3.
 SKILL_20150317_002968	Body Basic Attack : Enhance
 SKILL_20150317_002969	Basic attack damage increases per attribute level during spirit mode.
 SKILL_20150317_002970	Ectoplasm Attack: Damage to Circle 2
 SKILL_20150317_002971	Damage of [Ectoplasm Attack] is enhanced to Sadhu Circle 2.
-SKILL_20150317_002972	Ectoplasm Attack: Damage to Circle 2
+SKILL_20150317_002972	Ectoplasm Attack: Damage to Circle 3
 SKILL_20150317_002973	Damage of [Ectoplasm Attack] is enhanced to Sadhu Circle 3.
 SKILL_20150317_002974	Restoration: Enhance
 SKILL_20150317_002975	HP recovery effect of [Restoration] increases per attribute level
@@ -3010,9 +3010,9 @@ SKILL_20150317_003009	Damage of [Doom Spike] is enhanced to Cataphract circle 2.
 SKILL_20150317_003010	Doom Spike: Enhance 2
 SKILL_20150317_003011	Damage of [Doom Spike] is enhanced to Cataphract circle 3.
 SKILL_20150317_003012	Zombify : Large Zombie
-SKILL_20150317_003013	Chance of creating large zombies when zombifying monsters increase by 1% per attribute level.
+SKILL_20150317_003013	Chance of creating large zombies when zombifying monsters increases by 1% per attribute level.
 SKILL_20150317_003014	Zombify : Wheelchair Zombie
-SKILL_20150317_003015	Chance of wheelchair zombie when creating zombies increase by 1% per attribute level
+SKILL_20150317_003015	Chance of wheelchair zombie when creating zombies increases by 1% per attribute level
 SKILL_20150317_003016	Flare shot: Enhance 3
 SKILL_20150317_003017	Damage of [Flare Shot] is enhanced to Scout Circle 3.
 SKILL_20150317_003018	Astral Body Explosion: Enhance 2
@@ -3020,11 +3020,11 @@ SKILL_20150317_003019	Damage of [Astral Body Explosion] is enhanced to Sadhu Cir
 SKILL_20150317_003020	Astral Body Explosion: Enhance 3
 SKILL_20150317_003021	Damage of [Astral Body Explosion] is enhanced to Sadhu Circle 3.
 SKILL_20150317_003022	Use One-handed sword
-SKILL_20150317_003023	[One-handed Sword] is based weapon it is possible to wear
+SKILL_20150317_003023	Can use [One-handed Sword] type weapons.
 SKILL_20150317_003024	Use Two-handed sword
-SKILL_20150317_003025	[Both hands sword] series weapon will be available to wearing
+SKILL_20150317_003025	Can use [Two-handed sword] type weapons.
 SKILL_20150317_003026	Use of One-handed spear
-SKILL_20150317_003027	[One-handed window] series weapon will be available to wearing
+SKILL_20150317_003027	Can use [One-handed spear] type weapons.
 SKILL_20150317_003028	Use Two-handed spear
 SKILL_20150317_003029	Can use [Two-handed Spear] type weapons.
 SKILL_20150317_003030	Use Bow
@@ -3465,7 +3465,7 @@ SKILL_20150401_003464	Damage of [Bodkin Point] is enhanced to Fletcher Circle 2.
 SKILL_20150401_003465	Bodkin Point: Enhance 3
 SKILL_20150401_003466	Damage of [Bodkin Point] is enhanced to Fletcher Circle 3.
 SKILL_20150401_003467	Barbed Arrow: Enhance
-SKILL_20150401_003468	Damage of [Barbed Arrowe] Increase per Attribute level.
+SKILL_20150401_003468	Damage of [Barbed Arrow] Increase per Attribute level.
 SKILL_20150401_003469	Barbed Arrow: Enhance 2
 SKILL_20150401_003470	Damage of [Barbed Arrow] is enhanced to Fletcher Circle 2.
 SKILL_20150401_003471	Barbed Arrow: Enhance 3

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1639,7 +1639,7 @@ SKILL_20150317_001638	Attack reduction. Periodically receive the poison damage. 
 SKILL_20150317_001639	Evasion
 SKILL_20150317_001640	Increased Evasion.
 SKILL_20150317_001641	Defense Shock
-SKILL_20150317_001642	Shocked by having its attack blocked. Chance of enemy attacks to hit critical will increase by 100%.
+SKILL_20150317_001642	The character is shocked by having its attacks blocked. The chance of attacks on this character increase by 100%.
 SKILL_20150317_001643	Petrify
 SKILL_20150317_001644	Turned to stone.
 SKILL_20150317_001645	Enhance patience

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -923,7 +923,7 @@ SKILL_20150317_000922	Attack #{SkillAtkAdd}#{nl}Splash #{SkillSR}#
 SKILL_20150317_000923	Bash
 SKILL_20150317_000924	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Attack many enemies with a wide swing.
 SKILL_20150317_000925	Gung Ho
-SKILL_20150317_000926	Increase attack power while decreasing defense.
+SKILL_20150317_000926	Increases attack while decreasing defense.
 SKILL_20150317_000927	Physical Damage + #{CaptionRatio}#{nl}Physical Defense - #{CaptionRatio2}# {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_000928	Concentrate
 SKILL_20150317_000929	Attacks deal additional damage.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -977,7 +977,7 @@ SKILL_20150317_000976	Attack #{SkillAtkAdd}#{nl}Max. Duration 10 seconds{nl}Cons
 SKILL_20150317_000977	Montano
 SKILL_20150317_000978	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Hit an enemy's feet to knock it back and stun it.
 SKILL_20150317_000979	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Stun]{/}{/} Duration 7 seconds
-SKILL_20150317_000980	Target Smash
+SKILL_20150317_000980	Targe Smash
 SKILL_20150317_000981	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl} Slam your shield on the enemy. Has a high chance of inflicted the dark status.
 SKILL_20150317_000982	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Dark]{/}{/} Duration 3 seconds{nl}Splash #{SkillSR}#
 SKILL_20150317_000983	Shield Push
@@ -1168,7 +1168,7 @@ SKILL_20150317_001167	Swell Body
 SKILL_20150317_001168	Enlarge size of target. Target's HP, EXP, and drop rate are doubled.
 SKILL_20150317_001169	Small -> Medium -> Large {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001170	Transpose
-SKILL_20150317_001171	Swaps INT and CON.
+SKILL_20150317_001171	Swaps INT and CON for a limited period of time.
 SKILL_20150317_001172	Reversi
 SKILL_20150317_001173	Gain control of enemy magic circles.
 SKILL_20150317_001174	Change enemy's magic circles to friendly ones in target area. {nl}Level 1 Master

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -956,7 +956,7 @@ SKILL_20150317_000955	Cross Guard
 SKILL_20150317_000956	Defend using your weapon.
 SKILL_20150317_000957	Defense + #{CaptionRatio}#{nl}Block + #{CaptionRatio2}#
 SKILL_20150317_000958	Moulinet
-SKILL_20150317_000959	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Attack enemy 5 times without stopping.
+SKILL_20150317_000959	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Continously attack an enemy 5 times.
 SKILL_20150317_000960	Stabbing
 SKILL_20150317_000961	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Stab the enemy continuously.
 SKILL_20150317_000962	Pierce
@@ -1980,53 +1980,53 @@ SKILL_20150317_001979	Attack increases when HP is below 40%. {Nl} For Level 1 on
 SKILL_20150317_001980	Ice Spear
 SKILL_20150317_001981	Ice Bolt deals additional damage to frozen enemies {Nl} (added by 25% per level)
 SKILL_20150317_001982	Blow of Rupture
-SKILL_20150317_001983	Chacne of inlficting explosion damage on enemies with hit attack. {Nl} (triggered at 5% chance per level)
+SKILL_20150317_001983	Chance of inflicting explosion damage on enemies with hit attack. {Nl} (triggered at 5% chance per level)
 SKILL_20150317_001984	Rupture
-SKILL_20150317_001985	Damage to Chain Armor type will increase when using blunt. {Nl} (increase by 20% per level)
+SKILL_20150317_001985	Blunt weapons will deal more damage to plate armor. {Nl} (increase by 20% per level)
 SKILL_20150317_001986	Overcome
-SKILL_20150317_001987	Critical probability will increase when using sword. {Nl} (increased by critical rate of 10% per level)
+SKILL_20150317_001987	Have increased critical rate when using swords. {Nl} (increased by critical rate of 10% per level)
 SKILL_20150317_001988	Jump
 SKILL_20150317_001989	You can jump. Press the [X] key to jump.
 SKILL_20150317_001990	Sidestep
-SKILL_20150317_001991	Move sidewards. Press arrow keys while holding down the [Shift] key, to move sidewards. Consumes energy.
+SKILL_20150317_001991	Move sideways. Press arrow keys while holding down the [Shift] key, to move sideways. Consumes energy.
 SKILL_20150317_001992	Dash
-SKILL_20150317_001993	You can run. Press arrow key twice to start the running.
+SKILL_20150317_001993	You can run. Press an arrow key twice to start the running.
 SKILL_20150317_001994	Meditation
 SKILL_20150317_001995	SP recovery amount increase. {Nl} (increased by 1% of the maximum energy level x)
 SKILL_20150317_001996	Play
 SKILL_20150317_001997	Amount of HP recovery increases. {Nl} (increased by level x 1% of max. HP)
 SKILL_20150317_001998	Inspiration
-SKILL_20150317_001999	Defense level will increase. {Nl} (increased by level x 10)
+SKILL_20150317_001999	Defense level increases. {Nl} (increased by level x 10)
 SKILL_20150317_002000	Enemies hit with strong strike have chance of being stunned for 5 seconds.
-SKILL_20150317_002001	Traverse
+SKILL_20150317_002001	Dash
 SKILL_20150317_002002	Move short distance at high speed. Stamina is consumed. Press arrow key twice to use. -- Squire Characteristic
 SKILL_20150317_002003	Lv.1 STA consumption 4
 SKILL_20150317_002004	Shield Heater
-SKILL_20150317_002005	Reflect attacks when using skill Parrying. (Reflected damage increases in proportion to the defense force and attribute level.)
+SKILL_20150317_002005	Reflect damage when Parrying. (Reflected damage increases in proportion to the defense force and attribute level.)
 SKILL_20150317_002006	Anger
-SKILL_20150317_002007	Enemy is stunned by chance when attacked with Mace-type weapon.{nl} (Increases by 10% per level.)
+SKILL_20150317_002007	Maces have a chance to stun enemies on hit.{nl} (Increases by 10% per level.)
 SKILL_20150317_002008	Lv.1 Stun probability 10%, 3 seconds duration Lv.2 Stun probability 20%, 4 seconds duration Lv.3 Stun probability 30%, lasts 5 seconds.
 SKILL_20150317_002009	Intuition
-SKILL_20150317_002010	Using stab skill to bleeding enemy inflicts critical damage at certain chance. {Nl} (Basic chance of 30% + 5% added per level.)
+SKILL_20150317_002010	Stab has a higher chance of inflicting criticals on bleeding enemies. {Nl} (Basic chance of 30% + 5% added per level.)
 SKILL_20150317_002011	Cut
-SKILL_20150317_002012	After a successful overkill,the  amount of damage doubles for 10 seconds on one attack.
+SKILL_20150317_002012	The next attack within 10  seconds will do double damage after overkilling an enemy.
 SKILL_20150317_002013	Guard
 SKILL_20150317_002014	Movement speed increases when HP is below 15%.
 SKILL_20150317_002015	Two-handed Sword Mastery
-SKILL_20150317_002016	Mastered weapon. Physical Attack will increase when using a Two-handed sword.
+SKILL_20150317_002016	One's proficiency with Two-handed Swords. Physical Attack increases when using a Two-handed sword.
 SKILL_20150317_002017	Apply # {IncrValue1} #% Lv.1 Attack{nl}Apply # {IncrValue1} #% Lv.2 Attack{nl}Apply # {IncrValue1} #% Lv.3 Attack
 SKILL_20150317_002018	Whipping Top
 SKILL_20150317_002019	Rotation time of Whirlwind increases.
 SKILL_20150317_002020	Lv.1 Rotation time + # {IncrValue1} # seconds {nl} Lv.2 Rotation time + # {IncrValue1} # seconds
 SKILL_20150317_002021	Nether Web
-SKILL_20150317_002022	Number of hold attack using Telekinesis increases. {Nl} (Increase as much as level.)
+SKILL_20150317_002022	Number of attacks Telekinesis can do increases. {Nl} (Increase as much as level.)
 SKILL_20150317_002023	Ignite
-SKILL_20150317_002024	Amount of damage is doubled when attacking enemy under Slow with Fire Ball.
-SKILL_20150317_002025	Add a chance of Stun for Spear Blow skill{Nl} (Increases by 5% per level.)
+SKILL_20150317_002024	Fire Ball does double damage to slowed enemies.
+SKILL_20150317_002025	Spear Blow has gains a chance to stun{Nl} (Increases by 5% per level.)
 SKILL_20150317_002026	Surprise Attack
-SKILL_20150317_002027	Have chance of inflicting additional damage when attacking a stunned enemy. {Nl} (Basic chance of 30% + 5% added per level.)
+SKILL_20150317_002027	Additional critical chance against stunned enemies. {Nl} (Basic chance of 30% + 5% added per level.)
 SKILL_20150317_002028	Concentration
-SKILL_20150317_002029	Critical is applied at certain chance when attacking enemy near the farthest range. {Nl} (Basic chance of 50% + 5% added per level.)
+SKILL_20150317_002029	Critical rate increases when attacking far away enemies. {Nl} (Basic chance of 50% + 5% added per level.)
 SKILL_20150317_002030	Self Vitality
 SKILL_20150317_002031	Potion buff duration increases. {Nl} (Increases by 5% per level.)
 SKILL_20150317_002032	Strike
@@ -2035,15 +2035,15 @@ SKILL_20150317_002034	Nanta
 SKILL_20150317_002035	Reduce Knockback range of monsters when using whirlwind.
 SKILL_20150317_002036	STR increases for Melee-type attacks.
 SKILL_20150317_002037	Agility is increased. Affects ranged Physical attacks, chance of critical, and evasion.
-SKILL_20150317_002038	Physical strength ability value will improve. It will affect the maximum value of the life force and energy.
+SKILL_20150317_002038	Physical strength improves. Max HP increases.
 SKILL_20150317_002039	Increase INT
-SKILL_20150317_002040	Intelligence increases. Affect the max SPR and magic attack.
+SKILL_20150317_002040	Intelligence increases. Increases max SP and magic attack.
 SKILL_20150317_002041	Balance
 SKILL_20150317_002042	Gung Ho skill's resistance probability increase. {Nl} (Increases by 5% per level.)
 SKILL_20150317_002043	Smash
-SKILL_20150317_002044	Umbo Blow skill knock down power increase. {Nl} (Increased by 50% per level.)
+SKILL_20150317_002044	Umbo Blow's knock down power increases. {Nl} (Increased by 50% per level.)
 SKILL_20150317_002045	Sharp Spear Head
-SKILL_20150317_002046	Add a chance of Bleed for Spear Blow skill. {Nl} (Increases by 5% per level.)
+SKILL_20150317_002046	Spear Blow gains a chance to bleed on hit. {Nl} (Increases by 5% per level.)
 SKILL_20150317_002047	Wire Rope
 SKILL_20150317_002048	Centrifugal Force
 SKILL_20150317_002049	Tricks

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -934,7 +934,7 @@ SKILL_20150317_000933	Physical Attack + #{CaptionRatio}#{nl}Maximum HP - #{Capti
 SKILL_20150317_000934	Umbo Blow
 SKILL_20150317_000935	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using shield. {nl} Does two hits if used after blocking an attack.
 SKILL_20150317_000936	Rim Blow
-SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} >Deals additional damage to both petrified and frozen enemies.
+SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} Deals additional damage to both petrified and frozen enemies.
 SKILL_20150317_000938	Swash Buckling
 SKILL_20150317_000939	Hit your shield to attract enemies.
 SKILL_20150317_000940	Target #{SkillSR}#{nl}Max. provoke +#{CaptionRatio}# for #{CaptionTime}# seconds

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -464,7 +464,7 @@ SKILL_20150317_000463	[Green Ellom] Physical, Strike, Poison Property Attack
 SKILL_20150317_000464	[Pokuborn] Physical, Stab, Poison Property Attack
 SKILL_20150317_000465	[Pokuborn] Physical, Stab, Lightning Property Attack
 SKILL_20150317_000466	[Vubbe Chaser] Physical, Stab, Dark Property Attack 2 times
-SKILL_20150317_000467	[Vubbe Chaser] Physical, Stab, Dark Property, 5회 Attack
+SKILL_20150317_000467	[Vubbe Chaser] Physical, Stab, Dark Property, Attack 5 times
 SKILL_20150317_000468	[Shaman Doll] Physical, Stab, Dark Property Attack
 SKILL_20150317_000469	[Green Drake] Physical, Strike, Poison Property Attack
 SKILL_20150317_000470	[Green Drake] Magic, Magic, Poison Property Attack
@@ -921,113 +921,113 @@ SKILL_20150317_000920	Thrust
 SKILL_20150317_000921	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Stab and push away enemy.
 SKILL_20150317_000922	Attack #{SkillAtkAdd}#{nl}Splash #{SkillSR}#
 SKILL_20150317_000923	Bash
-SKILL_20150317_000924	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Swing weapon widely to damage target.
+SKILL_20150317_000924	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Attack many enemies with a wide swing.
 SKILL_20150317_000925	Gung Ho
-SKILL_20150317_000926	Increase attack while decreasing defense.
+SKILL_20150317_000926	Increase attack power while decreasing defense.
 SKILL_20150317_000927	Physical Damage + #{CaptionRatio}#{nl}Physical Defense - #{CaptionRatio2}# {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_000928	Concentrate
-SKILL_20150317_000929	Increase skill power.
+SKILL_20150317_000929	Attacks deal additional damage.
 SKILL_20150317_000930	Additional Damage + #{CaptionRatio2}#{nl}Attack#{CaptionRatio}# times {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_000931	Restrain
-SKILL_20150317_000932	Lower maximum HP and increase attack.
+SKILL_20150317_000932	Lower maximum HP and gain a chance to stun on.
 SKILL_20150317_000933	Physical Attack + #{CaptionRatio}#{nl}Maximum HP - #{CaptionRatio2}# {nl} Duration #{CaptionTime}# seconds
 SKILL_20150317_000934	Umbo Blow
-SKILL_20150317_000935	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using shield. {nl} Attack after blocking enemy for additional damage.
+SKILL_20150317_000935	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using shield. {nl} Does two hits if used after blocking an attack.
 SKILL_20150317_000936	Rim Blow
-SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} Attack when enemy is petrified or frozen for additional damage.
+SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} >Deals additional damage to both petrified and frozen enemies.
 SKILL_20150317_000938	Swash Buckling
-SKILL_20150317_000939	Hit shield to threathen enemy.
+SKILL_20150317_000939	Hit your shield to attract enemies.
 SKILL_20150317_000940	Target #{SkillSR}#{nl}Max. provoke +#{CaptionRatio}# for #{CaptionTime}# seconds
-SKILL_20150317_000941	Reduce attack and increase defense.
+SKILL_20150317_000941	Reduce attack power to increase defense.
 SKILL_20150317_000942	Physical Defense + #{CaptionRatio}#{nl}Physical Damage - #{CaptionRatio2}# {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_000943	Shield Lob
 SKILL_20150317_000944	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl} Throw shield to attack enemy.
 SKILL_20150317_000945	High Guard
 SKILL_20150317_000946	Butterfly
 SKILL_20150317_000947	Wagon Wheel
-SKILL_20150317_000948	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Uppercut with weapon to Blow away enemy.
+SKILL_20150317_000948	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Launch enemies with an uppercut.
 SKILL_20150317_000949	Cartar Stroke
-SKILL_20150317_000950	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl} Gather strength and hit the ground to attack enemy
+SKILL_20150317_000950	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl} Attack enemies with a charged smash.
 SKILL_20150317_000951	Attack #{SkillAtkAdd}#{nl}Cast Time 0.5 seconds{nl}Splash #{SkillSR}#
 SKILL_20150317_000952	Crown
-SKILL_20150317_000953	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Smash enemy's head. Temporarily decreases the enemy's INT and SPR.
+SKILL_20150317_000953	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Temporarily decreases the enemy's INT and SPR by smacking the enemy on the head.
 SKILL_20150317_000954	Attack #{SkillAtkAdd}#{nl}Splash #{SkillSR}#{nl}{#339999}{ol}[Shock]{/}{/} Duration #{CaptionTime}# seconds
 SKILL_20150317_000955	Cross Guard
-SKILL_20150317_000956	Take defensive stance using weapon.
+SKILL_20150317_000956	Defend using your weapon.
 SKILL_20150317_000957	Defense + #{CaptionRatio}#{nl}Block + #{CaptionRatio2}#
 SKILL_20150317_000958	Moulinet
-SKILL_20150317_000959	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Attack enemy continuously 5 times
+SKILL_20150317_000959	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Attack enemy 5 times without stopping.
 SKILL_20150317_000960	Stabbing
-SKILL_20150317_000961	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Attack enemy continuously using spear.
+SKILL_20150317_000961	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Stab the enemy continuously.
 SKILL_20150317_000962	Pierce
-SKILL_20150317_000963	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Strongly stab enemy. {nl}Continuous attack bonus applies depending on size of enemy.
+SKILL_20150317_000963	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Strongly stab enemy. {nl}Does multiple hits on larger enemies.
 SKILL_20150317_000964	Attack #{SkillAtkAdd}#{nl}2 Attacks on medium target{nl}3 Attacks on large target
 SKILL_20150317_000965	Finestra
-SKILL_20150317_000966	Change to Window formation. {Nl}Critical is increased while Evasion decreases.
+SKILL_20150317_000966	Enter an aggressive stance. {Nl}Critical and block rate increase while Evasion decreases.
 SKILL_20150317_000967	Critical + #{CaptionRatio}#{nl}Evasion - #{CaptionRatio2}#{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_000968	Synchro Thrusting
-SKILL_20150317_000969	{#DD5500}{ol}[Physical] - [Stab] - [Strike]{/}{/}{nl}Attack enemy using shield and spear.
+SKILL_20150317_000969	{#DD5500}{ol}[Physical] - [Stab] - [Strike]{/}{/}{nl}Attack with shield and spear simultaneously.
 SKILL_20150317_000970	Spear Attack #{SkillAtkAdd}#{nl}Shield Attack #{CaptionRatio}#{nl}Splash #{SkillSR}#
 SKILL_20150317_000971	Long Stride
-SKILL_20150317_000972	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Teleport and attack enemies within range.
+SKILL_20150317_000972	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Hit enemies with a long ranged jump attack.
 SKILL_20150317_000973	Spear Throw
 SKILL_20150317_000974	Shield Charge
-SKILL_20150317_000975	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl} Carry shield and run. Enemies hit nearby falls down.
+SKILL_20150317_000975	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl} Raise your shield and rush enemies, anything hit is knocked down.
 SKILL_20150317_000976	Attack #{SkillAtkAdd}#{nl}Max. Duration 10 seconds{nl}Consume STA
 SKILL_20150317_000977	Montano
-SKILL_20150317_000978	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Attack bottom of the target strongly.
+SKILL_20150317_000978	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Hit an enemy's feet to knock it back and stun it.
 SKILL_20150317_000979	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Stun]{/}{/} Duration 7 seconds
-SKILL_20150317_000980	Targe Smash
-SKILL_20150317_000981	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl} Whack strongly subject to the shield will increase. Target is stuck in a dark state with high probability.
+SKILL_20150317_000980	Target Smash
+SKILL_20150317_000981	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl} Slam your shield on the enemy. Has a high chance of inflicted the dark status.
 SKILL_20150317_000982	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Dark]{/}{/} Duration 3 seconds{nl}Splash #{SkillSR}#
 SKILL_20150317_000983	Shield Push
-SKILL_20150317_000984	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Interfere enemy with shield.{nl} Target falls under unbalanced state.
+SKILL_20150317_000984	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Shoves the enemy with your shield.{nl} Inflicts unbalance upon the target.
 SKILL_20150317_000985	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Unbalance]{/}{/} Duration 5 seconds
 SKILL_20150317_000986	Impaler
-SKILL_20150317_000987	{#DD5500}{ol}[Stab]{/}{/}{nl} I go to plug through the small monsters in the window. If you use the skill to take down to the ground after you plug in the window will increase.
+SKILL_20150317_000987	{#DD5500}{ol}[Stab]{/}{/}{nl} Impale a small or medium monster on your spear. Can attack other enemies with the skewered one. Can move freely while using this skill.
 SKILL_20150317_000988	Earth Wave
-SKILL_20150317_000989	{#DDD300}{ol}[Strike]{/}{/}{nl}Gather strength and smash the ground to attack enemy.
-SKILL_20150317_000990	Trout
-SKILL_20150317_000991	Movement speed will increase.
+SKILL_20150317_000989	{#DDD300}{ol}[Strike]{/}{/}{nl}Charge up to your stregth to attack enemies with a massive ground slam.
+SKILL_20150317_000990	Trot
+SKILL_20150317_000991	Increases movement speed.
 SKILL_20150317_000992	Movement Speed +#{CaptionRatio}#%{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_000993	Stead Charge
-SKILL_20150317_000994	{#DDD300}{ol}[Strike]{/}{/}{nl}Rush forward and push away enemy.
+SKILL_20150317_000994	{#DDD300}{ol}[Strike]{/}{/}{nl}Charge forward to knock back all enemies in your path.
 SKILL_20150317_000995	Doom Spike
-SKILL_20150317_000996	{#DDD300}{ol}[Strike]{/}{/}{nl}Gather force and and strongly stab enemy.
+SKILL_20150317_000996	{#DDD300}{ol}[Stab]{/}{/}{nl}Charge up for a strong stab attack.
 SKILL_20150317_000997	Rush
-SKILL_20150317_000998	{#DD5500}{ol}[Slash]{/}{/}{nl}Attack enemy in fron continuously while spinning the spear over head.
+SKILL_20150317_000998	{#DD5500}{ol}[Slash]{/}{/}{nl}Spin your spear above your head to attack nearby enemies. Can move freely while using this skill.
 SKILL_20150317_000999	Attack #{SkillAtkAdd}#{nl}Max. Duration 10 seconds{nl}Splash #{SkillSR}#
 SKILL_20150317_001000	Dragging Death
 SKILL_20150317_001001	{#DDD300}{ol}[Stab]{/}{/}{nl}Attacks enemies in front continuously.
 SKILL_20150317_001002	Embowel
-SKILL_20150317_001003	{#DD5500}{ol}[Stab]{/}{/}{nl} Kick the enemies after strongly stinging.
+SKILL_20150317_001003	{#DD5500}{ol}[Stab]{/}{/}{nl} Stab an enemy then kick it away.
 SKILL_20150317_001004	Flange
-SKILL_20150317_001005	Continuously attack enemy with basic attack after using skill to increase ATK.
+SKILL_20150317_001005	Boost your ATK by continously attacking the same enemy with normal attacks.
 SKILL_20150317_001006	Attack + #{CaptionRatio}#{nl}Max. overlap #{CaptionRatio2}# times {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001007	Aggressor
-SKILL_20150317_001008	Attack is accurate but chance of critical and critical evasion decreases.
+SKILL_20150317_001008	Increases your critical chance and critical resistence.
 SKILL_20150317_001009	Critical Chance -#{CaptionRatio}#%{nl}Critical Evasion -#{CaptionRatio}#%{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001010	Savagery
-SKILL_20150317_001011	While the buff is activated, addtional bonus is applied to {#DD5500}{ol}[Sting]{/}{/} attack.
-SKILL_20150317_001012	{#DD5500}{ol}[Stab]{/}{/} Batter Bonus {nl} Duration #{CaptionTime}#sec
+SKILL_20150317_001011	While the buff is activated, {#DD5500}{ol}[Stab]{/}{/} attacks hit multiple times.
+SKILL_20150317_001012	{#DD5500}{ol}[Stab]{/}{/} Multi-hit bonus {nl} Duration #{CaptionTime}#sec
 SKILL_20150317_001013	Warcry
 SKILL_20150317_001014	Reduces the target's defense nearby and add it to your attack.
 SKILL_20150317_001015	Target #{CaptionRatio}#player{nl} MAX Physical DEF - #{CaptionRatio2}# {nl}Duration #{CaptionTime}#seconds
 SKILL_20150317_001016	Stomping Kick
-SKILL_20150317_001017	{#DD5500}{ol}[Strike]{/}{/}{nl} When in the air, landing hard to to inflict damage on target.
+SKILL_20150317_001017	{#DD5500}{ol}[Strike]{/}{/}{nl} Jump in the air and stomp on the enemy.
 SKILL_20150317_001018	Weapon Maintenance
-SKILL_20150317_001019	Open shop for repairing weapons.
+SKILL_20150317_001019	Open a shop to increase weapon performance.
 SKILL_20150317_001020	Armor Maintenance
-SKILL_20150317_001021	Create shop for repairing armors.
+SKILL_20150317_001021	Open a shop to increasing armor performance.
 SKILL_20150317_001022	Repair
-SKILL_20150317_001023	Use shield to push away and interfere enemy.
+SKILL_20150317_001023	Open a shop to repair weapons and armor. Repaired items have higher durability than their max.
 SKILL_20150317_001024	Arrest
 SKILL_20150317_001025	Jolly Roger
 SKILL_20150317_001026	Iron hook
 SKILL_20150317_001027	Keel Hauling
 SKILL_20150317_001028	Unlock Chest
-SKILL_20150317_001029	Cancel Sub Weapon
-SKILL_20150317_001030	{#DDD300}{ol}[Buff]{/}{/}{nl}Bonus attack is added to {#CC3300}{ol}[Sting]{/}{/}while buff is activated.
+SKILL_20150317_001029	Endless Assault
+SKILL_20150317_001030	{#DDD300}{ol}[Buff]{/}{/}{nl}Can combo normal attacks into subweapon attacks without delay.
 SKILL_20150317_001031	Duration #{CaptionTime}# seconds{nl}Consume #{SpendSP}# SP
 SKILL_20150317_001032	Conscript
 SKILL_20150317_001033	Phalanx
@@ -1039,16 +1039,16 @@ SKILL_20150317_001038	Testuto
 SKILL_20150317_001039	Skirmisher
 SKILL_20150317_001040	Change Direction
 SKILL_20150317_001041	Deeds of Valor
-SKILL_20150317_001042	Increase Attack Speed, Attack Rate during hit, Decrease Defense
+SKILL_20150317_001042	Gain Attack Speed and lose Defense upon taking damage. 
 SKILL_20150317_001043	Pain Barrier
-SKILL_20150317_001044	Movement Speed +#{CaptionTime}# for #{CaptionRatio}#% seconds
+SKILL_20150317_001044	Be immune to knockback and hitstun from attacks for +#{CaptionTime}# seconds
 SKILL_20150317_001045	Mordschlag
 SKILL_20150317_001046	{#CC3300}{ol}[Stab]{/}{/} Attribute{nl}Damage #{SkillFactor}#%{nl}Splash #{SkillSR}#{nl} Consumption SP #{SpendSP}#
 SKILL_20150317_001047	Double Pay Earn
-SKILL_20150317_001048	Three times of hit damage
+SKILL_20150317_001048	Defeat an enemy within Attack#{CaptionRatio}# times to earn double exp and rewards. Damage taken and durability lost are tripled while this buff is active.
 SKILL_20150317_001049	Punish
 SKILL_20150317_001050	Cyclone
-SKILL_20150317_001051	Make powerful rotation attack to nearby enemies.
+SKILL_20150317_001051	Hit nearby enemies with a powerful spinning attack.
 SKILL_20150317_001052	Lv.1 Attack Rate #{SkillFactor}#, Splash 3Lv.2 Attack Rate #{SkillFactor}#, Splash 6Lv.3 Attack Rate #{SkillFactor}#, Splash 9Lv.4 Attack Rate #{SkillFactor}#, Splash 12Lv.5 Attack Rate #{SkillFactor}#, Splash 15
 SKILL_20150317_001053	Suicide Bombing
 SKILL_20150317_001054	Clone
@@ -1063,95 +1063,95 @@ SKILL_20150317_001062	Increase Knockdown Power
 SKILL_20150317_001063	Use chain to capture and swing nearby enemy.
 SKILL_20150317_001064	Curse
 SKILL_20150317_001065	Energy Bolt
-SKILL_20150317_001066	{#993399}{ol}[Magic]{/}{/}{nl} Attack target with powerful energy.
+SKILL_20150317_001066	{#993399}{ol}[Magic]{/}{/}{nl} Gather energy to launch at the enemy.
 SKILL_20150317_001067	Attack #{SkillAtkAdd}#{nl}Cast Time 1 second{nl}Splash #{SkillSR}#
 SKILL_20150317_001068	Lethargy
-SKILL_20150317_001069	Make target become lethargic.
+SKILL_20150317_001069	Inflict lethargy upon the target.
 SKILL_20150317_001070	Physical damage - #{CaptionRatio}#{nl} Magic Attack - #{CaptionRatio}#{nl} Evasion - #{CaptionRatio2}#{nl} {#339999}{ol}[Lethargy]{/}{/}Duration #{CaptionTime}# seconds
 SKILL_20150317_001071	Sleep
-SKILL_20150317_001072	Make target fall into sleep. Enemies in sleep will wake when reaching attack limit.
+SKILL_20150317_001072	Inflicts sleep upon targets. Enemies will awake after taking a certain number of hits or once sleep runs out.
 SKILL_20150317_001073	{#339999}{ol}[Sleep]{/}{/}Duration #{SkillFactor}# seconds {nl}Attack limit #{CaptionRatio}# times
 SKILL_20150317_001074	Reflect Shield
-SKILL_20150317_001075	Create a barrier reflecting attack of the enemy.
+SKILL_20150317_001075	Creates a shield that reflects some of the damage you take back on the attacker.
 SKILL_20150317_001076	Damage Reflection #{CaptionRatio}#{nl}Duration #{CaptionTime}# seconds {nl}Reflect #{CaptionRatio2}# times
-SKILL_20150317_001077	Earth Quake
-SKILL_20150317_001078	{#993399}{ol}[Magic] - [Earth]{/}{/}{nl}Cause a massive Earthquake to damage target.
+SKILL_20150317_001077	Earthquake
+SKILL_20150317_001078	{#993399}{ol}[Magic] - [Earth]{/}{/}{nl}Create an earthquake infront of you to damage and launch nearby enemies.
 SKILL_20150317_001079	Sure Spell
-SKILL_20150317_001080	Being attacked does not cancel casting when skill is used.
+SKILL_20150317_001080	Being attacked while casting a spell will not cancel it.
 SKILL_20150317_001081	Duration #{CaptionTime}# seconds
 SKILL_20150317_001082	Magic Missile
-SKILL_20150317_001083	{#993399}{ol}[Magic]{/}{/}{nl} Fire Magic Missile to target
+SKILL_20150317_001083	{#993399}{ol}[Magic]{/}{/}{nl} Fires Magic Missiles at the target
 SKILL_20150317_001084	Attack #{SkillAtkAdd}#{nl}3 Magic Missiles
 SKILL_20150317_001085	Quick Cast
 SKILL_20150317_001086	Cast Time decreased.
 SKILL_20150317_001087	Cast Time - #{CaptionRatio}#% {nl} Duration #{CaptionTime}# seconds
 SKILL_20150317_001088	Fire Ball
-SKILL_20150317_001089	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Summon Fire sphere. You can Blow the sphere using sword attack.
+SKILL_20150317_001089	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Summons a stationary fireball. You can move it by hitting it with physical attacks.
 SKILL_20150317_001090	Attack #{SkillAtkAdd}#{nl}Attack #{SkillSR}# times{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001091	Fire Wall
-SKILL_20150317_001092	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Create flame barrier to damage adjacent enemies.
+SKILL_20150317_001092	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Create wall of flame to attack nearby enemies.
 SKILL_20150317_001093	Attack #{SkillAtkAdd}#{nl}#{CaptionRatio}# Fire Wall #{nl}Attack #{CaptionRatio2}# times{nl}Duration 15 seconds
 SKILL_20150317_001094	Enchant Fire
-SKILL_20150317_001095	Grant Fire Property attack force to target. Additional damage is applied for basic attack.
+SKILL_20150317_001095	Gives all attacks an additional fire damage attack as well as increasing normal damage.
 SKILL_20150317_001096	Fire Property attack + #{CaptionRatio}#{nl} Additional Damage + #{CaptionRatio2}#{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001097	Flare
-SKILL_20150317_001098	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Explode enemy in abnornal state except petrified and frozen state.
+SKILL_20150317_001098	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Immolate enemy burning enemies.
 SKILL_20150317_001099	Attack #{SkillAtkAdd}#
 SKILL_20150317_001100	Fire Pillar
 SKILL_20150317_001101	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Summon fire pillar to damage enemies.
 SKILL_20150317_001102	Attack #{SkillAtkAdd}#{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001103	Hell Breath
-SKILL_20150317_001104	{#993399}{ol}[Magic] - [Fire]{/}{/}{nlContinuously fume flame forward.
+SKILL_20150317_001104	{#993399}{ol}[Magic] - [Fire]{/}{/}{nlContinuously burn enemies with a cone of flame.
 SKILL_20150317_001105	Attack #{SkillAtkAdd}#{nl}Consume #{CaptionRatio}#% SP per 0.5 seconds
 SKILL_20150317_001106	Ice Bolt
-SKILL_20150317_001107	{#993399}{ol}[Magic] - [Ice] - [Stab]{/}{/}{nl}Blow Ice force with chance of freezing enemy.
+SKILL_20150317_001107	{#993399}{ol}[Magic] - [Ice] - [Stab]{/}{/}{nl}Shoot an enemy with a bolt of ice. Can freeze targets.
 SKILL_20150317_001108	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Frozen]{/}{/} Duration 3 seconds
 SKILL_20150317_001109	Ice Pike
-SKILL_20150317_001110	{#993399}{ol}[Magic] - [Ice] - [Stab] {/} {/}} {nl}Create ice waves with chance of freezing enemy.
+SKILL_20150317_001110	{#993399}{ol}[Magic] - [Ice] - [Stab] {/} {/}} {nl}Attack enemies with a wave of ice spikes, can freeze targets.
 SKILL_20150317_001111	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Frozen]{/}{/} Duration 4 seconds
-SKILL_20150317_001112	Create Ice Wall with a chance of freezing the enemy.
+SKILL_20150317_001112	Create Ice Wall that can freeze adjacent enemies. Attacking the ice wall will shoot icicles at enemies.
 SKILL_20150317_001113	Ice Wall #{CaptionRatio}# {nl}{#339999}{ol}[Ice]{/}{/}{nl} Duration 3 seconds {nl} Ice Wall Duration 10 seconds
 SKILL_20150317_001114	Ice Blast
-SKILL_20150317_001115	{#993399}{ol}[Magic] - [Ice]{/}{/}{nl}Blast frozen enemies in front.
+SKILL_20150317_001115	{#993399}{ol}[Magic] - [Ice]{/}{/}{nl}Blow up frozen enemies with a chance to refreeze them.
 SKILL_20150317_001116	{#339999}{ol}[Ice]{/}{/}Target to Attack #{SkillAtkAdd}#
 SKILL_20150317_001117	Create wall of ice and defend against attacks.
 SKILL_20150317_001118	Enemies attacked {#339999}{ol}[Ice]{/}{/}Rate 50% {nl} {#339999}{ol}[Ice]{/}{/}Duration 3 seconds
 SKILL_20150317_001119	Gust
-SKILL_20150317_001120	Create strong wind to push away enemy. Inflict damage on frozen enemies or nearby Ice Wall.
+SKILL_20150317_001120	Knockback enemies with a powerful blast of wind. Damages nearby enemies.
 SKILL_20150317_001121	Frost Pillar
 SKILL_20150317_001122	Summon ice tree and pull targets nearby.
 SKILL_20150317_001123	{#339999}{ol}[Ice]{/}{/}probability #{CaptionRatio}#% {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001124	Psychic Pressure
-SKILL_20150317_001125	{#993399}{ol}[Magic]{/}{/}{nl}Give continuous damage to targets in front.
+SKILL_20150317_001125	{#993399}{ol}[Magic]{/}{/}{nl}Attack an enemy and anyone nearby with crushing pressure.
 SKILL_20150317_001126	Attack #{SkillAtkAdd}#{nl}Splash #{CaptionRatio}#{nl}Consume #{CaptionRatio2}#% of SP per second.
 SKILL_20150317_001127	Telekinesis
-SKILL_20150317_001128	{#993399}{ol}[Magic]{/}{/}{nl}Catch target with psychokinesis. {nl}Throw target to desire direction and give damage.
+SKILL_20150317_001128	{#993399}{ol}[Magic]{/}{/}{nl}Control an enemy with telekinesis. {nl}Use the arrow keys to throw the enemy about to inflict damage.
 SKILL_20150317_001129	Attack #{SkillAtkAdd}#{nl}Attack count #{CaptionRatio}# times {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001130	Swap
-SKILL_20150317_001131	Change position of target and yourself.
+SKILL_20150317_001131	Change locations with the target.
 SKILL_20150317_001132	Target #{CaptionRatio}#{nl}Range limit 20 {nl}
 SKILL_20150317_001133	Teleportation
 SKILL_20150317_001134	Teleport to random location.
 SKILL_20150317_001135	Max. teleport distance #{CaptionRatio}#
 SKILL_20150317_001136	Magnetic Force
-SKILL_20150317_001137	{#993399}{ol}[Magic]{/}{/}{nl}Suck the enemies in target area.
+SKILL_20150317_001137	{#993399}{ol}[Magic]{/}{/}{nl}Enemies are sucked into the target area.
 SKILL_20150317_001138	Raise
-SKILL_20150317_001139	Lift targets around up in the air.
+SKILL_20150317_001139	Lift targets into the air.
 SKILL_20150317_001140	Target #{CaptionRatio}#{nl}Duration #{CaptionRatio2}# seconds
 SKILL_20150317_001141	Gravity Pole
-SKILL_20150317_001142	Create a stright gravitational field and pull in target.
+SKILL_20150317_001142	Create a line of enhanced gravity that sucks in all nearby enemies.
 SKILL_20150317_001143	Target #{CaptionRatio}#{nl}Max. duration 5 seconds
 SKILL_20150317_001144	Unbind
-SKILL_20150317_001145	Release all connected links.
+SKILL_20150317_001145	Cut all links.
 SKILL_20150317_001146	Cut all links at once {nl} Level 1 master
 SKILL_20150317_001147	Physical link
-SKILL_20150317_001148	Link party members and divide damage.
+SKILL_20150317_001148	Link party members to divide damage taken.
 SKILL_20150317_001149	More links results to less damage{nl} Max. Link #{CaptionRatio}#{nl}Duration #{CaptionTime}# seconds{nl}Consuem 16% of Stamina
 SKILL_20150317_001150	Joint Penalty
-SKILL_20150317_001151	Put link on enemy. Enemies that are linked receive damage together.
+SKILL_20150317_001151	Link enemies together. Damage inflicted on one linked enemy is inflicted upon all linked ones.
 SKILL_20150317_001152	Max. Links #{SkillFactor}#{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001153	Hangman's Knot
-SKILL_20150317_001154	Gather enemies under link to one area.
+SKILL_20150317_001154	Groups together all linked enemies.
 SKILL_20150317_001155	Gather time of 0.3 seconds
 SKILL_20150317_001156	Spiritual Chain
 SKILL_20150317_001157	Link party members and share buff effects.
@@ -1159,70 +1159,70 @@ SKILL_20150317_001158	Umbilical Cord
 SKILL_20150317_001159	Share defense and HP with the linked target.
 SKILL_20150317_001160	Physical Defense passed #{CaptionRatio}#{nl} HP recovery passed #{CaptionRatio2}#{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001161	Swell Left Arm
-SKILL_20150317_001162	Enlarge target's left hand and increase attack.
+SKILL_20150317_001162	Enlarge target's left hand to increase attack.
 SKILL_20150317_001163	Physical Attack +#{CaptionRatio}#{nl}Magic attack #{CaptionRatio}#{nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001164	Shrink Body
 SKILL_20150317_001165	Reduce size of target.
 SKILL_20150317_001166	Large -> Medium -> Small {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001167	Swell Body
-SKILL_20150317_001168	Enlarge size of target.
+SKILL_20150317_001168	Enlarge size of target. Target's HP, EXP, and drop rate are doubled.
 SKILL_20150317_001169	Small -> Medium -> Large {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001170	Transpose
-SKILL_20150317_001171	Change your INT and CON for a while.
+SKILL_20150317_001171	Swaps INT and CON.
 SKILL_20150317_001172	Reversi
-SKILL_20150317_001173	Change magic circle of enemies to that of allies.
-SKILL_20150317_001174	Change enemy's magic circle in target area. {nl}Level 1 Master
+SKILL_20150317_001173	Gain control of enemy magic circles.
+SKILL_20150317_001174	Change enemy's magic circles to friendly ones in target area. {nl}Level 1 Master
 SKILL_20150317_001175	Swell Right Arm
-SKILL_20150317_001176	Enlarge target's right hand and increase attack.
-SKILL_20150317_001177	Use brain's full capacity
-SKILL_20150317_001178	Head is enlarged.
+SKILL_20150317_001176	Enlarge target's right hand and increase subweapon stats.
+SKILL_20150317_001177	Swell Brain
+SKILL_20150317_001178	Head is enlarged boosting INT.
 SKILL_20150317_001179	Electrocute
-SKILL_20150317_001180	{#993399}{ol}[Magic] - [Lightningity]{/}{/}{nl}Launch Lightning chain to attack target in front.
+SKILL_20150317_001180	{#993399}{ol}[Magic] - [Lightningity]{/}{/}{nl}Shoot lightning that chains between nearby enemies.
 SKILL_20150317_001181	Attack #{SkillAtkAdd}#{nl}Target #{CaptionRatio}#
 SKILL_20150317_001182	Stone Curse
 SKILL_20150317_001183	Petrify target.
 SKILL_20150317_001184	Duration #{CaptionTime}# seconds{nl}Splash #{CaptionRatio}#
 SKILL_20150317_001185	Hail
-SKILL_20150317_001186	{#993399}{ol}[Magic] - [Ice]{/}{/}{n}Drop ice pieces on target area and damage enemies.
+SKILL_20150317_001186	{#993399}{ol}[Magic] - [Ice]{/}{/}{n}Shards of ice fall upon the target area and damage enemies.
 SKILL_20150317_001187	Prominence
-SKILL_20150317_001188	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Release prominences around. Prominences randomly moves and damage enemies.
+SKILL_20150317_001188	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Swathes of fire appear around you. Fire randomly moves and damage enemies.
 SKILL_20150317_001189	Attack #{SkillAtkAdd}#{nl}Duration 15 seconds
 SKILL_20150317_001190	Meteor
-SKILL_20150317_001191	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Drop meteors in target area and damage enemies.
+SKILL_20150317_001191	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Drop a meteor on the target area to damage enemies.
 SKILL_20150317_001192	Attack #{SkillAtkAdd}#{nl}Cast Time #{CaptionTime}# seconds{nl}Splash #{SkillSR}#
 SKILL_20150317_001193	Summoning
-SKILL_20150317_001194	Summon spirits that follow you.
+SKILL_20150317_001194	Summon a devil from your grimoire to follow your every command.
 SKILL_20150317_001195	Attack Ground
-SKILL_20150317_001196	Spirit moves to target area while attacking nearby enemies.
+SKILL_20150317_001196	Summoned being moves to target area and attacks enemies nearby.
 SKILL_20150317_001197	Ride
-SKILL_20150317_001198	Ride on top of summoned spirit.
+SKILL_20150317_001198	Ride on top of summoned spirit. Can directly control it while riding.
 SKILL_20150317_001199	Variation
 SKILL_20150317_001200	Quicken
-SKILL_20150317_001201	Give buff that increases movement speed to 1 ally.
+SKILL_20150317_001201	Increase the attack speed of yourself or 1 ally.
 SKILL_20150317_001202	Reincarnate
-SKILL_20150317_001203	Kill the monster with the buff, and the monster will appear again before it dies.
+SKILL_20150317_001203	Respawns the monster immediately after it is killed.
 SKILL_20150317_001204	{#6644FF}{ol}[Fire]{/}{/}Attribute {nl} Attack #{SkillFactor}#% + #{SkillAtkAdd} per 0.5 seconds# damage {nl} Duration 10 seconds {nl}Consume #{{nl} SpendSP}# SP
 SKILL_20150317_001205	Stop
-SKILL_20150317_001206	Monsters hold their current state. All monsters in the area will stop their actions.
+SKILL_20150317_001206	Stops all monsters in target area. Stopped monsters cannot be hurt.
 SKILL_20150317_001207	Slow
 SKILL_20150317_001208	Movement Speed -#{CaptionRatio}#%{nl}Slow duration 5 seconds {nl}Consume #{SpendSP}# SP
 SKILL_20150317_001209	Haste
 SKILL_20150317_001210	Back Masking
-SKILL_20150317_001211	Change time of area to that of before skill was used.
+SKILL_20150317_001211	Reverses time in target area to a previous state.
 SKILL_20150317_001212	Gather Corpse
-SKILL_20150317_001213	Accumulate dead parts when killing monster with this skill.
+SKILL_20150317_001213	Gather body parts from enemies killed in target area.
 SKILL_20150317_001214	Create Shoggoth
-SKILL_20150317_001215	Use dead parts to summon Shoggoth
+SKILL_20150317_001215	Use corpses to summon a Shoggoth from the necronomicon.
 SKILL_20150317_001216	Flesh Cannon
-SKILL_20150317_001217	Throw dead parts at target area.
+SKILL_20150317_001217	Launch corpses at target area.
 SKILL_20150317_001218	Flesh Hoop
-SKILL_20150317_001219	Surround yourself with wall fo dead parts and inflict damange on monsters within radius.
+SKILL_20150317_001219	Surround yourself with wall of corpses and inflict damange on monsters within radius.
 SKILL_20150317_001220	Dirty Wall
-SKILL_20150317_001221	Descenter
+SKILL_20150317_001221	Disinter
 SKILL_20150317_001222	Combustion
-SKILL_20150317_001223	Magic Pavise
+SKILL_20150317_001223	Awaken Item
 SKILL_20150317_001224	Dig
-SKILL_20150317_001225	Roasting
+SKILL_20150317_001225	Gem Roasting
 SKILL_20150317_001226	Briquetting
 SKILL_20150317_001227	Tincturing
 SKILL_20150317_001228	Magnum Opus
@@ -1267,138 +1267,138 @@ SKILL_20150317_001266	Buff for adding attack speed
 SKILL_20150317_001267	Make ground skill of enemies be usable by allies.
 SKILL_20150317_001268	test
 SKILL_20150317_001269	Multi Shot
-SKILL_20150317_001270	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Quickly fire multiple arrows to specified area.
+SKILL_20150317_001270	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Quickly fire multiple arrows at the target area.
 SKILL_20150317_001271	Attack #{SkillAtkAdd}#{nl}Shoot #{CaptionRatio}# times
 SKILL_20150317_001272	Fulldraw
-SKILL_20150317_001273	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Pull bowstring and shoot arrow straight through the enemy. Target becomes skewed.
+SKILL_20150317_001273	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Charge a shot that can skewer an enemy and link it to an adjacent one.
 SKILL_20150317_001274	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Skew]{/}{/} Duration #{CaptionTime}# seconds
 SKILL_20150317_001275	Kneeling Shot
-SKILL_20150317_001276	{#DD5500}{ol}[Physical] - [Stab]{/}{/} {nl}Attack while kneeling down. Increases attack damage and range.
+SKILL_20150317_001276	{#DD5500}{ol}[Physical] - [Stab]{/}{/} {nl}Kneel to increase attack speed, damage, and range.
 SKILL_20150317_001277	Physical Damage + #{CaptionRatio}#{nl} Range + #{CaptionRatio2}#
 SKILL_20150317_001278	Swift step
-SKILL_20150317_001279	Moving speed of the moving shot will increase.
+SKILL_20150317_001279	Increase movement speed while attacking.
 SKILL_20150317_001280	Moving Shot movement speed +#{SkillFactor}#% {nl} Defense - #{CaptionRatio}# {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001281	Oblique Shot
-SKILL_20150317_001282	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Arrow bounces to another enemy nearby.
+SKILL_20150317_001282	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Fire an arrow that bounces off of the target to hit an adjacent enemy.
 SKILL_20150317_001283	Attack #{SkillAtkAdd}#{nl}Bounced arrow damage #{CaptionRatio}#%
 SKILL_20150317_001284	Barrage
-SKILL_20150317_001285	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot 5 arrows in arc shape towards the ground.
+SKILL_20150317_001285	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot 5 arrows in an arc.
 SKILL_20150317_001286	High Anchoring
 SKILL_20150317_001287	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Pull bowstring strongly and shoot arrow that penetrages enemy in front.
 SKILL_20150317_001288	Critical shot
-SKILL_20150317_001289	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot arrow to target with high chance of critical.
+SKILL_20150317_001289	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot arrow to target with a high critical chance.
 SKILL_20150317_001290	Attack #{SkillAtkAdd}#{nl}Chance of additional critical 50%
 SKILL_20150317_001291	Steady Aim
-SKILL_20150317_001292	Attak power increase but attack speed decrease.
+SKILL_20150317_001292	Increase attack power at the cost of attack speed.
 SKILL_20150317_001293	Additional Damage + #{CaptionRatio}#{nl}Attack Speed -#{CaptionRatio2}#% {nl}Duration 40 seconds
-SKILL_20150317_001294	Time Bomb Arror
-SKILL_20150317_001295	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Hang bomb on arrow and shoot.
+SKILL_20150317_001294	Time Bomb Arrow
+SKILL_20150317_001295	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Hang bomb on arrow and shoot it at an enemy. bomb will explode after a set period of time.
 SKILL_20150317_001296	Attack #{SkillAtkAdd}#{nl}Bomb duration 5 seconds
 SKILL_20150317_001297	Bounce Shot
-SKILL_20150317_001298	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot arrow that bolt nearby when target is killed with attack.
-SKILL_20150317_001299	Arrow Sprinkle
-SKILL_20150317_001300	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Jump backwards and shoot multiple arrows forward.
+SKILL_20150317_001298	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot arrow that bounces off the target to hit nearby enemies.
+SKILL_20150317_001299	Retreat shot
+SKILL_20150317_001300	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Jump backwards while shooting multiple arrows forward.
 SKILL_20150317_001301	Attack #{SkillAtkAdd}#{nl}Attack 5 times
 SKILL_20150317_001302	Spiral Arrow
-SKILL_20150317_001303	Next attack inflicts continuous attack.
+SKILL_20150317_001303	Buffs your next attacks to do an additional hit.
 SKILL_20150317_001304	Attack # {CaptionRatio} # times {nl}Duration 10 seconds
 SKILL_20150317_001305	Deploy Pavise
-SKILL_20150317_001306	Install Pavise on ground and defend long rage projectile.
+SKILL_20150317_001306	Install a Pavise on the ground to defend against projectiles.
 SKILL_20150317_001307	Defend range projectile #{SkillFactor}# times{nl}Pavise duration #{CaptionTime}# seconds
 SKILL_20150317_001308	Scatter Caltrop
-SKILL_20150317_001309	{#DD5500}{ol}[Physical] - [Stab]{/}{/}Throw caldrop on ground to damage and slow down enemies when stepping on it.
+SKILL_20150317_001309	{#DD5500}{ol}[Physical] - [Stab]{/}{/}Throw caldrops on the ground to damage and slow down enemies.
 SKILL_20150317_001310	Attack #{SkillAtkAdd}#{nl}Throw #{CaptionRatio2}#{nl}Caldrop duration 20 seconds{nl}{#339999}{ol}[Slow]{/}{/} Duration 10 seconds
 SKILL_20150317_001311	Stone Picking
-SKILL_20150317_001312	Pick up things to use as stone bullets in field. Cannot be ontained in town.
+SKILL_20150317_001312	Pick up stones to use as bullets for stone shot. Cannot be ontained in town.
 SKILL_20150317_001313	Get up to #{SkillFactor}# stone bullets
 SKILL_20150317_001314	Stone shot
-SKILL_20150317_001315	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nlFire stone bullet and push away enemy. Target becomes stun by chance.
+SKILL_20150317_001315	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nlFire a stone at the enemy to stun and knockback the enemy.
 SKILL_20150317_001316	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Stun]{/}{/} Duration #{CaptionRatio2}# seconds{nl}Use 1 stone bullet
 SKILL_20150317_001317	Rapid Fire
-SKILL_20150317_001318	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl} After loading a number of arrows in the crossbow and fired on targets.
+SKILL_20150317_001318	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl} Load multiple arrows into your weapon and then quickly shoot them at the enemy.
 SKILL_20150317_001319	Attack #{SkillAtkAdd}#{nl}Max. loading time #{CaptionTime}# seconds
 SKILL_20150317_001320	Broom Trap
-SKILL_20150317_001321	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Install trap and inflict damage to nearby targets.
+SKILL_20150317_001321	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Install a trap that creates rotating  lasers that damage enemies.
 SKILL_20150317_001322	Attack #{SkillAtkAdd}#{nl}Duration 15 seconds
 SKILL_20150317_001323	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Install trap that fires buckshot and damage enemy.
 SKILL_20150317_001324	Attack #{SkillAtkAdd}#{nl}Splash #{CaptionRatio}#
 SKILL_20150317_001325	Punji Stake
-SKILL_20150317_001326	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Install trap that blows away enemies when stepping on it.
+SKILL_20150317_001326	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Install trap that launches enemies that step on it.
 SKILL_20150317_001327	Attack #{SkillAtkAdd}#{nl}Cast Time 3 seconds
 SKILL_20150317_001328	Detonate Traps
-SKILL_20150317_001329	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Blast magic circle and installation to inflict damage on enemies.
+SKILL_20150317_001329	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Detonate nearby traps and magic circles to damage enemies.
 SKILL_20150317_001330	Attack #{SkillAtkAdd}#{nl}Bomb explosion #{CaptionRatio}# times
 SKILL_20150317_001331	Coursing
-SKILL_20150317_001332	Companion bites and holds on to target. Bonus chance of critical is applied on target.
-SKILL_20150317_001333	Critical chance +30% {nl}Duration #{CaptionTime}# seconds
+SKILL_20150317_001332	Companion bites and holds on to target. Target loses defense and has a higher chance of taking critical hits.
+SKILL_20150317_001333	Defense - #{CaptionRatio}# Critical chance +30% {nl}Duration #{CaptionTime}# seconds
 SKILL_20150317_001334	Retrieve
-SKILL_20150317_001335	Companion bites and brings target to owner.
+SKILL_20150317_001335	Companion bites the target and brings it to the player.
 SKILL_20150317_001336	Drive in enemies with less HP less than #{CaptionRatio}#%{nl} Duration 4 seconds
 SKILL_20150317_001337	Snatching
-SKILL_20150317_001338	Companion bites air type monsters to the ground.
+SKILL_20150317_001338	Companion bites flying enemies and drags them to the ground.
 SKILL_20150317_001339	Praise
 SKILL_20150317_001340	Temporarily increase movement speed and attack speed of companion.
 SKILL_20150317_001341	Companion movement speed + #{CaptionRatio}#% {nl} Duration 60 seconds
 SKILL_20150317_001342	Pointing
-SKILL_20150317_001343	Companion wanders around target. Target's evasion decreases.
+SKILL_20150317_001343	Companion wanders around target  decreasing the target's evasion.
 SKILL_20150317_001344	Evasion -#{CaptionRatio}#{nl}Duration 10 seconds
 SKILL_20150317_001345	Hounding
-SKILL_20150317_001346	Companion finds hidden target around.
+SKILL_20150317_001346	Companion finds hidden enemies.
 SKILL_20150317_001347	Detoxifiy
-SKILL_20150317_001348	Release target from addiction. Cannot remove poisons with higher level than detoxification and duration decreases.
+SKILL_20150317_001348	Removes poison from the target. Cannot cure poisons that are higher level than Detoxify, instead decreasing their duration.
 SKILL_20150317_001349	Duration - #{CaptionRatio}# seconds{nl} Use #{SpendPoison}# Poison pot poison
 SKILL_20150317_001350	Needle Blow
-SKILL_20150317_001351	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Shoot poison arrow that inflicts lasting damage.
+SKILL_20150317_001351	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Shoot toxic arrow that poisons the enemy to inflict damage over time.
 SKILL_20150317_001352	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Poison]{/}{/} Duration 30 seconds{nl}Use #{SpendPoison}# Poison pot
 SKILL_20150317_001353	Bewitch
-SKILL_20150317_001354	Make intoxicated enemy become confused.
+SKILL_20150317_001354	Confuse a poisoned enemy.
 SKILL_20150317_001355	{#339999}{ol}[confused]{/}{/}{nl} lasts 10 seconds Poison Poison Podcast # {SpendPoison} # consumption
 SKILL_20150317_001356	Wugong Gu
-SKILL_20150317_001357	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Shoot contagious poison arrow.Target spreads poison around whenever receiving magic attack.
+SKILL_20150317_001357	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Shoot contagious poison arrow. Target spreads poison around to nearby enemies whenever it is hit with magic.
 SKILL_20150317_001358	Attack #{SkillAtkAdd}#{nl}{#339999}{ol}[Poison]{/}{/} Duration 10 seconds{nl}Use #{SpendPoison}# Poison pot
 SKILL_20150317_001359	Throw Gu Pot
-SKILL_20150317_001360	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Throw Poison jar and create poison puddle.
+SKILL_20150317_001360	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Throw Poison jar and create poison puddle. Enemies that step in the puddle become poisoned.
 SKILL_20150317_001361	Attack #{SkillAtkAdd}#{nl}Duration 10 seconds{nl}Use #{SpendPoison}# Poison pot
 SKILL_20150317_001362	Jincan Gu
-SKILL_20150317_001363	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Shoot arrows with hairpin bugs to attack target.
+SKILL_20150317_001363	{#DD5500}{ol}[Physical] - [Poison] - [Stab]{/}{/}{nl}Shoot a hairpin containing parasites at the enemy. Parasites burst out of the enemy when it is killed.
 SKILL_20150317_001364	Attack #{SkillAtkAdd}#{nl}Use #{SpendPoison}# Poison pot
 SKILL_20150317_001365	Camouflage
-SKILL_20150317_001366	Hide yourself in apple box and stay away from enemies' vision. Defend againt Physical attacks.
+SKILL_20150317_001366	Hide yourself in an apple box and stay away from enemies' vision. The box defends againt Physical attacks.
 SKILL_20150317_001367	Defend #{CaptionRatio}# times{nl}Movement Speed -#{CaptionRatio}#
 SKILL_20150317_001368	Flu Flu
-SKILL_20150317_001369	Shoot arrows that make sound. Also affect enemies nearby.
+SKILL_20150317_001369	Shoot a noisemaker arrow at the enemy. The arrow makes a noise that can cause fear and chaos to nearby enemies.
 SKILL_20150317_001370	Attack #{SkillAtkAdd}#{nl}target hit {#339999}{ol}[Fear]{/}{/}+{#339999}{ol}[Chaos]{/}{/}{nl}{#339999}{ol}Inflict [Fear] to max. target #{CaptionRatio}# {#339999}{ol}{/}{/}{nl}Duration #{CaptionTime}#
 SKILL_20150317_001371	Flare shot
-SKILL_20150317_001372	Shoot flash arrow on ground. Flame bouncing off the ground inflict damage on enemies.
+SKILL_20150317_001372	Shoot a flare at the target area. Sparks shoot out of the flare to damage nearby enemies.
 SKILL_20150317_001373	Attack #{SkillAtkAdd}#{nl}Duration 10 seconds
 SKILL_20150317_001374	Cloaking
-SKILL_20150317_001375	Hide.
+SKILL_20150317_001375	Hide from enemies to lose enemy attention. Effect is broken upon jumping or attacking.
 SKILL_20150317_001376	Duration #{CaptionTime}# seconds
 SKILL_20150317_001377	Undistance
-SKILL_20150317_001378	Distort your location and make close range attacks possible even from afar.
+SKILL_20150317_001378	Distort your location to make close range attacks possible even from afar.
 SKILL_20150317_001379	Max. duration 10 seconds {nl} #{CaptionRatio}# SP consumed per second
 SKILL_20150317_001380	Scan
-SKILL_20150317_001381	I shows the subject that are hidden within the front of the.
+SKILL_20150317_001381	I shows hidden enemies and items in the target area.
 SKILL_20150317_001382	Duration 10 seconds
 SKILL_20150317_001383	Be Prepared
-SKILL_20150317_001384	Reduce reuse skill time of all current skills
+SKILL_20150317_001384	Reduces the cooldown all current skills
 SKILL_20150317_001385	Cooltime -#{CaptionRatio} seconds#{nl}Consume #{SpendSP}# SP
 SKILL_20150317_001386	Sneak Hit
 SKILL_20150317_001387	Feint
 SKILL_20150317_001388	Brandish Bow
 SKILL_20150317_001389	Arrow fight...
-SKILL_20150317_001390	{#CC3300}{ol}[Sting]{/}{/}Attribute {nl}#{SkillFactor}#% + #{SkillAtkAdd}#{nl} Target 20% damage to the defending leather {nl} sheeting defensive target to -20% damage every 1 sec {nl} + #{CaptionRatio}# bleed damage sustained six seconds {nl} {nl} consumption bleeding SP #{SpendSP}#
+SKILL_20150317_001390	{#CC3300}{ol}[Stab]{/}{/}Attribute {nl}#{SkillFactor}#% + #{SkillAtkAdd}#{nl} Target 20% damage to the defending leather {nl} sheeting defensive target to -20% damage every 1 sec {nl} + #{CaptionRatio}# bleed damage sustained six seconds {nl} {nl} consumption bleeding SP #{SpendSP}#
 SKILL_20150317_001391	Burrow
 SKILL_20150317_001392	Broad head
-SKILL_20150317_001393	Shoot arrow that cause bleeding effect.
+SKILL_20150317_001393	Shoots a broadhead arrow that bleeds the enemy.
 SKILL_20150317_001394	Bodkin Point
-SKILL_20150317_001395	Shoot arrow that decrease defense of enemies and remove their shield.
-SKILL_20150317_001396	{#CC3300}{ol}[Sting]{/}{/}Attribute {nl}#{SkillFactor}#% + #{SkillAtkAdd}#{nl} Splash #{SkillSR}#{nl}#{odds shield removal CaptionRatio}#% {nl} Armor reduced by 30% to 70% chance {nl} consumption SP #{SpendSP}#
+SKILL_20150317_001395	Shoots an arrow that decreases enemy defense and removes shielding magic.
+SKILL_20150317_001396	{#CC3300}{ol}[Stab]{/}{/}Attribute {nl}#{SkillFactor}#% + #{SkillAtkAdd}#{nl} Splash #{SkillSR}#{nl}#{odds shield removal CaptionRatio}#% {nl} Armor reduced by 30% to 70% chance {nl} consumption SP #{SpendSP}#
 SKILL_20150317_001397	Barbed Arrow
-SKILL_20150317_001398	Shoot thorns. Continuous attack apply differently depending on armor type.
+SKILL_20150317_001398	Shoots a barbed arrow. Does a different number of attacks depending on the enemy's armor type.
 SKILL_20150317_001399	Attack rate #{SkillFactor}#
 SKILL_20150317_001400	Cross Fire
-SKILL_20150317_001401	Shoot arrow that explodes in cross when killing monster,
+SKILL_20150317_001401	Shoot arrow that explodes in a cross if it kills the monster.
 SKILL_20150317_001402	{#CC3300}{ol}[Stab]{/}{/}Attribute {nl}#{SkillFactor}#% + #{SkillAtkAdd}#{nl} Splash #{SkillSR}#{nl} Consume #{SpendSP }# SP
 SKILL_20150317_001403	Flute Performance
 SKILL_20150317_001404	Feelings
@@ -1423,130 +1423,130 @@ SKILL_20150317_001422	Caracole
 SKILL_20150317_001423	Limacon
 SKILL_20150317_001424	{#DD5500}{ol}[Stab]{/}{/}{nl} installs a large crossbow.
 SKILL_20150317_001425	Attack {#DD4400}{ol}[Physical Damage]{/}{/}+#{SkillAtkAdd}#{nl}Duration 60 seconds{nl}Consume #{SpendSP}# SP
-SKILL_20150317_001426	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl} Restores HP, or create magic circle that damage ground type enemies.
+SKILL_20150317_001426	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl} Creates a magic circle that heals allies and damage enemies that walk on it.
 SKILL_20150317_001427	Attack #{SkillAtkAdd}#{nl}HP Recovery #{CaptionRatio}# ~ #{CaptionRatio2}#{nl}Magic circle Duration 40 seconds
 SKILL_20150317_001428	Cure
-SKILL_20150317_001429	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl} Remove harmful effects on allies or create Magic circles to damage Earth type enemies.
+SKILL_20150317_001429	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl} Create a magic circle that removes harmful effects from allies and damages enemies that walk on it.
 SKILL_20150317_001430	Attack #{SkillAtkAdd}#{nl}Attack count #{CaptionRatio}# times {nl}Magic circle Duration #{CaptionTime}# seconds
 SKILL_20150317_001431	Safety Zone
 SKILL_20150317_001432	Creates a magic circle that blocks incoming attacks.
 SKILL_20150317_001433	Defense #{SkillFactor}# times{nl} Magic circle duration 20 seconds
 SKILL_20150317_001434	Deprotected Zone
-SKILL_20150317_001435	Create magic circle that continuously decrease the defense of target.
+SKILL_20150317_001435	Create magic circle that continuously decreases the defense of enemies on it.
 SKILL_20150317_001436	Defense -#{CaptionRatio}#{nl}- #{CaptionRatio2} per overlap #{nl}Magic circle duration #{CaptionTime}# seconds
 SKILL_20150317_001437	Divine Might
-SKILL_20150317_001438	Create magic circle that increases skill level of target. Effect is gone when used and cannot be overlapped.
+SKILL_20150317_001438	Create magic circle that increases skill level of the next skill used by the person inside the circle.
 SKILL_20150317_001439	Skill Level +#{SkillFactor}#{nl}Duration 10 seconds {nl}Magic circle duration 20 seconds
 SKILL_20150317_001440	Summon torch and increase HP recovery nearby.
 SKILL_20150317_001441	HP recovery ability increases {nl}Torch duration #{CaptionTime}# seconds
 SKILL_20150317_001442	Zalciai
-SKILL_20150317_001443	Generate magic circle that change critical capacity of the subject.
+SKILL_20150317_001443	Generate magic circle that increases ally critical damage and decreases enemy critical resistance.
 SKILL_20150317_001444	Critical of allies +#{CaptionRatio}#{nl}Enemy critical resistance -#{CaptionRatio2}#
 SKILL_20150317_001445	Daino
-SKILL_20150317_001446	Increase number of beneficial buffs that can be received.
+SKILL_20150317_001446	Increase number of beneficial buffs that a user can have at any one time.
 SKILL_20150317_001447	Max. count +#{SkillFactor}#{nl}Duration 200 seconds
-SKILL_20150317_001448	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Create magic circle circle to drop lightning.
+SKILL_20150317_001448	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Create magic circle circle that summons lightning to strike anything within it.
 SKILL_20150317_001449	Attack #{SkillAtkAdd}#{nl}Attack #{CaptionRatio}# times {nl}Magic circle Duration 30 seconds
 SKILL_20150317_001450	Divine Stigma
-SKILL_20150317_001451	Mark monster. STR and INT of targets that kill the marked enemy increase.
+SKILL_20150317_001451	Mark monster. The player that kills the monster will get increased STR and INT.
 SKILL_20150317_001452	STR, INT + #{CaptionRatio}#Duration 30 seconds {nl} {nl}Stigma duration #{CaptionRatio2}# seconds
 SKILL_20150317_001453	Melstis
-SKILL_20150317_001454	Create magic circle that retains buff time of party members.
+SKILL_20150317_001454	Create magic circle that retains buffs for party members.
 SKILL_20150317_001455	Max. duration 20 seconds {nl} #{CaptionRatio}#% of SP consumed per second
 SKILL_20150317_001456	Aspersion
-SKILL_20150317_001457	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl}Sprinkle holy water to increase defense of target and damage enemies.
+SKILL_20150317_001457	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl}Douse enemies in holy water to damage them and increase the defense of allies.
 SKILL_20150317_001458	Attack #{SkillAtkAdd}#{nl}Defense +#{CaptionRatio}# {nl}Target 10{nl}Duration #{CaptionRatio2}# seconds{nl}Use 1 Holy water
 SKILL_20150317_001459	Monstrance
-SKILL_20150317_001460	Dexterity of allies is increased and randomly create magic circle that cause evasion and Physical damage of enemies to decrease.
+SKILL_20150317_001460	Create a magic circle that increases ally's dexterity and decreases enemy defense and evasion.
 SKILL_20150317_001461	Create #{SkillFactor}# Magic Circle {nl}Ally DEX increase {nl}Enemy's evasion, defense -#{CaptionRatio}# {nl} Magic Circle Duration 20 seconds
 SKILL_20150317_001462	Blessing
-SKILL_20150317_001463	Increase attack skill power of party members.
+SKILL_20150317_001463	Increase the damage of party members for a set number of attacks.
 SKILL_20150317_001464	Additional Damage + #{CaptionRatio}# {nl} Attack# {CaptionRatio2} # times{nl} {nl} Duration 30 seconds{nl}Use 1 Holy Powder
 SKILL_20150317_001465	Resurrection
-SKILL_20150317_001466	Recover target in 'incapable of combat'
+SKILL_20150317_001466	Revive deceased players.
 SKILL_20150317_001467	Attack #{SkillAtkAdd}#{nl}Cast Time #{CaptionTime}# seconds{nl}Recover #{CaptionRatio}#% HP after recovering from incapable of combat
 SKILL_20150317_001468	Sacrament
-SKILL_20150317_001469	Grant Holy attribute ATK to part y member. Additional damage is applied with basic attacks.
+SKILL_20150317_001469	Party members deal an additional holy element attack as well as dealing additional damage on all attacks.
 SKILL_20150317_001470	Divine Attributes Attack + #{CaptionRatio}#{nl} Additional Damage + #{CaptionRatio2}#{nl} Duration #{CaptionTime} seconds#{nl}Use 1 Gislotis
-SKILL_20150317_001471	Protection
-SKILL_20150317_001472	Dodola
+SKILL_20150317_001471	Revive
+SKILL_20150317_001472	Protects ally from having their HP reduced to zero once.
 SKILL_20150317_001473	Hexing
-SKILL_20150317_001474	Curse enemy and decrease magic defense.
+SKILL_20150317_001474	Curse enemy and decrease its magic defense.
 SKILL_20150317_001475	Magic defense -#{CaptionRatio}#{nl} Hexing duration #{CaptionTime}# seconds
 SKILL_20150317_001476	Effigy
-SKILL_20150317_001477	{#993399}{ol}[Magic] - [Dark]{/}{/}{nl}Damage enemies under Hexing. Additional damage applied on 3rd attack.
+SKILL_20150317_001477	{#993399}{ol}[Magic] - [Dark]{/}{/}{nl}Damage enemies under Hexing. The third attack deals extra damage.
 SKILL_20150317_001478	Attack #{SkillAtkAdd}#{nl}Attack bonus on 3rd attack #{CaptionRatio}# times ~ #{CaptionRatio2}#times
 SKILL_20150317_001479	Tet Mamak La
 SKILL_20150317_001480	Lure zombies to target area.
 SKILL_20150317_001481	Summoned zombies requried {nl}Level 1 Master
 SKILL_20150317_001482	Zombify
-SKILL_20150317_001483	Create zombit magic circle on ground. Enemies killed in the circle becomes zombies.
+SKILL_20150317_001483	Create a magic circle on the ground. Enemies killed in the circle becomes zombies.
 SKILL_20150317_001484	Magic Circle Duration #{CaptionTime}# seconds{nl}Summon Max. #{CaptionRatio}# Zombies
 SKILL_20150317_001485	Mackangdal
-SKILL_20150317_001486	Throw amulet on target. Becomes invincible while under effect but receive accumulated damage when effect is gone.
+SKILL_20150317_001486	Throw amulet on target. You invincible while under it is active, but you receive all damage taken when it runs out.
 SKILL_20150317_001487	Invincible Duration #{CaptionTime}# seconds
 SKILL_20150317_001488	Bwa Kayiman
-SKILL_20150317_001489	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Zombies roam around target area. Enemies are pushed away and damaged when toufching the zombies.
+SKILL_20150317_001489	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Zombies roam around target area. Enemies are pushed away and damaged if they touching the zombies.
 SKILL_20150317_001490	Attack #{SkillAtkAdd}#{nl}Summoned zombie required
 SKILL_20150317_001491	Samdiveve
-SKILL_20150317_001492	Pin flag on ground. Movement speed and max. HP of targets around the flag increase.
+SKILL_20150317_001492	Place a flag on the ground that increases the Movement speed and max. HP of nearby targets.
 SKILL_20150317_001493	Max. HP +#{CaptionRatio}#{nl}Movement Speed +#{CaptionRatio2}#% Duration 30 seconds {nl}
 SKILL_20150317_001494	Ogouveve
-SKILL_20150317_001495	Pin flag on ground. STR of targets around the flag increase.
+SKILL_20150317_001495	Pin flag on ground that increases the STR of nearby allies targets.
 SKILL_20150317_001496	Strength + #{CaptionRatio}#{nl}Duration 30 seconds
 SKILL_20150317_001497	Damballa
-SKILL_20150317_001498	{#993399}{ol}[Magic]{/}{/}{nl}Blast the zombies in target area.
+SKILL_20150317_001498	{#993399}{ol}[Magic]{/}{/}{nl}Causes zombies in the target area to explode, damaging nearby enemies.
 SKILL_20150317_001499	Attack #{SkillAtkAdd}#{nl}Summoned zombie required{nl}Target #{SkillSR}#
-SKILL_20150317_001500	Carve Statue of Vakarine. You can warp to other area throught the Goddess Statue.
+SKILL_20150317_001500	Carve Statue of Vakarine. Statue can be used to warp to other Goddess Statue.
 SKILL_20150317_001501	Warp #{CaptionRatio}# times {nl}Statue Duration 30 seconds{nl}Use 3 Oak wood
 SKILL_20150317_001502	Zemyna Statue
-SKILL_20150317_001503	Carve Goddess Zemyna Statue. Party members around the statue consume less SP when using skill.
+SKILL_20150317_001503	Carve Goddess Zemyna Statue. Party members around the statue consume less SP when using skills.
 SKILL_20150317_001504	SP - #{CaptionRatio}# {nl} {nl} Statue Duration 30 seconds{nl}Use 5 Pine woods
 SKILL_20150317_001505	Laima Statue
-SKILL_20150317_001506	Carve Goddess Zemyna Statue. Spalsh of party members around the statue is increased.
-SKILL_20150317_001507	Splash +#{CaptionRatio}# {nl}Statue duration 30 seconds {nl} Use 5 cedar wood
+SKILL_20150317_001506	Carve Goddess Laima Statue. Cooldown of party members around the statue decreases.
+SKILL_20150317_001507	Cooltime -#{CaptionRatio}# {nl}Statue duration 30 seconds {nl} Use 4 cedar woods
 SKILL_20150317_001508	Carve
-SKILL_20150317_001509	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Use carving knife to attack the target. Additional damage applies to plant type monsters and can obtain statue materials
+SKILL_20150317_001509	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Use a carving knife to attack the target. Deals additional damage to plant type monsters and can obtain statue materials from them.
 SKILL_20150317_001510	Attack #{SkillAtkAdd}#{nl}Additional damage +#{CaptionRatio}#
 SKILL_20150317_001511	Owl Statue
-SKILL_20150317_001512	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Summon the owl statue to attack targets in front.
+SKILL_20150317_001512	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Summon the owl statue to attack targets in front of it.
 SKILL_20150317_001513	Attack #{SkillAtkAdd}#{nl}Defense #{CaptionRatio}# times{nl}Duration #{CaptionTime}# seconds{nl} Use 2 Oak tree
 SKILL_20150317_001514	Carve Austras Koks
-SKILL_20150317_001515	Carve piece of Big Tree and make enemy fall under Silence.
+SKILL_20150317_001515	Carve a statue of the holy tree to silence nearby enemies.
 SKILL_20150317_001516	Statue duration #{CaptionRatio} seconds#{nl}Use #{CaptionRatio2}# Ash wood
 SKILL_20150317_001517	Out of Body
-SKILL_20150317_001518	Remove spirit from body. Spirit can only move around the body.
+SKILL_20150317_001518	Remove spirit from body. Spirit can only move near the body.
 SKILL_20150317_001519	Body moving range 150
 SKILL_20150317_001520	Prakriti
-SKILL_20150317_001521	Move to where the body is located.
+SKILL_20150317_001521	Unite the spirit and body.
 SKILL_20150317_001522	Travel time 0.5 seconds to 1 seconds
 SKILL_20150317_001523	Possession
-SKILL_20150317_001524	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl}Bind targets and attack.
+SKILL_20150317_001524	{#993399}{ol}[Magic] - [Divine]{/}{/}{nl}Bind the enemy to stop its movement and damage it.
 SKILL_20150317_001525	Attack #{SkillAtkAdd}#{nl}Max. Duration 5 seconds
 SKILL_20150317_001526	Bashita Siddi
 SKILL_20150317_001527	Reduce STR, CON, INT, SPR, DEX of target.
 SKILL_20150317_001528	STR, CON, INT, SPR, DEX +#{CaptionRatio}#{nl}Max. duration 20 seconds
 SKILL_20150317_001529	Astral Body Explosion
-SKILL_20150317_001530	{#993399}{ol}[Magic]{/}{/}{nl}Blast fluid to damage target.
-SKILL_20150317_001531	Send Planar
-SKILL_20150317_001532	Give INT to target in front.
+SKILL_20150317_001530	{#993399}{ol}[Magic]{/}{/}{nl}Detonate your spirit form to damage nearby enemies and regain control of your body.
+SKILL_20150317_001531	Prana Transfer
+SKILL_20150317_001532	Give your INT to ally in front of you.
 SKILL_20150317_001533	Intelligence passed #{CaptionRatio}#
 SKILL_20150317_001534	Smite
-SKILL_20150317_001535	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Powerful strike down on enemy.
+SKILL_20150317_001535	{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Strike down the enemy with a poweful blow.
 SKILL_20150317_001536	Restoration
-SKILL_20150317_001537	Invoke aura and increase HP recovery of targets nearby.
+SKILL_20150317_001537	Create an aura that increases HP recovery if nearby allies.
 SKILL_20150317_001538	HP recovery +#{CaptionRatio}#{nl} Aura duration 60 seconds
 SKILL_20150317_001539	Conversion
-SKILL_20150317_001540	Create magic circle. There is a chance of enemies being convented when they are attacked in the circle.
+SKILL_20150317_001540	Create magic circle that has a chance of turning enemies into allies when they are attacked inside the circle.
 SKILL_20150317_001541	Magic circle duration 10 seconds
 SKILL_20150317_001542	Resist Elements
-SKILL_20150317_001543	Increase Fire, Ice, Holy resistance of target.
+SKILL_20150317_001543	Increase the Fire, Ice, and Holy resistances of target.
 SKILL_20150317_001544	Fire resistance +#{CaptionRatio}#{nl}Ice resistance +#{CaptionRatio}#{nl}Holy resistance +#{CaptionRatio}#{nl}Buff duration #{CaptionTime}# seconds
 SKILL_20150317_001545	Turn Undead
-SKILL_20150317_001546	Get rid of mutant or devil type monsters at once.
+SKILL_20150317_001546	Has a chance of instantly killing demon and mutant type enemies hit with the skill.
 SKILL_20150317_001547	Extinct Max. #{CaptionRatio}#
 SKILL_20150317_001548	Barrier
-SKILL_20150317_001549	Push away enemy and prevent it from entering the area.
+SKILL_20150317_001549	Creates a barrier that pushes away all enemies and prevents them from entering it.
 SKILL_20150317_001550	Iron Skin
 SKILL_20150317_001551	{#6644FF}{ol}[Divine]{/}{/}Attribute {nl} Recovery #{CaptionRatio}#% {nl} Attack #{SkillFactor}#% + #{SkillAtkAdd}#{nl} Magic circle 10 seconds {nl} Consuem #{SpendSP}# SP
 SKILL_20150317_001552	Double Punch
@@ -1594,36 +1594,36 @@ SKILL_20150317_001593	Use oracle to discable monsters from attacking the pc for 
 SKILL_20150317_001594	Continuously estore the strength of surrounding allies.
 SKILL_20150317_001595	Enemies have chance of getting debuffed when you are attacked.
 SKILL_20150317_001596	Decrease cooldown of party member by n%
-SKILL_20150317_001597	Faint
+SKILL_20150317_001597	Stun
 SKILL_20150317_001598	Can't move
 SKILL_20150317_001599	Fear
 SKILL_20150317_001600	While, after the falter, attack is low.
 SKILL_20150317_001601	Bleed
 SKILL_20150317_001602	Inflict bleeding damage every 1.5 seconds.
 SKILL_20150317_001603	Excessive Bleed
-SKILL_20150317_001604	Inflict strong bleeding damage.
+SKILL_20150317_001604	Inflict stronger bleeding damage.
 SKILL_20150317_001605	Spurt
 SKILL_20150317_001606	Movement speed increases for 15 seconds.
 SKILL_20150317_001607	Recovery
 SKILL_20150317_001608	Recover HP, SP by 5% per second
 SKILL_20150317_001609	Discovery
 SKILL_20150317_001610	Discovery.
-SKILL_20150317_001611	Break
-SKILL_20150317_001612	HP, SP, STA recovery will increase.
+SKILL_20150317_001611	Rest
+SKILL_20150317_001612	HP, SP, and STA recovery increases.
 SKILL_20150317_001613	Safety
 SKILL_20150317_001614	Safety.
-SKILL_20150317_001615	Cold air
+SKILL_20150317_001615	Chilled
 SKILL_20150317_001616	Movement speed decreases.
-SKILL_20150317_001617	Freeze
-SKILL_20150317_001618	Become frozen.
+SKILL_20150317_001617	Frozen
+SKILL_20150317_001618	Frozen solid.
 SKILL_20150317_001619	Ignite
-SKILL_20150317_001620	Fire lit up because of the oil buried.
+SKILL_20150317_001620	Fire lit up because of the oil burned.
 SKILL_20150317_001621	Aftereffects of resurrection
 SKILL_20150317_001622	Atereffect of revivial. Most combat skills decrease.
 SKILL_20150317_001623	Increase Movement Speed
 SKILL_20150317_001624	Increase movement speed.
 SKILL_20150317_001625	Shock wave
-SKILL_20150317_001626	Fire
+SKILL_20150317_001626	Burn
 SKILL_20150317_001627	Receive firedamage periodically.
 SKILL_20150317_001628	Hold
 SKILL_20150317_001629	Unmovable.
@@ -1635,13 +1635,13 @@ SKILL_20150317_001634	Attack increase.
 SKILL_20150317_001635	Deadly poison
 SKILL_20150317_001636	Receive poison damage periodically.
 SKILL_20150317_001637	Contagious deadly poison
-SKILL_20150317_001638	Attack reduction. Periodically receive the poison damage. The effect is transfered to targets around.
+SKILL_20150317_001638	Attack reduction. Periodically receive the poison damage. The effect is transfered to nearby targets.
 SKILL_20150317_001639	Evasion
-SKILL_20150317_001640	Evasion.
+SKILL_20150317_001640	Increased Evasion.
 SKILL_20150317_001641	Defense Shock
-SKILL_20150317_001642	Blocked by enemy and fall in to shock state. Chance of enemy attacks to hit critical will increase by100%.
+SKILL_20150317_001642	Shocked by having its attack blocked. Chance of enemy attacks to hit critical will increase by 100%.
 SKILL_20150317_001643	Petrify
-SKILL_20150317_001644	Petrified.
+SKILL_20150317_001644	Turned to stone.
 SKILL_20150317_001645	Enhance patience
 SKILL_20150317_001646	Damage received decrease by 20%
 SKILL_20150317_001647	Burning Flame
@@ -1665,16 +1665,16 @@ SKILL_20150317_001664	Increase SP, Stamina
 SKILL_20150317_001665	Amount of SP,stamina recoved increase
 SKILL_20150317_001666	Defense and attack will be reduced.
 SKILL_20150317_001667	Rage
-SKILL_20150317_001668	It becomes angry state. Intelligence and Physical defense, magic defense force is reduced, strength, Physical attack, movement speed will increase.
+SKILL_20150317_001668	Become enraged. Intelligence, Physical defense, and magic defense are reduced while Strength, Physical attack, and movement speed are increased.
 SKILL_20150317_001669	Curse target.
 SKILL_20150317_001670	Natural recovery impossible, magic defense decreases.
-SKILL_20150317_001671	Aurora of Addiction
-SKILL_20150317_001672	Spread poison to enemies around. Running and item usage is limited.
+SKILL_20150317_001671	Poisonous Aura
+SKILL_20150317_001672	Spreads poison to nearby enemies. Running and item usage is limited.
 SKILL_20150317_001673	Growth
 SKILL_20150317_001674	Confusion
 SKILL_20150317_001675	Can't distinguish friend and foe.
 SKILL_20150317_001676	Stiffen
-SKILL_20150317_001677	Player RAISEUP
+SKILL_20150317_001677	Deeds of Valor
 SKILL_20150317_001678	Attack is increased while defense is decreasd whenever attacked by the enemy.
 SKILL_20150317_001679	Frozen
 SKILL_20150317_001680	Actor Frozen
@@ -1705,14 +1705,14 @@ SKILL_20150317_001704	FeverTime! Attack increase by 5 per combo
 SKILL_20150317_001705	Fear and confusion occurs
 SKILL_20150317_001706	Effect of Flu Flu
 SKILL_20150317_001707	Fear occurrence
-SKILL_20150317_001708	Oil stains
-SKILL_20150317_001709	You'll be in big trouble if attacked with Fire Property attacks.
+SKILL_20150317_001708	Oil Spill
+SKILL_20150317_001709	You'll be in big trouble if attacked with Fire element attacks.
 SKILL_20150317_001710	Movement speed is increased,
 SKILL_20150317_001711	Holy Aura
 SKILL_20150317_001712	Spread the new buff received to allies
 SKILL_20150317_001713	Fog
 SKILL_20150317_001714	Decrease accuracy.
-SKILL_20150317_001715	Hide Box
+SKILL_20150317_001715	Hide in Box
 SKILL_20150317_001716	Hiding in the box.
 SKILL_20150317_001717	Bleeding.
 SKILL_20150317_001718	Parrying
@@ -1821,7 +1821,7 @@ SKILL_20150317_001820	Critical Resistance decrease
 SKILL_20150317_001821	Divine Stigma buff
 SKILL_20150317_001822	Status increased.
 SKILL_20150317_001823	HP is restore while activated.
-SKILL_20150317_001824	Reborn if defeated.
+SKILL_20150317_001824	Revive if defeated.
 SKILL_20150317_001825	Attack speed will increase.
 SKILL_20150317_001826	Moving Shot on
 SKILL_20150317_001827	Using moving attack.
@@ -1830,17 +1830,17 @@ SKILL_20150317_001829	Change INT and CON stats.
 SKILL_20150317_001830	Number of buff you can receive will increase.
 SKILL_20150317_001831	Attack is increased, attack speed is reduced.
 SKILL_20150317_001832	Ice Blast
-SKILL_20150317_001833	Receive Ice Property damage.
+SKILL_20150317_001833	Receive Ice Element damage.
 SKILL_20150317_001834	Increase Fire, Ice, Lightning resistance.
 SKILL_20150317_001835	Converted.
 SKILL_20150317_001836	Demon type monster will die instantly.
 SKILL_20150317_001837	Enhance attack
 SKILL_20150317_001838	Attack increase temporarily
 SKILL_20150317_001839	Increase Critical once
-SKILL_20150317_001840	Critical rate of next attack increases..
+SKILL_20150317_001840	Critical rate of next attack increases.
 SKILL_20150317_001841	Increase defense
 SKILL_20150317_001842	Strength Decrease
-SKILL_20150317_001843	Strength decrease
+SKILL_20150317_001843	Strength decreases
 SKILL_20150317_001844	Divineness
 SKILL_20150317_001845	Add Holy attack
 SKILL_20150317_001846	Reduce defense
@@ -1876,7 +1876,7 @@ SKILL_20150317_001875	Level up
 SKILL_20150317_001876	Enemy of the companion is gazing. It is disturbing.
 SKILL_20150317_001877	Clone
 SKILL_20150317_001878	Big Head
-SKILL_20150317_001879	Head is enlarged...
+SKILL_20150317_001879	Head is enlarged.
 SKILL_20150317_001880	Receiving stats.
 SKILL_20150317_001881	Status transfer state.
 SKILL_20150317_001882	STR, CON, INT, SPR, DEX decrease.
@@ -1890,7 +1890,7 @@ SKILL_20150317_001889	Companion follows and bugs enemy.
 SKILL_20150317_001890	The defend enemy attack.
 SKILL_20150317_001891	Companion follows hidden enemy.
 SKILL_20150317_001892	Increase Strength
-SKILL_20150317_001893	Strength increase
+SKILL_20150317_001893	Strength increases
 SKILL_20150317_001894	Increase HP
 SKILL_20150317_001895	Increase CON
 SKILL_20150317_001896	Increase INT
@@ -1941,7 +1941,7 @@ SKILL_20150317_001940	State of being continuously receiving damage.
 SKILL_20150317_001941	Velorchard card activated
 SKILL_20150317_001942	Evasion will increase.
 SKILL_20150317_001943	Jack-o'-lantern Card activated
-SKILL_20150317_001944	Icrease attack against demon type monsters.
+SKILL_20150317_001944	Increase attack against demon type monsters.
 SKILL_20150317_001945	Sparnas card activated
 SKILL_20150317_001946	Critical damage will increase.
 SKILL_20150317_001947	Rikaus Card activated
@@ -1968,13 +1968,13 @@ SKILL_20150317_001967	HP potion cooldown is reduced. {Nl} (decrease by 10% per l
 SKILL_20150317_001968	SP Potion Booster
 SKILL_20150317_001969	SP potion cooldown decreases. {Nl} (decrease by 10% per level)
 SKILL_20150317_001970	Sword Mastery
-SKILL_20150317_001971	Handle Sword type items well. {Nl} (Damage increase by 5% per level when using Sword type items)
+SKILL_20150317_001971	One's proficiecy with Swords. {Nl} (Damage increased by 5% per level when using Sword type items)
 SKILL_20150317_001972	Staff Mastery
-SKILL_20150317_001973	Handle Staff type items well. {Nl} (Damage increase by 5% per level when using Staff type items)
+SKILL_20150317_001973	One's proficiecy with Staves. {Nl} (Damage increased by 5% per level when using Staff type items)
 SKILL_20150317_001974	Bow Mastery
-SKILL_20150317_001975	Handle Bow type items well. {Nl} (Damage increase by 5% per level when using Bow type items)
+SKILL_20150317_001975	One's proficiecy with bows. {Nl} (Damage increased by 5% per level when using Bow type items)
 SKILL_20150317_001976	Mace Mastery
-SKILL_20150317_001977	Handle Mace type items well. {Nl} (Damage increase by 5% per level when using Mace type items)
+SKILL_20150317_001977	One's proficiecy with maces. {Nl} (Damage increased by 5% per level when using Mace type items)
 SKILL_20150317_001978	Survival instinct
 SKILL_20150317_001979	Attack increases when HP is below 40%. {Nl} For Level 1 only. Learn only once!
 SKILL_20150317_001980	Ice Spear
@@ -1997,7 +1997,7 @@ SKILL_20150317_001996	Play
 SKILL_20150317_001997	Amount of HP recovery increases. {Nl} (increased by level x 1% of max. HP)
 SKILL_20150317_001998	Inspiration
 SKILL_20150317_001999	Defense level will increase. {Nl} (increased by level x 10)
-SKILL_20150317_002000	Enemies hit with strong strike have chance of fainting for 5 seconds.
+SKILL_20150317_002000	Enemies hit with strong strike have chance of being stunned for 5 seconds.
 SKILL_20150317_002001	Traverse
 SKILL_20150317_002002	Move short distance at high speed. Stamina is consumed. Press arrow key twice to use. -- Squire Characteristic
 SKILL_20150317_002003	Lv.1 STA consumption 4
@@ -3298,7 +3298,7 @@ SKILL_20150401_003297	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Shoot quick fire 
 SKILL_20150401_003298	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Shoot forward while moving back.
 SKILL_20150401_003299	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Quickly move towards target and fire shots.
 SKILL_20150401_003300	Attack #{SkillAtkAdd}#{nl}Can use while riding
-SKILL_20150401_003301	Retreat Shot
+SKILL_20150401_003301	Arrow Sprinkle
 SKILL_20150401_003302	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Shoot opposite the direction you move.
 SKILL_20150401_003303	Erase sign to remove monsters' threat and is not attacked first by monsters.
 SKILL_20150401_003304	Create Guardian Saint magic circle. Target receives damage instead of skill caster.
@@ -3607,9 +3607,9 @@ SKILL_20150414_003606	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Stab and push aw
 SKILL_20150414_003607	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Make strong attacks on enemy.
 SKILL_20150414_003608	Make new resolutions and increase your attack while decreasing defense.
 SKILL_20150414_003609	Increase your ATK.
-SKILL_20150414_003610	Reduce your max. HP but enemy has high chance of faint.
-SKILL_20150414_003611	Chance of Enemy Faint #{CaptionRatio}#%{nl}Max. HP -#{CaptionRatio2}# {nl}Duration #{CaptionTime}# seconds
-SKILL_20150414_003612	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Strike enemy with sword handle.{nl}Inflict additional damage on fainted monsters, and partially ignore defense of small and medium sized enemies.
+SKILL_20150414_003610	Reduce your max hp but attacks have a chance of stunning enemies.
+SKILL_20150414_003611	Chance of Enemy Stun #{CaptionRatio}#%{nl}Max. HP -#{CaptionRatio2}# {nl}Duration #{CaptionTime}# seconds
+SKILL_20150414_003612	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Strike enemy with sword handle.{nl}Inflict additional damage to stunned monsters, and partially ignore defense of small and medium sized enemies.
 SKILL_20150414_003613	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Use bump of shield to attack. Inflict additional attack on enemies under block.
 SKILL_20150414_003614	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Use corner of shield to attack. Inflict additional on frozen enemies.
 SKILL_20150414_003615	Tap the shield to provoke and make enemies follow you.
@@ -3796,7 +3796,7 @@ SKILL_20150414_003795	Hide on the ground. You can attack but cannot move.
 SKILL_20150414_003796	Steal enemy's trap and magic circle. You may use it alter when you need it.
 SKILL_20150414_003797	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Enemy explodes when killed with this attack and your party's strength temporarily increase.
 SKILL_20150414_003798	{#DD5500}{ol}[Physical] - [Hit]{/}{/}{nl}Throw tear gas on target area. Enemies fall under [Dark].
-SKILL_20150414_003799	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Make continuous attack using sword. Double attack with high rate of critical and has chance of fainting enemy.
+SKILL_20150414_003799	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Make continuous attack using sword. Double attack with high rate of critical and has chance of stunning enemy.
 SKILL_20150414_003800	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot broadhead arrow. Enemies hit falls under Bleed.
 SKILL_20150414_003801	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot bodkin arrow with strong penetration. Defense of enemy hit temporarily decreases and nullify magic protecting the enemy.
 SKILL_20150414_003802	{#DD5500}{ol}[Physical] - [Stab]{/}{/}{nl}Shoot barbed arrow. Hit count depends on defense type of enemy.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -934,7 +934,7 @@ SKILL_20150317_000933	Physical Attack + #{CaptionRatio}#{nl}Maximum HP - #{Capti
 SKILL_20150317_000934	Umbo Blow
 SKILL_20150317_000935	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using shield. {nl} Does two hits if used after blocking an attack.
 SKILL_20150317_000936	Rim Blow
-SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} Deals additional damage to both petrified or frozen enemies.
+SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} Deals additional damage to petrified or frozen enemies.
 SKILL_20150317_000938	Swash Buckling
 SKILL_20150317_000939	Hit your shield to attract enemies.
 SKILL_20150317_000940	Target #{SkillSR}#{nl}Max. provoke +#{CaptionRatio}# for #{CaptionTime}# seconds

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -2048,7 +2048,7 @@ SKILL_20150317_002047	Wire Rope
 SKILL_20150317_002048	Centrifugal Force
 SKILL_20150317_002049	Tricks
 SKILL_20150317_002050	Shiver
-SKILL_20150317_002051	[Swoosh Buckling] critical occurrence of skill will increase. {nl} (Increases by 1% per level.)
+SKILL_20150317_002051	[Swash Buckling] critical occurrence of skill will increase. {nl} (Increases by 1% per level.)
 SKILL_20150317_002052	Thrust: Knockback Distance
 SKILL_20150317_002053	Pushing Force of [Thrust] increases by 50% per attribute level.
 SKILL_20150317_002054	Thrust: Continuous Attack
@@ -2056,7 +2056,7 @@ SKILL_20150317_002055	Trigger Continuous Attack when using [Thrust] at 1% chance
 SKILL_20150317_002056	Bash: Splash
 SKILL_20150317_002057	Splash is increased by 1 per attribute level in [Bash].
 SKILL_20150317_002058	Gung Ho: Remaining Defense
-SKILL_20150317_002059	Remaining defense after using [Gung Ho] is 5% per level.
+SKILL_20150317_002059	Remaining defense after using [Gung Ho] is increased by 5% per level.
 SKILL_20150317_002060	Bash: Knock Down
 SKILL_20150317_002061	Monsters attacked with [Bash] are knocked down.
 SKILL_20150317_002062	Concentrate: Stun
@@ -2065,10 +2065,10 @@ SKILL_20150317_002064	Restrain: Duration
 SKILL_20150317_002065	Duration of [Retrain] will increase by 5 seconds per level
 SKILL_20150317_002066	Thrust: Chance of Critical
 SKILL_20150317_002067	Critical probability of [Thrust] is increased by 10% per attribute level.
-SKILL_20150317_002068	Swoosh Buckling: Max. HP
-SKILL_20150317_002069	Max. HP of character increases by 5% per attribute level while [Swoosh Buckling] is enabled.
-SKILL_20150317_002070	Swoosh Buckling: Range
-SKILL_20150317_002071	Provocation range of [Swoosh Buckling] increase by 0.2m per level.
+SKILL_20150317_002068	Swash Buckling: Max. HP
+SKILL_20150317_002069	Max. HP of character increases by 5% per attribute level while [Swash Buckling] is enabled.
+SKILL_20150317_002070	Swash Buckling: Range
+SKILL_20150317_002071	Provocation range of [Swash Buckling] increase by 0.2m per level.
 SKILL_20150317_002072	Umbo Blow: Stun
 SKILL_20150317_002073	Enemies attacked with [Umbo Blow] fall under [Stun] by a chance of 5% per attribute level.
 SKILL_20150317_002074	Shield Lob: Splash

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1026,7 +1026,7 @@ SKILL_20150317_001025	Jolly Roger
 SKILL_20150317_001026	Iron hook
 SKILL_20150317_001027	Keel Hauling
 SKILL_20150317_001028	Unlock Chest
-SKILL_20150317_001029	Endless Assault
+SKILL_20150317_001029	Double Weapon Assault
 SKILL_20150317_001030	{#DDD300}{ol}[Buff]{/}{/}{nl}Can combo normal attacks into subweapon attacks without delay.
 SKILL_20150317_001031	Duration #{CaptionTime}# seconds{nl}Consume #{SpendSP}# SP
 SKILL_20150317_001032	Conscript

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -934,7 +934,7 @@ SKILL_20150317_000933	Physical Attack + #{CaptionRatio}#{nl}Maximum HP - #{Capti
 SKILL_20150317_000934	Umbo Blow
 SKILL_20150317_000935	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using shield. {nl} Does two hits if used after blocking an attack.
 SKILL_20150317_000936	Rim Blow
-SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} Deals additional damage to both petrified and frozen enemies.
+SKILL_20150317_000937	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack using edge of shield. {nl} Deals additional damage to both petrified or frozen enemies.
 SKILL_20150317_000938	Swash Buckling
 SKILL_20150317_000939	Hit your shield to attract enemies.
 SKILL_20150317_000940	Target #{SkillSR}#{nl}Max. provoke +#{CaptionRatio}# for #{CaptionTime}# seconds

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1978,7 +1978,7 @@ SKILL_20150317_001977	One's proficiecy with maces. {Nl} (Damage increased by 5% 
 SKILL_20150317_001978	Survival instinct
 SKILL_20150317_001979	Attack increases when HP is below 40%. {Nl} For Level 1 only. Learn only once!
 SKILL_20150317_001980	Ice Spear
-SKILL_20150317_001981	Attack frozen enemies with Ice Bolt for additional damage {Nl} (added by 25% per level)
+SKILL_20150317_001981	Ice Bolt deals additional damage to frozen enemies {Nl} (added by 25% per level)
 SKILL_20150317_001982	Blow of Rupture
 SKILL_20150317_001983	Chacne of inlficting explosion damage on enemies with hit attack. {Nl} (triggered at 5% chance per level)
 SKILL_20150317_001984	Rupture

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1968,13 +1968,13 @@ SKILL_20150317_001967	HP potion cooldown is reduced. {Nl} (decrease by 10% per l
 SKILL_20150317_001968	SP Potion Booster
 SKILL_20150317_001969	SP potion cooldown decreases. {Nl} (decrease by 10% per level)
 SKILL_20150317_001970	Sword Mastery
-SKILL_20150317_001971	One's proficiecy with Swords. {Nl} (Damage increased by 5% per level when using Sword type items)
+SKILL_20150317_001971	The character's proficiency with with swords. {Nl} (Damage increased by 5% per level when using Sword type items)
 SKILL_20150317_001972	Staff Mastery
-SKILL_20150317_001973	One's proficiecy with Staves. {Nl} (Damage increased by 5% per level when using Staff type items)
+SKILL_20150317_001973	The character's proficiency with Staves. {Nl} (Damage increased by 5% per level when using Staff type items)
 SKILL_20150317_001974	Bow Mastery
-SKILL_20150317_001975	One's proficiecy with bows. {Nl} (Damage increased by 5% per level when using Bow type items)
+SKILL_20150317_001975	The character's proficiency with bows. {Nl} (Damage increased by 5% per level when using Bow type items)
 SKILL_20150317_001976	Mace Mastery
-SKILL_20150317_001977	One's proficiecy with maces. {Nl} (Damage increased by 5% per level when using Mace type items)
+SKILL_20150317_001977	The character's proficiency with maces. {Nl} (Damage increased by 5% per level when using Mace type items)
 SKILL_20150317_001978	Survival instinct
 SKILL_20150317_001979	Attack increases when HP is below 40%. {Nl} For Level 1 only. Learn only once!
 SKILL_20150317_001980	Ice Spear


### PR DESCRIPTION
This covers mainly between lines 467-3116
Changes:
All instances of Swoosh Buckling were changed to Swash Buckling, as that is the name of the skill.
All instances of Faint were replaced with Stun as that is the name of the status
All instances of Kelberos were replaced with Kerberos, the correct name for the three-headed dog.
All instances of Bloom Trap were replaced with Broom Trap, the correct name for the skill.

Various instances of English were made grammatically correct and cleared up throughout all instances of class skills and attributes throughout the entire document.
While much, much longer than the guidelines recommend, this fork drastically improves the descriptions for most skills and attributes.

Takes machine translated sections and turns them into normal English.
I apologize for the huge number of changes, but they were all necessary.

Skill name typos fixed:
Disinter
Trot
Double Weapon Assault
Swash Buckling

And yes we read and agree to the new TOS
