### PR TITLE
Update QUEST_LV_0200.tsv

### DIFF
--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -1,27 +1,27 @@
 QUEST_LV_0200_20150317_000001	$Philipas' Soldiers
-QUEST_LV_0200_20150317_000002	The monsters' attacks are becoming more violent. {nl} I'm determined to succeed, but I also fear for our safety.
-QUEST_LV_0200_20150317_000003	It doesn't matter whether I give up my life today or become a dead man tomorrow.
-QUEST_LV_0200_20150317_000004	Commander Vacenin
+QUEST_LV_0200_20150317_000002	$The monsters' attacks are becoming more violent. {nl} I'm determined to succeed, but I also fear for our safety.
+QUEST_LV_0200_20150317_000003	$It doesn't matter - I can give up my life today, or be a dead man tomorrow.
+QUEST_LV_0200_20150317_000004	$Commander Vacenin
 QUEST_LV_0200_20150317_000005	Somehow, we need to resolve our poor supplies and forces. {nl} However, we must acquire this point in order to break through the forest.
-QUEST_LV_0200_20150317_000006	Even though everyone's getting tired, I can't give up until Kateen Forest is fully retrieved.
+QUEST_LV_0200_20150317_000006	$Even though everyone's getting tired, we can't give up until Katyne Forest is ours again.
 QUEST_LV_0200_20150317_000007	$Senior Officer Philipas
-QUEST_LV_0200_20150317_000008	I wish for a peaceful world. {nl} In order for it to happen, I need to work harder.
-QUEST_LV_0200_20150317_000009	I will do anything to regain this forest from the monsters. {nl} It's worth risking my life for.
-QUEST_LV_0200_20150317_000010	$Our forward unit is composed exclusively of Philipas's monks. {nl} They'll follow Philipas's commands through anything.
-QUEST_LV_0200_20150317_000011	Live with the idea that each moment could always become your last. {nl} We must learn from past events and use it to our advantage.
-QUEST_LV_0200_20150317_000012	Officer Felix
-QUEST_LV_0200_20150317_000013	The Entrance of Kateen Forest is rather on the safe side, but please refrain from going any deeper than this.
-QUEST_LV_0200_20150317_000014	Weak Owl Statue
-QUEST_LV_0200_20150317_000015	My power is slowly weakening. {nl} Even though there are many souls that need guidance..
-QUEST_LV_0200_20150317_000016	Scared Owl Statue
-QUEST_LV_0200_20150317_000017	The sacred power of the forest is weakening. {nl} What will happen to us from now on?!
-QUEST_LV_0200_20150317_000018	It's too scary. {nl} This never happened when the Goddess was still around..
-QUEST_LV_0200_20150317_000019	Sincere Captain Owl
-QUEST_LV_0200_20150317_000020	This forest is cursed... It consumed the owl. {nl} I have only one thing to compel.
-QUEST_LV_0200_20150317_000021	Ever since a huge tree suddenly arose, this forest has changed horribly. {nl} Even the trees' roots frighten whoever stares at them.
-QUEST_LV_0200_20150317_000022	Devoted Owl Statue
-QUEST_LV_0200_20150317_000023	Also someone called Mokuhyoto was held captive. {nl} I have a feeling he's going to disappear...
-QUEST_LV_0200_20150317_000024	The sacred force created by the Goddess hasn't vanished yet. {nl}Will it be able to suppress the devastation? {nl}
+QUEST_LV_0200_20150317_000008	$I wish for a peaceful world. {nl} In order for this to happen, I need to work harder.
+QUEST_LV_0200_20150317_000009	$I'll do anything to regain this forest from the monsters. {nl} It's worth risking my life for.
+QUEST_LV_0200_20150317_000010	$Our front line is composed exclusively of Philipas's monks. {nl} They'll follow Philipas's commands through anything.
+QUEST_LV_0200_20150317_000011	$Live with the idea that any moment could become your last. {nl} We must learn from the past and use it to our advantage.
+QUEST_LV_0200_20150317_000012	$Officer Felix
+QUEST_LV_0200_20150317_000013	$The Entrance of Katyne Forest is rather on the safe side, but please refrain from going any deeper than this.
+QUEST_LV_0200_20150317_000014	$Weak Owl Statue
+QUEST_LV_0200_20150317_000015	$My power is slowly weakening. {nl} Even though there are many souls that need guidance...
+QUEST_LV_0200_20150317_000016	$Scared Owl Statue
+QUEST_LV_0200_20150317_000017	$The sacred power of the forest is weakening. {nl} What will happen to us after it's gone?!
+QUEST_LV_0200_20150317_000018	$It's too scary. {nl} This never happened when the Goddess was still around...
+QUEST_LV_0200_20150317_000019	$Sincere Owl Captain
+QUEST_LV_0200_20150317_000020	This forest is cursed...it consumed the owl. {nl} I have only one thing to compel.
+QUEST_LV_0200_20150317_000021	$Ever since that huge tree suddenly arose, this forest has changed into something horrid. {nl} Even the trees' roots frighten whoever stares at them.
+QUEST_LV_0200_20150317_000022	$Devoted Owl Statue
+QUEST_LV_0200_20150317_000023	$Someone called Mokuhyoto was held captive. {nl} I have a feeling he's going to disappear...
+QUEST_LV_0200_20150317_000024	$The sacred force created by the Goddess hasn't completely dissipated. {nl}Will it be able to suppress this devastation? {nl}
 QUEST_LV_0200_20150317_000025	The Captain gave me power.{nl}I won't be scared.
 QUEST_LV_0200_20150317_000026	Not gonna be afraid anymore.[nl}I will never be eaten by monsters.
 QUEST_LV_0200_20150317_000027	Painful Owl Statue


### PR DESCRIPTION
Line 10: "forward unit" was changed to "front line," as I'm pretty sure that's the intended expression.  Forward unit is a made up / improper term, nonetheless.

Instances of Kateen Forest were changed to Katyne, as per ensata's translation guideline (https://github.com/ensata/TreeOfSavior-en-research/blob/master/mapnames.tsv)
