### PR TITLE
Damage type standardization SKILL part 1/2

### DIFF
--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1,10 +1,10 @@
 SKILL_20150317_000001	Attack
-SKILL_20150317_000002	[Elite Kepa] 1 time, Physical, Poison Property, Hit
+SKILL_20150317_000002	[Elite Kepa] 1 time, Physical, Poison Property, Strike
 SKILL_20150317_000003	[Rafflesia] Spread Poison
 SKILL_20150317_000004	[Rafflesia] Poison Bomb
 SKILL_20150317_000005	[Raffly] Physical, Strike, Poison Property, Attack 1 time
 SKILL_20150317_000006	[Raffly] Physical, Strike, Poison Property, Jump Attack 1 time
-SKILL_20150317_000007	[Puragi] Physical, Hit, Poison Property, Normal Attack 1 time
+SKILL_20150317_000007	[Puragi] Physical, Strike, Poison Property, Normal Attack 1 time
 SKILL_20150317_000008	[Puragi] Physical, Strike, Poison Property, Attack 1 time
 SKILL_20150317_000009	[Puragi] Physical, Strike, Poison Property, Stomp 1 time
 SKILL_20150317_000010	[Zigri] Normal Attack, Conical AoE
@@ -31,9 +31,9 @@ SKILL_20150317_000030	[Big Griba] Physical, Strike, Lightning Property,Ground Sm
 SKILL_20150317_000031	[Haming] Physical, Strike, Lightning Property, Head Strike
 SKILL_20150317_000032	[Haming] Physical, Strike, Lightning Property, Counter Skill
 SKILL_20150317_000033	[Haming] Physical, Strike, Lightning Property, Jump and rotating attack
-SKILL_20150317_000034	[Truffle] Physical, Hit, Lightning Property, Body Slam
-SKILL_20150317_000035	[Truffle] Physical, Hit, Lightning Property, Smash
-SKILL_20150317_000036	[Truffle] Physical, Hit, Lightning Property, Body Slam
+SKILL_20150317_000034	[Truffle] Physical, Strike, Lightning Property, Body Slam
+SKILL_20150317_000035	[Truffle] Physical, Strike, Lightning Property, Smash
+SKILL_20150317_000036	[Truffle] Physical, Strike, Lightning Property, Body Slam
 SKILL_20150317_000037	[Slime_Dark] Physical, Strike, Dark Property, Headbutt
 SKILL_20150317_000038	[Slime_Dark] Physical, Strike, Dark Property, Attack 1 time
 SKILL_20150317_000039	[Kepa] Physical, Strike, Poison Property, Conical AoE
@@ -61,15 +61,15 @@ SKILL_20150317_000060	[Cockatrice] Magic, Magic, Fire Property, Fume Fire 3 time
 SKILL_20150317_000061	[Zinute] Physical Pierce Fire Property Attack 1 time
 SKILL_20150317_000062	[Zinute] Physical Slash Fire Property Attack 1 time
 SKILL_20150317_000063	[Tontulia] Physical Strike Lightning Property Attack 1 time
-SKILL_20150317_000064	[Tontulia] Physical Hit Lightning Property Attack 2 times
-SKILL_20150317_000065	[Tontus] Physical Hit, Poison Property Attack 2 times
+SKILL_20150317_000064	[Tontulia] Physical Strike Lightning Property Attack 2 times
+SKILL_20150317_000065	[Tontus] Physical Strike, Poison Property Attack 2 times
 SKILL_20150317_000066	[Tontus] Physical Pierce, Poison Property Attack 1 time
-SKILL_20150317_000067	[Tontus] Physical Hit, Poison Property Attack 1 time
+SKILL_20150317_000067	[Tontus] Physical Strike, Poison Property Attack 1 time
 SKILL_20150317_000068	[Vekarabe] Physical, Pierce, Poison Property, Forward Pierce Attack
 SKILL_20150317_000069	[Vekarabe] Physical, Pierce, Poison Property, Forward Upper Pierce Attack
 SKILL_20150317_000070	[Geppetto] Physical Strike, Earth Property Attack 2 times
 SKILL_20150317_000071	[Geppetto] Physical Strike, Earth Property Attack 1 time
-SKILL_20150317_000072	[Geppetto] Physical Hit, Earth Property Attack 1 time
+SKILL_20150317_000072	[Geppetto] Physical Strike, Earth Property Attack 1 time
 SKILL_20150317_000073	[Boowook] Physical, Strike, Earth Property Attack 1 time
 SKILL_20150317_000074	[Boowook] Physical, Strike, Earth Property Feet Stomp Attack 1 time,
 SKILL_20150317_000075	[Desmodus] Physical, Pierce, Dark Property Tail Blow
@@ -234,7 +234,7 @@ SKILL_20150317_000233	[Zignuts] Physical Poison Property Strike
 SKILL_20150317_000234	[Zignuts] Physical Normal Slash
 SKILL_20150317_000235	[Moglan] Physical, Pierce, Lightning Property Attack
 SKILL_20150317_000236	[Moglan] Physical, Pierce, Lightning Property Rotation Attack 2 times
-SKILL_20150317_000237	[Denden] Physical, Hit, Dark Property Attack
+SKILL_20150317_000237	[Denden] Physical, Strike, Dark Property Attack
 SKILL_20150317_000238	[Denden] Range, Magic, Dark Property Shoot 1 time
 SKILL_20150317_000239	[Doyor] Physical, Strike, Poison Property Attack
 SKILL_20150317_000240	[Doyor] Magic Reflect Shield Magic
@@ -254,7 +254,7 @@ SKILL_20150317_000253	[Wheelen] Physical, Pierce, Lightning Property Strong Pier
 SKILL_20150317_000254	[Rockter] Physical, Strike, Non-Property, Body Slam
 SKILL_20150317_000255	[Caro] Physical, Slash, Poison Property, Attack 2 times
 SKILL_20150317_000256	[Vubbe Fighter] 1 time , Physical, Strike, Earth Property
-SKILL_20150317_000257	[Red_Kepa] 1 time Physical,Hit, Fire Property
+SKILL_20150317_000257	[Red_Kepa] 1 time Physical,Strike, Fire Property
 SKILL_20150317_000258	[Tiny] Physical, Slash, Lightning Property, Attack 2 times
 SKILL_20150317_000259	[Treeambulo] Physical, Strike, Earth Property, Attack
 SKILL_20150317_000260	[Spion] Physical, Strike, Poison Property, Attack 2 times
@@ -263,24 +263,24 @@ SKILL_20150317_000262	[Shredded] Magic, Magic, Dark Property, Dark Property
 SKILL_20150317_000263	[Yekubite] Physical, Strike, Ice Property, Head stomp
 SKILL_20150317_000264	[Shardstatue] Physical, Pierce, Lightning Property, Wing strike
 SKILL_20150317_000265	[Cire] Physical, Strike, Lightning Property, Attack
-SKILL_20150317_000266	[Treegool] Physical, Hit, Dark Property, Attack
+SKILL_20150317_000266	[Treegool] Physical, Strike, Dark Property, Attack
 SKILL_20150317_000267	[Ammon] Physical, Slash, Earth Property Attack
 SKILL_20150317_000268	[Operor] Physical, Pierce, Poison Property, Bee Pierce Attack
 SKILL_20150317_000269	[Chafperor] Physical, Pierce, Poison Property, Pierce
 SKILL_20150317_000270	[Ravinelerva] Range, Magic, Poison Property, Attack
 SKILL_20150317_000271	[Vesper] Physical, Strike, Dark Property, Tail whip
 SKILL_20150317_000272	[Karas] Physical, Slash, Dark Property, Attack
-SKILL_20150317_000273	[Echad] Physical, Hit, Earth Property, Attack
-SKILL_20150317_000274	[Shtayim] Physical, Hit, Earth Property, Attack
+SKILL_20150317_000273	[Echad] Physical, Strike, Earth Property, Attack
+SKILL_20150317_000274	[Shtayim] Physical, Strike, Earth Property, Attack
 SKILL_20150317_000275	[Tombsinker] Physical, Pierce, Dark Property, Attack
-SKILL_20150317_000276	[Weaver] Physical, Hit, Earth Property, Smoke attack
+SKILL_20150317_000276	[Weaver] Physical, Strike, Earth Property, Smoke attack
 SKILL_20150317_000277	[Hallowventer] Magic, Magic, Dark Property, Attack
 SKILL_20150317_000278	[Infro Rocktor] Physical, Strike, Earth Property, One-handed hit
 SKILL_20150317_000279	[Meleech] Physical, Slash, Poison Property, Attack
 SKILL_20150317_000280	[Infroburk] Physical, Strike, Fire Property, Attack
 SKILL_20150317_000281	[Zolem] Physical, Strike, Earth Property, Attack
 SKILL_20150317_000282	[Kepa Raider] Physical, Strike, Dark Property, Attack
-SKILL_20150317_000283	[Mushcarfung] Physical, Hit, Dark Property, Body Attack
+SKILL_20150317_000283	[Mushcarfung] Physical, Strike, Dark Property, Body Attack
 SKILL_20150317_000284	[Woodman] Physical, Slash, Dark Property, Attack
 SKILL_20150317_000285	[Wood_Goblin] Physical, Strike, Lightning Property, Attack
 SKILL_20150317_000286	[Stoneorca] Physical, Strike, Ice Property, Tail Hook
@@ -314,7 +314,7 @@ SKILL_20150317_000313	[Hogma Battle Commander] Physical Slash Dark Property, Att
 SKILL_20150317_000314	[Hogma Battle Commander] Physical Pierce Dark Property Attack
 SKILL_20150317_000315	[Hogma Battle Commander] Monster Summon
 SKILL_20150317_000316	[Lizardman] Physical, Strike, Lightning Property, Attack
-SKILL_20150317_000317	[Chupaluka] Physical, Hit, Dark Property Attack
+SKILL_20150317_000317	[Chupaluka] Physical, Strike, Dark Property Attack
 SKILL_20150317_000318	[Ellomago] Physical, Pierce, Lightning Property, Attack
 SKILL_20150317_000319	[Ellogua] Physical, Pierce, Lightning Property Attack
 SKILL_20150317_000320	[Ellogua] Range, Magic, Lightning Property Shoot
@@ -347,8 +347,8 @@ SKILL_20150317_000346	[Arma] Physical, Pierce, Fire Property, Attack
 SKILL_20150317_000347	[Arma] Physical, Pierce, Fire Property, Dash and Attack 2 times
 SKILL_20150317_000348	[Flask] Physical, Strike, Fire Property, Attack
 SKILL_20150317_000349	[Black Shaman Doll] Physical, Pierce, Dark Property, Attack
-SKILL_20150317_000350	[Dimmer] Physical, Hit, Fire Property, Attack
-SKILL_20150317_000351	[Dimmer] Physical, Hit, Fire Property, Attack 2 times
+SKILL_20150317_000350	[Dimmer] Physical, Strike, Fire Property, Attack
+SKILL_20150317_000351	[Dimmer] Physical, Strike, Fire Property, Attack 2 times
 SKILL_20150317_000352	[Wizard Shaman Doll] Physical, Strike, Dark Property, Attack
 SKILL_20150317_000353	[Wizard Shaman Doll] Physical, Strike, Dark Property, Rotate and Attack 3 times
 SKILL_20150317_000354	[Sequoia Flame] Magic, Magic, Fire Property, Attack
@@ -382,10 +382,10 @@ SKILL_20150317_000381	[Grummer] Physical, Strike, Poison Property, Attack
 SKILL_20150317_000382	[Hummingbird] Physical, Pierce, Poison Property Attack
 SKILL_20150317_000383	[Leafly] Physical, Slash, Lightning Property, Attack
 SKILL_20150317_000384	[Desert Chupacabra] Buff, Magic, Hide HP restoration
-SKILL_20150317_000385	[Desert Chupacabra] Physical, Hit, Earth Property Attack
+SKILL_20150317_000385	[Desert Chupacabra] Physical, Strike, Earth Property Attack
 SKILL_20150317_000386	[Chromadog] Physical, Strike, Fire Property Attack
-SKILL_20150317_000387	[Seedmia] Physical, Hit, Poison Property, Attack
-SKILL_20150317_000388	[Seedmia] Physical, Hit, Poison Property, 1 Range Attack
+SKILL_20150317_000387	[Seedmia] Physical, Strike, Poison Property, Attack
+SKILL_20150317_000388	[Seedmia] Physical, Strike, Poison Property, 1 Range Attack
 SKILL_20150317_000389	[Glock] Physical, Slash, Dark Property Attack
 SKILL_20150317_000390	[Glock] Magic, Magic, Dark Property Attack
 SKILL_20150317_000391	[Wupent] Physical, Slash, Ice Property Attack Ice Debuff
@@ -410,7 +410,7 @@ SKILL_20150317_000409	[Pawndel] Physical, Slash, Dark Property Attack 3 times
 SKILL_20150317_000410	[Carcashu] Physical, Strike, Poison Property Attack
 SKILL_20150317_000411	[Carcashu] Physical, Strike, Poison Property Attack 4 times
 SKILL_20150317_000412	[Black Maize] Physical, Strike, Poison Property
-SKILL_20150317_000413	[Firent] Physical, Earth Property, Hit Attack
+SKILL_20150317_000413	[Firent] Physical, Earth Property, Strike Attack
 SKILL_20150317_000414	[Firent]
 SKILL_20150317_000415	[Specter Monarch]
 SKILL_20150317_000416	[Golem] Continuous Attack, Right
@@ -433,7 +433,7 @@ SKILL_20150317_000432	[Infrohoglan] Physical, Strike, Poison Property Attack
 SKILL_20150317_000433	[Colistump] Physical, Strike, Lightning Property Attack
 SKILL_20150317_000434	[Lapasape] Physical, Slash, Poison Property Attack
 SKILL_20150317_000435	[Infroblud] Physical, Strike, Poison Property Attack
-SKILL_20150317_000436	[Leaf Bug] 1 hit Physical, Earth Property, Hit
+SKILL_20150317_000436	[Leaf Bug] 1 hit Physical, Earth Property, Strike
 SKILL_20150317_000437	[Hanaming] 1 hitPhysical, Earth Property, Strike
 SKILL_20150317_000438	[Crystal Spider] 1 hit Physical, Ice Property, Pierce
 SKILL_20150317_000439	[Gray Jukopus] 1 hit Magic, Ice Property, Strike
@@ -441,7 +441,7 @@ SKILL_20150317_000440	[Gray Pokubu]
 SKILL_20150317_000441	[Red Vubbe Archer] Range, Pierce, Fire Property Attack
 SKILL_20150317_000442	[Red Fisherman] 1?? Physical, Strike, Fire Property
 SKILL_20150317_000443	[Red Fisherman] Magic, Buff, Aggressor Buff Skill
-SKILL_20150317_000444	[Simorph] Physical, Earth Property, Strike,
+SKILL_20150317_000444	[Simorph] Physical, Earth Property, Strike
 SKILL_20150317_000445	[Duckey] Physical, Strike, Fire Property Attack
 SKILL_20150317_000446	[Yognome] Magic, Magic, Lightning Property Attack
 SKILL_20150317_000447	[Pawnd] Physical, Range, Dark Property Attack
@@ -471,7 +471,7 @@ SKILL_20150317_000470	[Green Drake] Magic, Magic, Poison Property Attack
 SKILL_20150317_000471	[Black Drake] Physical, Strike, Dark Property Attack
 SKILL_20150317_000472	[Black Drake] Magic, Magic, Dark Property Attack
 SKILL_20150317_000473	[Vubbe Warrior] Physical, Slash, Dark Property Attack
-SKILL_20150317_000474	[Blue Puragi] Physical, Hit, Ice Property Attack
+SKILL_20150317_000474	[Blue Puragi] Physical, Strike, Ice Property Attack
 SKILL_20150317_000475	[Red Vubbe Thief] Physical, Pierce, Fire Property Attack 1 time
 SKILL_20150317_000476	[Black Big Gribaru] Physical, Strike, Dark Property Attack
 SKILL_20150317_000477	[Black Big Gribaru] Magic, Magic, Dark Property Attack
@@ -901,7 +901,7 @@ SKILL_20150317_000900	[Mushwort Card] Magic Poison Property Magic
 SKILL_20150317_000901	[Lepus Card] Physical Water Property Pierce
 SKILL_20150317_000902	[Sparnas Card] Physical Lightning Property Magic
 SKILL_20150317_000903	[Cactusvel Card] Physical Poison Property Magic
-SKILL_20150317_000904	[Throw] Physical Non-Property Hit
+SKILL_20150317_000904	[Throw] Physical Non-Property Strike
 SKILL_20150317_000905	[Velorchard Card] Magic Poison Property Magic
 SKILL_20150317_000906	[Luropus Card] Physical Non-Property Pierce
 SKILL_20150317_000907	[Dionia Card] Magic Non-Property Magic
@@ -936,7 +936,7 @@ SKILL_20150317_000935	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack
 SKILL_20150317_000936	$Rim Blow
 SKILL_20150317_000937	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack by using the edge of your shield. {nl} Inflicts more damage to both petrified and frozen enemies.
 SKILL_20150317_000938	$Swash Buckling
-SKILL_20150317_000939	{memo X}$Hit your shield to provoke nearby enemies.
+SKILL_20150317_000939	{memo X}$Strike your shield to provoke nearby enemies.
 SKILL_20150317_000940	$Targets: #{SkillSR}#{nl}Max. provoke +#{CaptionRatio}# for #{CaptionTime}# seconds
 SKILL_20150317_000941	{memo X}Decreases your attack, but increases your defense.
 SKILL_20150317_000942	Physical Defense + #{CaptionRatio}#{nl}Physical Damage - #{CaptionRatio2}# {nl}Duration #{CaptionTime}# seconds
@@ -1980,7 +1980,7 @@ SKILL_20150317_001979	$Increases attack when your HP is below 40%.{nl}Level 1 on
 SKILL_20150317_001980	$Ice Spear
 SKILL_20150317_001981	$Adds additional damage to frozen enemies when attacking with Ice Bolt.{nl}(Adds 25% per level)
 SKILL_20150317_001982	$Rupture Blow
-SKILL_20150317_001983	Has a chance of inflicting damage with an explosion on nearby enemies when attacking with Hit-attacks. (5% chance of activating per level)
+SKILL_20150317_001983	Has a chance of inflicting damage with an explosion on nearby enemies when attacking with Strike-attacks. (5% chance of activating per level)
 SKILL_20150317_001984	$Rupture
 SKILL_20150317_001985	$Increases damage when using a Blunt weapon on chain armor-type enemies.{nl}(Increases by 20% per level)
 SKILL_20150317_001986	Overcome
@@ -2114,7 +2114,7 @@ SKILL_20150317_002113	$Adds 10% of INT to physical damage while [Finestra] is ac
 SKILL_20150317_002114	$Synchro Thrusting: Critical Rate
 SKILL_20150317_002115	$Increases the rate for the next critical attack by 5% for 5 seconds per attribute level, when successfully countering an attack with [Synchro Thrusting]
 SKILL_20150317_002116	$Synchro Thrusting: Pierce
-SKILL_20150317_002117	{memo X}Hit damage of the shield attack decrease by 10% per attribute level while the  Pierce damage increase by 20% per attribute level.
+SKILL_20150317_002117	{memo X}Strike damage of the shield attack decrease by 10% per attribute level while the  Pierce damage increase by 20% per attribute level.
 SKILL_20150317_002118	$Finestra: Splash
 SKILL_20150317_002119	{memo X}Spash increase by 2 and evasion decrease twice as much when [Finestra] is enabled.
 SKILL_20150317_002120	{memo X}Warcry: defense decrease
@@ -2162,7 +2162,7 @@ SKILL_20150317_002161	{memo X}Attack monster in [sleep] state with [Energy Bolt]
 SKILL_20150317_002162	$Lethargy: Duration
 SKILL_20150317_002163	$Increases the duration of [Lethargy] by 2 seconds per level.
 SKILL_20150317_002164	{memo X}Lethargy: Strike
-SKILL_20150317_002165	{memo X}Hit type attacks do 20% more damage to enemies suffering from [Lethargy].
+SKILL_20150317_002165	{memo X}Strike type attacks do 20% more damage to enemies suffering from [Lethargy].
 SKILL_20150317_002166	$Quick Cast: Magic Damage
 SKILL_20150317_002167	{memo X}Magic damage of next attack increases by 10% per attribute level when [Quick Cast] is active.
 SKILL_20150317_002168	$Fireball: Flame Debuff
@@ -2466,7 +2466,7 @@ SKILL_20150317_002465	{memo X}Chance of [Keel Hauling] inflicting [Stun] increas
 SKILL_20150317_002466	Movement increase by 10% per attribute level for 5 seconds when opening treasure chest with [Unlock Chest]
 SKILL_20150317_002467	Form Pirates
 SKILL_20150317_002468	Can form [Pirates] party with 1 member per attribute level.
-SKILL_20150317_002469	Palm Strike: Hit
+SKILL_20150317_002469	Palm Strike: Strike
 SKILL_20150317_002470	Enemies receive 50% of Physical damage when launched into a wall by [Palm Strike].
 SKILL_20150317_002471	{memo X}Iron Skin: Additional damage
 SKILL_20150317_002472	{memo X}Reflected damage of [Iron Skin] increases by 10% of your Physical damage per attribute level.
@@ -3322,7 +3322,7 @@ SKILL_20150401_003321	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use pa
 SKILL_20150401_003322	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use hand knife to smack down enemy.
 SKILL_20150401_003323	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Shortly stretch hands to push away target and exhause target's SP. Target temporarily received continuous damage.
 SKILL_20150401_003324	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Gather force and shoot forward. Target hit is pushed back and receives damage.
-SKILL_20150401_003325	{memo X}Hit damage 30%~50%{nl}Consume #{CaptionRatio}# SP per 0.5 seconds
+SKILL_20150401_003325	{memo X}Strike damage 30%~50%{nl}Consume #{CaptionRatio}# SP per 0.5 seconds
 SKILL_20150401_003326	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Throw coin to attack enemy. Max SP of target decrease temporarily.
 SKILL_20150401_003327	{memo X}Attack #{SkillAtkAdd}#{nl}Duration #{CaptionRatio}# seconds{nl}Use #{CaptionRatio2}# silver
 SKILL_20150401_003328	{memo X}Temporarily defense against damage.
@@ -3799,7 +3799,7 @@ SKILL_20150414_003798	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Throw 
 SKILL_20150414_003799	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Make continuous attack using sword. Double attack with high rate of critical and has chance of fainting enemy.
 SKILL_20150414_003800	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Shoot broadhead arrow. Enemies hit falls under Bleeding.
 SKILL_20150414_003801	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Shoot bodkin arrow with strong penetration. Defense of enemy hit temporarily decreases and nullify magic protecting the enemy.
-SKILL_20150414_003802	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Shoot barbed arrow. Hit count depends on defense type of enemy.
+SKILL_20150414_003802	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Shoot barbed arrow. Strike count depends on defense type of enemy.
 SKILL_20150414_003803	{memo X}{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Shoot arrow that explodes enemy in cross form when killed.
 SKILL_20150414_003804	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Flame fumes from area shot with arrow and attacks enemy.
 SKILL_20150414_003805	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Hang bomb on arrow and shoot. Arrow explodes after hitting enemy.
@@ -4104,16 +4104,16 @@ SKILL_20150428_004103	{memo X}Status buff where Legacy of Legwyn Family buff can
 SKILL_20150428_004104	$Legwyn Family's Legacy
 SKILL_20150428_004105	Recover SP per second. Total of 200 SP is recovered for 5 seconds.
 SKILL_20150428_004106	{memo X}Critical rate of [Thrust] is increase by 5% per level.
-SKILL_20150428_004107	{memo X}Hit damage of [Synchro Thrusting] decrease by 10% per attribute level, and Pierce damage increease by 20% per attribute level.
+SKILL_20150428_004107	{memo X}Strike damage of [Synchro Thrusting] decrease by 10% per attribute level, and Pierce damage increease by 20% per attribute level.
 SKILL_20150428_004108	{memo X}Splash increases by 3 while [Finestra] is activated, Evasion decrease rate is doubled
 SKILL_20150428_004109	{memo X}[Montano] triggered [Slow] on target for 10 seconds. Duration of [Slow] increases by 3/2/1 second for small/medium/large monsters respectively.
 SKILL_20150428_004110	$Lethargy: Additional Damage
-SKILL_20150428_004111	$Enemies affected by [Lethargy] will receive 20% additional damage with Hit-type attacks.
+SKILL_20150428_004111	$Enemies affected by [Lethargy] will receive 20% additional damage with Strike-type attacks.
 SKILL_20150428_004112	{memo X}Character's Fire attack increases by 3 per attribute level when using [Staff] weapon.
 SKILL_20150428_004113	{memo X}Evasion increases by 10% per attribute level when using [Gravity Pull].
 SKILL_20150428_004114	{memo X}Skill duration of [Spiritual Chain] increases by 1 seconds per attribute level.
 SKILL_20150428_004115	$Punji Stake: Knockdown Damage
-SKILL_20150428_004116	{memo X}Air type monsters that fall on ground with [Snatching] receives 20% more damage per attribute level when attacked with Slash, Hit type attacks.
+SKILL_20150428_004116	{memo X}Air type monsters that fall on ground with [Snatching] receives 20% more damage per attribute level when attacked with Slash, Strike type attacks.
 SKILL_20150428_004117	{memo X}Ice attack increases by 3 per attribute level when using [Rod].
 SKILL_20150428_004118	{memo X}There is 1% chance per attribute level for enemies pushed away with [Rush] to fall under [Stun].
 SKILL_20150714_004119	$Lv. 1 Attack Ratio: #{SkillFactor}#, AoE Attack Ratio: #{SkillSR}#
@@ -4901,7 +4901,7 @@ SKILL_20150724_004900	$Lv3 Lethargy required
 SKILL_20150724_004901	$Lv3 Reflect Shield required
 SKILL_20150724_004902	{memo X}$Wizard 2nd Circle required
 SKILL_20150724_004903	$Wizard 3rd Circle required
-SKILL_20150729_004904	$[Cafrisun] Physical/Hit/No Property
+SKILL_20150729_004904	$[Cafrisun] Physical/Strike/No Property
 SKILL_20150729_004905	Increase HP, SP restoration
 SKILL_20150729_004906	Restore HP +100{nl}Restore SP +100{nl}Duration -5 sec
 SKILL_20150729_004907	$Increase Stats


### PR DESCRIPTION
Change damage types to Pierce/Slash/Strike
Replacing instances of Hit, Impact, and Stab.
