### PR TITLE
Update ETC.tsv (Help Menu)

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -1993,7 +1993,7 @@ ETC_20150317_001992	All
 ETC_20150317_001993	Points
 ETC_20150317_001994	You do not have enough slots.
 ETC_20150317_001995	Quest List
-ETC_20150317_001996	Updated Adventure Journal
+ETC_20150317_001996	Adventure Journal Updated
 ETC_20150317_001997	{#000000} item is not recorded in the journal.
 ETC_20150317_001998	This monster was not recorded in the journal.
 ETC_20150317_001999	Lance Mastery
@@ -6005,7 +6005,7 @@ ETC_20150317_006004	{memo X}If you have all the required materials in your inven
 ETC_20150317_006005	{memo X}the button to proceed with item crafting.
 ETC_20150317_006006	{memo X}The item will appear in your inventory when crafting is successful.
 ETC_20150317_006007	{memo X}Shop System
-ETC_20150317_006008	You can buy and sell items through the Merchant NPC's.
+ETC_20150317_006008	You can buy and sell items through the Merchant NPCs.
 ETC_20150317_006009	{memo X}You can find merchant NPCs around the city
 ETC_20150317_006010	{memo X}Find the merchant NPCs located in safe zones. {nl} {nl}
 ETC_20150317_006011	{memo X}Use the trade window at the bottom to trade items with NPCs.{nl}{nl}[Buy] : Right-click the items you want to buy, set qty, then settle. {nl}[Sell]: Right-click the items you want to sell from your inventory, set qty, then settle. {nl} {nl}
@@ -6034,7 +6034,7 @@ ETC_20150317_006034	{memo X}You can use the 'Return' button to complete quests m
 ETC_20150317_006035	When you complete quests, in the mission window UI 
 ETC_20150317_006036	 this button will be activated.
 ETC_20150317_006037	Return button
-ETC_20150317_006038	 allows you to teleport to the Quest NPC right away by clicking on the ({img questinfo_return 40 40}) button.
+ETC_20150317_006038	 allows you to teleport to the Quest NPC right away by clicking on the {img questinfo_return 40 40}  button.
 ETC_20150317_006039	{memo X}or you can use the shortcut key
 ETC_20150317_006040	{memo X}Backspace
 ETC_20150317_006041	{memo X}key
@@ -12234,7 +12234,7 @@ ETC_20150714_012235	Team (5vs5)
 ETC_20150714_012236	{memo X}Party (2vs2)
 ETC_20150714_012237	{memo X}Party (3vs3)
 ETC_20150714_012238	Party (5vs5)
-ETC_20150714_012239	/Card Battle
+ETC_20150714_012239	/CardBattle
 ETC_20150714_012240	Gem Roasting Shop
 ETC_20150714_012241	Incorrect combination.
 ETC_20150714_012242	Loading...
@@ -13346,8 +13346,8 @@ ETC_20150717_013347	{memo X}You require money and an anvil to enhance equipment.
 ETC_20150717_013348	{memo X} can be purchased from the Tools Merchant or obtained from monsters.
 ETC_20150717_013349	{memo X}Press {img mouseclick_right 40 40} on the anvil, then select an equipment item to open the Enhancement window. Select
 ETC_20150717_013350	 and 
-ETC_20150717_013351	will appear. Hit the 
-ETC_20150717_013352	 three times to Enhance the item.
+ETC_20150717_013351	 will appear. Hit the 
+ETC_20150717_013352	 three times to enhance the item.
 ETC_20150717_013353	{memo X}When enhancing a weapon beyond +5, Potential will be consumed on failure and its effects will be reset. The item will be destroyed when Potential drops to zero.
 ETC_20150717_013354	Enhancement penalties occur beyond +2 for armors, bracelets, and necklaces.
 ETC_20150717_013355	You can't use an item with 0 durability.
@@ -13717,13 +13717,13 @@ ETC_20150729_013718	{nl}{nl}Use the search function to find specific items{nl} i
 ETC_20150729_013719	{nl}{nl}The lower part displays the total carry weight of your items, funds, and iCoins.
 ETC_20150729_013720	Available quests can be found in the Quest window.
 ETC_20150729_013721	Press {img F5 40 40} to view available quests {nl}or quests that are in progress.
-ETC_20150729_013722	{nl}{nl}You can restart abandoned quests by pressing 
+ETC_20150729_013722	{nl}{nl}You can restart abandoned quests by pressing the 
 ETC_20150729_013723	 button. Some quests cannot be abandoned.
 ETC_20150729_013724	{nl}{nl}Track quests by marking the checkbox in front of the quest title.
 ETC_20150729_013725	Check your character's game progress or rankings{nl} in the Adventure Journal.
 ETC_20150729_013726	Your character's progress is recorded in the Adventure Journal. Press {img F4 40 40} to view.
 ETC_20150729_013727	You can earn Adventure Index through Items, Monsters, Crafting, Map, and Game Progression.
-ETC_20150729_013728	You can receive rewards from
+ETC_20150729_013728	You can receive rewards from 
 ETC_20150729_013729	Press {img F1 40 40} to open Character Information window and choose the Achievement tab to view character's achievements.
 ETC_20150729_013730	Revive your character's death by using Resurrection.
 ETC_20150729_013731	A character will die when its HP reaches 0 and becomes 
@@ -13761,14 +13761,14 @@ ETC_20150729_013762	{nl}{nl}If you have all required materials, press the
 ETC_20150729_013763	 button to begin crafting.
 ETC_20150729_013764	Optionally, you can add a unique name or memo on your newly crafted item.
 ETC_20150729_013765	Use the trade window to trade items with Merchant NPCs.
-ETC_20150729_013766	[Buy] : Select the item you want to buy with {img mouseclick_right 40 40}, then press
+ETC_20150729_013766	[Buy] : Select the item you want to buy with {img mouseclick_right 40 40}, then press 
 ETC_20150729_013767	button to trade. {nl}To trade multiple items, use {img shift 40 40}+{img mouseclick_right 40 40} to set a quantity. {nl}{nl}[Sell] : {img mouseclick_right 40 40} on the items you want to sell from your inventory, and set quantity, then press
 ETC_20150729_013768	button to trade. {nl}Double {img mouseclick_right 40 40} to sell all of that item. {nl}{nl}
 ETC_20150729_013769	Items sold to the shops can be purchased back.
 ETC_20150729_013770	{img mouseclick_right 40 40} on the item from 'My Sold Items' below {nl}to buy back an item or to delete it from the list.
 ETC_20150729_013771	Enhance your equipment to increase its power.
 ETC_20150729_013772	You need funds and an anvil to enhance your item.
-ETC_20150729_013773	can be purchased from the Tools Merchant or obtained from monsters.
+ETC_20150729_013773	 can be purchased from the Tools Merchant or obtained from monsters.
 ETC_20150729_013774	{nl}{nl}{img mouseclick_right 40 40} on the anvil, then select an item to open Enhancement window.
 ETC_20150729_013775	{nl}{nl}When your equipment is enhanced, its power increases. 
 ETC_20150729_013776	{nl}{nl}When enhancing a weapon beyond +5, Potential will be consumed on failure and the effects will be reset. The item will be destroyed when Potential drops to 0.
@@ -13830,7 +13830,7 @@ ETC_20150729_013831	Monsters found in dungeons will attack players on sight.
 ETC_20150729_013832	Gems may be lost when you die in dungeons. So, be careful!
 ETC_20150729_013833	When you die in a dungeon, click 
 ETC_20150729_013834	 to revive at the entrance outside the dungeon.
-ETC_20150729_013835	 $       Receive beneficial effects when you worship {nl}                                   a Goddess Statue.
+ETC_20150729_013835	 $Receive beneficial effects when worshipping a Goddess Statue.
 ETC_20150729_013836	 gives you bonus Status Points.
 ETC_20150729_013837	 enables you to warp to other areas.
 ETC_20150729_013838	There are many types of treasure chests {nl}and you can obtain special items from them.
@@ -14058,7 +14058,7 @@ ETC_20150730_014059	area formed a party {count}
 ETC_20150730_014060	{memo X}You've obtained the parts of the detector from the monsters!
 ETC_20150730_014061	You haven't explored all regions in Crystal Mine yet!
 ETC_20150730_014062	Since there are too many monsters nearby, you can't obtain the tendon of Big Siaulamb
-ETC_20150730_014063	Card Battle is only possible in a village
+ETC_20150730_014063	Card Battle is only possible in a village.
 ETC_20150730_014064	Member Irumantas
 ETC_20150730_014065	Member Grazina
 ETC_20150730_014066	Member Alina
@@ -14088,15 +14088,15 @@ ETC_20150803_014089	You can set various settings for the team which your charact
 ETC_20150803_014090	When you select Lodge Settings, you can change your team name
 ETC_20150803_014091	When you select Change Lodge, the list of Lodges will appear. When you click on a Lodge, you can preview it.
 ETC_20150803_014092	You can create up to 5 characters with the basic Lodge. The number of characters you can create depends on which Lodge you have.
-ETC_20150803_014093	{nl} {nl}There is a Message Box at the lower right side of your Lodge. You can check messages by selecting it.
+ETC_20150803_014093	{nl} {nl}There is a Messages Box at the lower right side of your Lodge. You can check messages by selecting it.
 ETC_20150803_014094	Any items or money that are attached in a message can be received by {img mouseclick_right 40 40}.
-ETC_20150803_014095	{nl} {nl}By {img mouseclick_right 40 40}, you can visit the Lodge of other users who you met in the game.
+ETC_20150803_014095	{nl} {nl}With {img mouseclick_right 40 40}, you can visit the Lodge of other users who you met in the game.
 ETC_20150803_014096	Screen Capture
 ETC_20150803_014097	Tree of Savior provides a Screen Capture function.
 ETC_20150803_014098	You can take a screenshot using PrintScreen key.
-ETC_20150803_014099	Screenshots taken will be stored in the screenshot folder located in the release folder within your Tree of Savior directory.
+ETC_20150803_014099	Screenshots taken will be stored in the screenshot folder located in the 'TreeOfSavior\release\screenshot' directory.
 ETC_20150803_014100	{nl} {nl}With {img F12 40 40}, you can use the Video Capture function.
-ETC_20150803_014101	When you press {img F12 40 40} again, the captured video will be stored.{nl}The captured video will be stored in the avicapture folder located in the release of your Tree of Savior directory.
+ETC_20150803_014101	When you press {img F12 40 40} again, the captured video will be stored.{nl}The captured video will be stored in the 'TreeOfSavior\release\avicapture' directory.
 ETC_20150803_014102	{memo X}DoTimeAction:Collectign:2:SITGROPE:None
 ETC_20150803_014103	{memo X}Property:1/PropertyAdd:1/EffectNPC:Local:F_pc_making_finish_white:1:TOP/Notice:NOTICE_Dm_GetItem:Collected the copses and saved the keepstakes!:5/NPCDead/GiveItem:FLASH_29_1_SQ_040_ITEM_2:1
 ETC_20150803_014104	{memo X}Notice:NOTICE_Dm_GetItem:You've collected the corpses!:5/NPCDead


### PR DESCRIPTION
@imcgames 

I created a separate ETC pull request for your attention. The Help Menu is an important encyclopedia for new users to Tree of Savior. There are a few instances of '$NoData', while translating these lines is simple, inserting them is not.

![GitHub Logo](http://i.imgur.com/6NZq6cb.png)

↑ When I add the English version of these lines, the images will just overlap. I would have to create a very very short description of just a few characters, but that doesn't give the player a proper explanation on the feature.

![GitHub Logo](http://i.imgur.com/6C1dJLZ.png)

↑ 

ETC_20150729_013857 Chatting window
ETC_20150714_012239 /CardBattle
ETC_20150729_013858 When you input, Card Battle Table will be opened.{nl}Your opponent can participate in a Card Battle by pressing {img SPACE 40 40}.

The message contains a combination out of 3 separate strings. This works in the Korean language, but not in English. There are a few more examples of this in the Help Menu. 

Please resolve this, because this is important. 
