### PR TITLE
Spector -> Specter // Master -> Monarch

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -653,7 +653,7 @@ ETC_20150317_000652	A variety of Chupacabra dwell in various places, causing har
 ETC_20150317_000653	Royal Mausoleum Gate
 ETC_20150317_000654	Yellow Zinute
 ETC_20150317_000655	Blue Lauzinute
-ETC_20150317_000656	Field Spector
+ETC_20150317_000656	Field Specter
 ETC_20150317_000657	Varv
 ETC_20150317_000658	Although small, it has grown bigger than its original state and hunts for meat throughout its life
 ETC_20150317_000659	Field Blue Woodspirit
@@ -967,7 +967,7 @@ ETC_20150317_000966	Mission Cyclops
 ETC_20150317_000967	Mission Stone Whale
 ETC_20150317_000968	Mission Salamander
 ETC_20150317_000969	Mission Shadowgaler
-ETC_20150317_000970	Mission Specter Master
+ETC_20150317_000970	Mission Specter Monarch
 ETC_20150317_000971	Mission Ironbaum
 ETC_20150317_000972	Mission Archon
 ETC_20150317_000973	Mission Yonazolem
@@ -1001,7 +1001,7 @@ ETC_20150317_001000	Summon of Glass Mole
 ETC_20150317_001001	Yognome
 ETC_20150317_001002	It is speculated whether this underground spirit has been deformed and corrupted.
 ETC_20150317_001003	Syaulrabe
-ETC_20150317_001004	Specter Master' Summon Post
+ETC_20150317_001004	Specter Monarch's Summon Post
 ETC_20150317_001005	Capria
 ETC_20150317_001006	Varistor
 ETC_20150317_001007	Summoned of Cyclops
@@ -3162,7 +3162,7 @@ ETC_20150317_003161	] should be completed before passing through
 ETC_20150317_003162	Someone might own it so just copy it
 ETC_20150317_003163	Defeat the horde of Vubbes!
 ETC_20150317_003164	You need to place the crystal in district 9 in order to go down
-ETC_20150317_003165	You can go down the rejected Spector
+ETC_20150317_003165	You can go down the rejected Specter
 ETC_20150317_003166	You need the Vubbe Holystone
 ETC_20150317_003167	Dungeon Vubbe Holystone
 ETC_20150317_003168	Offer
@@ -8115,7 +8115,7 @@ ETC_20150317_008115	Kepa AI2
 ETC_20150317_008116	Blow
 ETC_20150317_008117	Chapparition's shadow
 ETC_20150317_008118	Vubbe Fighter is very tired.
-ETC_20150317_008119	Get rid of the summon things to be summoned by Specter Master
+ETC_20150317_008119	Get rid of the summon things to be summoned by Specter Monarch
 ETC_20150317_008120	if not removed, The lighting is going to be continuous.
 ETC_20150317_008121	Tombstone
 ETC_20150317_008122	Stone Whale is very tired.
@@ -9168,7 +9168,7 @@ ETC_20150317_009168	Chupacabra Hunter
 ETC_20150317_009169	Vubbe Hunter
 ETC_20150317_009170	Mitris Eye Hunter
 ETC_20150317_009171	Ghost Armor Hunter
-ETC_20150317_009172	Spector Hunter
+ETC_20150317_009172	Specter Hunter
 ETC_20150317_009173	Equipment Trade Point Shop
 ETC_20150317_009174	{memo X}Soul Peak_1_2
 ETC_20150317_009175	[Rodelero Master]{nl} Kamiya
@@ -10688,7 +10688,7 @@ ETC_20150406_010689	Outer World White Operor
 ETC_20150406_010690	Outer World Loftlem
 ETC_20150406_010691	Outer World White Harpia
 ETC_20150406_010692	Outer World Stone Whale
-ETC_20150406_010693	Outer World Spector Monarch
+ETC_20150406_010693	Outer World Specter Monarch
 ETC_20150406_010694	Outer World Magbirk
 ETC_20150406_010695	Outer World Fire Lord
 ETC_20150406_010696	Outer World Netherbovine


### PR DESCRIPTION
Going around doing some spot fixes for the naming of this boss (and general spelling error correction for any reference of this type of mob), which was agreed upon to be "Specter Monarch," after a recent merge.

Lines 4514, 4515, 4516, and 4518: I didn't change since it looked a bit like a scripting issue, so I didn't want to touch it.
