### PR TITLE
recipe name changed based equipment name change [ETC 8234~]

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -8359,7 +8359,7 @@ ETC_20150317_008359	Recipe - Morto
 ETC_20150317_008360	Recipe - Smith Crossbow
 ETC_20150317_008361	Recipe - Klavis Crossbow
 ETC_20150317_008362	Recipe - Mace
-ETC_20150317_008363	$Recipe - Morning star
+ETC_20150317_008363	$Recipe - Morning Star
 ETC_20150317_008364	Recipe - Mallet
 ETC_20150317_008365	Recipe - Goedendag
 ETC_20150317_008366	Recipe - Warpick
@@ -8371,7 +8371,7 @@ ETC_20150317_008371	Recipe - Five Hammer
 ETC_20150317_008372	$Recipe - Spiked Mace
 ETC_20150317_008373	Recipe - Shield Breaker
 ETC_20150317_008374	Recipe - Skull Crushers
-ETC_20150317_008375	$Recipe - Valtas Morning star
+ETC_20150317_008375	$Recipe - Valtas Morning Star
 ETC_20150317_008376	Recipe - Suncus Maul
 ETC_20150317_008377	Recipe - Holy Smasher
 ETC_20150317_008378	Recipe - Kaloo Hammer

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -8230,7 +8230,7 @@ ETC_20150317_008230	Recipe - Shamshir
 ETC_20150317_008231	Recipe - Scimitar
 ETC_20150317_008232	Recipe - Kris
 ETC_20150317_008233	Recipe - Snickersnee
-ETC_20150317_008234	Recipe - Mopla
+ETC_20150317_008234	$Recipe - Moplah
 ETC_20150317_008235	Recipe - Spatha
 ETC_20150317_008236	Recipe - Panto Sword
 ETC_20150317_008237	Recipe - Steel Falchion
@@ -8318,8 +8318,8 @@ ETC_20150317_008318	Recipe - Composite Bow
 ETC_20150317_008319	Recipe - Self Bow
 ETC_20150317_008320	Recipe - Rokas Bow
 ETC_20150317_008321	Recipe - Goritos
-ETC_20150317_008322	Recipe - Gulyle
-ETC_20150317_008323	Recipe - Karman
+ETC_20150317_008322	$Recipe - Gulail
+ETC_20150317_008323	$Recipe - Kaman
 ETC_20150317_008324	Recipe - Gendawa
 ETC_20150317_008325	Recipe - Strong Bow
 ETC_20150317_008326	Recipe - Iron Bow
@@ -8335,7 +8335,7 @@ ETC_20150317_008335	Recipe - Viper
 ETC_20150317_008336	Recipe - Blood Gain
 ETC_20150317_008337	Recipe - Tempest Shooter
 ETC_20150317_008338	Recipe - Short Bow
-ETC_20150317_008339	Recipe - Pully Bow
+ETC_20150317_008339	$Recipe - Pulley Bow
 ETC_20150317_008340	Recipe - Smith Bow
 ETC_20150317_008341	Recipe - Klavis Bow
 ETC_20150317_008342	Recipe - Crossbow
@@ -8344,7 +8344,7 @@ ETC_20150317_008344	Recipe - Quarrel Bow
 ETC_20150317_008345	Recipe - Oak Crossbow
 ETC_20150317_008346	Recipe - Seal Crossbow
 ETC_20150317_008347	Recipe - Catapult
-ETC_20150317_008348	Recipe - Cranequine
+ETC_20150317_008348	$Recipe - Cranequin
 ETC_20150317_008349	Recipe - Sniper Crossbow
 ETC_20150317_008350	Recipe - Heavy Crossbow
 ETC_20150317_008351	Recipe - Wide Crossbow
@@ -8359,19 +8359,19 @@ ETC_20150317_008359	Recipe - Morto
 ETC_20150317_008360	Recipe - Smith Crossbow
 ETC_20150317_008361	Recipe - Klavis Crossbow
 ETC_20150317_008362	Recipe - Mace
-ETC_20150317_008363	Recipe - Morningstar
+ETC_20150317_008363	$Recipe - Morning star
 ETC_20150317_008364	Recipe - Mallet
 ETC_20150317_008365	Recipe - Goedendag
 ETC_20150317_008366	Recipe - Warpick
 ETC_20150317_008367	Recipe - Maul
 ETC_20150317_008368	Recipe - Battle Hammer
-ETC_20150317_008369	Recipe - Chakan
+ETC_20150317_008369	$Recipe - Chekan
 ETC_20150317_008370	Recipe - Minor Hammer
 ETC_20150317_008371	Recipe - Five Hammer
-ETC_20150317_008372	Recipe - Spike Mace
+ETC_20150317_008372	$Recipe - Spiked Mace
 ETC_20150317_008373	Recipe - Shield Breaker
 ETC_20150317_008374	Recipe - Skull Crushers
-ETC_20150317_008375	Recipe - Valtas Morningstar
+ETC_20150317_008375	$Recipe - Valtas Morning star
 ETC_20150317_008376	Recipe - Suncus Maul
 ETC_20150317_008377	Recipe - Holy Smasher
 ETC_20150317_008378	Recipe - Kaloo Hammer
@@ -8386,10 +8386,10 @@ ETC_20150317_008386	Recipe - Short Spear
 ETC_20150317_008387	Recipe - Espontoon
 ETC_20150317_008388	Recipe - Winged Espontoon
 ETC_20150317_008389	Recipe - Spontoon
-ETC_20150317_008390	Recipe - Asta
-ETC_20150317_008391	Recipe - Long Asta
+ETC_20150317_008390	$Recipe - Hasta
+ETC_20150317_008391	$Recipe - Long Hasta
 ETC_20150317_008392	Recipe - Sauroter
-ETC_20150317_008393	Recipe - Duty
+ETC_20150317_008393	$Recipe - Dory
 ETC_20150317_008394	Recipe - Grand Spontoon
 ETC_20150317_008395	Recipe - Zega Spear
 ETC_20150317_008396	Recipe - Harl Spear


### PR DESCRIPTION
changes are based on equipment name changed in #917 
8234 - mopla to moplah
8322 - gulyle to gulail
8323 - karman to kaman
8339 - pully to pulley
8363, 8375 - morningstar to morning star
8369 - chakan to chekan
8372 - spike to spiked
8390,8391 - asta to hasta
8393 - duty to dory
