### PR TITLE
Update ETC.tsv

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2518,7 +2518,7 @@ ETC_20150317_002517	{memo X}Another player is already harvesting.
 ETC_20150317_002518	{memo X}Using Scroll..
 ETC_20150317_002519	{memo X}Setting up Jar of Fire..
 ETC_20150317_002520	{memo X}Opening the box..
-ETC_20150317_002521	{memo X}Found the jewel of prominence already
+ETC_20150317_002521	{memo X}Already found the jewel of prominence 
 ETC_20150317_002522	{memo X}Found the jewel of prominence
 ETC_20150317_002523	$Information on the Central Purifier on the 1st Floor
 ETC_20150317_002524	$Information on the Passage Purifier on the 1st Floor
@@ -10627,7 +10627,7 @@ ETC_20150401_010628	Purifying the evil energy in
 ETC_20150401_010629	{memo X}seconds.
 ETC_20150401_010630	{memo X}Completed purifying Magi. {nl}The energy of light is permeating the Royal Mausoleum Workers Lodge
 ETC_20150401_010631	{memo X}Barrier of the chapel is released!
-ETC_20150401_010632	{memo X}Altar is activated already.
+ETC_20150401_010632	{memo X}Altar is already activated.
 ETC_20150401_010633	{memo X}Critical power of light is activated in the monsters of the chapel.
 ETC_20150401_010634	{memo X}You can only have 1 of this item.
 ETC_20150401_010635	Lighting the candle
@@ -11142,7 +11142,7 @@ ETC_20150414_011143	Harugals was betrayed? {nl}That's absurd.
 ETC_20150414_011144	{memo X}There are monsters guarding the seal.
 ETC_20150414_011145	Sucked enough power from Bloot.
 ETC_20150414_011146	Now let's attack Bloot!
-ETC_20150414_011147	You were fooled already. Are you going to be fooled again?
+ETC_20150414_011147	You were already fooled. Are you going to be fooled again?
 ETC_20150414_011148	Followers of the Goddesses act like Goddesses themselves.
 ETC_20150414_011149	I wished to save you..
 ETC_20150414_011150	Cupol
@@ -12740,7 +12740,7 @@ ETC_20150714_012741	It wasn't the tree with the sounds.
 ETC_20150714_012742	Less than 3 of them were caught!
 ETC_20150714_012743	More than 3 of them were caught!
 ETC_20150714_012744	You've collected the rubber copies.{nl}Go back to the Epigraphist Smid!
-ETC_20150714_012745	You defeated all InfroBurks that are interrupting!{nl}Start the process of making copies!
+ETC_20150714_012745	You defeated all Infrobirks that are interrupting!{nl}Start the process of making copies!
 ETC_20150714_012746	You are too far away from the spiritual pots{nl}To collect the spirits, defeat them from more near distance
 ETC_20150714_012747	You defeated the Devilglove that was disturbing you while checking the tombstone{nl}Check what's written on the tombstone
 ETC_20150714_012748	Using Zubeck's Secret Moves has increased the stat by 1


### PR DESCRIPTION
Edited misspelling and grammar errors.
- The word 'alread'y cannot be used to end a sentence, unless it comes before the verb 'be'. 
- The word 'already' has to used before the verb 'be' if used in a present simple or past simple tense.
