### PR TITLE
Update QUEST.tsv

### DIFF
--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -309,7 +309,7 @@ QUEST_20150317_000308	This is the divine district in Fedimian. {nl}May the Godde
 QUEST_20150317_000309	Right now, the commerce district is closed for reconstruction. {nl}Please do not enter the district.
 QUEST_20150317_000310	The Fedimian divine district welcomes you.
 QUEST_20150317_000311	Thank you so much for your efforts. We are going to investigate here one more time. {nl}Cheer up!
-QUEST_20150317_000312	Finished already? {nl}Amazing! You'd expect nothing less from a Revelator!
+QUEST_20150317_000312	Already finished? {nl}Amazing! You'd expect nothing less from a Revelator!
 QUEST_20150317_000313	It is said that if one receives too much good, he begins to believe it's his right. {nl}Maybe, we relied too much on the Goddess.
 QUEST_20150317_000314	Soldier Pitt
 QUEST_20150317_000315	Are you the Revelator? {nl}It is such an honor to meet you!
@@ -373,7 +373,7 @@ QUEST_20150317_000372	The Divine Place of Blessing
 QUEST_20150317_000373	Are you going to make a contribution?
 QUEST_20150317_000374	A dewdrop slipped and fell down onto the ground.
 QUEST_20150317_000375	{memo X}Naktis and his followers will probably looking for clues to enter the great cathedral.
-QUEST_20150317_000376	{memo X}Naktis is loyal to Gesti and will do anything to be recognized. {nl}Maybe the Pilgrim Path was also a means to get the clues to enter the Cathedral and be recognized by Gesti? {nl}Ahh, then could Naktis have entered the Cathedral already?
+QUEST_20150317_000376	{memo X}Naktis is loyal to Gesti and will do anything to be recognized. {nl}Maybe the Pilgrim Path was also a means to get the clues to enter the Cathedral and be recognized by Gesti? {nl}Ahh, then could Naktis have already entered the Cathedral?
 QUEST_20150317_000377	{memo X}It won't budge. {nl}Where's the key?
 QUEST_20150317_000378	{memo X}What's the story behind this? {nl}The entrapped soul simply gave the scriptures and vanished.
 QUEST_20150317_000379	{memo X}Does the medicine really work?
@@ -1002,7 +1002,7 @@ QUEST_20150317_001001	{nl}(There is something written, but it's all jumbled up a
 QUEST_20150317_001002	Unknown Date {nl}- {nl}Several days must've passed. {nl}I've been on the run for around two days now without food or sleep. {nl}The people who fled Klaipeda were all caught and killed. {nl}I don't even know how many are still alive and can walk. {nl}Everything is as quiet as the the shadows, yet moving at a high pace. We are all tense from fear of attack.
 QUEST_20150317_001003	They did not wish for any uproar or disorder. {nl}They are not people. {nl}We must somehow notify Klaipeda. {nl}A last resort would be to abandon everything we can't use and to move in.
 QUEST_20150317_001004	{memo X}Oh. It's you. {nl}This our army base camp, so feel free to relax.
-QUEST_20150317_001005	{memo X}Have you met the other soldiers already? {nl}Hmm… What's your name?
+QUEST_20150317_001005	{memo X}Have you already met the other soldiers? {nl}Hmm… What's your name?
 QUEST_20150317_001006	{memo X}Alright, thanks. You guys are working hard. {nl}I want to talk to my aides. Where are they?
 QUEST_20150317_001007	Do you have something to say?
 QUEST_20150317_001008	Send two from the entrance to the front lines? {nl}Ha, that's nonsense. Did they ask you for that?
@@ -1477,7 +1477,7 @@ QUEST_20150323_001477	Notice for the Tree of Brothers
 QUEST_20150323_001478	First Tree of Brothers {nl}Guard the Tree of Faith with the name of the Goddess.
 QUEST_20150323_001479	Second Tree of Brothers {nl}Purify the evil force with the power of the Goddess.
 QUEST_20150323_001480	Third Tree of Brothers. {nl}Live a full life with the grace of the Goddess.
-QUEST_20150323_001481	{memo X}Spoiled already? Here, take this.
+QUEST_20150323_001481	{memo X}Already spoiled? Here, take this.
 QUEST_20150323_001482	Magic circle is shaking.
 QUEST_20150323_001483	Baron Allerno
 QUEST_20150323_001484	{memo X}Wait, I came to see if the device is working well, but isn't my territory quiet and great to live in? There aren't that many people though. 


### PR DESCRIPTION
Fixed grammar errors relating to the use of the word 'already'.

-The word 'already' cannot be used to end a sentence, unless it comes before the verb 'be'.
-The word 'already' has to used before a noun or verb.
