### PR TITLE
'Gittis' Settlement Area - scrnshot edit ++ QUEST200 'the' Master standardization

### DIFF
--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -1708,7 +1708,7 @@ QUEST_20150323_001709	$How to Smash
 QUEST_20150323_001710	$Monster Gone Wild
 QUEST_20150323_001711	Suspicious Sword
 QUEST_20150323_001712	$Monster Preying on Military Supplies
-QUEST_20150323_001713	Louis' Farmland
+QUEST_20150323_001713	$Louise's Farmland
 QUEST_20150323_001714	$Unsatisfactory Crops
 QUEST_20150323_001715	$Old Seeds
 QUEST_20150323_001716	{memo X}$Shaton's Stubbornness

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -3805,11 +3805,11 @@ QUEST_LV_0200_20150323_003804	Your skills are as I heard.{nl}Could you wait a se
 QUEST_LV_0200_20150323_003805	I can feel the energy of the spell with the unknown poison.{nl}I am sure that the true nature of them lies somewhere on the land..
 QUEST_LV_0200_20150323_003806	I can feel something scary from the samples.{nl}Please be careful..
 QUEST_LV_0200_20150323_003807	The leather and the dagger with the magic field engraved on them.{nl}Unfortunately, they are not my specialities so I don't know about them well.
-QUEST_LV_0200_20150323_003808	From this place, it will be better if we ask Bokor Master.{nl}No one can compete with him in terms of spells.
+QUEST_LV_0200_20150323_003808	$From here on, it will be better if we ask Bokor Master.{nl}No one can compete with her in terms of spells.
 QUEST_LV_0200_20150323_003809	$You want to know what spell is cast upon these objects?{nl}Hmm. It is a very filthy spell.{nl}
-QUEST_LV_0200_20150323_003810	That's right. This spell spreads the poison that is pasted on the dagger.{nl}Everything near it.
+QUEST_LV_0200_20150323_003810	$I see. This spell spreads a poison that is pasted on the dagger.{nl} To everything near it.
 QUEST_LV_0200_20150323_003811	You will find the answer to the question when you ask Bokor Master.{nl}I am sorry that I can't help you anymore.
-QUEST_LV_0200_20150323_003812	But, I don't know what this poison is.{nl}But the dagger.. How about you go meet Ranger Master?
+QUEST_LV_0200_20150323_003812	$However, I don't know what this poison is.{nl}But this dagger.. How about you go meet Ranger Master?
 QUEST_LV_0200_20150323_003813	$This dagger. Where is this from?{nl} You better tell me quick, before I lose my patience.
 QUEST_LV_0200_20150323_003814	$Ranger Master studied daggers for some time in the past.{nl}That was due to Evoniphon..Anyways she will give you the answer.
 QUEST_LV_0200_20150323_003815	$It was cast with a spell to spread poison on that land?{nl}Hmm. I've received help from an unexpected place.{nl}

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -2453,7 +2453,7 @@ QUEST_LV_0200_20150317_002452	Dorzen seems to trust you a lot. Listen to what he
 QUEST_LV_0200_20150317_002453	Defeat the monsters who ruined the brewery business
 QUEST_LV_0200_20150317_002454	Dorzen told you that if you could defeat the monsters that ruined the brewery business, his anger may subside. Get the revenge on the monsters for Dorzen.
 QUEST_LV_0200_20150317_002455	You've defeated the monsters as requested by Dorzen. Let Dorzen know about it.
-QUEST_LV_0200_20150317_002456	{memo X}Defeat Chuparukas who ruined the brewery business
+QUEST_LV_0200_20150317_002456	{memo X}Defeat Chupalukas who ruined the brewery business
 QUEST_LV_0200_20150317_002457	Check the bee houses at Rodonon Apiary
 QUEST_LV_0200_20150317_002458	Check the bee houses at Rodonon Apiary
 QUEST_LV_0200_20150317_002459	Defeat Sparnas
@@ -2471,8 +2471,8 @@ QUEST_LV_0200_20150317_002470	{memo X}Talk with Micolas
 QUEST_LV_0200_20150317_002471	{memo X}Talk with Micolas on behalf of Cleopas.
 QUEST_LV_0200_20150317_002472	{memo X}You heard why Micolas is angry. Tell Cleopas about it.
 QUEST_LV_0200_20150317_002473	{memo X}Check with Cleopas whether she remembers something.
-QUEST_LV_0200_20150317_002474	{memo X}Obtain the brewery device from Elite Chuparukas
-QUEST_LV_0200_20150317_002475	{memo X}Cleopas once saw the Elite Chuparukas licking the device recklessly. Check with the Elite Chuparuka whether it has the brewery device.
+QUEST_LV_0200_20150317_002474	{memo X}Obtain the brewery device from Elite Chupalukas
+QUEST_LV_0200_20150317_002475	{memo X}Cleopas once saw the Elite Chupalukas licking the device recklessly. Check with the Elite Chuparuka whether it has the brewery device.
 QUEST_LV_0200_20150317_002476	{memo X}Hand the brewery device to Micolas
 QUEST_LV_0200_20150317_002477	{memo X}Elite Chuparuka has the brewery device. Hand it over to Micolas.
 QUEST_LV_0200_20150317_002478	{memo X}Obtain %s by killing large Chupa Luca
@@ -5240,10 +5240,10 @@ QUEST_LV_0200_20150323_005239	$You can see Gitis who is worried a lot at the set
 QUEST_LV_0200_20150323_005240	$Ask for help from the Pyromancer Master in Klaipeda
 QUEST_LV_0200_20150323_005241	$Gitis told you that the workers at the settlement land were attacked by the monsters and they are sick. Talk to the Pyromancer Master to get her help.
 QUEST_LV_0200_20150323_005242	$The Pyromancer Master told you that she will definitely help you. Talk to the Pyromancer Master again.
-QUEST_LV_0200_20150323_005243	$Collect the samples of Pink Chuparukas at the settlement land
-QUEST_LV_0200_20150323_005244	{memo X}Pyromancer Master told you that she will definitely help you. First get some samples of Pink Chuparukas at the settlement land.
+QUEST_LV_0200_20150323_005243	$Collect the samples of Pink Chupalukas at the settlement land
+QUEST_LV_0200_20150323_005244	{memo X}Pyromancer Master told you that she will definitely help you. First get some samples of Pink Chupalukas at the settlement land.
 QUEST_LV_0200_20150323_005245	$Hand it over to the Pyromancer Master
-QUEST_LV_0200_20150323_005246	$You've obtained the samples of Pink Chuparukas. Hand them over to the Pyromancer Master.
+QUEST_LV_0200_20150323_005246	$You've obtained the samples of Pink Chupalukas. Hand them over to the Pyromancer Master.
 QUEST_LV_0200_20150323_005247	Obtain %s from the settlement land
 QUEST_LV_0200_20150323_005248	$The Pyromancer Master who was investigating the samples of the monsters doesn't feel good about something. Talk to the Pyromancer Master.
 QUEST_LV_0200_20150323_005249	Search for the clues of the massive chaos at the settlement land

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -4458,12 +4458,12 @@ QUEST_LV_0200_20150323_004457	Time for farewell
 QUEST_LV_0200_20150323_004458	Secure the farmland
 QUEST_LV_0200_20150323_004459	I will look for the soldiers
 QUEST_LV_0200_20150323_004460	Tell him that it will be alright
-QUEST_LV_0200_20150323_004461	The farmland of Louise(1)
+QUEST_LV_0200_20150323_004461	$Louise's Farmland(1)
 QUEST_LV_0200_20150323_004462	I will defeat the monsters on behalf of him
 QUEST_LV_0200_20150323_004463	$About the settlement land of Gitis
-QUEST_LV_0200_20150323_004464	The farmland of Louise(2)
-QUEST_LV_0200_20150323_004465	The farmland of Louise(3)
-QUEST_LV_0200_20150323_004466	The farmland of Louise(3)
+QUEST_LV_0200_20150323_004464	$Louise's Farmland(2)
+QUEST_LV_0200_20150323_004465	$Louise's Farmland(3)
+QUEST_LV_0200_20150323_004466	$Louise's Farmland(3)
 QUEST_LV_0200_20150323_004467	Terrible result of harvesting(1)
 QUEST_LV_0200_20150323_004468	About the settlement land
 QUEST_LV_0200_20150323_004469	Terrible result of harvesting(2)
@@ -5237,23 +5237,23 @@ QUEST_LV_0200_20150323_005236	The disciple, Prosit can't forgive the demons that
 QUEST_LV_0200_20150323_005237	You've defeated many demons. Talk to the disciple, Prosit.
 QUEST_LV_0200_20150323_005238	$Talk to Gitis
 QUEST_LV_0200_20150323_005239	$You can see Gitis who is worried a lot at the settlement land of Gitis. Talk with Gitis.
-QUEST_LV_0200_20150323_005240	Ask for help from Pyromancer Master at Klaipeda
-QUEST_LV_0200_20150323_005241	$Gitis told you that the workers at the settlement land were attacked by the monsters and they are sick. Talk to Pyromance Master to get his help.
-QUEST_LV_0200_20150323_005242	Pyromancer Master told you that he will definitely help you. Talk to Pyromancer Master again.
+QUEST_LV_0200_20150323_005240	$Ask for help from the Pyromancer Master at Klaipeda
+QUEST_LV_0200_20150323_005241	$Gitis told you that the workers at the settlement land were attacked by the monsters and they are sick. Talk to the Pyromancer Master to get her help.
+QUEST_LV_0200_20150323_005242	$The Pyromancer Master told you that he will definitely help you. Talk to Pyromancer Master again.
 QUEST_LV_0200_20150323_005243	Collect the samples of pink Chuparukas at the settlement land
 QUEST_LV_0200_20150323_005244	{memo X}Pyromancer Master told you that he will definitely help you. First get some samples of pink Chuparukas at the settlement land.
-QUEST_LV_0200_20150323_005245	Hand it over to Pyromancer Master
-QUEST_LV_0200_20150323_005246	You've obtained the samples of pink Chuparukas. Hand them over to Pyromancer Master.
+QUEST_LV_0200_20150323_005245	$Hand it over to the Pyromancer Master
+QUEST_LV_0200_20150323_005246	$You've obtained the samples of pink Chuparukas. Hand them over to the Pyromancer Master.
 QUEST_LV_0200_20150323_005247	Obtain %s from the settlement land
-QUEST_LV_0200_20150323_005248	Pyromancer Master who was investigating the samples of the monsters doesn't feel good about something. Talk to Pyromancer Master.
+QUEST_LV_0200_20150323_005248	$The Pyromancer Master who was investigating the samples of the monsters doesn't feel good about something. Talk to Pyromancer Master.
 QUEST_LV_0200_20150323_005249	Search for the clues of the massive chaos at the settlement land
-QUEST_LV_0200_20150323_005250	Pyromancer Master can feel some unknown poison and the spell. Go back to the settlement land and find out the true nature of the poison and the spell.
-QUEST_LV_0200_20150323_005251	You've found a leather and a dagger with the magic field drawn in them at Nuodo Bank. Take them to Pyromancer Master.
+QUEST_LV_0200_20150323_005250	$The Pyromancer Master can feel some unknown poison and the spell. Go back to the settlement land and find out the true nature of the poison and the spell.
+QUEST_LV_0200_20150323_005251	$You've found a leather and a dagger with the magic field drawn in them at Nuodo Bank. Take them to the Pyromancer Master.
 QUEST_LV_0200_20150323_005252	Destroy the unknown altar
-QUEST_LV_0200_20150323_005253	Unfortunately, Pyromancer Master doesn't know well about the spell. Talk to Pyromancer Master again.
-QUEST_LV_0200_20150323_005254	Talk to Bokor Master about the true nature of the spell.
-QUEST_LV_0200_20150323_005255	Bokor Master knows well about the spells. Ask Bokor Master about the true nature of the spells.
-QUEST_LV_0200_20150323_005256	Bokor Master told you that the spell spreads the poison that is on the the dagger. But, he told you that he doesn't know well about the dagger so told you to meet Ranger Master.
+QUEST_LV_0200_20150323_005253	$Unfortunately, the Pyromancer Master doesn't know well about the spell. Talk to the Pyromancer Master again.
+QUEST_LV_0200_20150323_005254	$Talk to the Bokor Master about the true nature of the spell.
+QUEST_LV_0200_20150323_005255	$The Bokor Master knows well about the spells. Ask Bokor Master about the true nature of the spell.
+QUEST_LV_0200_20150323_005256	$The Bokor Master told you that the spell spreads the poison that is on the the dagger. But, she told you that she doesn't know well about the dagger so told you to meet the Ranger Master.
 QUEST_LV_0200_20150323_005257	$Talk to Gitis
 QUEST_LV_0200_20150323_005258	Use the antidote
 QUEST_LV_0200_20150323_005259	Cure the people who is suffering from the massive explosion using the antidote
@@ -5275,25 +5275,25 @@ QUEST_LV_0200_20150323_005274	Look for the soldiers who went out to defeat Gorgo
 QUEST_LV_0200_20150323_005275	You've defeated the Gorgon that was chasing after the colleagues of Denise. Tell this to Denise.
 QUEST_LV_0200_20150323_005276	Defeat Gorgon
 QUEST_LV_0200_20150323_005277	Talk to Louise
-QUEST_LV_0200_20150323_005278	Louise needs your help. Talk to Louise near the Louise Farm.
-QUEST_LV_0200_20150323_005279	Defeat Ridimed at Louise Farm
-QUEST_LV_0200_20150323_005280	Louise told you that he can't work at all due to Ridimed that came into his farmland. Defeat Ridimed at Louise farmland.
-QUEST_LV_0200_20150323_005281	You've defeated many Ridimeds. Report to Louise.
-QUEST_LV_0200_20150323_005282	Defeat Ridimed at Louise Farm
+QUEST_LV_0200_20150323_005278	$Louise needs your help. Talk to Louise near the Louise's Farm.
+QUEST_LV_0200_20150323_005279	$Defeat Ridimed at Louise's Farm
+QUEST_LV_0200_20150323_005280	$Louise told you that he can't work at all due to the Ridimed that came into his farmland. Defeat the Ridimed at Louise's farmland.
+QUEST_LV_0200_20150323_005281	$You've defeated many Ridimeds. Report to Louise.
+QUEST_LV_0200_20150323_005282	$Defeat Ridimed at Louise's Farm
 QUEST_LV_0200_20150323_005283	{memo X}Louise told you that he defeated the monsters for now, but he is more worried about the future. Talk to Louise.
-QUEST_LV_0200_20150323_005284	Collect the woods to make fences
+QUEST_LV_0200_20150323_005284	$Collect the wood to make fences
 QUEST_LV_0200_20150323_005285	{memo X}Louise asked you to help him since he wants to make the fences. Bring the woods from the land where settlement is planned.
 QUEST_LV_0200_20150323_005286	Report to Louise
-QUEST_LV_0200_20150323_005287	You've selected decent woods. Hand them over to Louise.
-QUEST_LV_0200_20150323_005288	Louise made the fences within a short period of time with the woods. Talk to Louise again.
-QUEST_LV_0200_20150323_005289	Set the fences on the farmland of Louise
-QUEST_LV_0200_20150323_005290	Louise told you that there are still many monsters so asked you to set the completed fences. Set the fences on the farm land of Louise.
-QUEST_LV_0200_20150323_005291	You've set the all the fences. Talk to Louise.
+QUEST_LV_0200_20150323_005287	$You've selected decent wood. Hand them over to Louise.
+QUEST_LV_0200_20150323_005288	$Louise made the fences within a short period of time with the wood. Talk to Louise again.
+QUEST_LV_0200_20150323_005289	$Set up the fences on Louise's Farmland
+QUEST_LV_0200_20150323_005290	$Louise told you that there are still many monsters so asked you to set up the completed fences. Set up the fences on Louise's Farmland.
+QUEST_LV_0200_20150323_005291	$You've set up all the fences. Talk to Louise.
 QUEST_LV_0200_20150323_005292	Obtain %s that will be used as the materials for the scracrow
 QUEST_LV_0200_20150323_005293	Obtain the materials that are lacking by defeating the monsters
 QUEST_LV_0200_20150323_005294	It seems that something is not going well for Gares. Talk to Gares.
 QUEST_LV_0200_20150323_005295	Collect the samples of Shakmoli
-QUEST_LV_0200_20150323_005296	Gares told you that the rate at the crops are growing is not fast so he wants to know why. Please obtain the samples of orange Shakmolis.
+QUEST_LV_0200_20150323_005296	$Gares told you that the rate at which the crops are growing is not as fast as usual, so he wants to know why. Please obtain the samples of orange Shakmolis.
 QUEST_LV_0200_20150323_005297	Hand them over to Gares
 QUEST_LV_0200_20150323_005298	You've obtained the samples of Shakmolis. Hand them over to Gares.
 QUEST_LV_0200_20150323_005299	Talk to Gares

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -3803,25 +3803,25 @@ QUEST_LV_0200_20150323_003802	Pyromancer Master told you that he would help?{nl}
 QUEST_LV_0200_20150323_003803	The monsters became vicious and the poison..{nl}There are so many things these days that can't be trusted.
 QUEST_LV_0200_20150323_003804	Your skills are as I heard.{nl}Could you wait a sec? It wouldn't take that long to check.
 QUEST_LV_0200_20150323_003805	I can feel the energy of the spell with the unknown poison.{nl}I am sure that the true nature of them lies somewhere on the land..
-QUEST_LV_0200_20150323_003806	I can feel somthing scary from the samples.{nl}Please be careful..
+QUEST_LV_0200_20150323_003806	I can feel something scary from the samples.{nl}Please be careful..
 QUEST_LV_0200_20150323_003807	The leather and the dagger with the magic field engraved on them.{nl}Unfortunately, they are not my specialities so I don't know about them well.
 QUEST_LV_0200_20150323_003808	From this place, it will be better if we ask Bokor Master.{nl}No one can compete with him in terms of spells.
-QUEST_LV_0200_20150323_003809	You want to know what spell is casted upon these objects?{nl}Hmm. It is a very filthy spell.{nl}
+QUEST_LV_0200_20150323_003809	$You want to know what spell is cast upon these objects?{nl}Hmm. It is a very filthy spell.{nl}
 QUEST_LV_0200_20150323_003810	That's right. This spell spreads the poison that is pasted on the dagger.{nl}Everything near it.
 QUEST_LV_0200_20150323_003811	You will find the answer to the question when you ask Bokor Master.{nl}I am sorry that I can't help you anymore.
 QUEST_LV_0200_20150323_003812	But, I don't know what this poison is.{nl}But the dagger.. How about you go meet Ranger Master?
-QUEST_LV_0200_20150323_003813	This dagger. Where is this from?{nl}Before you make me mad, you better tell me fast.
-QUEST_LV_0200_20150323_003814	Ranger Master studied daggers for some time in the past.{nl}That was due to Ebonipon..Anyways he will give you the answer.
-QUEST_LV_0200_20150323_003815	They were casted with the spell to spread the poison on that land?{nl}Hmm. I received a help from the unexpected place.{nl}
-QUEST_LV_0200_20150323_003816	Anyways, this dagger belongs to Ebonipon. You can know by looking at the shape of the blade and the symbol. {nl}But I can't detoxify it. Anyways, we've got some clues.
-QUEST_LV_0200_20150323_003817	Don't worry about that. Hunter master knows well about the poison.{nl}He is chasing after Ebonipon with me so he will definitely welcome you.
+QUEST_LV_0200_20150323_003813	$This dagger. Where is this from?{nl} You better tell me quick, before I lose my patience.
+QUEST_LV_0200_20150323_003814	$Ranger Master studied daggers for some time in the past.{nl}That was due to Evoniphon..Anyways she will give you the answer.
+QUEST_LV_0200_20150323_003815	$It was cast with a spell to spread poison on that land?{nl}Hmm. I've received help from an unexpected place.{nl}
+QUEST_LV_0200_20150323_003816	$Anyways, this dagger belongs to Evoniphon. You can know by looking at the shape of the blade and the symbol. {nl}But I can't detoxify it. Anyways, we've got some clues.
+QUEST_LV_0200_20150323_003817	$Don't worry about that. The Hunter Master knows much about poisons.{nl} Like me, he is also after Evoniphon, so he will definitely welcome you.
 QUEST_LV_0200_20150323_003818	Can I help you with anything?{nl}So you want to know how to detoxify this poison...
-QUEST_LV_0200_20150323_003819	How could he dare come to Klaipeda..{nl}Ebonipon. I will not miss you this time.
+QUEST_LV_0200_20150323_003819	$How could he dare come to Klaipeda..{nl}Evoniphon. I will not miss you this time.
 QUEST_LV_0200_20150323_003820	What happened to Pyromancer's task?
 QUEST_LV_0200_20150323_003821	So should I just report about the task to Pyromancer Master?
 QUEST_LV_0200_20150323_003822	Thanks for helping me.
 QUEST_LV_0200_20150323_003823	I should reward you since you helped me.
-QUEST_LV_0200_20150323_003824	{memo X}These are the research documents. Tell Creomancer Master that you would hand over the research documents on behalf of Gitise.
+QUEST_LV_0200_20150323_003824	{memo X}These are the research documents. Tell Cryomancer Master that you would hand over the research documents on behalf of Gitise.
 QUEST_LV_0200_20150323_003825	It is so fortunate that it resolved well enough.
 QUEST_LV_0200_20150323_003826	These are the research documents that I asked from Gitise. I will use them well.
 QUEST_LV_0200_20150323_003827	Please take it to him quickly.

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -3827,11 +3827,11 @@ QUEST_LV_0200_20150323_003826	These are the research documents that I asked from
 QUEST_LV_0200_20150323_003827	Please take it to him quickly.
 QUEST_LV_0200_20150323_003828	I am feeling little better now.
 QUEST_LV_0200_20150323_003829	Soldier Denise
-QUEST_LV_0200_20150323_003830	The expiry date for the farm construction is coming.{nl}Monsters have became suddenly vicious so the workers can't get their touches on them.
-QUEST_LV_0200_20150323_003831	The other soldiers went to defeat Gorgon and I can't leave this place.{nl}The only one I can trust is you. I am counting on you.
-QUEST_LV_0200_20150323_003832	Really? Thanks..{nl}The location is the joint arable land. I am counting on you!
+QUEST_LV_0200_20150323_003830	$The deadline for the farm's construction is approaching,{nl} but the monsters have suddenly became vicious, so the workers can't even touch the site.
+QUEST_LV_0200_20150323_003831	$The other soldiers went to defeat Gorgon, and I can't leave this place.{nl}I can only trust you now for this. I am counting on you.
+QUEST_LV_0200_20150323_003832	$Really? Thanks..{nl}The location is the Joint Farmland. I am counting on you!
 QUEST_LV_0200_20150323_003833	Do you think this makes sense?{nl}Those monsters used to be scared of humans, but they now attack humans with their poison.
-QUEST_LV_0200_20150323_003834	If it weren't you, Uska must have scolded me.. Thank you so much.{nl}Anyways, how come there is no order of return?
+QUEST_LV_0200_20150323_003834	$If it weren't you, Uska must have scolded me.. Thank you so much.{nl}Anyways, I wonder why there aren't any news of the soldiers' return?
 QUEST_LV_0200_20150323_003835	Ah, I am worried about it too much.{nl}I heard the monsters here were naive before, but they turned violent suddenly.{nl}
 QUEST_LV_0200_20150323_003836	I don't know how the world would be like.{nl}And Alan, my colleague. He is protecting the entrance gate of the farm himself.{nl}
 QUEST_LV_0200_20150323_003837	Can you really do that?{nl}If that's so, please take care of Alan before the other soldiers return.

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -662,7 +662,7 @@ QUEST_LV_0200_20150317_000661	I heard from the soldier in felled area that there
 QUEST_LV_0200_20150317_000662	I heard the strange grass is in Naudingas Felled Area. {nl}What a relief that you're here. Haha.
 QUEST_LV_0200_20150317_000663	Naudangis Felled Area is not that far from here. {nl}But the Vubbes will keep chasing you so better be careful.
 QUEST_LV_0200_20150317_000664	You plan to cross this forest? {nl}You can't. This place is seriously dangerous!{nl}
-QUEST_LV_0200_20150317_000665	Ahh, I'm Scott. {nl}I'm a member of Highlander Master and Peltasta Master's joint investigation team. {nl}We were ordered to investigate what's happening in here.
+QUEST_LV_0200_20150317_000665	Ahh, I'm Scott. {nl}I'm a member of the Highlander and Peltasta Masters' joint investigation team. {nl}We were ordered to investigate what's happening in here.
 QUEST_LV_0200_20150317_000666	I heard that you have great abilities. {nl}So if you insist that you must cross this area.. Why don't you just help our investigation?
 QUEST_LV_0200_20150317_000667	Oh, now we're talking. I like you. Haha. {nl}First, get me some tree barks those Vubbes are carrying around. {nl}The Vubbes won't carry around tree barks for no reason, don't you think? {nl}
 QUEST_LV_0200_20150317_000668	Vubbes are spread all over the area. {nl}They go around in groups so you better be careful.
@@ -2387,7 +2387,7 @@ QUEST_LV_0200_20150317_002386	Bilhemina Carriot asked you to soothe the kingdom 
 QUEST_LV_0200_20150317_002387	{memo X}Look for the dead guard
 QUEST_LV_0200_20150317_002388	{memo X}You've discovered a guard who is already dead due to the effect of Stone Frosts. Let's go back to the guard.
 QUEST_LV_0200_20150317_002389	{memo X}As Bilhemina Carriot requested of you, you've received the belongings and the wills from the victims. Let's go back to Bilhemina Carriot.
-QUEST_LV_0200_20150317_002390	Talk to Master Bokor
+QUEST_LV_0200_20150317_002390	Talk to the Bokor Master
 QUEST_LV_0200_20150317_002391	The Bokor Editor in the Petrified City is seeking for someone's help.
 QUEST_LV_0200_20150317_002392	{memo X}Collect the ingredients for the medicine
 QUEST_LV_0200_20150317_002393	{memo X}Bokor Editor asked you to defeat the host monsters and bring the ingredients for the medicine.
@@ -2822,7 +2822,7 @@ QUEST_LV_0200_20150317_002821	Offer worship to sanctuary
 QUEST_LV_0200_20150317_002822	{memo X}Gathered monster meat to use as sacrifice and offered worship but it was a polluted sanctuary!
 QUEST_LV_0200_20150317_002823	Defeat the monsters near the sanctuary
 QUEST_LV_0200_20150317_002824	{memo X}Monsters swarmed out when you prayed to the sanctuary! Looks like the monsters appeared after smelling the meat because the sanctuary is polluted. Defeat the monsters first then look for a way to purify the sanctuary.
-QUEST_LV_0200_20150317_002825	Go to Priest Master
+QUEST_LV_0200_20150317_002825	Go to the Priest Master
 QUEST_LV_0200_20150317_002826	{memo X}The Priest Master manages this sanctuary so he must know how to purify it. It's going to be a long journey, but let's begin.
 QUEST_LV_0200_20150317_002827	Defeat the monsters that gathered around the sanctuary
 QUEST_LV_0200_20150317_002828	{memo X}The polluted altar of Pamaish Hills in Purple Tree Fault Forest was under the watch of Priest Master. Talk to Priest Master on the altar can be purified.
@@ -2848,7 +2848,7 @@ QUEST_LV_0200_20150317_002847	{memo X}Is the Goddess Statue repaired well? Let's
 QUEST_LV_0200_20150317_002848	{memo X}This Goddess Statue was fake! And the monsters even spread out a summon circle around it! Remove the monster summon circles!
 QUEST_LV_0200_20150317_002849	Defeat the monsters that rushed out
 QUEST_LV_0200_20150317_002850	{memo X}Defeat the monsters that rushed out of the polluted sanctuary!
-QUEST_LV_0200_20150317_002851	Go to Cleric Master
+QUEST_LV_0200_20150317_002851	Go to the Cleric Master
 QUEST_LV_0200_20150317_002852	{memo X}As written in the signboard, this sanctuary is under the watch Cleric Master. Ask him what must be done to purify it.
 QUEST_LV_0200_20150317_002853	{memo X}Talk to Cleric Master about the sanctuary in Purple Tree Fault Forest.
 QUEST_LV_0200_20150317_002854	{memo X}Find the Badge of Sanctuary
@@ -3792,33 +3792,33 @@ QUEST_LV_0200_20150323_003791	After he gets out from the curse, he will be total
 QUEST_LV_0200_20150323_003792	$Gitis
 QUEST_LV_0200_20150323_003793	{memo X}Revelator, we are in trouble. Please help us!{nl}As you can see, the workers are dying due to the poison of the monsters.
 QUEST_LV_0200_20150323_003794	While we were clearing the forest to obtain some food as Uska ordered us, the incident occured.{nl}The monsters here were in fact not that vicious before, but now they have the poison.. I don't know what happened to them..
-QUEST_LV_0200_20150323_003795	Pyromancer Master may help since he owes me something. {nl}Please. I am counting on you.
+QUEST_LV_0200_20150323_003795	The Pyromancer Master may help since she owes me something. {nl}Please. I am counting on you.
 QUEST_LV_0200_20150323_003796	I know well because I am from this region.{nl}Even on Medis Diena, those monsters ran away from the people instead of using the poison.
 QUEST_LV_0200_20150323_003797	But they attacked the workers with the poison.{nl}If we don't complete the farm, then we would have trouble supplying the food..
 QUEST_LV_0200_20150323_003798	The monsters on that land?{nl}I can't belive it. I know it well since I used to go there a lot.
-QUEST_LV_0200_20150323_003799	Long time ago, I had helped Pyromancer Master before..{nl}He is the only one we can rely on now.
+QUEST_LV_0200_20150323_003799	Long time ago, I had helped the Pyromancer Master before..{nl}She is the only one we can rely on now.
 QUEST_LV_0200_20150323_003800	$But if Gitis told you like that, then it would be true.{nl}I owe something to Gitis.. Good. Let's find a way together.
 QUEST_LV_0200_20150323_003801	First, we should find out why the monsters became vicious.{nl}Go back to the land and get me the samples of the monsters.
-QUEST_LV_0200_20150323_003802	Pyromancer Master told you that he would help?{nl}That is so fortunate.
+QUEST_LV_0200_20150323_003802	The Pyromancer Master told you that she would help?{nl}That is so fortunate.
 QUEST_LV_0200_20150323_003803	The monsters became vicious and the poison..{nl}There are so many things these days that can't be trusted.
 QUEST_LV_0200_20150323_003804	Your skills are as I heard.{nl}Could you wait a sec? It wouldn't take that long to check.
 QUEST_LV_0200_20150323_003805	I can feel the energy of the spell with the unknown poison.{nl}I am sure that the true nature of them lies somewhere on the land..
 QUEST_LV_0200_20150323_003806	I can feel something scary from the samples.{nl}Please be careful..
 QUEST_LV_0200_20150323_003807	The leather and the dagger with the magic field engraved on them.{nl}Unfortunately, they are not my specialities so I don't know about them well.
-QUEST_LV_0200_20150323_003808	$From here on, it will be better if we ask Bokor Master.{nl}No one can compete with her in terms of spells.
+QUEST_LV_0200_20150323_003808	$From here on, it will be better if we ask the Bokor Master.{nl}No one can compete with her in terms of spells.
 QUEST_LV_0200_20150323_003809	$You want to know what spell is cast upon these objects?{nl}Hmm. It is a very filthy spell.{nl}
 QUEST_LV_0200_20150323_003810	$I see. This spell spreads a poison that is pasted on the dagger.{nl} To everything near it.
-QUEST_LV_0200_20150323_003811	You will find the answer to the question when you ask Bokor Master.{nl}I am sorry that I can't help you anymore.
-QUEST_LV_0200_20150323_003812	$However, I don't know what this poison is.{nl}But this dagger.. How about you go meet Ranger Master?
+QUEST_LV_0200_20150323_003811	$You will find the answer to the question when you ask the Bokor Master.{nl}I am sorry that I can't help you anymore.
+QUEST_LV_0200_20150323_003812	$However, I don't know what this poison is.{nl}But this dagger.. How about you go meet the Ranger Master?
 QUEST_LV_0200_20150323_003813	$This dagger. Where is this from?{nl} You better tell me quick, before I lose my patience.
-QUEST_LV_0200_20150323_003814	$Ranger Master studied daggers for some time in the past.{nl}That was due to Evoniphon..Anyways she will give you the answer.
+QUEST_LV_0200_20150323_003814	$The Ranger Master studied daggers for some time in the past.{nl}That was due to Evoniphon..Anyways she will give you the answer.
 QUEST_LV_0200_20150323_003815	$It was cast with a spell to spread poison on that land?{nl}Hmm. I've received help from an unexpected place.{nl}
 QUEST_LV_0200_20150323_003816	$Anyways, this dagger belongs to Evoniphon. You can know by looking at the shape of the blade and the symbol. {nl}But I can't detoxify it. Anyways, we've got some clues.
 QUEST_LV_0200_20150323_003817	$Don't worry about that. The Hunter Master knows much about poisons.{nl} Like me, he is also after Evoniphon, so he will definitely welcome you.
 QUEST_LV_0200_20150323_003818	Can I help you with anything?{nl}So you want to know how to detoxify this poison...
 QUEST_LV_0200_20150323_003819	$How could he dare come to Klaipeda..{nl}Evoniphon. I will not miss you this time.
 QUEST_LV_0200_20150323_003820	What happened to Pyromancer's task?
-QUEST_LV_0200_20150323_003821	So should I just report about the task to Pyromancer Master?
+QUEST_LV_0200_20150323_003821	$So should I just report about the task to the Pyromancer Master?
 QUEST_LV_0200_20150323_003822	Thanks for helping me.
 QUEST_LV_0200_20150323_003823	I should reward you since you helped me.
 QUEST_LV_0200_20150323_003824	{memo X}These are the research documents. Tell Cryomancer Master that you would hand over the research documents on behalf of Gitis.
@@ -3983,7 +3983,7 @@ QUEST_LV_0200_20150323_003982	Oh my god, please look at this. The ritual was suc
 QUEST_LV_0200_20150323_003983	{memo X}Until the master comes back, I am going to do some base work for the large scale purification.{nl}Can you collect the five bottles of Tanus fluids from the Kvie farm?
 QUEST_LV_0200_20150323_003984	Thanks for helping me.{nl}Anyways, the girl who left the trees.. what is her identity?
 QUEST_LV_0200_20150323_003985	These trees are so mysterious.{nl}It's like the revelator brought the clues of purification.
-QUEST_LV_0200_20150323_003986	You've done enough.{nl}I should tell Druid Master that you've been a great help.{nl}
+QUEST_LV_0200_20150323_003986	You've done enough.{nl}I should tell the Druid Master that you've been a great help.{nl}
 QUEST_LV_0200_20150323_003987	Ah, I have one more thing to request to you lastly.
 QUEST_LV_0200_20150323_003988	This is the box that we discovered with the trees.{nl}If you get a chance to go to Shaton farm, please hand it over to Martineck.
 QUEST_LV_0200_20150323_003989	He likes to interfere with others' lives so he may have involved in some kind of matter.{nl}Maybe, we should ask the other people about the whereabout of him.
@@ -3996,7 +3996,7 @@ QUEST_LV_0200_20150323_003995	Damn. I guess we should leave this place.{nl}We we
 QUEST_LV_0200_20150323_003996	{memo X}Monsters are the bigger problem we have at the moment besides failing harvesting due to vicious energy.{nl}If you could move out the monsters, then we may be able to endure little more.
 QUEST_LV_0200_20150323_003997	We may be able to stand until the harvest season.{nl}But, the land is keep getting polluted so one day it may turn into like the thorny forest.
 QUEST_LV_0200_20150323_003998	I received the unexpected help from you.{nl}You and the druids are all trying hard so I can't just fall down like this.
-QUEST_LV_0200_20150323_003999	We were lucky though. Do you know Druid Master?{nl}Jina Green, the owner of this garden.{nl}
+QUEST_LV_0200_20150323_003999	We were lucky though. Do you know the Druid Master?{nl}Jina Green, the owner of this garden.{nl}
 QUEST_LV_0200_20150323_004000	She lent me the land without asking for any consideration to me after I lost my hometown due to Medis Diena.{nl}But, what should I do now. Harvesting is becoming ineffective, and the number of monster is increasing.{nl}
 QUEST_LV_0200_20150323_004001	{memo X}I was so thankful until now, but I can't let the families starve..{nl}If the vicious energy of the garden does not get removed, we have no choice, but to leave.
 QUEST_LV_0200_20150323_004002	Did you feel something strange while you were coming here?{nl}I mean dandelions. They are big compared to the ones in other places.. and they are quite threatening.{nl}
@@ -4446,7 +4446,7 @@ QUEST_LV_0200_20150323_004445	I will investigate the settlement area
 QUEST_LV_0200_20150323_004446	Reject since it looks dangerous
 QUEST_LV_0200_20150323_004447	Suspicious dagger(1)
 QUEST_LV_0200_20150323_004448	Suspicious dagger(2)
-QUEST_LV_0200_20150323_004449	I will go see Ranger Master
+QUEST_LV_0200_20150323_004449	I will go see the Ranger Master
 QUEST_LV_0200_20150323_004450	I will go there later
 QUEST_LV_0200_20150323_004451	Antidote(2)
 QUEST_LV_0200_20150323_004452	Solve the problem
@@ -4776,9 +4776,9 @@ QUEST_LV_0200_20150323_004775	You need a sacrifice in order to receive the bless
 QUEST_LV_0200_20150323_004776	You've contributed enough monsters as sacrifices. Pray to receive the blessings.
 QUEST_LV_0200_20150323_004777	{memo X}Monsters rushed in as you prayed in front of the sanctum. You better defeat the monsters first.
 QUEST_LV_0200_20150323_004778	We should look for a way to purify the sanctum. Go meet the Priest Master who is the manager of the sanctum.
-QUEST_LV_0200_20150323_004779	We should first purify the polluted sanctum on Pamaishi Hills. Talk to the priest master what to do.
+QUEST_LV_0200_20150323_004779	We should first purify the polluted sanctum on Pamaishi Hills. Talk to the Priest Master what to do.
 QUEST_LV_0200_20150323_004780	Purify the sanctum using the divine water
-QUEST_LV_0200_20150323_004781	Priest Master asked you to purify the sanctum on Pamaishi Hills using the divine water. Go back to the Forest of Prayer and purify the polluted sanctum.
+QUEST_LV_0200_20150323_004781	The Priest Master asked you to purify the sanctum on Pamaishi Hills using the divine water. Go back to the Forest of Prayer and purify the polluted sanctum.
 QUEST_LV_0200_20150323_004782	Pray in front of the statue of the Goddess near the grave of the saint
 QUEST_LV_0200_20150323_004783	There is the statue of the Goddess near the grave of the saint. Pray in front of the statue.
 QUEST_LV_0200_20150323_004784	This statue was fake. Defeat Sparnahorn that was disguised as the statue of the Goddess.
@@ -4799,12 +4799,12 @@ QUEST_LV_0200_20150323_004798	You've completed repairing the statue. Look closel
 QUEST_LV_0200_20150323_004799	Break the demon summon field
 QUEST_LV_0200_20150323_004800	The statue which you spent the time repairing it was fake. Break it fast since you don't know what will happen at the demon summon field.
 QUEST_LV_0200_20150323_004801	The sanctum is already polluted. Defeat the monsters that are coming to the polluted sanctum.
-QUEST_LV_0200_20150323_004802	The manager of this sanctum is Cleric Master. Ask him what he should do to purify the pollution of the sanctum.
-QUEST_LV_0200_20150323_004803	Listen to the advices of Cleric Master
+QUEST_LV_0200_20150323_004802	The manager of this sanctum is the Cleric Master. Ask him what he should do to purify the pollution of the sanctum.
+QUEST_LV_0200_20150323_004803	Listen to the advices of the Cleric Master
 QUEST_LV_0200_20150323_004804	Get some advices from the Cleric Master regarding the polluted sanctum at the Forest of Prayer.
-QUEST_LV_0200_20150323_004805	You've obtained an advise on the way to purify the polluted sanctum from the cleric master. Go back to the Forest of Prayer.
+QUEST_LV_0200_20150323_004805	You've obtained an advise on the way to purify the polluted sanctum from the Cleric Master. Go back to the Forest of Prayer.
 QUEST_LV_0200_20150323_004806	Look for the symbol of the religious belief at the sanctum
-QUEST_LV_0200_20150323_004807	To prepare times like this, the cleric master hid the symbol of the religious belief at the sanctum. Look for the symbol of the religious belief at the sanctum.
+QUEST_LV_0200_20150323_004807	To prepare times like this, the Cleric Master hid the symbol of the religious belief at the sanctum. Look for the symbol of the religious belief at the sanctum.
 QUEST_LV_0200_20150323_004808	Burn the badge of the sanctum after finding it
 QUEST_LV_0200_20150323_004809	As the Cleric Master taught you, use the symbol of the religious belief to find the badge of the sanctum which the monster swallowed.
 QUEST_LV_0200_20150323_004810	Burn the badge of the sanctum at the sanctum
@@ -4819,11 +4819,11 @@ QUEST_LV_0200_20150323_004818	As you prayed, the statue was attacked. Remove the
 QUEST_LV_0200_20150323_004819	Devote Flowers
 QUEST_LV_0200_20150323_004820	You should devote the flowers on this sanctum. Put the flowering plants on the sanctum and pray in front of it.
 QUEST_LV_0200_20150323_004821	Since you have the flowers, devote them to the sanctum and receive the blessings.
-QUEST_LV_0200_20150323_004822	Obtain some advices from Pardoner Master
+QUEST_LV_0200_20150323_004822	Obtain some advices from the Pardoner Master
 QUEST_LV_0200_20150323_004823	{memo X}It seems that this place is also polluted so go meet the Pardoner Master who is the manager of the sanctum and get some advices. If you purchase the warp scroll that will direct you to the outer edge of Fedimian from the stand beside, you will be able to move faster.
 QUEST_LV_0200_20150323_004824	Purify the pollution at the sanctum
-QUEST_LV_0200_20150323_004825	The purification device that you bought from Pardoner Master can purify the sanctum a bit. Burn the purification device in front of the sanctum.
-QUEST_LV_0200_20150323_004826	Ask Pardoner Master how to purify the sanctum
+QUEST_LV_0200_20150323_004825	The purification device that you bought from the Pardoner Master can purify the sanctum a bit. Burn the purification device in front of the sanctum.
+QUEST_LV_0200_20150323_004826	Ask the Pardoner Master how to purify the sanctum
 QUEST_LV_0200_20150323_004827	As you were about to pray in front of the sanctums, the monsters appeared from somewhere. You better defeat the monsters first.
 QUEST_LV_0200_20150323_004828	Pray in front of the sanctum and receive the blessing.
 QUEST_LV_0200_20150323_004829	Fortunately, it seems that the sanctum is not polluted yet. Pray again at the sanctum and receive the blessing.
@@ -5239,26 +5239,26 @@ QUEST_LV_0200_20150323_005238	$Talk to Gitis
 QUEST_LV_0200_20150323_005239	$You can see Gitis who is worried a lot at the settlement land of Gitis. Talk with Gitis.
 QUEST_LV_0200_20150323_005240	$Ask for help from the Pyromancer Master at Klaipeda
 QUEST_LV_0200_20150323_005241	$Gitis told you that the workers at the settlement land were attacked by the monsters and they are sick. Talk to the Pyromancer Master to get her help.
-QUEST_LV_0200_20150323_005242	$The Pyromancer Master told you that he will definitely help you. Talk to Pyromancer Master again.
+QUEST_LV_0200_20150323_005242	$The Pyromancer Master told you that he will definitely help you. Talk to the Pyromancer Master again.
 QUEST_LV_0200_20150323_005243	Collect the samples of pink Chuparukas at the settlement land
 QUEST_LV_0200_20150323_005244	{memo X}Pyromancer Master told you that he will definitely help you. First get some samples of pink Chuparukas at the settlement land.
 QUEST_LV_0200_20150323_005245	$Hand it over to the Pyromancer Master
 QUEST_LV_0200_20150323_005246	$You've obtained the samples of pink Chuparukas. Hand them over to the Pyromancer Master.
 QUEST_LV_0200_20150323_005247	Obtain %s from the settlement land
-QUEST_LV_0200_20150323_005248	$The Pyromancer Master who was investigating the samples of the monsters doesn't feel good about something. Talk to Pyromancer Master.
+QUEST_LV_0200_20150323_005248	$The Pyromancer Master who was investigating the samples of the monsters doesn't feel good about something. Talk to the Pyromancer Master.
 QUEST_LV_0200_20150323_005249	Search for the clues of the massive chaos at the settlement land
 QUEST_LV_0200_20150323_005250	$The Pyromancer Master can feel some unknown poison and the spell. Go back to the settlement land and find out the true nature of the poison and the spell.
 QUEST_LV_0200_20150323_005251	$You've found a leather and a dagger with the magic field drawn in them at Nuodo Bank. Take them to the Pyromancer Master.
 QUEST_LV_0200_20150323_005252	Destroy the unknown altar
 QUEST_LV_0200_20150323_005253	$Unfortunately, the Pyromancer Master doesn't know well about the spell. Talk to the Pyromancer Master again.
 QUEST_LV_0200_20150323_005254	$Talk to the Bokor Master about the true nature of the spell.
-QUEST_LV_0200_20150323_005255	$The Bokor Master knows well about the spells. Ask Bokor Master about the true nature of the spell.
+QUEST_LV_0200_20150323_005255	$The Bokor Master knows well about the spells. Ask the Bokor Master about the true nature of the spell.
 QUEST_LV_0200_20150323_005256	$The Bokor Master told you that the spell spreads the poison that is on the the dagger. But, she told you that she doesn't know well about the dagger so told you to meet the Ranger Master.
 QUEST_LV_0200_20150323_005257	$Talk to Gitis
 QUEST_LV_0200_20150323_005258	Use the antidote
 QUEST_LV_0200_20150323_005259	Cure the people who is suffering from the massive explosion using the antidote
-QUEST_LV_0200_20150323_005260	Talk to Pyromancer Master
-QUEST_LV_0200_20150323_005261	Talk to Creomancer Master
+QUEST_LV_0200_20150323_005260	Talk to the Pyromancer Master
+QUEST_LV_0200_20150323_005261	Talk to the Cryomancer Master
 QUEST_LV_0200_20150323_005262	Talk to Soldier Denise
 QUEST_LV_0200_20150323_005263	You can see Denise who looks to be troubled. Talk to Denise.
 QUEST_LV_0200_20150323_005264	Defeat the monsters at the joint harvesting area
@@ -6841,7 +6841,7 @@ QUEST_LV_0200_20150414_006844	Find out someone who knows the several fragments.
 QUEST_LV_0200_20150414_006845	Talk to Jonas
 QUEST_LV_0200_20150414_006846	Regain the Padeka Altar
 QUEST_LV_0200_20150414_006847	All Place of Sanctuary
-QUEST_LV_0200_20150414_006848	Pyromancer Master said he'd gladly help us. Firstly, collect the sample of Pink Chupaluka in the Pioneer Place.
+QUEST_LV_0200_20150414_006848	The Pyromancer Master said she'd gladly help us. Firstly, collect the sample of Pink Chupaluka in the Pioneer Place.
 QUEST_LV_0200_20150414_006849	Louise said she's more worried about the future even though we defeated the monsters just now. Talk to Louise again.
 QUEST_LV_0200_20150414_006850	Louise wants you to help making the fence for the future. Get the woods from the Pioneer place.
 QUEST_LV_0200_20150414_006851	Obtain the Blud's symbol
@@ -7055,12 +7055,12 @@ QUEST_LV_0200_20150714_007058	Hopefully this can be resolved without causing a c
 QUEST_LV_0200_20150714_007059	For the most part, do try and appease the monk's demands.{nl}We'll assist you wherever we can.
 QUEST_LV_0200_20150714_007060	I'm glad to hear that Natasha is doing well.{nl} I wish you the best at Raoki Swamps.
 QUEST_LV_0200_20150714_007061	Good. So finally the time to retrieve the monastery.{nl}We will be using our power in a such a long time.
-QUEST_LV_0200_20150714_007062	We've reached this far with your help, revelator.{nl}Now we just to have to hope that Ebonippon gets taken care of well. Let's go.
+QUEST_LV_0200_20150714_007062	We've reached this far with your help, revelator.{nl}Now we just to have to hope that Evoniphon gets taken care of well. Let's go.
 QUEST_LV_0200_20150714_007063	Senior Monk Potos
 QUEST_LV_0200_20150714_007064	What brought you here?{nl}Things are not the way they used to be, but we will try our best to help you.
 QUEST_LV_0200_20150714_007065	I am sorry if you've come here to visit the monastery.{nl}We are like this since the monsters rushed in.
 QUEST_LV_0200_20150714_007066	The goddersses told us to greet everyone warmly.{nl}Due to the difficulty we are having at the moment, we weren't able to greet Hunters warmly. I regret...
-QUEST_LV_0200_20150714_007067	If that trap was set by Ebonippon, I will stand by Hunters' side.{nl}Whatever excuses you make, they can't be compared with our pains.
+QUEST_LV_0200_20150714_007067	If that trap was set by Evoniphon, I will stand by Hunters' side.{nl}Whatever excuses you make, they can't be compared with our pains.
 QUEST_LV_0200_20150714_007068	Marko brothers are at Viltis Forest and Guus is at Laukyme Swampy place.{nl}Without their support, we woud not be able to persuade the abbot.
 QUEST_LV_0200_20150714_007069	I support the Hunters, but I don't know how other senior monks would think.{nl}However, I don't think it would be a problem if we get a decisive proof.
 QUEST_LV_0200_20150714_007070	Monk Wiley
@@ -7068,16 +7068,16 @@ QUEST_LV_0200_20150714_007071	My heart aches to see our brothers feel the pains.
 QUEST_LV_0200_20150714_007072	For me, our brothers come first instead of the Hunters or the Monastery.{nl}I am praying to the goddesses so that they can be cured quickly.{nl}
 QUEST_LV_0200_20150714_007073	Hunter Reina
 QUEST_LV_0200_20150714_007074	You should be careful when you are crossing this forest.{nl}The traps are everywhere in this forest.
-QUEST_LV_0200_20150714_007075	You don't seem like a monk... Do you know anything about Ebonippon?{nl}I heard they created a mess near the farm in Klaipeda.
+QUEST_LV_0200_20150714_007075	You don't seem like a monk... Do you know anything about Evoniphon?{nl}I heard they created a mess near the farm in Klaipeda.
 QUEST_LV_0200_20150714_007076	Even after taking a antidote, the paralysis doesn't go away.{nl}But, as a Hunter, I can't go back until I finish the task.
-QUEST_LV_0200_20150714_007077	I don't know how many people are suffering due to one Ebonippon.{nl}To put this in other words, Ebonippon's so great.
+QUEST_LV_0200_20150714_007077	I don't know how many people are suffering due to one Evoniphon.{nl}To put this in other words, Evoniphon's so great.
 QUEST_LV_0200_20150714_007078	Senior Monk Marko
-QUEST_LV_0200_20150714_007079	The abbot is locked inside the monastery where there are full of monsters, but mentioning about Ebonippon...{nl}Should not be that rude. Don't you think so?
+QUEST_LV_0200_20150714_007079	The abbot is locked inside the monastery where there are full of monsters, but mentioning about Evoniphon...{nl}Should not be that rude. Don't you think so?
 QUEST_LV_0200_20150714_007080	If you are going to talk about Hunters, I refuse to listen.{nl}They are so rude.
 QUEST_LV_0200_20150714_007081	He barely walked here and then fainted.{nl}I think he is breathing for now...
 QUEST_LV_0200_20150714_007082	Boros! Wake up, Boros!
 QUEST_LV_0200_20150714_007083	I regret that I was being so harsh to the Hunters til now.{nl}I hope my decision helps the Hunters
-QUEST_LV_0200_20150714_007084	You should persuade Guus at Laukyme Swampy place.{nl}But, since you don't have the decisive proof about Ebonippon... I can't guarantee the withdrawl of the protection.
+QUEST_LV_0200_20150714_007084	You should persuade Guus at Laukyme Swampy place.{nl}But, since you don't have the decisive proof about Evoniphon... I can't guarantee the withdrawl of the protection.
 QUEST_LV_0200_20150714_007085	Hunter Natasha
 QUEST_LV_0200_20150714_007086	Persuading someone is so hard.{nl}I hope someone helps me...
 QUEST_LV_0200_20150714_007087	How would the commander Mints react if he was in this situation...
@@ -7090,14 +7090,14 @@ QUEST_LV_0200_20150714_007093	Are you going to Tyla Monastery?{nl}The monsters a
 QUEST_LV_0200_20150714_007094	Careless, careless.{nl}I was so careless...
 QUEST_LV_0200_20150714_007095	Monk Chad
 QUEST_LV_0200_20150714_007096	Please do not get close to those Hunters.{nl}They are so rude.
-QUEST_LV_0200_20150714_007097	I don't like those Hunters.{nl}I hope they would not change their minds because we are protecting Ebonippon
+QUEST_LV_0200_20150714_007097	I don't like those Hunters.{nl}I hope they would not change their minds because we are protecting Evoniphon
 QUEST_LV_0200_20150714_007098	Senior Monk Guus
 QUEST_LV_0200_20150714_007099	If you are the pilgrim who came to see Tyla Monastery, I am so sorry.{nl}We lost the place to the monsters...
 QUEST_LV_0200_20150714_007100	I don't know what the goddesses would say if she sees this...{nl}Gloomy...
-QUEST_LV_0200_20150714_007101	This is all I know about Ebonippon.{nl}I think there weren't anything special besides that.
-QUEST_LV_0200_20150714_007102	If you need to more about Ebonippon, please ask me anytime.{nl}I will answer everything I know about Ebonippon.
+QUEST_LV_0200_20150714_007101	This is all I know about Evoniphon.{nl}I think there weren't anything special besides that.
+QUEST_LV_0200_20150714_007102	If you need to more about Evoniphon, please ask me anytime.{nl}I will answer everything I know about Evoniphon.
 QUEST_LV_0200_20150714_007103	Finally, we are near Tyla Monastery.{nl}We want to attack, but we should also think about the monks.
-QUEST_LV_0200_20150714_007104	To defeat Ebonippon, we will do anything.{nl}To the ones who are from the tower of the stars, Ebonippon is a such creature.
+QUEST_LV_0200_20150714_007104	To defeat Evoniphon, we will do anything.{nl}To the ones who are from the tower of the stars, Evoniphon is a such creature.
 QUEST_LV_0200_20150714_007105	Monk Jones
 QUEST_LV_0200_20150714_007106	The moment now seems like a short nightmare.{nl}We were studying scriptures and drawing water at the monastery not long ago.
 QUEST_LV_0200_20150714_007107	I know that I am pathetic since I was forced out by the monsters...{nl}But, I am worried more about the abbot who is praying at the prayer room without knowing anything.
@@ -7106,7 +7106,7 @@ QUEST_LV_0200_20150714_007109	Long time ago, this place used to be packed with t
 QUEST_LV_0200_20150714_007110	I want to know where these monsters all came from.{nl}After the purification, the only monsters were the ones that lost their ways.
 QUEST_LV_0200_20150714_007111	Hey! Wake up!{nl}Can you hear my voice?
 QUEST_LV_0200_20150714_007112	He is fainted, but fortunately he is breathing.{nl}But, the fracture is serious.
-QUEST_LV_0200_20150714_007113	Ebonippon, you cheap...
+QUEST_LV_0200_20150714_007113	Evoniphon, you cheap...
 QUEST_LV_0200_20150714_007114	Fortunatly, his inner organs seem alright.{nl}But, I can't cure him by transporting him to other places.
 QUEST_LV_0200_20150714_007115	I am going to take care of the outer edge of the monastery.{nl}In the name of the goddesses, I wish you the good luck.
 QUEST_LV_0200_20150714_007116	We are all ready here.{nl}Although I can't participate in saving the abbot, I will do my best here.
@@ -7119,7 +7119,7 @@ QUEST_LV_0200_20150714_007122	You can't open it outside without the crystal sphe
 QUEST_LV_0200_20150714_007123	It's so good to hear that you are okay.{nl}While you are getting the crystal sphere, we should get ready to rescue the abbot.
 QUEST_LV_0200_20150714_007124	I would've bled a lot if it weren't you.{nl}The goddesses must have helped me.
 QUEST_LV_0200_20150714_007125	Fortunately, the abbot seems to know nothing.{nl}I guess that's better. Anyways, the issues have been resolved.
-QUEST_LV_0200_20150714_007126	I am less worried to find out the abbot is okay.{nl}Now what should we do about Ebonippon...
+QUEST_LV_0200_20150714_007126	I am less worried to find out the abbot is okay.{nl}Now what should we do about Evoniphon...
 QUEST_LV_0200_20150714_007127	I am discussing with the abbot.{nl}Please wait beside Mintz for a while.
 QUEST_LV_0200_20150714_007128	We haven't finished discussing yet.{nl}Please wait little more.
 QUEST_LV_0200_20150714_007129	You will leave soon. May the goddesses bless you.{nl}Come to Tyla Monastery sometimes.
@@ -7127,16 +7127,16 @@ QUEST_LV_0200_20150714_007130	I regret a bit since we should have allied togethe
 QUEST_LV_0200_20150714_007131	It is so fortunate that the abbot is okay.{nl}I... feel like crying.
 QUEST_LV_0200_20150714_007132	I kinda expected that he would be alright since he was in the prayer room...{nl}But seeing him okay with my own eyes comforts me more.
 QUEST_LV_0200_20150714_007133	Please wait beside Mintz for a while.{nl}I should explain everything so it may take little time.
-QUEST_LV_0200_20150714_007134	I've heard about Ebonippon's letter from Guus.{nl}Please wait little more since everything fits the situation.
+QUEST_LV_0200_20150714_007134	I've heard about Evoniphon's letter from Guus.{nl}Please wait little more since everything fits the situation.
 QUEST_LV_0200_20150714_007135	We've retrieved the monastery and the Hunters fulfilled what they wanted...{nl}These are all blessings of the goddesses.
 QUEST_LV_0200_20150714_007136	Without your help, I am sure that it would've not gone so easy.{nl}I've heard the stories of many revelators before, but you are the only one I saw in person.
 QUEST_LV_0200_20150714_007137	Monk Moheim
 QUEST_LV_0200_20150714_007138	It's so good that we've retrieved the monastery...{nl}But it's a mess.
 QUEST_LV_0200_20150714_007139	Should we get rid of the monsters first or clean this place first...{nl}That's the problem we are facing at the moment.
-QUEST_LV_0200_20150714_007140	Now is the best chance to get Ebonippon.{nl}We are surrounding the monastery so I guess even he would not be able to sneak out.
-QUEST_LV_0200_20150714_007141	You saw Ebonippon?{nl}He is not here. We better go down a bit more.
-QUEST_LV_0200_20150714_007142	Please pray so that we could get Ebonippon.{nl}I wish you the good luck.
-QUEST_LV_0200_20150714_007143	Don't worry revelator. Just go on your way. The people here are just fainted temporarily.{nl}I hope to see you next time for something better instead of Ebonippon.
+QUEST_LV_0200_20150714_007140	Now is the best chance to get Evoniphon.{nl}We are surrounding the monastery so I guess even he would not be able to sneak out.
+QUEST_LV_0200_20150714_007141	You saw Evoniphon?{nl}He is not here. We better go down a bit more.
+QUEST_LV_0200_20150714_007142	Please pray so that we could get Evoniphon.{nl}I wish you the good luck.
+QUEST_LV_0200_20150714_007143	Don't worry revelator. Just go on your way. The people here are just fainted temporarily.{nl}I hope to see you next time for something better instead of Evoniphon.
 QUEST_LV_0200_20150714_007144	I lost many colleagues from Stone Frosts here.{nl}I don't understand why I am here to support a newbie Chronomancer here.
 QUEST_LV_0200_20150714_007145	On top of that, we don't know when those violent monsters would attack here.{nl}I don't care what you do, I just hope those monsters get taken care of.
 QUEST_LV_0200_20150714_007146	We are still sad that we lost our colleagues.{nl}It is very unfortunate that we should take care of that woman in this time.
@@ -7671,15 +7671,15 @@ QUEST_LV_0200_20150714_007674	Damn!{nl}Monsters came after smelling the polluted
 QUEST_LV_0200_20150714_007675	If you go near the bushes, the hidden monsters may suddenly appear.{nl}I am counting on you.
 QUEST_LV_0200_20150714_007676	More monsters will appear when you shake the bushes.
 QUEST_LV_0200_20150714_007677	I paid a lot for this from the black market in Fedimian.{nl}It will be much more helpful than the revelator like you or those shameless druids.{nl}
-QUEST_LV_0200_20150714_007678	This is sturdy. You've been suffered by the trap of Ebonippon.{nl}But, what have brought you here?{nl}
+QUEST_LV_0200_20150714_007678	This is sturdy. You've been suffered by the trap of Evoniphon.{nl}But, what have brought you here?{nl}
 QUEST_LV_0200_20150714_007679	You were the revelator? It's so nice to meet you.{nl}Thanks for saving me... I have another request for you.
 QUEST_LV_0200_20150714_007680	We are doing an important mission at the moment.
-QUEST_LV_0200_20150714_007681	It's little complicated. We are chasing after Ebonippon who is the suspect of the murder case at the Tower of the Stars.{nl}But, this guys is being protected by the religious rules at the monastery near here.{nl}
-QUEST_LV_0200_20150714_007682	So please help us to get Ebonippon.{nl}We should somehow first persuade the monks...
+QUEST_LV_0200_20150714_007681	It's little complicated. We are chasing after Evoniphon who is the suspect of the murder case at the Tower of the Stars.{nl}But, this guys is being protected by the religious rules at the monastery near here.{nl}
+QUEST_LV_0200_20150714_007682	So please help us to get Evoniphon.{nl}We should somehow first persuade the monks...
 QUEST_LV_0200_20150714_007683	I am so sorry. {nl}Please first persuade Potos at Ditis Garden.
-QUEST_LV_0200_20150714_007684	But, the monks shake their heads in denial when we mention Ebonippon...
+QUEST_LV_0200_20150714_007684	But, the monks shake their heads in denial when we mention Evoniphon...
 QUEST_LV_0200_20150714_007685	Do you know the Tower of the Stars?{nl}Starting with Lydia Schaffen, the greatest archers are all from that place.{nl}
-QUEST_LV_0200_20150714_007686	The head of the tower was murdered by Ebonippon.{nl}I've chased him upto here, but I can't do anything further due to those god damn religious rules.{nl}
+QUEST_LV_0200_20150714_007686	The head of the tower was murdered by Evoniphon.{nl}I've chased him upto here, but I can't do anything further due to those god damn religious rules.{nl}
 QUEST_LV_0200_20150714_007687	They protect the ones who are falsely charged.{nl}I thought that law was ineffective after the day of divine tree... I want to resolve it by avoiding a conflict with them.
 QUEST_LV_0200_20150714_007688	Hello. Traveller.{nl}What has brought you here?
 QUEST_LV_0200_20150714_007689	If you are going to ask about Hunters, I am sorry, but I can't tell you anything.{nl}
@@ -7688,12 +7688,12 @@ QUEST_LV_0200_20150714_007691	Hunters... They must know how to detoxify.{nl}Thes
 QUEST_LV_0200_20150714_007692	If our brothers help, I am willing to help you as well.{nl}I have a load on my mind.
 QUEST_LV_0200_20150714_007693	This... okay. It's so obvious who did this.{nl}First, give them this antidote. Fortunately, the poison is not that poisonous.
 QUEST_LV_0200_20150714_007694	I can't see Hunters... sorry.{nl}We also have to consider the position of monastery.
-QUEST_LV_0200_20150714_007695	But, if the poison is from Ebonippon, then the story will be different.{nl}I am sorry, but I want to see the trap myself.
+QUEST_LV_0200_20150714_007695	But, if the poison is from Evoniphon, then the story will be different.{nl}I am sorry, but I want to see the trap myself.
 QUEST_LV_0200_20150714_007696	Recently, monsters rushed into the monastery.{nl}It was very quick and the monsters went crazy in the monastery as if they were possessed by something.{nl}
 QUEST_LV_0200_20150714_007697	We had no other choices, except for running away.{nl}The problem was the father superior. He was praying in the Prayer Room.{nl}
 QUEST_LV_0200_20150714_007698	Fortunately, Prayer Room is safest place in the monastery.{nl}We know that even monsters can't do anything on Prayer Room, but we also couldn't just do nothing.
 QUEST_LV_0200_20150714_007699	So there aren't enough evidences huh.{nl}
-QUEST_LV_0200_20150714_007700	Reina who is my subordinate is looking for the traces of Ebonippon down there.{nl}She found something recently, but she seems to have some problem.
+QUEST_LV_0200_20150714_007700	Reina who is my subordinate is looking for the traces of Evoniphon down there.{nl}She found something recently, but she seems to have some problem.
 QUEST_LV_0200_20150714_007701	It seems that the task is going smoothly.{nl}I've received the rewards bigger than my life.
 QUEST_LV_0200_20150714_007702	Don't walk around since it's dangerous.{nl}I recommend you to move out from this forest.
 QUEST_LV_0200_20150714_007703	Hello. Traveller.{nl}What has brought you here?
@@ -7704,7 +7704,7 @@ QUEST_LV_0200_20150714_007707	I guess I am not competent enough yet.{nl}I wanted
 QUEST_LV_0200_20150714_007708	Let's see... That's the skill I've seen often. {nl}The commander is looking for a decent trap right? Please bring him this.
 QUEST_LV_0200_20150714_007709	As your competence increases, people won't know who made the traps.{nl}But, on the contrary, people may find out who made the traps easily.{nl}
 QUEST_LV_0200_20150714_007710	And if there's only one suspect like this case, the difficulty gets lowered a lot.{nl}We just have to find his characteristics.
-QUEST_LV_0200_20150714_007711	That's indeed Ebonippon. {nl}I can hardly find his traces.{nl}
+QUEST_LV_0200_20150714_007711	That's indeed Evoniphon. {nl}I can hardly find his traces.{nl}
 QUEST_LV_0200_20150714_007712	But, the traps are easily made with the materials nearby. {nl}We just have to hope that the monk notices it. First, take it and show it to him.
 QUEST_LV_0200_20150714_007713	After the persuasion of the monk is done, please meet Natasha at Viltis Forest.{nl}She must have some trouble.
 QUEST_LV_0200_20150714_007714	Look here. This is the silk that will be used in the trap... I think I've seen it before.{nl}If someone touched on the supplies of the monastery, we can think of only one person.{nl}
@@ -7736,15 +7736,15 @@ QUEST_LV_0200_20150714_007739	We should retrieve the monastery.{nl}If we don't m
 QUEST_LV_0200_20150714_007740	The father superior here is called Marco and he leads the monastery here.{nl}But, he is too stubborn. He is too difficult.{nl}
 QUEST_LV_0200_20150714_007741	I will support here with all I could so I hope you pass my position.
 QUEST_LV_0200_20150714_007742	I should've persuaded him slowly, but I think we were in a rush.{nl}But, it was that important...
-QUEST_LV_0200_20150714_007743	You are a different person. Even so, no is no.{nl}They are very rude. They know the circumstances well, and Ebonippon...{nl}
+QUEST_LV_0200_20150714_007743	You are a different person. Even so, no is no.{nl}They are very rude. They know the circumstances well, and Evoniphon...{nl}
 QUEST_LV_0200_20150714_007744	And the father superior is locked in the monastery.{nl}Unless we retrieve the monastery, do not mention about the deportation.
 QUEST_LV_0200_20150714_007745	If retrieving monastery is more important, that's good.{nl}If they approve, we will support with everything we can.{nl}
 QUEST_LV_0200_20150714_007746	You should first help those monks.{nl}They would have more than one trouble. You should show them the favor first.
 QUEST_LV_0200_20150714_007747	Hunters will step up first. They should have done that in the first place.{nl}Then, I have something to request to you.{nl}
 QUEST_LV_0200_20150714_007748	We were preparing to retrieve the monastery ourselves.{nl}Please let our brothers down there know that hunters are helping.{nl}
 QUEST_LV_0200_20150714_007749	I shall wait for Boros. I am counting on you.
-QUEST_LV_0200_20150714_007750	Do not think bad about us.{nl}We should first retrieve the monastery, but they are only talking about Ebonippon so we don't feel comfortable.
-QUEST_LV_0200_20150714_007751	We have a problem. {nl}One of the monks have been suffered by the poison of Ebonippon.{nl}
+QUEST_LV_0200_20150714_007750	Do not think bad about us.{nl}We should first retrieve the monastery, but they are only talking about Evoniphon so we don't feel comfortable.
+QUEST_LV_0200_20150714_007751	We have a problem. {nl}One of the monks have been suffered by the poison of Evoniphon.{nl}
 QUEST_LV_0200_20150714_007752	He is breathing, but he is becoming stiff.{nl}What should we do about this...
 QUEST_LV_0200_20150714_007753	This place is dangerous.{nl}Be careful all the time.
 QUEST_LV_0200_20150714_007754	We've passed the dangerous situation with an emergency procedure, but...{nl}If we don't detoxify it completely, there will be more crisis.{nl}
@@ -7759,15 +7759,15 @@ QUEST_LV_0200_20150714_007762	I am going to absorb poison with this.{nl}I am goi
 QUEST_LV_0200_20150714_007763	You won't understand how embarassed and painful I am.{nl}My brother almost died due to the poisonn and I received help from the hunters that I kicked out...{nl}
 QUEST_LV_0200_20150714_007764	Good. You would have to persuade Guus at Laukyme Swampy Place.{nl}Please tell Marco that I've decided to go with Hunters.
 QUEST_LV_0200_20150714_007765	It's is so fortunate that it turned out alright.{nl}Please meet Mintz commander on your way to Laukyme Swampy Place and tell him that everything went alright.
-QUEST_LV_0200_20150714_007766	Senior monk, Guus is leading the brothers at Laukyme Swampy Place.{nl}If Ebonippon did all of these, the goddesses would also understand my rage.
+QUEST_LV_0200_20150714_007766	Senior monk, Guus is leading the brothers at Laukyme Swampy Place.{nl}If Evoniphon did all of these, the goddesses would also understand my rage.
 QUEST_LV_0200_20150714_007767	It's so nice seeing you.{nl}So how did the task at Viltis Forest go?
 QUEST_LV_0200_20150714_007768	Go first.{nl}I will follow you to Laukyme Swampy Place if he gets alright.
-QUEST_LV_0200_20150714_007769	So that's it. We now have to persuade one of the monks and retrieve the monastery...{nl}After that, we would be able to contact with the father superior who would decide what to do with Ebonippon.
+QUEST_LV_0200_20150714_007769	So that's it. We now have to persuade one of the monks and retrieve the monastery...{nl}After that, we would be able to contact with the father superior who would decide what to do with Evoniphon.
 QUEST_LV_0200_20150714_007770	I will gather the hunters.{nl}Please continue to help Natasha at Laukyme Swampy Place.
 QUEST_LV_0200_20150714_007771	When you go up the Ershike Path, you will reach Laukyme Swampy Place.{nl}If you fail to persuade, then we would have to retrieve the monastery ourselves.
 QUEST_LV_0200_20150714_007772	You've come a long way.{nl}So I heard a monk called Guus is taking the place of the father superior.
 QUEST_LV_0200_20150714_007773	Strange... traveller in this place.
-QUEST_LV_0200_20150714_007774	It's so shameful as a hunter...{nl}After fiding the trace of Ebonippon, I was really delighted, but I found out that was a trap...{nl}
+QUEST_LV_0200_20150714_007774	It's so shameful as a hunter...{nl}After fiding the trace of Evoniphon, I was really delighted, but I found out that was a trap...{nl}
 QUEST_LV_0200_20150714_007775	I am sorry, but can you look for the grass which he is looking for?{nl}I can only move one of my arms and my neck.
 QUEST_LV_0200_20150714_007776	It's so fortunate that you came before the monsters.{nl}I am counting on you.
 QUEST_LV_0200_20150714_007777	Good. Good. {nl}We should first survive before feeling embarassment. Thanks!
@@ -7783,7 +7783,7 @@ QUEST_LV_0200_20150714_007786	Stranger...{nl}If you don't have any task here, pl
 QUEST_LV_0200_20150714_007787	The monastery is locked with the barriers of the monks so it won't be possible without the persuasion from Guus.{nl}But, I... it's too difficult.
 QUEST_LV_0200_20150714_007788	Hunters... they just won't give up.{nl}I've heard Marco and Potos are with the hunters.{nl}
 QUEST_LV_0200_20150714_007789	But, you should be cautious.{nl}We just can't listen to one side.
-QUEST_LV_0200_20150714_007790	After persuading him, we can immediately start to retrieve the monastery.{nl}We can expect to expel Ebonippon at then.
+QUEST_LV_0200_20150714_007790	After persuading him, we can immediately start to retrieve the monastery.{nl}We can expect to expel Evoniphon at then.
 QUEST_LV_0200_20150714_007791	Witout Guus, we won't be able to recover the monastery.{nl}I hope you succeed in persuading him.
 QUEST_LV_0200_20150714_007792	But, I think we can resume the talk after retrieving the monastery.{nl}Please show me the competence which I could rely on so I can cooperate with you.
 QUEST_LV_0200_20150714_007793	Good.{nl}The Liverworts and Stonakons aroud here would be enough. Please also bring the proofs.
@@ -7791,31 +7791,31 @@ QUEST_LV_0200_20150714_007794	You can give up if you feel that's too much for yo
 QUEST_LV_0200_20150714_007795	You definitely possess the competence. We also have the same objective.{nl}There is no reason to insist anymore.
 QUEST_LV_0200_20150714_007796	The senior monk here is very picky.
 QUEST_LV_0200_20150714_007797	I will gather the monks in front of the entrance of the monastery so tell hunters to gather as well.{nl}After they are gathered, we will unleash the seals that are blocked so that the monsters won't be able to follow.{nl}
-QUEST_LV_0200_20150714_007798	But, although we retrieved the monastery, don't expect us to expel Ebonippon.{nl}The father superior will decide everything after he comes out from the Prayer Room.
+QUEST_LV_0200_20150714_007798	But, although we retrieved the monastery, don't expect us to expel Evoniphon.{nl}The father superior will decide everything after he comes out from the Prayer Room.
 QUEST_LV_0200_20150714_007799	Please understand that we could only do this.{nl}We've only listened to your story.
-QUEST_LV_0200_20150714_007800	What Guus said also makes sense.{nl}As they gather in front of the monastery, we should have some decisive evidences that would withdraw Ebonippon's declaration.
-QUEST_LV_0200_20150714_007801	I think we would have enough time.{nl}I am sorry, but please go back to Guus and ask him what happened when Ebonippon was coming.
+QUEST_LV_0200_20150714_007800	What Guus said also makes sense.{nl}As they gather in front of the monastery, we should have some decisive evidences that would withdraw Evoniphon's declaration.
+QUEST_LV_0200_20150714_007801	I think we would have enough time.{nl}I am sorry, but please go back to Guus and ask him what happened when Evoniphon was coming.
 QUEST_LV_0200_20150714_007802	You can't prove that he was a cruel assasin.{nl}We can't unlock the ones that are being protected in the castle by just guessing.{nl}
-QUEST_LV_0200_20150714_007803	What they said about the traps and the monsters that conquered the monastery are also the same.{nl}It's only an one-sided story that this was done by Ebonippon.{nl}
-QUEST_LV_0200_20150714_007804	We are the people who pray for the generosity of the goddesses.{nl}So to withdraw the protection of Ebonippon, you should show them some decisive evidences.
-QUEST_LV_0200_20150714_007805	Hmm. I remember that clearly.{nl}One day, a guy called Ebonippon knocked on the door of the monastery. With his wounded body...{nl}
+QUEST_LV_0200_20150714_007803	What they said about the traps and the monsters that conquered the monastery are also the same.{nl}It's only an one-sided story that this was done by Evoniphon.{nl}
+QUEST_LV_0200_20150714_007804	We are the people who pray for the generosity of the goddesses.{nl}So to withdraw the protection of Evoniphon, you should show them some decisive evidences.
+QUEST_LV_0200_20150714_007805	Hmm. I remember that clearly.{nl}One day, a guy called Evoniphon knocked on the door of the monastery. With his wounded body...{nl}
 QUEST_LV_0200_20150714_007806	After having him in the room, I started to cure him.{nl}He also requested to protect the sanctuary at then.
 QUEST_LV_0200_20150714_007807	That's right. Before he came on that day, one man who seemed to be addicted by the poison also came.{nl}He was in a severe status, so he passed away before I could even ask him a question.{nl}
-QUEST_LV_0200_20150714_007808	His grave is in Pasaro Rest Area. With his keepstakes.{nl}Ah, Ebonippon also asked me whether there was someone who came before him.
-QUEST_LV_0200_20150714_007809	The man addicted by the poison... I am sure he ran away from Ebonippon.{nl}Why did he run away from Ebonippon...
+QUEST_LV_0200_20150714_007808	His grave is in Pasaro Rest Area. With his keepstakes.{nl}Ah, Evoniphon also asked me whether there was someone who came before him.
+QUEST_LV_0200_20150714_007809	The man addicted by the poison... I am sure he ran away from Evoniphon.{nl}Why did he run away from Evoniphon...
 QUEST_LV_0200_20150714_007810	There weren't any other things besides that.{nl}Did this help you?
-QUEST_LV_0200_20150714_007811	It's not good for the dead one, but I think I should look for his keepstakes from his grave.{nl}To find out why Ebonippon was chasing after him. Please help me.
+QUEST_LV_0200_20150714_007811	It's not good for the dead one, but I think I should look for his keepstakes from his grave.{nl}To find out why Evoniphon was chasing after him. Please help me.
 QUEST_LV_0200_20150714_007812	Did you find anything?
 QUEST_LV_0200_20150714_007813	This is the directory of Schaffensta.{nl}There's a letter in the middle of it... This is the seal of Schaffensta. Let's rip it off.
-QUEST_LV_0200_20150714_007814	This is the request letter for murder and the confirmation of the receipt. The receiver is Ebonippon...{nl}I think Ebonippon thought this letter would be at the monastery.{nl}
-QUEST_LV_0200_20150714_007815	I am sure that Ebonippon caused the mess of the monsters to look for this. It's easy for him.{nl}This is a decisive evidence. Let's show it to Guus.
+QUEST_LV_0200_20150714_007814	This is the request letter for murder and the confirmation of the receipt. The receiver is Evoniphon...{nl}I think Evoniphon thought this letter would be at the monastery.{nl}
+QUEST_LV_0200_20150714_007815	I am sure that Evoniphon caused the mess of the monsters to look for this. It's easy for him.{nl}This is a decisive evidence. Let's show it to Guus.
 QUEST_LV_0200_20150714_007816	Murder request... this is a decisive evidence.{nl}The father superior would think differently when he sees this.{nl}
 QUEST_LV_0200_20150714_007817	All other monks are ready and went in front of the monastery.{nl}Let's go. I will see you in front of the monastery.
 QUEST_LV_0200_20150714_007818	Everything is clear now.{nl}I will go to the entrance of the monastery first. Let's join there together.
 QUEST_LV_0200_20150714_007819	You've come?{nl}We are ready to enter the monastery.
 QUEST_LV_0200_20150714_007820	Everyone seems to be gathering in front of the monastery.{nl}Let's hurry.
 QUEST_LV_0200_20150714_007821	I thought it was a manner not to touch it since it was the last keepstake.{nl}How would anyone have thought his would turn out like this.
-QUEST_LV_0200_20150714_007822	Everyone knows that Hunter Master and Ranger Master are chasing after Ebonippon.{nl}But, the reason why no one could step forward is because they don't have a decisive evidence.{nl}
+QUEST_LV_0200_20150714_007822	Everyone knows that the Hunter Master and the Ranger Master are chasing after Evoniphon.{nl}But, the reason why no one could step forward is because they don't have a decisive evidence.{nl}
 QUEST_LV_0200_20150714_007823	Now, it is different. This letter is the evidence.{nl}Since we have the seal of Schaffensta, we don't have to worry about it.
 QUEST_LV_0200_20150714_007824	This place is dangerous... I miss the monastery.
 QUEST_LV_0200_20150714_007825	I want to be safe until I go back to the monastery.{nl}But the monsters near here are very threatening.
@@ -7858,8 +7858,8 @@ QUEST_LV_0200_20150714_007861	Okay. I will discuss with the father superior.{nl}
 QUEST_LV_0200_20150714_007862	I will wait for their decision here first.{nl}If their declaration doesn't get withdrawn, then I should think about what to do at then.
 QUEST_LV_0200_20150714_007863	So it seems that their discussion is over.{nl}Let's go there and listen to their conclusion.
 QUEST_LV_0200_20150714_007864	We haven't finished our discussion.{nl}Please wait with the hunters.
-QUEST_LV_0200_20150714_007865	After we've discussed with the senior monks...{nl}We've decided to withdraw our declaration to protect Ebonippon.
-QUEST_LV_0200_20150714_007866	From this point on, Ebonippon won't be protected by Tila Monastery and we request Ebonippon to leave at once.{nl}Also, we are not going to be involved with others' decision to punish him.
+QUEST_LV_0200_20150714_007865	After we've discussed with the senior monks...{nl}We've decided to withdraw our declaration to protect Evoniphon.
+QUEST_LV_0200_20150714_007866	From this point on, Evoniphon won't be protected by Tila Monastery and we request Evoniphon to leave at once.{nl}Also, we are not going to be involved with others' decision to punish him.
 QUEST_LV_0200_20150714_007867	I hope the goddessess will be with you on your rest of journey.
 QUEST_LV_0200_20150714_007868	Besides from the expulsion, we can't forgive his actions that ruined the monastery.{nl}We should find him since he should be here somewhere.
 QUEST_LV_0200_20150714_007869	He made the monastery like this due to that letter. {nl}Please be careful.
@@ -7867,7 +7867,7 @@ QUEST_LV_0200_20150714_007870	He is so cunning..{nl}The hunters are surrounding 
 QUEST_LV_0200_20150714_007871	We would have had hard time without your help.{nl}Thank you so much for your efforts. I pray that the goddesses be with you on your journey.
 QUEST_LV_0200_20150714_007872	If it wasn't for your help, the circumstances would have not been like this.
 QUEST_LV_0200_20150714_007873	I've read it from the book before. {nl}Some smell has the power to pull the monsters.{nl}
-QUEST_LV_0200_20150714_007874	I should've noticed when Ebonippon brought that lump... I didn't expect that would be enlarged this big...{nl}We are eliminating them as we see them, but I want you to help us as well.{nl}
+QUEST_LV_0200_20150714_007874	I should've noticed when Evoniphon brought that lump... I didn't expect that would be enlarged this big...{nl}We are eliminating them as we see them, but I want you to help us as well.{nl}
 QUEST_LV_0200_20150714_007875	We are luring the monsters with the smell so it won't be effective if you just destroy them.{nl}Please destroy the lumps using this liquid medicine.
 QUEST_LV_0200_20150714_007876	When I saw it, it was about the size of my palm so I don't understand how it got that big.{nl}This is all my fault...
 QUEST_LV_0200_20150714_007877	I don't know how long it would take to drive those monsters out...{nl}Now is the start.
@@ -8114,7 +8114,7 @@ QUEST_LV_0200_20150714_008117	Unlucky day
 QUEST_LV_0200_20150714_008118	The trouble at Tila Monastery
 QUEST_LV_0200_20150714_008119	Tell him that you would help
 QUEST_LV_0200_20150714_008120	Tell him that you are not completely healed yet
-QUEST_LV_0200_20150714_008121	About Ebonippon
+QUEST_LV_0200_20150714_008121	About Evoniphon
 QUEST_LV_0200_20150714_008122	Support the relief activities
 QUEST_LV_0200_20150714_008123	Tell him that you will ask the hunters
 QUEST_LV_0200_20150714_008124	Tell him that you don't know how to do it
@@ -8162,14 +8162,14 @@ QUEST_LV_0200_20150714_008165	Fastidious Ointment(2)
 QUEST_LV_0200_20150714_008166	Tell him that you would persuade Guus
 QUEST_LV_0200_20150714_008167	The proof of power
 QUEST_LV_0200_20150714_008168	A doubtful stranger
-QUEST_LV_0200_20150714_008169	About the protection of Ebonippon
+QUEST_LV_0200_20150714_008169	About the protection of Evoniphon
 QUEST_LV_0200_20150714_008170	The murdered traveller
 QUEST_LV_0200_20150714_008171	Ask him if there were any other strange things
 QUEST_LV_0200_20150714_008172	Revelation of the true character
 QUEST_LV_0200_20150714_008173	Reject since you don't feel good about it
 QUEST_LV_0200_20150714_008174	To meet the father superior
 QUEST_LV_0200_20150714_008175	Tell him that you need some time to think
-QUEST_LV_0200_20150714_008176	About the chase of Ebonippon
+QUEST_LV_0200_20150714_008176	About the chase of Evoniphon
 QUEST_LV_0200_20150714_008177	Please make a quiet environment
 QUEST_LV_0200_20150714_008178	I will defeat the monsters so don't worry
 QUEST_LV_0200_20150714_008179	It looks safe
@@ -8306,7 +8306,7 @@ QUEST_LV_0200_20150714_008309	{memo X}
 QUEST_LV_0200_20150714_008310	{memo X}
 QUEST_LV_0200_20150714_008311	Collect the dark crystals
 QUEST_LV_0200_20150714_008312	Bokor Editor asked you to call the host monsters and find out the causes of the curse. To make a medicine to call out the host monster, he asked you to defeat the monsters at Vienti Fortress and collect the dark crystals.
-QUEST_LV_0200_20150714_008313	Hand them over to Master Bokor
+QUEST_LV_0200_20150714_008313	Hand them over to the Bokor Master
 QUEST_LV_0200_20150714_008314	You've collected enough dark crystals as Bokor Editor requested to you. Go back to the Editor.
 QUEST_LV_0200_20150714_008315	{memo X}
 QUEST_LV_0200_20150714_008316	Release the petrified soldier
@@ -8323,7 +8323,7 @@ QUEST_LV_0200_20150714_008326	{memo X}
 QUEST_LV_0200_20150714_008327	Defeat Tetraox
 QUEST_LV_0200_20150714_008328	Tetraox is hiding in this altar rather than the spirits of the pilgrims being restrained here. Defeat Tetraox before you get into a danger.
 QUEST_LV_0200_20150714_008329	Defeat Tetraox that is hiding in the altar
-QUEST_LV_0200_20150714_008330	This sanctuary also seems contaminated. Go to Pardoner Master for advice. You can move to Pardoner Master easily if you buy the warp scroll from the stand right beside you.
+QUEST_LV_0200_20150714_008330	This sanctuary also seems contaminated. Go to the Pardoner Master for advice. You can move to the Pardoner Master easily if you buy the warp scroll from the stand right beside you.
 QUEST_LV_0200_20150714_008331	Talk to the disciple, Raius
 QUEST_LV_0200_20150714_008332	The disciple, Raius is waiting for someone's help. Talk to Raius.
 QUEST_LV_0200_20150714_008333	Search for the orb that can contain vigor
@@ -8561,10 +8561,10 @@ QUEST_LV_0200_20150714_008564	Talk with Hunter, Reina
 QUEST_LV_0200_20150714_008565	Mintz said Hunter Reina would be able to find an adequate evidence. Go look for Hunter Reina at Rikdimo Gate Route.
 QUEST_LV_0200_20150714_008566	Hunter Reina looks ill. Talk to her first.
 QUEST_LV_0200_20150714_008567	Search for the traps using Jareth
-QUEST_LV_0200_20150714_008568	Hunter Reina lent you her companion, Jareth since she can't move. Use Jareth to look for Ebonippon's trap.
-QUEST_LV_0200_20150714_008569	You found the Ebonippon's trap. Go back to Reina with Jareth.
+QUEST_LV_0200_20150714_008568	Hunter Reina lent you her companion, Jareth since she can't move. Use Jareth to look for Evoniphon's trap.
+QUEST_LV_0200_20150714_008569	You found the Evoniphon's trap. Go back to Reina with Jareth.
 QUEST_LV_0200_20150714_008570	You've found a trap which can be an evidence. Hand it over to Mintz.
-QUEST_LV_0200_20150714_008571	Show Ebonippon's trap to Potos. If Potos has good eyes, he may able to find an evidence of Ebonippon.
+QUEST_LV_0200_20150714_008571	Show Evoniphon's trap to Potos. If Potos has good eyes, he may able to find an evidence of Evoniphon.
 QUEST_LV_0200_20150714_008572	Talk with Hunter, Natasha
 QUEST_LV_0200_20150714_008573	Mintz said after finish persuading Potos, you should help Natasha. Go meet Natasha in Viltis Forest.
 QUEST_LV_0200_20150714_008574	Talk with the monk Wiley
@@ -8641,13 +8641,13 @@ QUEST_LV_0200_20150714_008644	Hand them over to Senior Monk, Guus
 QUEST_LV_0200_20150714_008645	Guus would be satisfied with this. Bring the evidence to Guus.
 QUEST_LV_0200_20150714_008646	It seems that Guus acknowledged you. Talk to him again.
 QUEST_LV_0200_20150714_008647	Guus requested you to pass the message to gather the hunters in front of the entrance of the monastery. Pass the words of Guus to Natasha.
-QUEST_LV_0200_20150714_008648	Hunter Natasha wants to find a decisive evidence about Ebonippon while the monks and the hunters gather in front of the entrance of the monastery. Ask the senior monk, Guus about the details.
-QUEST_LV_0200_20150714_008649	You've heard about the dead man who may be related to Ebonippon from Guus. Tell this to Natasha.
-QUEST_LV_0200_20150714_008650	Hunter Natasha wants to find out what Ebonippon was looking for from the dead man. Talk to Natasha again.
+QUEST_LV_0200_20150714_008648	Hunter Natasha wants to find a decisive evidence about Evoniphon while the monks and the hunters gather in front of the entrance of the monastery. Ask the senior monk, Guus about the details.
+QUEST_LV_0200_20150714_008649	You've heard about the dead man who may be related to Evoniphon from Guus. Tell this to Natasha.
+QUEST_LV_0200_20150714_008650	Hunter Natasha wants to find out what Evoniphon was looking for from the dead man. Talk to Natasha again.
 QUEST_LV_0200_20150714_008651	Investigate the grave at Pasaro Rest Area
-QUEST_LV_0200_20150714_008652	Find the grave of the dead man who was killed by the poison of Ebonippon and look for some clues about Ebonippon.
+QUEST_LV_0200_20150714_008652	Find the grave of the dead man who was killed by the poison of Evoniphon and look for some clues about Evoniphon.
 QUEST_LV_0200_20150714_008653	You've found a book with the sentence. Show the book to Hunter Natasha.
-QUEST_LV_0200_20150714_008654	The details of what Ebonippon did is written on the old book of the drifter. Show the letter to Guus and talk to him.
+QUEST_LV_0200_20150714_008654	The details of what Evoniphon did is written on the old book of the drifter. Show the letter to Guus and talk to him.
 QUEST_LV_0200_20150714_008655	{memo X}
 QUEST_LV_0200_20150714_008656	{memo X}
 QUEST_LV_0200_20150714_008657	There are many monks and hunters gathered at Tila Monastery. Go to the entrance of Tila Monastery.
@@ -8703,13 +8703,13 @@ QUEST_LV_0200_20150714_008706	Call out the father superior.
 QUEST_LV_0200_20150714_008707	To call out the father superior, Guus is trying to manipulate the device in Prayer Room. Wait until the device gets activated.
 QUEST_LV_0200_20150714_008708	Talk with the father superior
 QUEST_LV_0200_20150714_008709	The father superior moved out from the room. Tell him what has happened so far.
-QUEST_LV_0200_20150714_008710	The father superior moved out from the room. Ask him to withdraw the decision to protect Ebonippon.
+QUEST_LV_0200_20150714_008710	The father superior moved out from the room. Ask him to withdraw the decision to protect Evoniphon.
 QUEST_LV_0200_20150714_008711	The father superior won't decide quickly. While he discusses with senior monks, go meet the commander, Mintz.
-QUEST_LV_0200_20150714_008712	After listening from the senior monks, the father superior finally discovered the trun nature of Ebonippon. Talk to him.
-QUEST_LV_0200_20150714_008713	It seems that the decision about what to do with Ebonippon has been confirmed. Talk to the father superior.
-QUEST_LV_0200_20150714_008714	Search for the assassin, Ebonippon.
-QUEST_LV_0200_20150714_008715	The father superior requested you to kick out Ebonippon from the monastery. Look for Ebonippon first in the monastery.
-QUEST_LV_0200_20150714_008716	Unfortunately, Ebonippon ran away and Mintz is injured. Talk with Mintz.
+QUEST_LV_0200_20150714_008712	After listening from the senior monks, the father superior finally discovered the trun nature of Evoniphon. Talk to him.
+QUEST_LV_0200_20150714_008713	It seems that the decision about what to do with Evoniphon has been confirmed. Talk to the father superior.
+QUEST_LV_0200_20150714_008714	Search for the assassin, Evoniphon.
+QUEST_LV_0200_20150714_008715	The father superior requested you to kick out Evoniphon from the monastery. Look for Evoniphon first in the monastery.
+QUEST_LV_0200_20150714_008716	Unfortunately, Evoniphon ran away and Mintz is injured. Talk with Mintz.
 QUEST_LV_0200_20150714_008717	The senior monk, Potos thinks that the strange lumps that are scattered across the monastery are luring monsters. Talk to him.
 QUEST_LV_0200_20150714_008718	Eliminate the stinky lump
 QUEST_LV_0200_20150714_008719	Potos requested you to eliminate the lump that is spreading the odor that is luring the monsters. Use the liquid medicine to eliminate them so they can't get near anymore.

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -3831,7 +3831,7 @@ QUEST_LV_0200_20150323_003830	$The deadline for the farm's construction is appro
 QUEST_LV_0200_20150323_003831	$The other soldiers went to defeat Gorgon, and I can't leave this place.{nl}I can only trust you now for this. I am counting on you.
 QUEST_LV_0200_20150323_003832	$Really? Thanks..{nl}The location is the Joint Farmland. I am counting on you!
 QUEST_LV_0200_20150323_003833	Do you think this makes sense?{nl}Those monsters used to be scared of humans, but they now attack humans with their poison.
-QUEST_LV_0200_20150323_003834	$If it weren't you, Uska must have scolded me.. Thank you so much.{nl}Anyways, I wonder why there aren't any news of the soldiers' return?
+QUEST_LV_0200_20150323_003834	$If it weren't you, Sir Uska must have scolded me.. Thank you so much.{nl}Anyways, I wonder why there aren't any news of the soldiers' return?
 QUEST_LV_0200_20150323_003835	Ah, I am worried about it too much.{nl}I heard the monsters here were naive before, but they turned violent suddenly.{nl}
 QUEST_LV_0200_20150323_003836	I don't know how the world would be like.{nl}And Alan, my colleague. He is protecting the entrance gate of the farm himself.{nl}
 QUEST_LV_0200_20150323_003837	Can you really do that?{nl}If that's so, please take care of Alan before the other soldiers return.
@@ -4444,29 +4444,29 @@ QUEST_LV_0200_20150323_004443	Ask him what to do next
 QUEST_LV_0200_20150323_004444	The monster that went crazy(2)
 QUEST_LV_0200_20150323_004445	I will investigate the settlement area
 QUEST_LV_0200_20150323_004446	Reject since it looks dangerous
-QUEST_LV_0200_20150323_004447	Suspicious dagger(1)
-QUEST_LV_0200_20150323_004448	Suspicious dagger(2)
+QUEST_LV_0200_20150323_004447	$Suspicious Dagger (1)
+QUEST_LV_0200_20150323_004448	$Suspicious Dagger (2)
 QUEST_LV_0200_20150323_004449	I will go see the Ranger Master
 QUEST_LV_0200_20150323_004450	I will go there later
 QUEST_LV_0200_20150323_004451	Antidote(2)
 QUEST_LV_0200_20150323_004452	Solve the problem
 QUEST_LV_0200_20150323_004453	Tell him about the conditions
-QUEST_LV_0200_20150323_004454	The monsters that are after the supplies(1)
-QUEST_LV_0200_20150323_004455	The monsters that are after the supplies(2)
+QUEST_LV_0200_20150323_004454	$Monsters after the Supplies (1)
+QUEST_LV_0200_20150323_004455	$Monsters after the Supplies (2)
 QUEST_LV_0200_20150323_004456	I will help Alan
 QUEST_LV_0200_20150323_004457	Time for farewell
 QUEST_LV_0200_20150323_004458	Secure the farmland
 QUEST_LV_0200_20150323_004459	I will look for the soldiers
 QUEST_LV_0200_20150323_004460	Tell him that it will be alright
-QUEST_LV_0200_20150323_004461	$Louise's Farmland(1)
+QUEST_LV_0200_20150323_004461	$Louise's Farmland (1)
 QUEST_LV_0200_20150323_004462	I will defeat the monsters on behalf of him
 QUEST_LV_0200_20150323_004463	$About the settlement land of Gitis
-QUEST_LV_0200_20150323_004464	$Louise's Farmland(2)
-QUEST_LV_0200_20150323_004465	$Louise's Farmland(3)
-QUEST_LV_0200_20150323_004466	$Louise's Farmland(3)
-QUEST_LV_0200_20150323_004467	Terrible result of harvesting(1)
+QUEST_LV_0200_20150323_004464	$Louise's Farmland (2)
+QUEST_LV_0200_20150323_004465	$Louise's Farmland (3)
+QUEST_LV_0200_20150323_004466	$Louise's Farmland (3)
+QUEST_LV_0200_20150323_004467	$Terrible Harvest (1)
 QUEST_LV_0200_20150323_004468	About the settlement land
-QUEST_LV_0200_20150323_004469	Terrible result of harvesting(2)
+QUEST_LV_0200_20150323_004469	$Terrible Harvest (2)
 QUEST_LV_0200_20150323_004470	Ask him how you could help
 QUEST_LV_0200_20150323_004471	Leave here since you've done what you should've done
 QUEST_LV_0200_20150323_004472	The place where you can't reach(1)
@@ -4776,9 +4776,9 @@ QUEST_LV_0200_20150323_004775	You need a sacrifice in order to receive the bless
 QUEST_LV_0200_20150323_004776	You've contributed enough monsters as sacrifices. Pray to receive the blessings.
 QUEST_LV_0200_20150323_004777	{memo X}Monsters rushed in as you prayed in front of the sanctum. You better defeat the monsters first.
 QUEST_LV_0200_20150323_004778	We should look for a way to purify the sanctum. Go meet the Priest Master who is the manager of the sanctum.
-QUEST_LV_0200_20150323_004779	We should first purify the polluted sanctum on Pamaishi Hills. Talk to the Priest Master what to do.
+QUEST_LV_0200_20150323_004779	We should first purify the polluted sanctum on Pamaish Hills. Talk to the Priest Master what to do.
 QUEST_LV_0200_20150323_004780	Purify the sanctum using the divine water
-QUEST_LV_0200_20150323_004781	The Priest Master asked you to purify the sanctum on Pamaishi Hills using the divine water. Go back to the Forest of Prayer and purify the polluted sanctum.
+QUEST_LV_0200_20150323_004781	The Priest Master asked you to purify the sanctum on Pamaish Hills using the divine water. Go back to the Forest of Prayer and purify the polluted sanctum.
 QUEST_LV_0200_20150323_004782	Pray in front of the statue of the Goddess near the grave of the saint
 QUEST_LV_0200_20150323_004783	There is the statue of the Goddess near the grave of the saint. Pray in front of the statue.
 QUEST_LV_0200_20150323_004784	This statue was fake. Defeat Sparnahorn that was disguised as the statue of the Goddess.
@@ -4802,7 +4802,7 @@ QUEST_LV_0200_20150323_004801	The sanctum is already polluted. Defeat the monste
 QUEST_LV_0200_20150323_004802	The manager of this sanctum is the Cleric Master. Ask him what he should do to purify the pollution of the sanctum.
 QUEST_LV_0200_20150323_004803	Listen to the advices of the Cleric Master
 QUEST_LV_0200_20150323_004804	Get some advices from the Cleric Master regarding the polluted sanctum at the Forest of Prayer.
-QUEST_LV_0200_20150323_004805	You've obtained an advise on the way to purify the polluted sanctum from the Cleric Master. Go back to the Forest of Prayer.
+QUEST_LV_0200_20150323_004805	You've obtained advice on the way to purify the polluted sanctum from the Cleric Master. Return to the Forest of Prayer.
 QUEST_LV_0200_20150323_004806	Look for the symbol of the religious belief at the sanctum
 QUEST_LV_0200_20150323_004807	To prepare times like this, the Cleric Master hid the symbol of the religious belief at the sanctum. Look for the symbol of the religious belief at the sanctum.
 QUEST_LV_0200_20150323_004808	Burn the badge of the sanctum after finding it
@@ -5219,9 +5219,9 @@ QUEST_LV_0200_20150323_005218	{memo X}You would be able to restore this region t
 QUEST_LV_0200_20150323_005219	{memo X}You've eliminated the magic field in this region! Tell this to Albina!
 QUEST_LV_0200_20150323_005220	{memo X}Eliminate the seal magic field
 QUEST_LV_0200_20150323_005221	Discuss with Horaceus
-QUEST_LV_0200_20150323_005222	It seems that Horaceus has somthing to discuss with you. Go meet him.
+QUEST_LV_0200_20150323_005222	$It seems that Horaceus has something to discuss with you. Go meet him.
 QUEST_LV_0200_20150323_005223	Distribute the joint signature seal
-QUEST_LV_0200_20150323_005224	The day which Horaceus had planned is near. The last thing to do is to receive the consent from the farmer in Tenants' farm. Get their signature on the hand written letter of Horaceus and the joint signature seal that he gave to you. You should receive the signature from eight of them.
+QUEST_LV_0200_20150323_005224	$The day Horaceus planned for is nearing. The last thing to do is to receive consent from the farmers of Tenants' Farm. Get their signature on Horaceus' hand written letter and joint signature seal. You should receive eight signatures.
 QUEST_LV_0200_20150323_005225	Hand over the joint signature seal
 QUEST_LV_0200_20150323_005226	You've obtained their signatures on the joint signature seal! Now pass it to Horaceus.
 QUEST_LV_0200_20150323_005227	Collect the samples of the demons that are needed for the research
@@ -5237,18 +5237,18 @@ QUEST_LV_0200_20150323_005236	The disciple, Prosit can't forgive the demons that
 QUEST_LV_0200_20150323_005237	You've defeated many demons. Talk to the disciple, Prosit.
 QUEST_LV_0200_20150323_005238	$Talk to Gitis
 QUEST_LV_0200_20150323_005239	$You can see Gitis who is worried a lot at the settlement land of Gitis. Talk with Gitis.
-QUEST_LV_0200_20150323_005240	$Ask for help from the Pyromancer Master at Klaipeda
+QUEST_LV_0200_20150323_005240	$Ask for help from the Pyromancer Master in Klaipeda
 QUEST_LV_0200_20150323_005241	$Gitis told you that the workers at the settlement land were attacked by the monsters and they are sick. Talk to the Pyromancer Master to get her help.
-QUEST_LV_0200_20150323_005242	$The Pyromancer Master told you that he will definitely help you. Talk to the Pyromancer Master again.
-QUEST_LV_0200_20150323_005243	Collect the samples of pink Chuparukas at the settlement land
-QUEST_LV_0200_20150323_005244	{memo X}Pyromancer Master told you that he will definitely help you. First get some samples of pink Chuparukas at the settlement land.
+QUEST_LV_0200_20150323_005242	$The Pyromancer Master told you that she will definitely help you. Talk to the Pyromancer Master again.
+QUEST_LV_0200_20150323_005243	$Collect the samples of Pink Chuparukas at the settlement land
+QUEST_LV_0200_20150323_005244	{memo X}Pyromancer Master told you that she will definitely help you. First get some samples of Pink Chuparukas at the settlement land.
 QUEST_LV_0200_20150323_005245	$Hand it over to the Pyromancer Master
-QUEST_LV_0200_20150323_005246	$You've obtained the samples of pink Chuparukas. Hand them over to the Pyromancer Master.
+QUEST_LV_0200_20150323_005246	$You've obtained the samples of Pink Chuparukas. Hand them over to the Pyromancer Master.
 QUEST_LV_0200_20150323_005247	Obtain %s from the settlement land
 QUEST_LV_0200_20150323_005248	$The Pyromancer Master who was investigating the samples of the monsters doesn't feel good about something. Talk to the Pyromancer Master.
 QUEST_LV_0200_20150323_005249	Search for the clues of the massive chaos at the settlement land
-QUEST_LV_0200_20150323_005250	$The Pyromancer Master can feel some unknown poison and the spell. Go back to the settlement land and find out the true nature of the poison and the spell.
-QUEST_LV_0200_20150323_005251	$You've found a leather and a dagger with the magic field drawn in them at Nuodo Bank. Take them to the Pyromancer Master.
+QUEST_LV_0200_20150323_005250	$The Pyromancer Master senses some unknown poison and a spell. Return to the settlement land and find out the true nature of the poison and the spell.
+QUEST_LV_0200_20150323_005251	$You've found a leather and a dagger with the magic circle drawn in them at Nuodo Coast. Take them to the Pyromancer Master.
 QUEST_LV_0200_20150323_005252	Destroy the unknown altar
 QUEST_LV_0200_20150323_005253	$Unfortunately, the Pyromancer Master doesn't know well about the spell. Talk to the Pyromancer Master again.
 QUEST_LV_0200_20150323_005254	$Talk to the Bokor Master about the true nature of the spell.
@@ -5275,11 +5275,11 @@ QUEST_LV_0200_20150323_005274	Look for the soldiers who went out to defeat Gorgo
 QUEST_LV_0200_20150323_005275	You've defeated the Gorgon that was chasing after the colleagues of Denise. Tell this to Denise.
 QUEST_LV_0200_20150323_005276	Defeat Gorgon
 QUEST_LV_0200_20150323_005277	Talk to Louise
-QUEST_LV_0200_20150323_005278	$Louise needs your help. Talk to Louise near the Louise's Farm.
-QUEST_LV_0200_20150323_005279	$Defeat Ridimed at Louise's Farm
-QUEST_LV_0200_20150323_005280	$Louise told you that he can't work at all due to the Ridimed that came into his farmland. Defeat the Ridimed at Louise's farmland.
+QUEST_LV_0200_20150323_005278	$Louise needs your help. Talk to Louise near the Louise's Farmland.
+QUEST_LV_0200_20150323_005279	$Defeat Ridimed at Louise's Farmland
+QUEST_LV_0200_20150323_005280	$Louise told you that he can't work at all due to the Ridimed that came into his farmland. Defeat the Ridimed at Louise's Farmland.
 QUEST_LV_0200_20150323_005281	$You've defeated many Ridimeds. Report to Louise.
-QUEST_LV_0200_20150323_005282	$Defeat Ridimed at Louise's Farm
+QUEST_LV_0200_20150323_005282	$Defeat Ridimed at Louise's Farmland
 QUEST_LV_0200_20150323_005283	{memo X}Louise told you that he defeated the monsters for now, but he is more worried about the future. Talk to Louise.
 QUEST_LV_0200_20150323_005284	$Collect the wood to make fences
 QUEST_LV_0200_20150323_005285	{memo X}Louise asked you to help him since he wants to make the fences. Bring the woods from the land where settlement is planned.
@@ -5293,7 +5293,7 @@ QUEST_LV_0200_20150323_005292	Obtain %s that will be used as the materials for t
 QUEST_LV_0200_20150323_005293	Obtain the materials that are lacking by defeating the monsters
 QUEST_LV_0200_20150323_005294	It seems that something is not going well for Gares. Talk to Gares.
 QUEST_LV_0200_20150323_005295	Collect the samples of Shakmoli
-QUEST_LV_0200_20150323_005296	$Gares told you that the rate at which the crops are growing is not as fast as usual, so he wants to know why. Please obtain the samples of orange Shakmolis.
+QUEST_LV_0200_20150323_005296	$Gares told you that the rate at which the crops are growing is not as fast as usual, so he wants to know why. Please obtain the samples of Orange Shakmolis.
 QUEST_LV_0200_20150323_005297	Hand them over to Gares
 QUEST_LV_0200_20150323_005298	You've obtained the samples of Shakmolis. Hand them over to Gares.
 QUEST_LV_0200_20150323_005299	Talk to Gares
@@ -6843,7 +6843,7 @@ QUEST_LV_0200_20150414_006846	Regain the Padeka Altar
 QUEST_LV_0200_20150414_006847	All Place of Sanctuary
 QUEST_LV_0200_20150414_006848	The Pyromancer Master said she'd gladly help us. Firstly, collect the sample of Pink Chupaluka in the Pioneer Place.
 QUEST_LV_0200_20150414_006849	Louise said she's more worried about the future even though we defeated the monsters just now. Talk to Louise again.
-QUEST_LV_0200_20150414_006850	Louise wants you to help making the fence for the future. Get the woods from the Pioneer place.
+QUEST_LV_0200_20150414_006850	Louise wants you to help making the fence for the future. Get the wood from the Settlement Area.
 QUEST_LV_0200_20150414_006851	Obtain the Blud's symbol
 QUEST_LV_0200_20150414_006852	{memo X}Kyupol Audra said we need to weaken the power of Blud. Take the Blud's symbol in Byeaulleo Hideout.
 QUEST_LV_0200_20150414_006853	You have stolen all of Blud's symbols from the demons. Take them to Kyupol Audra on Demon Prison.
@@ -7851,7 +7851,7 @@ QUEST_LV_0200_20150714_007854	Father Superior
 QUEST_LV_0200_20150714_007855	Thanks for resolving the crisis.{nl}I can feel the goddesses are protecting you.
 QUEST_LV_0200_20150714_007856	So you've come. Soon, the father superior would come out.{nl}Please wait a bit here.
 QUEST_LV_0200_20150714_007857	Why is the monastery like this and why are you all gathered here?{nl}And you... you seem to have some business with me.
-QUEST_LV_0200_20150714_007858	He is the father superior of Tila Monastery.
+QUEST_LV_0200_20150714_007858	He is the father superior of Tyla Monastery.
 QUEST_LV_0200_20150714_007859	We barely managed to come this far so I am hoping for good results.
 QUEST_LV_0200_20150714_007860	So you are asking me to withdraw my declaration to protect Ebonioppon.{nl}You came this far to do that...
 QUEST_LV_0200_20150714_007861	Okay. I will discuss with the father superior.{nl}Can you wait until then?
@@ -7859,7 +7859,7 @@ QUEST_LV_0200_20150714_007862	I will wait for their decision here first.{nl}If t
 QUEST_LV_0200_20150714_007863	So it seems that their discussion is over.{nl}Let's go there and listen to their conclusion.
 QUEST_LV_0200_20150714_007864	We haven't finished our discussion.{nl}Please wait with the hunters.
 QUEST_LV_0200_20150714_007865	After we've discussed with the senior monks...{nl}We've decided to withdraw our declaration to protect Evoniphon.
-QUEST_LV_0200_20150714_007866	From this point on, Evoniphon won't be protected by Tila Monastery and we request Evoniphon to leave at once.{nl}Also, we are not going to be involved with others' decision to punish him.
+QUEST_LV_0200_20150714_007866	From this point on, Evoniphon won't be protected by Tyla Monastery and we request Evoniphon to leave at once.{nl}Also, we are not going to be involved with others' decision to punish him.
 QUEST_LV_0200_20150714_007867	I hope the goddessess will be with you on your rest of journey.
 QUEST_LV_0200_20150714_007868	Besides from the expulsion, we can't forgive his actions that ruined the monastery.{nl}We should find him since he should be here somewhere.
 QUEST_LV_0200_20150714_007869	He made the monastery like this due to that letter. {nl}Please be careful.
@@ -8111,7 +8111,7 @@ QUEST_LV_0200_20150714_008114	Tell him that you are ready
 QUEST_LV_0200_20150714_008115	Tell him that it's not ready yet
 QUEST_LV_0200_20150714_008116	Talking
 QUEST_LV_0200_20150714_008117	Unlucky day
-QUEST_LV_0200_20150714_008118	The trouble at Tila Monastery
+QUEST_LV_0200_20150714_008118	The trouble at Tyla Monastery
 QUEST_LV_0200_20150714_008119	Tell him that you would help
 QUEST_LV_0200_20150714_008120	Tell him that you are not completely healed yet
 QUEST_LV_0200_20150714_008121	About Evoniphon
@@ -8196,7 +8196,7 @@ QUEST_LV_0200_20150714_008199	Declare Withdrawal of Protection
 QUEST_LV_0200_20150714_008200	I will wait.
 QUEST_LV_0200_20150714_008201	Push the discussions to later.
 QUEST_LV_0200_20150714_008202	Start of a New Chase
-QUEST_LV_0200_20150714_008203	I will chase the Evoniphon
+QUEST_LV_0200_20150714_008203	I will chase Evoniphon
 QUEST_LV_0200_20150714_008204	Lessen the Head Count
 QUEST_LV_0200_20150714_008205	I will help too
 QUEST_LV_0200_20150714_008206	Clean Inside
@@ -8562,7 +8562,7 @@ QUEST_LV_0200_20150714_008565	Mintz said Hunter Reina would be able to find an a
 QUEST_LV_0200_20150714_008566	Hunter Reina looks ill. Talk to her first.
 QUEST_LV_0200_20150714_008567	Search for the traps using Jareth
 QUEST_LV_0200_20150714_008568	Hunter Reina lent you her companion, Jareth since she can't move. Use Jareth to look for Evoniphon's trap.
-QUEST_LV_0200_20150714_008569	You found the Evoniphon's trap. Go back to Reina with Jareth.
+QUEST_LV_0200_20150714_008569	$You found Evoniphon's trap. Go back to Reina with Jareth.
 QUEST_LV_0200_20150714_008570	You've found a trap which can be an evidence. Hand it over to Mintz.
 QUEST_LV_0200_20150714_008571	Show Evoniphon's trap to Potos. If Potos has good eyes, he may able to find an evidence of Evoniphon.
 QUEST_LV_0200_20150714_008572	Talk with Hunter, Natasha
@@ -8650,7 +8650,7 @@ QUEST_LV_0200_20150714_008653	You've found a book with the sentence. Show the bo
 QUEST_LV_0200_20150714_008654	The details of what Evoniphon did is written on the old book of the drifter. Show the letter to Guus and talk to him.
 QUEST_LV_0200_20150714_008655	{memo X}
 QUEST_LV_0200_20150714_008656	{memo X}
-QUEST_LV_0200_20150714_008657	There are many monks and hunters gathered at Tila Monastery. Go to the entrance of Tila Monastery.
+QUEST_LV_0200_20150714_008657	There are many monks and hunters gathered at Tyla Monastery. Go to the entrance of Tyla Monastery.
 QUEST_LV_0200_20150714_008658	Talk to the monk Jones
 QUEST_LV_0200_20150714_008659	The monk, Jones doensn't know what to do. Ask him what his worry is.
 QUEST_LV_0200_20150714_008660	Defeat Liverworts and Stonakons
@@ -8705,7 +8705,7 @@ QUEST_LV_0200_20150714_008708	Talk with the father superior
 QUEST_LV_0200_20150714_008709	The father superior moved out from the room. Tell him what has happened so far.
 QUEST_LV_0200_20150714_008710	The father superior moved out from the room. Ask him to withdraw the decision to protect Evoniphon.
 QUEST_LV_0200_20150714_008711	The father superior won't decide quickly. While he discusses with senior monks, go meet the commander, Mintz.
-QUEST_LV_0200_20150714_008712	After listening from the senior monks, the father superior finally discovered the trun nature of Evoniphon. Talk to him.
+QUEST_LV_0200_20150714_008712	After listening from the senior monks, the father superior finally discovered the true nature of Evoniphon. Talk to him.
 QUEST_LV_0200_20150714_008713	It seems that the decision about what to do with Evoniphon has been confirmed. Talk to the father superior.
 QUEST_LV_0200_20150714_008714	Search for the assassin, Evoniphon.
 QUEST_LV_0200_20150714_008715	The father superior requested you to kick out Evoniphon from the monastery. Look for Evoniphon first in the monastery.
@@ -8720,7 +8720,7 @@ QUEST_LV_0200_20150714_008723	There are still many monsters in the monastery. De
 QUEST_LV_0200_20150714_008724	You've reduced the number of monsters a lot. Tell this to Moheim.
 QUEST_LV_0200_20150714_008725	Defeat the monsters in the monastery
 QUEST_LV_0200_20150714_008726	It seems that Moheim has a trouble cleaning up the monastery. Talk with Moheim.
-QUEST_LV_0200_20150714_008727	Look for the scripture at Tila Monastery
+QUEST_LV_0200_20150714_008727	Look for the scripture at Tyla Monastery
 QUEST_LV_0200_20150714_008728	Moheim requested you to look for scattered pages of the scripture. Find the scriptures that are scattered across the monastery and hand them over to Moheim.
 QUEST_LV_0200_20150714_008729	Hand them over to Moheim
 QUEST_LV_0200_20150714_008730	You've found all scriptures. Hand them over to Moheim.
@@ -8868,7 +8868,7 @@ QUEST_LV_0200_20150717_008871	Explore the hidden area
 QUEST_LV_0200_20150717_008872	The General's soul move you to a hidden area. Explore the area.
 QUEST_LV_0200_20150717_008873	Colelct %s from the abandoned Honeycomb
 QUEST_LV_0200_20150717_008874	Talk to Hunter Natasha about the letter
-QUEST_LV_0200_20150717_008875	Talk to Senior Monk Goss in Tila Monastery
+QUEST_LV_0200_20150717_008875	Talk to Senior Monk Goss in Tyla Monastery
 QUEST_LV_0200_20150717_008876	Defeat the monsters gathered
 QUEST_LV_0200_20150729_008877	Would it have been better to scrape off the coal powder from Phyracon?
 QUEST_LV_0200_20150729_008878	Unlease this seal. {nl}The seal can be opened by collecting and breaking the Restraint Crystal from the Flask Mages.

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -3789,7 +3789,7 @@ QUEST_LV_0200_20150323_003788	Oh my god, so you are the one who saved me.{nl}I a
 QUEST_LV_0200_20150323_003789	I will take care of him beside until he gets completely removed from his curse.{nl}Maybe, I could also cure the other curses.
 QUEST_LV_0200_20150323_003790	{memo X}The curse of gluttony makes a person not to digest the food well.{nl}That's why the cursed people are always hungry. {nl}
 QUEST_LV_0200_20150323_003791	After he gets out from the curse, he will be totally exhausted so I will take care of him beside.
-QUEST_LV_0200_20150323_003792	Gitise
+QUEST_LV_0200_20150323_003792	$Gitis
 QUEST_LV_0200_20150323_003793	{memo X}Revelator, we are in trouble. Please help us!{nl}As you can see, the workers are dying due to the poison of the monsters.
 QUEST_LV_0200_20150323_003794	While we were clearing the forest to obtain some food as Uska ordered us, the incident occured.{nl}The monsters here were in fact not that vicious before, but now they have the poison.. I don't know what happened to them..
 QUEST_LV_0200_20150323_003795	Pyromancer Master may help since he owes me something. {nl}Please. I am counting on you.
@@ -3797,7 +3797,7 @@ QUEST_LV_0200_20150323_003796	I know well because I am from this region.{nl}Even
 QUEST_LV_0200_20150323_003797	But they attacked the workers with the poison.{nl}If we don't complete the farm, then we would have trouble supplying the food..
 QUEST_LV_0200_20150323_003798	The monsters on that land?{nl}I can't belive it. I know it well since I used to go there a lot.
 QUEST_LV_0200_20150323_003799	Long time ago, I had helped Pyromancer Master before..{nl}He is the only one we can rely on now.
-QUEST_LV_0200_20150323_003800	But if Gitis told you like that, then it would be true.{nl}I owe something to Gitis.. Good. Let's find a way together.
+QUEST_LV_0200_20150323_003800	$But if Gitis told you like that, then it would be true.{nl}I owe something to Gitis.. Good. Let's find a way together.
 QUEST_LV_0200_20150323_003801	First, we should find out why the monsters became vicious.{nl}Go back to the land and get me the samples of the monsters.
 QUEST_LV_0200_20150323_003802	Pyromancer Master told you that he would help?{nl}That is so fortunate.
 QUEST_LV_0200_20150323_003803	The monsters became vicious and the poison..{nl}There are so many things these days that can't be trusted.
@@ -3821,9 +3821,9 @@ QUEST_LV_0200_20150323_003820	What happened to Pyromancer's task?
 QUEST_LV_0200_20150323_003821	So should I just report about the task to Pyromancer Master?
 QUEST_LV_0200_20150323_003822	Thanks for helping me.
 QUEST_LV_0200_20150323_003823	I should reward you since you helped me.
-QUEST_LV_0200_20150323_003824	{memo X}These are the research documents. Tell Cryomancer Master that you would hand over the research documents on behalf of Gitise.
+QUEST_LV_0200_20150323_003824	{memo X}These are the research documents. Tell Cryomancer Master that you would hand over the research documents on behalf of Gitis.
 QUEST_LV_0200_20150323_003825	It is so fortunate that it resolved well enough.
-QUEST_LV_0200_20150323_003826	These are the research documents that I asked from Gitise. I will use them well.
+QUEST_LV_0200_20150323_003826	$These are the research documents that I asked from Gitis. I will use them well.
 QUEST_LV_0200_20150323_003827	Please take it to him quickly.
 QUEST_LV_0200_20150323_003828	I am feeling little better now.
 QUEST_LV_0200_20150323_003829	Soldier Denise
@@ -3841,7 +3841,7 @@ QUEST_LV_0200_20150323_003840	{memo X}It's so fortunate that you are here.{nl}Ho
 QUEST_LV_0200_20150323_003841	Was Alan okay?{nl}It is so fortunate that you were here, otherwise the whole district would have been swept away.
 QUEST_LV_0200_20150323_003842	So you are the revelator that I heard from the rumors. Thank you so much.{nl}I don't know why those monsters turned out like that.
 QUEST_LV_0200_20150323_003843	Louise
-QUEST_LV_0200_20150323_003844	{memo X}I received the farm land from Gitese, but it's such a mess.{nl}Especially Ridimed. But, what can I do with my hands that only touched hoes before.
+QUEST_LV_0200_20150323_003844	${memo X}I received the farm land from Gitis, but it's such a mess.{nl}Especially Ridimed. But, what can I do with my hands that only touched hoes before.
 QUEST_LV_0200_20150323_003845	I didn't know what to do, but it was so fortunate that I've met the Goddesses.{nl}I am counting on you. It's already late to manage the crops.
 QUEST_LV_0200_20150323_003846	So you really drove that tedious Ridimed away?{nl}That's such a good news.
 QUEST_LV_0200_20150323_003847	It's so good to hear that you drove the Ridimed away.{nl}Now we should think about what to do.{nl}
@@ -3858,7 +3858,7 @@ QUEST_LV_0200_20150323_003857	I am worried about the monsters, but I am also wor
 QUEST_LV_0200_20150323_003858	I appreciate you for making the fence.{nl}It will help the citizens of Klaipeda.
 QUEST_LV_0200_20150323_003859	Researcher Gares
 QUEST_LV_0200_20150323_003860	The speed of the crops' growth is too bad.{nl}If we don't solve this, we may miss the right time to harvest.. could you help me?
-QUEST_LV_0200_20150323_003861	As Uska ordered, Gitis is leading the construction.{nl}Instead of taking the danger of restoring the farm that was polluted on Medis Diena, they want to cultivate the forest.{nl}
+QUEST_LV_0200_20150323_003861	$As Uska ordered, Gitis is leading the construction.{nl}Instead of taking the danger of restoring the farm that was polluted on Medis Diena, they want to cultivate the forest.{nl}
 QUEST_LV_0200_20150323_003862	Originally, that land belonged to the city so the owner of the farm didn't have to come.{nl}But since there's food problem, they made the farm in the name of the city.
 QUEST_LV_0200_20150323_003863	First, could you get me the samples of Sakmoli?{nl}That monster is plant-type so it must have received the same influence as the crops.
 QUEST_LV_0200_20150323_003864	This is our last chance.{nl}If we don't find out why the crops grow slowly, we may have to give up on this place.
@@ -4438,7 +4438,7 @@ QUEST_LV_0200_20150323_004437	The way to crush it(1)
 QUEST_LV_0200_20150323_004438	The way to crush it(2)
 QUEST_LV_0200_20150323_004439	Purifying the great cathedral
 QUEST_LV_0200_20150323_004440	I will defeat the monsters
-QUEST_LV_0200_20150323_004441	The worry of Gitese
+QUEST_LV_0200_20150323_004441	$The worry of Gitis
 QUEST_LV_0200_20150323_004442	The monster that went crazy(1)
 QUEST_LV_0200_20150323_004443	Ask him what to do next
 QUEST_LV_0200_20150323_004444	The monster that went crazy(2)
@@ -4460,7 +4460,7 @@ QUEST_LV_0200_20150323_004459	I will look for the soldiers
 QUEST_LV_0200_20150323_004460	Tell him that it will be alright
 QUEST_LV_0200_20150323_004461	The farmland of Louise(1)
 QUEST_LV_0200_20150323_004462	I will defeat the monsters on behalf of him
-QUEST_LV_0200_20150323_004463	About the settlement land of Gitese
+QUEST_LV_0200_20150323_004463	$About the settlement land of Gitis
 QUEST_LV_0200_20150323_004464	The farmland of Louise(2)
 QUEST_LV_0200_20150323_004465	The farmland of Louise(3)
 QUEST_LV_0200_20150323_004466	The farmland of Louise(3)
@@ -5235,10 +5235,10 @@ QUEST_LV_0200_20150323_005234	The disciple, Goda seems to have lots of complaint
 QUEST_LV_0200_20150323_005235	Defeat the demons that are ruining the great cathedral
 QUEST_LV_0200_20150323_005236	The disciple, Prosit can't forgive the demons that are ruining the great cathedral. Defeat the demons on behalf of the disciple, Prosit.
 QUEST_LV_0200_20150323_005237	You've defeated many demons. Talk to the disciple, Prosit.
-QUEST_LV_0200_20150323_005238	Talk to Gitise
-QUEST_LV_0200_20150323_005239	You can see Gitise who is worried a lot at the settlement land of Gitese. Talk with Gitese.
+QUEST_LV_0200_20150323_005238	$Talk to Gitis
+QUEST_LV_0200_20150323_005239	$You can see Gitis who is worried a lot at the settlement land of Gitis. Talk with Gitis.
 QUEST_LV_0200_20150323_005240	Ask for help from Pyromancer Master at Klaipeda
-QUEST_LV_0200_20150323_005241	Gitese told you that the workers at the settlement land were attacked by the monsters and they are sick. Talk to Pyromance Master to get his help.
+QUEST_LV_0200_20150323_005241	$Gitis told you that the workers at the settlement land were attacked by the monsters and they are sick. Talk to Pyromance Master to get his help.
 QUEST_LV_0200_20150323_005242	Pyromancer Master told you that he will definitely help you. Talk to Pyromancer Master again.
 QUEST_LV_0200_20150323_005243	Collect the samples of pink Chuparukas at the settlement land
 QUEST_LV_0200_20150323_005244	{memo X}Pyromancer Master told you that he will definitely help you. First get some samples of pink Chuparukas at the settlement land.
@@ -5254,7 +5254,7 @@ QUEST_LV_0200_20150323_005253	Unfortunately, Pyromancer Master doesn't know well
 QUEST_LV_0200_20150323_005254	Talk to Bokor Master about the true nature of the spell.
 QUEST_LV_0200_20150323_005255	Bokor Master knows well about the spells. Ask Bokor Master about the true nature of the spells.
 QUEST_LV_0200_20150323_005256	Bokor Master told you that the spell spreads the poison that is on the the dagger. But, he told you that he doesn't know well about the dagger so told you to meet Ranger Master.
-QUEST_LV_0200_20150323_005257	Talk to Gitise
+QUEST_LV_0200_20150323_005257	$Talk to Gitis
 QUEST_LV_0200_20150323_005258	Use the antidote
 QUEST_LV_0200_20150323_005259	Cure the people who is suffering from the massive explosion using the antidote
 QUEST_LV_0200_20150323_005260	Talk to Pyromancer Master
@@ -6749,7 +6749,7 @@ QUEST_LV_0200_20150414_006752	We really owe you one.
 QUEST_LV_0200_20150414_006753	Thank you.{nl}I will find all ways to avoid opening the contaminated gap.
 QUEST_LV_0200_20150414_006754	How long can Aldona keep..
 QUEST_LV_0200_20150414_006755	If the Vakarine has received the Laima's warning in advance..{nl}The situation is better than now?
-QUEST_LV_0200_20150414_006756	Even I received the land from Gitise but it's all dirty.{nl}Especially, Ridimed. But, what can he do with the hand just got the pick?
+QUEST_LV_0200_20150414_006756	$I received land from Gitis, but it's all dirty.{nl}The Ridimeds are the problem. But, what can I do with just a hoe and pick?
 QUEST_LV_0200_20150414_006757	I will attract demons to the evil stone a while due to the weakened seal.
 QUEST_LV_0200_20150414_006758	From now on, we can be relieved.{nl}A late Welcome. I'm a Priest Raeli believing in the Goddess Austeza.{nl}
 QUEST_LV_0200_20150414_006759	The Goddess Austeza has sealed the two places of the evil source.{nl}But the sealed place has become weak because of the demon's continuous attack.


### PR DESCRIPTION
first pass. Spadow and others free to look over when they get here

renamed "gitise/gitese" to Gitis pertaining to IMC's wiki

EDIT: Many lines in Quest200 had bad master standardization and wrong genders. Evoniphon's name was also incorrectly spelled
