### PR TITLE
Funny Error Fix and Setting Universal Mob Names

### DIFF
--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -2415,18 +2415,18 @@ ITEM_20150317_002414	Rodelin Cloth Piece
 ITEM_20150317_002415	Fonde Hair 
 ITEM_20150317_002416	Fonde Bow 
 ITEM_20150317_002417	Fondel Hair 
-ITEM_20150317_002418	Fondel Shaft 
-ITEM_20150317_002419	Because the metal is crafted by magic, it usually disintegrates when the monster dies. Very rarely will it stay intact. Obtained from Fondels. 
-ITEM_20150317_002420	Galok Leather 
-ITEM_20150317_002421	The leather of a very strong demon that has very high durability. Obtained from Galoks. 
-ITEM_20150317_002422	Galok Claw 
-ITEM_20150317_002423	Glizardon Bone 
-ITEM_20150317_002424	You need to face great danger to obtain this. Obtained from Glizardons. 
-ITEM_20150317_002425	Glizardon Heart 
-ITEM_20150317_002426	This heart is blessed with great life force but cursed with a powerful evil aura. Obtained from Glizardons. 
-ITEM_20150317_002427	Glizardon Tail 
-ITEM_20150317_002428	Pure Crystal 
-ITEM_20150317_002429	A gemstone carried by many powerful monsters in the Crystal Mines. Obtained from Carapaces and Specter Lords. 
+ITEM_20150317_002418	$Pawndel Shaft 
+ITEM_20150317_002419	$Because the metal is crafted by magic, it usually disintegrates when the monster dies. Very rarely will it stay intact. Obtained from Pawndels. 
+ITEM_20150317_002420	$Galok Leather 
+ITEM_20150317_002421	$The leather of a very strong demon that has very high durability. Obtained from Galoks. 
+ITEM_20150317_002422	$Galok Claw 
+ITEM_20150317_002423	$Glizardon Bone 
+ITEM_20150317_002424	$You need to face great danger to obtain this. Obtained from Glizardons. 
+ITEM_20150317_002425	$Glizardon Heart 
+ITEM_20150317_002426	$This heart is blessed with a great life force, but cursed with a powerful evil aura. Obtained from Glizardons. 
+ITEM_20150317_002427	$Glizardon Tail 
+ITEM_20150317_002428	$Pure Crystal 
+ITEM_20150317_002429	$A gemstone carried by many powerful monsters in the Crystal Mines. Obtained from Carapaces and Specter Masters. 
 ITEM_20150317_002430	Firewood 
 ITEM_20150317_002431	Used to start a campfire. You can start a campfire while sitting. 
 ITEM_20150317_002432	Lapas Resin 


### PR DESCRIPTION
2418/2419: Changed Fondel to Pawndel for monster naming consistency, and preventing a very humorous error.

2429: So, I know the wiki refers to this boss as Spector (a typo of Specter).  The in-game name for the monster is Specter Master, and some quest lines referring to it this was.  However, a handful of the translation's lines mention it as "Spector monarch" or "Specter Monarch."  I changed it to Specter Master here, but if I could get a definitive answer on an agreed upon name, I can go ahead and spot correct all its references to be universal.  Regardless of what's chosen (Specter, Specter Master, or Specter Monarch) it shouldn't be called Spector, as this is a spelling error as well as one of the (currently) least referenced of names for this boss.
