### PR TITLE
1-249 ETC.tsv (Corrected lots of $'d lines - be more careful, please)

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -3,9 +3,9 @@ ETC_20150317_000002	$The Kepa is not a strong monster. However, attacking it rec
 ETC_20150317_000003	$Large Kepa
 ETC_20150317_000004	$There are people who try to eat the Large Kepa sometimes. Don't let them.
 ETC_20150317_000005	$Red Kepa
-ETC_20150317_000006	$Contrary to common awareness, it is Red Kepa which is more similar to the original Kepa
-ETC_20150317_000007	$Poisoned Kepa.
-ETC_20150317_000008	$Monster
+ETC_20150317_000006	$Contrary to common belief, it's Red Kepa that are more similar to the original Kepa.
+ETC_20150317_000007	$Poisoned Kepa
+ETC_20150317_000008	Monster
 ETC_20150317_000009	$Hamming
 ETC_20150317_000010	$Despite its tough skin, the Hamming is a fairly feeble monster.
 ETC_20150317_000011	$Chinency
@@ -15,26 +15,26 @@ ETC_20150317_000014	$Jukopus
 ETC_20150317_000015	$Very little is known about the Jukopus' internal structure.
 ETC_20150317_000016	$Blue Jukopus
 ETC_20150317_000017	$Gray Jukopus
-ETC_20150317_000018	$Depending on its maturity this monster may develop a variety of different techniques.
+ETC_20150317_000018	$Depending on its maturity, this monster may develop a variety of different combat techniques.
 ETC_20150317_000019	$Pokuborn
 ETC_20150317_000020	$Yellow Pokuborn
 ETC_20150317_000021	$Blue Pokuborn
-ETC_20150317_000022	$There are many things you should be aware of this monster. Above all, don't get hit by its charge attack.
+ETC_20150317_000022	$There are many things you should be aware of with this monster. Above all, don't get hit by its charge attack.
 ETC_20150317_000023	$Green Pokuborn
-ETC_20150317_000024	$Even after mutating into monsters, their meat is still edible
+ETC_20150317_000024	$Even after mutating, their meat is still edible.
 ETC_20150317_000025	$Blue Pokubu
 ETC_20150317_000026	$Banshee
-ETC_20150317_000027	The souls of those who ventured to the underworld now show up as demons.
+ETC_20150317_000027	$The souls of those who ventured to the underworld now appear as demons.
 ETC_20150317_000028	$Red Banshee
 ETC_20150317_000029	$Evil Spirit
-ETC_20150317_000030	A soul that did not receive the guidance of the Goddess. It was born in response to the control of demons.
+ETC_20150317_000030	$A soul that did not receive the guidance of the Goddess. It was born through demonic control.
 ETC_20150317_000031	$Large Banshee
 ETC_20150317_000032	$Beehive
 ETC_20150317_000033	$Blue Beehive
 ETC_20150317_000034	$Grey Beehive
 ETC_20150317_000035	$Red Beehive
 ETC_20150317_000036	$Bushspider
-ETC_20150317_000037	Crawling in the forest shadows, this monster evolved greatly in size over time.
+ETC_20150317_000037	$Crawling amongst the shadows of the forest, this monster has evolved greatly in size over time.
 ETC_20150317_000038	$Black Bushspider
 ETC_20150317_000039	$Red Bushspider
 ETC_20150317_000040	$White Bushspider
@@ -42,13 +42,13 @@ ETC_20150317_000041	$Yellow Bushspider
 ETC_20150317_000042	Disgusting Dionia
 ETC_20150317_000043	Dionia Poza
 ETC_20150317_000044	$Blue Fragaras
-ETC_20150317_000045	$This monster grew bigger in size, but not much of it has changed. i.e., This was a deadly and vicious plant.
+ETC_20150317_000045	$This monster grew bigger in size, but not much has changed.  In the past, this still used to be a deadly and vicious plant.
 ETC_20150317_000046	$Black Fragaras
 ETC_20150317_000047	$Red Fragaras
 ETC_20150317_000048	$Vubbe Fighter
 ETC_20150317_000049	$Blue Vubbe Fighter
 ETC_20150317_000050	$Red Vubbe Fighter
-ETC_20150317_000051	$It is unknown whether Vubbe Fighters are trained or have a natural aptitude for combat.
+ETC_20150317_000051	$It is unknown whether Vubbe Fighters are trained, or just have a natural aptitude for combat.
 ETC_20150317_000052	$Golem
 ETC_20150317_000053	$Gray Golem
 ETC_20150317_000054	$Meduja
@@ -56,7 +56,7 @@ ETC_20150317_000055	$Some people say a Meduja can be used to contact the souls o
 ETC_20150317_000056	$Blue Meduja
 ETC_20150317_000057	$Green Meduja
 ETC_20150317_000058	$Red Meduja
-ETC_20150317_000059	$Researchers asserts that the plants have souls. And, the Medujas are the mutated form of their souls.
+ETC_20150317_000059	$Researchers have asserted that plants have souls. The Medujas are the mutated form of such souls.
 ETC_20150317_000060	$Meduja Larva
 ETC_20150317_000061	$Elaganos
 ETC_20150317_000062	$Bite
@@ -64,29 +64,29 @@ ETC_20150317_000063	$Some say they would rather choose to take an arrow than exp
 ETC_20150317_000064	$Puragi
 ETC_20150317_000065	$It's a forgotten secret that the Demons secretly deployed the Puragis to attack Ruklys' soldiers during the civil war.
 ETC_20150317_000066	$Blue Puragi
-ETC_20150317_000067	$Blue Puragis love to kill and pillage
+ETC_20150317_000067	$Blue Puragis love to kill and pillage.
 ETC_20150317_000068	$Green Puragi
-ETC_20150317_000069	No one has ever seen the face hidden behind the mask it wears.
+ETC_20150317_000069	$No one has ever seen the face hidden behind its mask.
 ETC_20150317_000070	$Red Puragi
 ETC_20150317_000071	$Large Puragi
 ETC_20150317_000072	$Zigri
 ETC_20150317_000073	$Brown Zigri
-ETC_20150317_000074	The demon minions enjoy slaughter.
+ETC_20150317_000074	$These demon minions enjoy slaughter.
 ETC_20150317_000075	$Black Zigri
-ETC_20150317_000076	A demon minion that is found throughout the world.
+ETC_20150317_000076	$A demon minion found throughout the world.
 ETC_20150317_000077	$Red Zigri
 ETC_20150317_000078	$Fisherman
-ETC_20150317_000079	$The reason why fishermen are classified as the mutant monster is because their fishing rods are affecting the creatures.
+ETC_20150317_000079	$The reason why Fishermen are classified as monsters is due to their fishing rods controlling the creatures.
 ETC_20150317_000080	$Blue Fisherman
 ETC_20150317_000081	$Green Fisherman
 ETC_20150317_000082	$Red Fisherman
 ETC_20150317_000083	$This fisherman's actions are often unexplainable.
 ETC_20150317_000084	$Gribaru
-ETC_20150317_000085	$Its stem head can be used for various purposes such as releasing attractants and detecting.
+ETC_20150317_000085	$Its head stem can be used for various purposes, such as releasing attractants and detecting hidden targets.
 ETC_20150317_000086	$Big Gribaru
 ETC_20150317_000087	Thorn Forest Griba
 ETC_20150317_000088	$Matsum
-ETC_20150317_000089	Whether the Matsum originated from a plant, animal, or mineral is unimportant. What you should know is that they are dangerous.
+ETC_20150317_000089	$Whether the Matsum originated from a plant, animal, or mineral is unimportant. What you should know is that its dangerous.
 ETC_20150317_000090	$Matsuma
 ETC_20150317_000091	Mirtis Ego
 ETC_20150317_000092	$Molich
@@ -103,11 +103,11 @@ ETC_20150317_000102	$A large, strong, tough monster and reluctant prey of hunter
 ETC_20150317_000103	$Green Big Griba
 ETC_20150317_000104	$Red Big Griba
 ETC_20150317_000105	$Old Kepa
-ETC_20150317_000106	$The Kepa ages quickly at the expense of its strength. Be careful of its pungent scent, which has gotten stronger with age.
+ETC_20150317_000106	$Kepa age quickly at the expense of their strength. Be careful of its pungent odor, which has gotten stronger with age.
 ETC_20150317_000107	$Gelsvas Old Kepa
 ETC_20150317_000108	$Black Old Kepa
 ETC_20150317_000109	$Red Old Kepa
-ETC_20150317_000110	$Its dilapidated color from aging through life only substantiates its danger.
+ETC_20150317_000110	$Its dilapidated color from aging only substantiates its danger.
 ETC_20150317_000111	$Large Old Kepa
 ETC_20150317_000112	$Rafflesia
 ETC_20150317_000113	$Green Rafflesia
@@ -121,7 +121,7 @@ ETC_20150317_000120	$Gray Raffly
 ETC_20150317_000121	$Black Raffly
 ETC_20150317_000122	$Ridimed
 ETC_20150317_000123	$Blue Ridimed
-ETC_20150317_000124	$Even though it mutated from a herb, its entire body is now made of solid wood.
+ETC_20150317_000124	$Even though it mutated from an herb, its entire body is now made of solid wood.
 ETC_20150317_000125	$Black Ridimed
 ETC_20150317_000126	$Red Ridimed
 ETC_20150317_000127	$Sakmoli
@@ -131,18 +131,18 @@ ETC_20150317_000130	$Orange Sakmoli
 ETC_20150317_000131	$Black Sakmoli
 ETC_20150317_000132	$Rikaus
 ETC_20150317_000133	$Green Apparition
-ETC_20150317_000134	$Ghosts affected by Demons often change their appearance in this way.
+ETC_20150317_000134	$Ghosts affected by demons often change their appearance in a way similar to this.
 ETC_20150317_000135	$Black Apparition
 ETC_20150317_000136	$Spectre
 ETC_20150317_000137	$Black Spectre
-ETC_20150317_000138	$Unlike other wraith monsters, these monsters were often evil souls even when they were living.
+ETC_20150317_000138	$Unlike other wraith monsters, these monsters were often evil souls even when they were alive.
 ETC_20150317_000139	$Giant Spectre
 ETC_20150317_000140	$Spectre of Deceit
 ETC_20150317_000141	$Green Rikaus
 ETC_20150317_000142	$Spectron
 ETC_20150317_000143	$Spectre Master
 ETC_20150317_000144	$Thornball
-ETC_20150317_000145	$This floating seed has transmutated, losing its outer fluff for a solid shell and thorns. However, its floating capability has stayed intact.
+ETC_20150317_000145	$This floating seed has transmutated, losing its outer fluff for a solid shell and thorns. However, its ability to float has stayed intact.
 ETC_20150317_000146	$Big Thornball
 ETC_20150317_000147	$Woodspirit
 ETC_20150317_000148	$Blue Woodspirit
@@ -155,16 +155,16 @@ ETC_20150317_000154	$Red Woodman
 ETC_20150317_000155	$Dark Slime
 ETC_20150317_000156	$Although slimes are similar in appearance, they vary in species due to differences between the materials they originated from.
 ETC_20150317_000157	$Rusrat
-ETC_20150317_000158	$These guardians were placed in many ruins, starting from the Royal Mausoleum of Zachariel the Great, to stop intruders. Its name comes from grave robbers who have encountered it.
+ETC_20150317_000158	$These guardians were placed in many tombs, starting with the Royal Mausoleum of Zachariel the Great, to stop intruders. Its name came from grave robbers who've encountered them.
 ETC_20150317_000159	$Madakia
-ETC_20150317_000160	$The Madakia were created by court wizards to fend off intruders that were not mere grave robbers.
+ETC_20150317_000160	$The Madakia were created by court wizards to fend off intruders that were more dangerous than grave robbers.
 ETC_20150317_000161	$Wheelen
-ETC_20150317_000162	$The Wheelen is one of many magical creations made to protect sealed ruins that have no overseer stationed.
-ETC_20150317_000163	$Wheelen 3
+ETC_20150317_000162	$The Wheelen is one of many magical creations made to protect the sealed tombs that have no current overseer.
+ETC_20150317_000163	Wheelen 3
 ETC_20150317_000164	$Mauros
 ETC_20150317_000165	$The stone cavalry of the Royal Mausoleum are magical creations made to withstand even the most heavily-armed of knights.
 ETC_20150317_000166	$Truffle
-ETC_20150317_000167	$For reasons unknown, this monster holds an extreme hatred towards humans. It prefers to attack humans rather than hunt more suitable prey or look out for its own survival.
+ETC_20150317_000167	$For reasons unknown, this monster holds an extreme hatred towards humans. It prefers to attack humans rather than hunt more suitable prey, or even care about its own survival.
 ETC_20150317_000168	$Treepellia
 ETC_20150317_000169	$Bramble
 ETC_20150317_000170	Bramble Ego
@@ -176,7 +176,7 @@ ETC_20150317_000175	$Chupacabra
 ETC_20150317_000176	$Their numbers grew after the Great Plant Cataclysm; now they tend to compete with humans for territory.
 ETC_20150317_000177	$Gray Chupacabra
 ETC_20150317_000178	$Large Gray Chupacabra
-ETC_20150317_000179	$Chupacabras move secretly. Based on this, it is more dangerous for humans if there are elite Chupacabras.
+ETC_20150317_000179	$Chupacabras move quite stealthily. That being said, it's much more dangerous for humans if there are elite Chupacabras.
 ETC_20150317_000180	$Yellow Chupacabra
 ETC_20150317_000181	$Popolion
 ETC_20150317_000182	$A Popolion's voice is said to break even glass bottles.
@@ -186,67 +186,67 @@ ETC_20150317_000185	$Scorpion
 ETC_20150317_000186	$Tontulia
 ETC_20150317_000187	$The Tontulia is a more mobile mutation of the Tontus.
 ETC_20150317_000188	$Tontus
-ETC_20150317_000189	$As cacti mutated into Tontus the lives of the residents in dry and harsh environments worsened.
+ETC_20150317_000189	$As cacti mutated into Tontus, the lives of the residents in desert environments worsened.
 ETC_20150317_000190	$Vekarabe
-ETC_20150317_000191	$Compared to other animal species, Vekarabes didn't change much from their original form when they became the monsters. However, their aggresion is the exception.
+ETC_20150317_000191	$Compared to other animal species, Vekarabe didn't change much from their original form when they turned into monsters. However, their aggresion definitely a new addition.
 ETC_20150317_000192	$Geppetto
 ETC_20150317_000193	$The name of this monster suits its appearance, but it doesn't reflect its nature at all.
 ETC_20150317_000194	$Boowook
-ETC_20150317_000195	$The Boowook is one of the many defensive systems left by Zachariel the Great in the Royal Mausoleum.
+ETC_20150317_000195	$The Boowook are one of the many defensive systems left by Zachariel the Great in the Royal Mausoleum.
 ETC_20150317_000196	$Bearkaras
 ETC_20150317_000197	$Pino
-ETC_20150317_000198	$The Pino is named so as its first discoverers noticed its similarities with Geppetto.
+ETC_20150317_000198	$The Pino was named so after its first discoverers noticed it held similarities with the Geppetto.
 ETC_20150317_000199	$Helmet Bug
-ETC_20150317_000200	$Monsters that have simply grown in size and aggressiveness are rather relieving
+ETC_20150317_000200	$Monsters that have simply grown in size and aggressiveness are a sight for sore eyes, at least when compared to some of the other terrors in this world.
 ETC_20150317_000201	$Cauliflower
 ETC_20150317_000202	$Though this stationary monster isn't especially hostile towards humans, it still attacks all warm-blooded animals.
 ETC_20150317_000203	$Cauliflower
-ETC_20150317_000204	Vikaras
-ETC_20150317_000205	Although originally created to defend the Royal Mausoleum, it has since malfunctioned into a state that attacks anyone who enters.
-ETC_20150317_000206	Cockatrice
-ETC_20150317_000207	While this Cockatrice is fairly small, its terrifying breath and glance can petrify its foes instantly.
-ETC_20150317_000208	Tsumudoku
-ETC_20150317_000209	Zinutekas
-ETC_20150317_000210	Though their appearance can be mistaken with other similar-looking monsters, Zinutekas are artificially constructed by magic.
-ETC_20150317_000211	Pokubu
-ETC_20150317_000212	Despite its appearance, the Pokubu can be a ferocious beast.
-ETC_20150317_000213	Gray Pokubu
-ETC_20150317_000214	Jinutena
-ETC_20150317_000215	Lauzinutena
-ETC_20150317_000216	Danderu
-ETC_20150317_000217	What's more frightening than Dandel's keratinized soft hair is its vitality and aggressiveness.
-ETC_20150317_000218	Candle Spider
-ETC_20150317_000219	Blue Candle Spider
-ETC_20150317_000220	Yellow Candle Spider
-ETC_20150317_000221	Corpse Flower
-ETC_20150317_000222	Blue Corpse Flower
-ETC_20150317_000223	Green Corpse Flower
-ETC_20150317_000224	Flying Frog
-ETC_20150317_000225	Because of its environment this monster has adapted to various forms. This one has evolved to have wings.
-ETC_20150317_000226	Green Wing Frog
-ETC_20150317_000227	Gray Wing Frog
-ETC_20150317_000228	Liverwort
+ETC_20150317_000204	$Vikaras
+ETC_20150317_000205	$Although originally created to defend the Royal Mausoleum, it has since shifted into a state that attacks anyone who enters.
+ETC_20150317_000206	$Cockatrice
+ETC_20150317_000207	$While the normal Cockatrice is fairly small, its terrifying breath and glance can petrify its foes instantly.
+ETC_20150317_000208	$Tsumudoku
+ETC_20150317_000209	$Zinutekas
+ETC_20150317_000210	$Though their appearance can be mistaken with other similar-looking monsters, Zinutekas are artificially constructed by magic.
+ETC_20150317_000211	$Pokubu
+ETC_20150317_000212	$Despite its appearance, the Pokubu can be quite ferocious.
+ETC_20150317_000213	$Gray Pokubu
+ETC_20150317_000214	$Jinutena
+ETC_20150317_000215	$Lauzinutena
+ETC_20150317_000216	$Dandel
+ETC_20150317_000217	$What's more frightening than a Dandel's soft, keratinized hair is its vitality and aggressiveness.
+ETC_20150317_000218	$Candle Spider
+ETC_20150317_000219	$Blue Candle Spider
+ETC_20150317_000220	$Yellow Candle Spider
+ETC_20150317_000221	$Corpse Flower
+ETC_20150317_000222	$Blue Corpse Flower
+ETC_20150317_000223	$Green Corpse Flower
+ETC_20150317_000224	$Flying Frog
+ETC_20150317_000225	$Due to its environment, this monster has come to have a variety of forms. This one has evolved to have wings.
+ETC_20150317_000226	$Green Wing Frog
+ETC_20150317_000227	$Gray Wing Frog
+ETC_20150317_000228	$Liverwort
 ETC_20150317_000229	Liverwort v2
-ETC_20150317_000230	Leaf Bug
-ETC_20150317_000231	These creatures are not hollow on the inside.
-ETC_20150317_000232	Catacomb Leaf Bug
-ETC_20150317_000233	King Liverwort
-ETC_20150317_000234	Unfortunate Liverwort
+ETC_20150317_000230	$Leaf Bug
+ETC_20150317_000231	$Despite it's appearance, these creatures are not hollow on the inside.
+ETC_20150317_000232	$Catacomb Leaf Bug
+ETC_20150317_000233	$King Liverwort
+ETC_20150317_000234	$Unfortunate Liverwort
 ETC_20150317_000235	Salamion
 ETC_20150317_000236	Salindi
 ETC_20150317_000237	Salun
-ETC_20150317_000238	Gravegolem
-ETC_20150317_000239	Originally created with good intentions, the golem now lives, possessed by evil forces.
-ETC_20150317_000240	Drake
-ETC_20150317_000241	A lesser demon summoned by its superiors in the Demonic realm to invade towers.
-ETC_20150317_000242	Green Drake
+ETC_20150317_000238	$Gravegolem
+ETC_20150317_000239	$Originally created with good intentions, the golem now lives possessed by evil forces.
+ETC_20150317_000240	$Drake
+ETC_20150317_000241	$A lesser demon summoned by its demonic superiors to invade towers.
+ETC_20150317_000242	$Green Drake
 ETC_20150317_000243	These lesser demons come in countless types due to their populous numbers.
-ETC_20150317_000244	Black Drake
-ETC_20150317_000245	These species were once fairly rare; however, in recent times their numbers have greatly increased.
-ETC_20150317_000246	Big Cockatrice
-ETC_20150317_000247	The Big Cockatrice is quite dangerous, as its glare and breath can petrify any opponents. Engaging this creature should not be taken lightly.
-ETC_20150317_000248	Green Kokateu
-ETC_20150317_000249	Red Kokateu
+ETC_20150317_000244	$Black Drake
+ETC_20150317_000245	$This species was once fairly rare; however, in recent times, their numbers have greatly increased.
+ETC_20150317_000246	$Big Cockatrice
+ETC_20150317_000247	$The Big Cockatrice is quite dangerous, as its glare and breath can petrify any opponent. Engaging this creature should not be taken lightly.
+ETC_20150317_000248	$Green Kokateu
+ETC_20150317_000249	$Red Kokateu
 ETC_20150317_000250	Sequoia
 ETC_20150317_000251	Blue Sequoia
 ETC_20150317_000252	Corrupted

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -3,7 +3,7 @@ ETC_20150317_000002	$The Kepa is not a strong monster. However, attacking it rec
 ETC_20150317_000003	$Large Kepa
 ETC_20150317_000004	$There are people who try to eat the Large Kepa sometimes. Don't let them.
 ETC_20150317_000005	$Red Kepa
-ETC_20150317_000006	$Contrary to common belief, it's Red Kepa that are more similar to the original Kepa.
+ETC_20150317_000006	$Contrary to popular belief, it's the Red Kepas that are most similar to the original Kepa.
 ETC_20150317_000007	$Poisoned Kepa
 ETC_20150317_000008	Monster
 ETC_20150317_000009	$Hamming
@@ -56,7 +56,7 @@ ETC_20150317_000055	$Some people say a Meduja can be used to contact the souls o
 ETC_20150317_000056	$Blue Meduja
 ETC_20150317_000057	$Green Meduja
 ETC_20150317_000058	$Red Meduja
-ETC_20150317_000059	$Researchers have asserted that plants have souls. The Medujas are the mutated form of such souls.
+ETC_20150317_000059	$Researchers have asserted that plants have souls. The Meduja are the mutated form of such souls.
 ETC_20150317_000060	$Meduja Larva
 ETC_20150317_000061	$Elaganos
 ETC_20150317_000062	$Bite


### PR DESCRIPTION
Went through the first 250 lines, attempting to finish any missing $'d lines, only to find this section was still riddled with errors.  I touched up a handful of stuff while I was at it, but a decent portion of this is error fixes for lines already marked with $'s.  A lot of stuff like this shouldn't pass through review - it's wasting all of our time if it does.

---

Line 124: "an herb" is proper for American English.

Line 158: changed "ruins" to "tombs," as it makes more sense in the context of the ambiguity as to when they were placed.
     -Based on the description of the Boowook, it seems like these "defensive creations" were created when Zachariel the Great was still
      around.  That being said, the Royal Mausoleum wouldn't have been ruins at the time of their creation (right?).

Line 162: same as above.

Line 191: I honestly view the plural of Vekarabe to be best kept identical to its singular form.  A knitpicky choice of mine, but correct me if I'm wrong here.

Line 195: Changed "is" to "are," for a similar reason to the above change.  Please correct me if this is not right / you don't agree with this fictional grammar.

Line 200: The description seemed unfinished? I'm not sure, but I went ahead and added a second part the sentence that made it seem way more complete.  Also used an idiom.

Line 216 / 217: Changed "Danderu" into "Dandel" for uniformity.  Please correct me if that was the wrong term to change, but more items and their descriptions are already aligned to the term Dandel.
