### PR TITLE
Update ETC.tsv Changes Kelberos and Didel names at 6859, 8261, 8427, 11230

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -6856,7 +6856,7 @@ ETC_20150317_006856	Earth Tower boss
 ETC_20150317_006857	Earth Tower Chapparition
 ETC_20150317_006858	Earth Tower Tomblord
 ETC_20150317_006859	Earth Tower mine loader
-ETC_20150317_006860	Earth Tower Kelberos
+ETC_20150317_006860	Earth Tower Kerberos
 ETC_20150317_006861	Earth Tower Vubbe Miner
 ETC_20150317_006862	Earth Tower Monster
 ETC_20150317_006863	Earth Tower Bat
@@ -8258,7 +8258,7 @@ ETC_20150317_008258	Recipe - Quaddara
 ETC_20150317_008259	Recipe - Ilwoon
 ETC_20150317_008260	Recipe - Temsus Flamberge
 ETC_20150317_008261	Recipe - Potentia
-ETC_20150317_008262	Recipe - Didel Colossus
+ETC_20150317_008262	Recipe - Didelis Colossus
 ETC_20150317_008263	Recipe - Hogma Great Sword
 ETC_20150317_008264	Recipe - Primaluce
 ETC_20150317_008265	Recipe - Priblanda
@@ -8424,7 +8424,7 @@ ETC_20150317_008424	Recipe - Antique Wand
 ETC_20150317_008425	Recipe - Dark Wand
 ETC_20150317_008426	Recipe - Grim Wand
 ETC_20150317_008427	Recipe - Skull Wand
-ETC_20150317_008428	Recipe - Didel Shaman Wand
+ETC_20150317_008428	Recipe - Didelis Shaman Wand
 ETC_20150317_008429	Recipe - Party Mang Wand
 ETC_20150317_008430	Recipe - Rampa Wand
 ETC_20150317_008431	Recipe - Vestia Wand
@@ -11227,7 +11227,7 @@ ETC_20150428_011228	Panto Archer
 ETC_20150428_011229	Yellow Zigri
 ETC_20150428_011230	Dionis
 ETC_20150428_011231	Disgusting Deathweaver
-ETC_20150428_011232	Pyrokinetic Kelberos
+ETC_20150428_011232	Pyrokinetic Kerberos
 ETC_20150428_011233	Dark Chapparition
 ETC_20150428_011234	Royal Mausoleum Builder's Chapel
 ETC_20150428_011235	Ugh.. What is this taste?


### PR DESCRIPTION
Changes all instances of Kelberos to Kerberos, in line with Kerberos being the correct name for the three-headed dog.
Didel Colossus and the items named after it have become Didelis, the lithuanian word for big, which was misspelled in the translation.
