### PR TITLE
Miscellaneous fixes

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -4767,7 +4767,7 @@ ETC_20150317_004766	Nudoku is available in Kochi!
 ETC_20150317_004767	Can be used in the tree Ferri!
 ETC_20150317_004768	$Magic charged (
 ETC_20150317_004769	Charging
-ETC_20150317_004770	Pocket Bukkake
+ETC_20150317_004770	Pocket
 ETC_20150317_004771	Bob came out from the body of the tree Feliciano!
 ETC_20150317_004772	Nudoku pocket was covered Kochi
 ETC_20150317_004773	Use effect in the vicinity of the Asmodian summoned enabled occurs!

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -449,7 +449,7 @@ ETC_20150317_000448	While it has maintained its original form, Operor has develo
 ETC_20150317_000449	Chafperor
 ETC_20150317_000450	A severely mutated bee and beetle hybrid with qualities of both, it operates in swarms.
 ETC_20150317_000451	Ravinelarva
-ETC_20150317_000452	Before it was revealed to be a mutated plant, it was speculated to be a monster's larvae.
+ETC_20150317_000452	Before it was revealed to be a mutated plant, it was speculated to be a monster's larva.
 ETC_20150317_000453	Nethercaffe
 ETC_20150317_000454	{memo X}Infrogalas
 ETC_20150317_000455	Carneybeopeong
@@ -12652,9 +12652,9 @@ ETC_20150714_012653	{memo X}setting completed
 ETC_20150714_012654	{memo X}The explosive is already set
 ETC_20150714_012655	{memo X}Arrived without getting caught by the guard!
 ETC_20150714_012656	Another player is holding onto the object
-ETC_20150714_012657	Event Requirements
-ETC_20150714_012658	Already in progress. If you want to stop, click Cancel.
-ETC_20150714_012659	The item you've registered to craft is enhanced. Are you going to use it as a material?
+ETC_20150714_012657	Event Requirement
+ETC_20150714_012658	It is already in progress. Click on Cancel if you want it to stop.
+ETC_20150714_012659	This item that you have added to craft is enhanced. Are you sure you want to use it as material?
 ETC_20150714_012660	Electricity Property
 ETC_20150714_012661	Poison Property
 ETC_20150714_012662	Fire Property
@@ -12662,7 +12662,7 @@ ETC_20150714_012663	Earth Property
 ETC_20150714_012664	Ice Property
 ETC_20150714_012665	Darkness Property
 ETC_20150714_012666	Gender Property
-ETC_20150714_012667	Barracks theme changed.
+ETC_20150714_012667	Lodge theme changed.
 ETC_20150714_012668	Like!
 ETC_20150714_012669	Cancel Like
 ETC_20150714_012670	The other party rejected 

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -849,7 +849,7 @@ ETC_20150317_000848	Vikaras Mage
 ETC_20150317_000849	A low-ranking demon who is always looking for opportunities to promote itself.
 ETC_20150317_000850	Blue Ogouveve Flag
 ETC_20150317_000851	Odamubara
-ETC_20150317_000852	Alchemist Briquettes
+ETC_20150317_000852	Alchemist Briquette
 ETC_20150317_000853	Alchemist Tincture
 ETC_20150317_000854	Nepenthes
 ETC_20150317_000855	Seedmia
@@ -2198,7 +2198,7 @@ ETC_20150317_002197	{memo X}Collecting the light stem of reed
 ETC_20150317_002198	{memo X}Did collect the light steom of reed but you are slashed over the reed leaf!
 ETC_20150317_002199	{memo X}The wound as the reed leaf was bleeding.
 ETC_20150317_002200	$Make a grave
-ETC_20150317_002201	$Making a grave for Liliya
+ETC_20150317_002201	$Making a grave for Lilija
 ETC_20150317_002202	Discarding the music box
 ETC_20150317_002203	{memo X}Discarded it into the place.
 ETC_20150317_002204	$Looking through the pile of grass
@@ -2235,7 +2235,7 @@ ETC_20150317_002234	{memo X}Even sooth the trapped souls, It has transformed to 
 ETC_20150317_002235	{memo X}I have no tolerance for guys!
 ETC_20150317_002236	{memo X}I can never forgive you guys for this matter even I will in hell!
 ETC_20150317_002237	{memo X}They betrayed us!
-ETC_20150317_002238	{memo X}Pilgrim Liliya
+ETC_20150317_002238	{memo X}Pilgrim Lilija
 ETC_20150317_002239	Discarding
 ETC_20150317_002240	Discarded the map again!
 ETC_20150317_002241	{memo X}Scouring the dust of the mountain
@@ -3484,7 +3484,7 @@ ETC_20150317_003483	Griva
 ETC_20150317_003484	Evon
 ETC_20150317_003485	[Lure Sparnas] must be completed to pass through
 ETC_20150317_003486	Gelsbas High Pokubu
-ETC_20150317_003487	WARNING! CAUTION! Wrong Way!
+ETC_20150317_003487	WARNING! CAUTION!{nl}Wrong Way!
 ETC_20150317_003488	Sounds like a good song so let's copy it
 ETC_20150317_003489	Defeat the Chupacabras that raided the supply base!
 ETC_20150317_003490	Defeat the monsters!
@@ -4179,7 +4179,7 @@ ETC_20150317_004178	Try item enhancement {/} {/}.
 ETC_20150317_004179	Upgradeable{nl}There are items.{nl}
 ETC_20150317_004180	Use a potion to restore your HP.
 ETC_20150317_004181	{nl} Shortcut: {#0000FF}
-ETC_20150317_004182	You can use a potion to recover your SP.
+ETC_20150317_004182	Use a potion to recover your SP.
 ETC_20150317_004183	By using a potion, you will be able to recover Stamina
 ETC_20150317_004184	{s18}{#001100}You can raise your character's stats {nl} by leveling up.
 ETC_20150317_004185	Click apply {nl} after increasing stats by using buttons.
@@ -4882,7 +4882,7 @@ ETC_20150317_004881	Default session:
 ETC_20150317_004882	Other sessions:
 ETC_20150317_004883	Session List by made NPC creation without basic session
 ETC_20150317_004884	Please check the details of quest by pressing the key{nl}{@st50}Detailed information can be found through the help
-ETC_20150317_004885	  allows you to teleport back to the Quest NPC.{nl}{@st50}You may also click on the {img questinfo_return 40 40}  button{/}
+ETC_20150317_004885	  allows you to teleport back to the Quest NPC.{nl}{@st50}You may also click on the {img questinfo_return 40 40}  button.{/}
 ETC_20150317_004886	{@st50}Key of the Quest Information{/}
 ETC_20150317_004887	The destroyer shaman doll has destroyed the Panto totem!
 ETC_20150317_004888	{memo X}The holy beads have been charged by attacking the Demon forces.
@@ -5227,8 +5227,8 @@ ETC_20150317_005226	Give us peace and salvation..
 ETC_20150317_005227	Please listen to our prayers..
 ETC_20150317_005228	For peace and happiness..
 ETC_20150317_005229	$Look over there! The spiders are coming!
-ETC_20150317_005230	$Liliya suddenly turned into a Carnivore!
-ETC_20150317_005231	{memo X}Carnivore Liliya
+ETC_20150317_005230	$Lilija suddenly turned into a Carnivore!
+ETC_20150317_005231	{memo X}Carnivore Lilija
 ETC_20150317_005232	$Pilgrim Julius turned into a Drapeliun!
 ETC_20150317_005233	{memo X}Touch the food pile to make River Feed appear!
 ETC_20150317_005234	Carrion worm
@@ -7598,7 +7598,7 @@ ETC_20150317_007598	Rescuing Aras (4)
 ETC_20150317_007599	Rescuing Aras (5)
 ETC_20150317_007600	Recapture the Eastern Woods (3)
 ETC_20150317_007601	Recapture the Eastern Woods (4)
-ETC_20150317_007602	Find clues from Popolions
+ETC_20150317_007602	Find a clue from Popolions
 ETC_20150317_007603	Commission of Aras (4)
 ETC_20150317_007604	Attacked Adventurer
 ETC_20150317_007605	Memorial Stone of adventure (1)
@@ -9387,7 +9387,7 @@ ETC_20150317_009387	{memo X}Trigger 4th Advancement of Pardoner
 ETC_20150317_009388	For the 4th advancement of Necromancer
 ETC_20150317_009389	Evil Aura
 ETC_20150317_009390	{memo X}Pilgrim Julius*
-ETC_20150317_009391	{memo X}Grave of Liliya*
+ETC_20150317_009391	{memo X}Grave of Lilija*
 ETC_20150317_009392	{memo X}Grave of Pilgrim Mathas*
 ETC_20150317_009393	{memo X}Tree Root Crystals of Laziness*
 ETC_20150317_009394	{memo X}Variant Laziness's tree root crystal*
@@ -13502,7 +13502,7 @@ ETC_20150717_013503	/Add Friend
 ETC_20150717_013504	/Block
 ETC_20150717_013505	Your name cannot exceed 16 characters {nl}including blank spaces.
 ETC_20150717_013506	Disconnected from the server.{nl}
-ETC_20150717_013507	Move to login mode after 3 seconds.
+ETC_20150717_013507	Moving to login mode after 3 seconds.
 ETC_20150717_013508	Cannot connect to server.
 ETC_20150717_013509	Your ID exceeds the maximum length allowed.
 ETC_20150717_013510	Your username or password is incorrect. {nl}Please note that passwords are case sensitive.

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -4782,7 +4782,7 @@ ETC_20150317_004781	About Goddess Laima
 ETC_20150317_004782	About Goddess Gabija
 ETC_20150317_004783	About Goddess Zemyna
 ETC_20150317_004784	About Goddess Vakarine
-ETC_20150317_004785	Ask about the Medis Diena
+ETC_20150317_004785	Ask about Medis Diena
 ETC_20150317_004786	Ask what happened next
 ETC_20150317_004787	I found a lever handle latch!
 ETC_20150317_004788	{memo X}I found the information about the flow of horsepower.
@@ -6196,7 +6196,7 @@ ETC_20150317_006196	Some devilish beasts are sensitive to iron, and the secrets 
 ETC_20150317_006197	Steel Claw
 ETC_20150317_006198	It's created using stronger, more resilient iron.  The rest is the same as an Iron Claw.
 ETC_20150317_006199	Forest Claw
-ETC_20150317_006200	Created after the Medis Diena to combat plant monsters.
+ETC_20150317_006200	Created after Medis Diena to combat plant monsters.
 ETC_20150317_006201	Rokas Claw
 ETC_20150317_006202	This claw's original recipe was lost, but it has been recreated by archaeologists who discovered it near Gateway of Great King.
 ETC_20150317_006203	Tooth

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -1910,8 +1910,8 @@ ETC_20150317_001909	Requires a record in the Adventure Journal. Press the A key 
 ETC_20150317_001910	You can now use the [{Auto_1}] title.
 ETC_20150317_001911	Attributes
 ETC_20150317_001912	{@st59} Click for more information {/}
-ETC_20150317_001913	The next level requires the same class advancement.
-ETC_20150317_001914	Use Skill Points to increase the skill level.
+ETC_20150317_001913	The next skill level requires the same class advancement.
+ETC_20150317_001914	Use a Skill Point to increase its skill level.
 ETC_20150317_001915	Equipment
 ETC_20150317_001916	Disabled
 ETC_20150317_001917	Enabled
@@ -11102,9 +11102,9 @@ ETC_20150414_011103	Recipe - Silver Bracelet
 ETC_20150414_011104	Recipe - Superior Pearl Bracelet
 ETC_20150414_011105	Recipe - Rune Bracelet
 ETC_20150414_011106	Falconer Advancement
-ETC_20150414_011107	Dispeller Craft attribute required.
+ETC_20150414_011107	Dispeller Craft attribute required
 ETC_20150414_011108	Craft Arrow
-ETC_20150414_011109	Arrow Crafting attribute required.
+ETC_20150414_011109	Arrow Crafting attribute required
 ETC_20150414_011110	Base camp does not exist.
 ETC_20150414_011111	{Auto_1} required
 ETC_20150414_011112	Cannot install offering box in this area.
@@ -13284,7 +13284,7 @@ ETC_20150717_013285	Advancement
 ETC_20150717_013286	{memo X}You can advance to another class when your Class Level has reached 15.
 ETC_20150717_013287	{memo X}After selecting another class to advance to, you will receive an advancement quest from the Class Master. Complete the quest to advance further.
 ETC_20150717_013288	{memo X}Once you begin the advancement quest, you cannot change your class until the next advancement.
-ETC_20150717_013289	When you reach Rank 2, you can learn attributes
+ETC_20150717_013289	When you reach Rank 2, you can learn the attribute 
 ETC_20150717_013290	from the Class Master.
 ETC_20150717_013291	You can quickly swap weapons by pressing {img Alt 40 40}+ {img Z 40 40} if you've learned the Weapon Swap attribute
 ETC_20150717_013292	Some classes may require you to learn Weapon Mastery before using special weapons.
@@ -13519,7 +13519,7 @@ ETC_20150717_013520	Please enter your account password.
 ETC_20150717_013521	Entering the world...
 ETC_20150717_013522	Do you want to learn this attribute?
 ETC_20150717_013523	Connecting to the server...
-ETC_20150717_013524	{gr gradation2}{s19}{ol}{b}{#ffcc00}Right-click: Sell / Buy Button{/}{/}{nl}Press and hold the Shift button + right-click to sell multiple quantities of an item.{nl}Double-click to sell all.
+ETC_20150717_013524	{gr gradation2}{s19}{ol}{b}{#ffcc00}Right-click: Sell / Buy Button{/}{/}{nl}Press and hold the Shift button + right-click{nl}to sell multiple quantities of an item.{nl}Double-click to sell all.
 ETC_20150717_013525	You will be moved to another channel, due to this one being too full.
 ETC_20150717_013526	When enhancing armor, bracelets or necklaces past +{Auto_1}, if it fails, the Potential of that item will decrease by 1.{nl} {nl}When the Potential falls below 0, the item will be destroyed. Do you want to continue?
 ETC_20150717_013527	When enhancing weapons past +{Auto_1}, if it fails, the Potential of that item will decrease by 1.{nl} {nl}When the Potential falls below 0, the item will be destroyed. Do you want to continue?
@@ -13720,7 +13720,7 @@ ETC_20150729_013721	Press {img F5 40 40} to view available quests {nl}or quests 
 ETC_20150729_013722	{nl}{nl}You can restart abandoned quests by pressing the 
 ETC_20150729_013723	 button. Some quests cannot be abandoned.
 ETC_20150729_013724	{nl}{nl}Track quests by marking the checkbox in front of the quest title.
-ETC_20150729_013725	Check your character's game progress or rankings{nl} in the Adventure Journal.
+ETC_20150729_013725	Check your character's game progress and rankings{nl} in your Adventure Journal.
 ETC_20150729_013726	Your character's progress is recorded in the Adventure Journal. Press {img F4 40 40} to view.
 ETC_20150729_013727	You can earn Adventure Index through Items, Monsters, Crafting, Map, and Game Progression.
 ETC_20150729_013728	You can receive rewards from 

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -1540,7 +1540,7 @@ ETC_20150317_001539	You cannot receive basic items because your inventory is ful
 ETC_20150317_001540	Your account ID cannot contain spaces.
 ETC_20150317_001541	You cannot use this skill because you have not equipped the required equipment.
 ETC_20150317_001542	Out of the range distance of herbivorous subject
-ETC_20150317_001543	You cannot use this yet
+ETC_20150317_001543	You may not use this yet
 ETC_20150317_001544	You cannot create anymore
 ETC_20150317_001545	Enchantment error (error code: {Auto_1})
 ETC_20150317_001546	Duel status activated. {nl}The squad will be withdrawn automatically.
@@ -4347,7 +4347,7 @@ ETC_20150317_004346	{s16}{ol} Defense {/}{/}{/}{nl}{s18}{ol}
 ETC_20150317_004347	{s16}{ol} Race {/}{/}
 ETC_20150317_004348	{s16}{ol} Defense {/}{/}{/}{s16}{ol}
 ETC_20150317_004349	{@s16}{ol}{Auto_1} and {a VIEW_LIKERS {Auto_2}}{ul}{#8888FF}{Auto_3} {/}{/}{/} like {/}
-ETC_20150317_004350	{a OPEN_ACHIEVE 0}Obtained the {#050505}{s24}[{Auto_1}]{nl}{s20}achievement.{/}{/}
+ETC_20150317_004350	{a OPEN_ACHIEVE 0}{#050505}{s24}[{Auto_1}]{nl}{s20} achievement obtained.{/}{/}
 ETC_20150317_004351	There is no information.
 ETC_20150317_004352	This name is already taken
 ETC_20150317_004353	Please enter a log
@@ -14617,7 +14617,7 @@ ETC_20150918_014618	Defeat the monsters nearby!
 ETC_20150918_014619	The guardian of the contract has appeared!
 ETC_20150918_014620	While defeating Vubbes, set the bombs on the secret hallway
 ETC_20150918_014621	Stop the monsters that are trying to ruin the seal ceremony!
-ETC_20150918_014622	$You've found Dry Thorn Forest Wood!
+ETC_20150918_014622	$You have found Dry Thorn Forest Wood!
 ETC_20150918_014623	Defeat the ominous spirit!
 ETC_20150918_014624	Defeat the boss monster on the 2nd floor of the Royal Mausoleum!
 ETC_20150918_014625	You have successfully tested the decoy!

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2186,8 +2186,8 @@ ETC_20150317_002185	Only 40% of ember is left!
 ETC_20150317_002186	Only 30% of ember is left!
 ETC_20150317_002187	Only 20% of ember is left!
 ETC_20150317_002188	Only 10% of ember is left!!
-ETC_20150317_002189	$Obtained Wooden Arrows! Throw them into the Fire to keep it burning!
-ETC_20150317_002190	$Throwing in Wooden Arrows
+ETC_20150317_002189	$Obtained a Wooden Arrow! Throw them into the fire to keep it burning!
+ETC_20150317_002190	$Throwing in a Wooden Arrow
 ETC_20150317_002191	Investigating the stone pillar
 ETC_20150317_002192	Looking at the Eyes of the Great King
 ETC_20150317_002193	{memo X}While releasing the seal
@@ -2198,7 +2198,7 @@ ETC_20150317_002197	{memo X}Collecting the light stem of reed
 ETC_20150317_002198	{memo X}Did collect the light steom of reed but you are slashed over the reed leaf!
 ETC_20150317_002199	{memo X}The wound as the reed leaf was bleeding.
 ETC_20150317_002200	$Make a grave
-ETC_20150317_002201	$Making a grave for Lilija
+ETC_20150317_002201	$Making a grave for Liliya
 ETC_20150317_002202	Discarding the music box
 ETC_20150317_002203	{memo X}Discarded it into the place.
 ETC_20150317_002204	$Looking through the pile of grass
@@ -2235,7 +2235,7 @@ ETC_20150317_002234	{memo X}Even sooth the trapped souls, It has transformed to 
 ETC_20150317_002235	{memo X}I have no tolerance for guys!
 ETC_20150317_002236	{memo X}I can never forgive you guys for this matter even I will in hell!
 ETC_20150317_002237	{memo X}They betrayed us!
-ETC_20150317_002238	{memo X}Pilgrim Lilija
+ETC_20150317_002238	{memo X}Pilgrim Liliya
 ETC_20150317_002239	Discarding
 ETC_20150317_002240	Discarded the map again!
 ETC_20150317_002241	{memo X}Scouring the dust of the mountain
@@ -5227,8 +5227,8 @@ ETC_20150317_005226	Give us peace and salvation..
 ETC_20150317_005227	Please listen to our prayers..
 ETC_20150317_005228	For peace and happiness..
 ETC_20150317_005229	$Look over there! The spiders are coming!
-ETC_20150317_005230	$Lilija suddenly turned into a Carnivore!
-ETC_20150317_005231	{memo X}Carnivore Lilija
+ETC_20150317_005230	$Liliya suddenly turned into a Carnivore!
+ETC_20150317_005231	{memo X}Carnivore Liliya
 ETC_20150317_005232	$Pilgrim Julius turned into a Drapeliun!
 ETC_20150317_005233	{memo X}Touch the food pile to make River Feed appear!
 ETC_20150317_005234	Carrion worm
@@ -7777,8 +7777,8 @@ ETC_20150317_007777	{memo X}3rd Collect a sap pot
 ETC_20150317_007778	Owl's Eternal (1)
 ETC_20150317_007779	Destroyer (1)
 ETC_20150317_007780	Protect yourself from monsters is attacking
-ETC_20150317_007781	Kill High Vubbe and get the wooden arrow
-ETC_20150317_007782	Input the wooden arrow to fire
+ETC_20150317_007781	Defeat High Vubbe and get the wooden arrow
+ETC_20150317_007782	Throw the wooden arrow into the fire
 ETC_20150317_007783	Steel the booty of Siaulamb
 ETC_20150317_007784	 - press this key to use a Status Point
 ETC_20150317_007785	To Klaipeda (5)
@@ -9387,7 +9387,7 @@ ETC_20150317_009387	{memo X}Trigger 4th Advancement of Pardoner
 ETC_20150317_009388	For the 4th advancement of Necromancer
 ETC_20150317_009389	Evil Aura
 ETC_20150317_009390	{memo X}Pilgrim Julius*
-ETC_20150317_009391	{memo X}Grave of Lilija*
+ETC_20150317_009391	{memo X}Grave of Liliya*
 ETC_20150317_009392	{memo X}Grave of Pilgrim Mathas*
 ETC_20150317_009393	{memo X}Tree Root Crystals of Laziness*
 ETC_20150317_009394	{memo X}Variant Laziness's tree root crystal*

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2198,7 +2198,7 @@ ETC_20150317_002197	{memo X}Collecting the light stem of reed
 ETC_20150317_002198	{memo X}Did collect the light steom of reed but you are slashed over the reed leaf!
 ETC_20150317_002199	{memo X}The wound as the reed leaf was bleeding.
 ETC_20150317_002200	$Make a grave
-ETC_20150317_002201	$Making a grave for Lylia
+ETC_20150317_002201	$Making a grave for Liliya
 ETC_20150317_002202	Discarding the music box
 ETC_20150317_002203	{memo X}Discarded it into the place.
 ETC_20150317_002204	$Looking through the pile of grass
@@ -2235,7 +2235,7 @@ ETC_20150317_002234	{memo X}Even sooth the trapped souls, It has transformed to 
 ETC_20150317_002235	{memo X}I have no tolerance for guys!
 ETC_20150317_002236	{memo X}I can never forgive you guys for this matter even I will in hell!
 ETC_20150317_002237	{memo X}They betrayed us!
-ETC_20150317_002238	{memo X}Pilgrim Lylia
+ETC_20150317_002238	{memo X}Pilgrim Liliya
 ETC_20150317_002239	Discarding
 ETC_20150317_002240	Discarded the map again!
 ETC_20150317_002241	{memo X}Scouring the dust of the mountain
@@ -5227,8 +5227,8 @@ ETC_20150317_005226	Give us peace and salvation..
 ETC_20150317_005227	Please listen to our prayers..
 ETC_20150317_005228	For peace and happiness..
 ETC_20150317_005229	$Look over there! The spiders are coming!
-ETC_20150317_005230	$Lylia suddenly turned into a Carnivore!
-ETC_20150317_005231	{memo X}Carnivore Lylia
+ETC_20150317_005230	$Liliya suddenly turned into a Carnivore!
+ETC_20150317_005231	{memo X}Carnivore Liliya
 ETC_20150317_005232	$Pilgrim Julius turned into a Drapeliun!
 ETC_20150317_005233	{memo X}Touch the food pile to make River Feed appear!
 ETC_20150317_005234	Carrion worm
@@ -9804,7 +9804,7 @@ ETC_20150323_009805	Elementalist
 ETC_20150323_009806	Vinas Camp
 ETC_20150323_009807	Rishkio City
 ETC_20150323_009808	Yujima Narthex
-ETC_20150323_009809	Lamivie Cliff
+ETC_20150323_009809	Ramybe Cliff
 ETC_20150323_009810	Gaule Altar
 ETC_20150323_009811	Viesha Altar
 ETC_20150323_009812	Ershike Altar

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -3041,7 +3041,7 @@ ITEM_20150317_003040	$Soldier's Belongings
 ITEM_20150317_003041	{memo X}$Belongings from a soldier, stolen by a Leafbug. Looks like it's been stolen many times since then. 
 ITEM_20150317_003042	$Piece of Vubbe Cloth  
 ITEM_20150317_003043	{memo X}$A ripped cloth piece from Vubbe. It's from the dirty waist area. 
-ITEM_20150317_003044	Weaver Claw 
+ITEM_20150317_003044	Weaver Claw
 ITEM_20150317_003045	{memo X}If you gather enough of these, they may have a use. 
 ITEM_20150317_003046	$Relief Goods 
 ITEM_20150317_003047	{memo X}$Goods used as a provision for emergencies in Miners' Village. 

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -3099,7 +3099,7 @@ ITEM_20150317_003098	{memo X}Portable supplies to be sent first to Danyus' squad
 ITEM_20150317_003099	Puragi's Hook 
 ITEM_20150317_003100	{memo X}A hook that soldier Roy has to collect. He can return to his troops as soon as he collects it. 
 ITEM_20150317_003101	Nagging Owl's Soul 
-ITEM_20150317_003102	A bloodstained page from a report. 
+ITEM_20150317_003102	Bloodstained Report Page
 ITEM_20150317_003103	{memo X}The contents are illegible. 
 ITEM_20150317_003104	Haming Stem 
 ITEM_20150317_003105	{memo X}A material used to fix the wagon. Cut from the the hard part of the stem of a Haming. 
@@ -5765,7 +5765,7 @@ ITEM_20150717_005764	The origin of this bracelet is connecting to Lydia Schaffen
 ITEM_20150717_005765	Goddess Jurate evicted demons living in the sea from her territory. As Merregina roams on land, its use as material is becoming known. 
 ITEM_20150717_005766	The study of strong demons and the creation of new magical weapons has become more important after the Medis Diena.
 ITEM_20150717_005767	Its name reflects that the item is easy to get, not that the item is shabby. 
-ITEM_20150717_005768	During the Millenary 90 years ago, many items were crafted to celebrate the Great King Zacheriel's founding of the kingdom. The items' necessity only increased after the Medis Diena.
+ITEM_20150717_005768	During the Millenary 90 years ago, many items were crafted to celebrate the Great King Zachariel's founding of the kingdom. The items' necessity only increased after the Medis Diena.
 ITEM_20150717_005769	Some avoid it for the source of its power but such thoughts are considered a luxury afte Medis Diena.
 ITEM_20150717_005770	Lapasape Mushroom
 ITEM_20150717_005771	Lapasape is a mushroom that grows on bodies. It smells very foul. It can be obtained from Lapasapes.
@@ -6329,7 +6329,7 @@ ITEM_20150918_006328	Booty gathered by Vubbes. As for the sorting??
 ITEM_20150918_006329	Supplies looted and gathered by Vubbes. You can see that some of them have been used.
 ITEM_20150918_006330	Feather decorations adorn the Vubbes' arrows. Useful for monster research.
 ITEM_20150918_006331	Report written by Moody. It details the attacks from monsters.
-ITEM_20150918_006332	A diligent Owl Sculpture's wing fragment. It is blessed with holy power.
+ITEM_20150918_006332	A diligent Owl Sculpture's wing fragment.{nl}It is blessed with holy power.
 ITEM_20150918_006333	A fragment of a wing of Scared Owl Sculpture's friend. It has become an ordinary piece of wood.
 ITEM_20150918_006334	An unpolished gem ore. The gem within the stone is also dull as it hasn't been polished yet.
 ITEM_20150918_006335	
@@ -6402,9 +6402,9 @@ ITEM_20150918_006401	A fragment of Woodman that sometimes wiggles creepily.
 ITEM_20150918_006402	A report by Joint Investigation Unit member Scott regarding suspicious activity in the area. Readable.
 ITEM_20150918_006403	A scroll that allows you to collect spirits. Only usable on certain monsters.
 ITEM_20150918_006404	An orb that has a Red Vubbe Shooter's spirit sealed within.
-ITEM_20150918_006405	Owl Sculpture's upper piece. Restoration is, unfortunately, infeasible.
-ITEM_20150918_006406	Lower piece of the Owl Sculpture. The shape is barely recognizable.
-ITEM_20150918_006407	Pedestal piece of the Owl Sculpture. It's about to break in half.
+ITEM_20150918_006405	The Owl Sculpture's upper piece.{nl}Restoration is, unfortunately, infeasible.
+ITEM_20150918_006406	The Owl Sculpture's lower piece.{nl}The shape is barely recognizable.
+ITEM_20150918_006407	A pedestal piece of the Owl Sculpture.{nl}It's about to break in half.
 ITEM_20150918_006408	A special oil to burn the Owl Sculpture which has unfortunately been shattered.
 ITEM_20150918_006409	A wheat box containing a small number of grains. The box has been ripped apart.
 ITEM_20150918_006410	A pocket which contains the strange medicine. When Vubbes consume it, they become brave, but if humans consume it, they will have stomachache.
@@ -6440,7 +6440,7 @@ ITEM_20150918_006439	A monster bait to complete the last mission of dead soldier
 ITEM_20150918_006440	Let's test it on a monster to confirm that it is working.
 ITEM_20150918_006441	Old Kepa skin. The powder falls off it when shaken.
 ITEM_20150918_006442	Needed to make the bait more convincing. Will this bait work well?
-ITEM_20150918_006443	Corpses of Johan's squad. Treat them well.
+ITEM_20150918_006443	A corpe of Johan's squad. Please treat them well.
 ITEM_20150918_006444	A hook that soldier Roy has to collect. He can return to his troops as soon as he collects it.
 ITEM_20150918_006445	Parts of it are covered in blood and unable to be read. Some parts are legible.
 ITEM_20150918_006446	A material used to fix the wagon. Cut from the the hard part of the stem of a Haming.

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -2111,7 +2111,7 @@ ITEM_20150317_002110	{memo X}A sturdy shell with a hexagonal pattern on it. Obta
 ITEM_20150317_002111	Chupacabra Tooth 
 ITEM_20150317_002112	Small and sharp tooth. Obtained from a Chupacabra. 
 ITEM_20150317_002113	Weaver Feeler 
-ITEM_20150317_002114	A blunt feeler with a hairy surface. Obtained from Weavers. 
+ITEM_20150317_002114	A blunt feeler with a hairy surface.{nl}Obtained from Weavers. 
 ITEM_20150317_002115	Pokubu Skin 
 ITEM_20150317_002116	Gray leather. Obtained from Pokubus. 
 ITEM_20150317_002117	Jukopus Leaf 

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -4471,7 +4471,7 @@ ITEM_20150401_004470	Meduja Tentacle
 ITEM_20150401_004471	Bite Stinger 
 ITEM_20150401_004472	Griba Stem 
 ITEM_20150401_004473	Meleech Shell 
-ITEM_20150401_004474	Tsurikaki Stem 
+ITEM_20150401_004474	Slick Sap 
 ITEM_20150401_004475	Treegool Stem 
 ITEM_20150401_004476	Cronewt Bones 
 ITEM_20150401_004477	Hoglan Beak 
@@ -5935,7 +5935,7 @@ ITEM_20150803_005934	The 2nd soul stone containing a strong grudge of a corrupt 
 ITEM_20150803_005935	The 3rd soul stone containing a strong grudge of a corrupt individual.
 ITEM_20150803_005936	A sign that the Angry Owl Sculpture had.
 ITEM_20150803_005937	The burnt branch when Sequoia created a riot.
-ITEM_20150803_005938	Portable supplies to be sent first to Danyus' squad.
+ITEM_20150803_005938	Portable supplies to be sent first to Danus' squad.
 ITEM_20150803_005939	A pouch that a Vubbe has been keeping to spread evil spirits.
 ITEM_20150803_005940	{memo X}Forgery that a decicive evidence of falsifaction. It is not finished yet.
 ITEM_20150803_005941	A sack containing a monster's head.

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -3351,7 +3351,7 @@ ITEM_20150317_003350	Lesser Bead of the Divine Spirit
 ITEM_20150317_003351	{memo X}When used, a Divine Spirit appears and provokes nearby Demons. 
 ITEM_20150317_003352	Revelator's Proof 
 ITEM_20150317_003353	An index describing how to obtain the Legendary Key from the West Barrier. 
-ITEM_20150317_003354	Crest of Space
+ITEM_20150317_003354	Seal of Space
 ITEM_20150317_003355	{memo X}A special key for finding revelations and hidden places. 
 ITEM_20150317_003356	{memo X}Merog Spittle 
 ITEM_20150317_003357	{memo X}It creates an awakening effect if it is mixed with Thorn Flower Powder Stimulant. 
@@ -5720,13 +5720,13 @@ ITEM_20150717_005719	There are people had asked that Goddess Zemyna really given
 ITEM_20150717_005720	Once the traders were also selling and claimed that these arms are the same type of product like Rucklys equipped at final time. Of course, It is a story after the Kadumal.
 ITEM_20150717_005721	Square Master Yustina Legwyn has exceptional ability to manufacture as well as repair. She is celebrating the fall family by putting the name of her family after she became famous due to the designed equipments.
 ITEM_20150717_005722	This equipment made by Square Master Yustina Legwyn according to the recipe was devised and disseminate. She leaves a handmade sign into some products. If lucky, you can also see the contents in honor of a brother and father who already died.
-ITEM_20150717_005723	There are many stroies related to Great King Zachariel of the founder. Some of story happened after he died. some of that is not ture,
+ITEM_20150717_005723	There are many stories related to the Great King Zachariel of the founder. Some of story happened after he died. some of that is not ture,
 ITEM_20150717_005724	The city went to ground after the Ruklys of civil war near the Roxona, the recipe crafted at that time was still alive. These recipes have passed and survived for many years through not only Kadumal but also the other old time.
 ITEM_20150717_005725	Someone told this weapon is directly related to Ruclyus, but it's not true. However, it's surely that the Master crafter before Roxona is first founder of it.
 ITEM_20150717_005726	Someone told considering the disaster encountered Roxona, It would be great if these weapons have an immunity against the petrifation. Although sorry for Roxona of petrified city, it's surely that this weapon is better than the other side.
 ITEM_20150717_005727	People may not know about it but the reason why they can get this for a cheap price is because of the plans and foresight of Goddess Laima. 
 ITEM_20150717_005728	No one knows how Jukopus give this weapon its ablities. Winterspoon family seems to know but do not share it. 
-ITEM_20150717_005729	The demon lord Mirtis said that before she used the Vubbes, the Vubbes carried no equipment with magical power in them.
+ITEM_20150717_005729	Demon Lord Mirtis said that before she used the Vubbes, the Vubbes carried no equipment with magical power in them.
 ITEM_20150717_005730	It has an effect to disperse the magic damage kind of a ligtning rod.
 ITEM_20150717_005731	Alive and death rely on the small difference in the battle. This necklace can save the weaver with an effect.
 ITEM_20150717_005732	A guardian Charm has been used in the kingdom a long time ago, there are many necklaces like this. Although there are people who believed that, it used beyond the foundation of the kingdom.
@@ -5992,11 +5992,11 @@ ITEM_20150804_005991	Title - Ausrine's Incarnation
 ITEM_20150804_005992	A title given to the first player who has reached the 6th rank during the 3rd CBT. Right-click to use.
 ITEM_20150804_005993	Title - Ausrine's Hero
 ITEM_20150804_005994	A title given to players between 2~10 who have reached the 6th rank during the 3rd CBT.
-ITEM_20150804_005995	The 1st Symbol of Trial of the Great King
+ITEM_20150804_005995	1st Symbol of Ordeal of the Great King
 ITEM_20150804_005996	{memo X}A symbol that means that you have passed the test prepared by Zachariel, the Great King. It seems related to the seal of the Royal Mausoleum.
-ITEM_20150804_005997	The 2nd Symbol of Trial of the Great King
-ITEM_20150804_005998	The 3rd Symbol of Trial of the Great King
-ITEM_20150804_005999	The 4th Symbol of Trial of the Great King
+ITEM_20150804_005997	2nd Symbol of Ordeal of the Great King
+ITEM_20150804_005998	3rd Symbol of Ordeal of the Great King
+ITEM_20150804_005999	4th Symbol of Ordeal of the Great King
 ITEM_20150918_006000	Wearing it will help you classify your allies. 
 ITEM_20150918_006001	Blood may not flow through if you tie it too tightly.
 ITEM_20150918_006002	Its long length makes it possible to be used as a substitute to bandage at urgent times. 
@@ -6346,7 +6346,7 @@ ITEM_20150918_006345	A small piece of rock that broke off from a stone pillar. I
 ITEM_20150918_006346	Refined powder collected from a stone pillar's surface. Its use is unclear.
 ITEM_20150918_006347	A small piece of a stone that was found in the monster's stomach. Seems to be part of a victim's relics.
 ITEM_20150918_006348	A scroll that opens a distortion in space. With this, it is possible to obtain the key that belonged to the Great King Zachariel.
-ITEM_20150918_006349	A key used for releasing the seal of Great King Zachariel.
+ITEM_20150918_006349	A key used for releasing the seal of the Great King Zachariel.
 ITEM_20150918_006350	One of the task requirements by the Hoplite Master. Looks extremely sturdy.
 ITEM_20150918_006351	One of the task requirements by the Hoplite Master. It would be fatal to be stabbed by it.
 ITEM_20150918_006352	One of the task requirements by the Hoplite Master. It scatters at the slightest breath.

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -5658,21 +5658,21 @@ ITEM_20150717_005657	The name has been first created from the Woodlands. This wa
 ITEM_20150717_005658	The equipment with this pattern originated from Kadumel period. At then, it was the official equipment of the kingdom soldiers, but the number of people who started to use this equipment gradually decreased. However, there are still many people using it.
 ITEM_20150717_005659	It's not that bad to use if you lower your expectations. 
 ITEM_20150717_005660	It may not be as great as the merchant claims, but it isn't so bad either. 
-ITEM_20150717_005661	As the Vubbes started to swing their arms after the Medis Diena, the equipment to prepare for the attacks of the Vubbes has developed. If the Vubbes go crazy from now on, there is a chance that the performance of the equipment may get better although the name of the equipment may be the same.
+ITEM_20150717_005661	As the Vubbes started to swing their arms after Medis Diena, the equipment to prepare for the attacks of the Vubbes has developed. If the Vubbes go crazy from now on, there is a chance that the performance of the equipment may get better although the name of the equipment may be the same.
 ITEM_20150717_005662	Unlike other equipment whose names originated from monsters, this equipment have been made at Gele Plateau from long time ago.
 ITEM_20150717_005663	This is the by-product of the period when the wizards and the priests haven't been good together in the history. Because of Maven, that trouble disappeared from the history, but the craft manual is being still used usefully in many areas.
 ITEM_20150717_005664	This is the equipment that has been changed a lot from the original equipment from Kadumel period. It generally possesses the improved qualities.
-ITEM_20150717_005665	For the amusement of the aristocrats, a kind of Metal Plate armor was needed so it was changed practically from then. It is being keep improved and developed after the Medis Diena.
+ITEM_20150717_005665	For the amusement of the aristocrats, a kind of Metal Plate armor was needed so it was changed practically from then. It is being keep improved and developed after Medis Diena.
 ITEM_20150717_005666	Under the stabilized royal regime, the Metal Plate Armor has developed with various reasons even when there weren't any large scale wars going on. The requests of the aristocrats who didn't forget the importance of militairy training were accepted many times and as a result, it has the shape of nowadays.
 ITEM_20150717_005667	Not only the wars and the tastes of the aristocrats developed the history of the battlegear. The master craftmen in Fedimian have been creating many equipment and craft items by utilizing their unique experimental minds for a long time. Also this is the result of the support from the goddesses who are trying to develop the cizilization of the humans.
 ITEM_20150717_005668	According to an old saying, the disciple of Agailla Flurry, Jane created this equipment. She resolved her limit by doing so, but there aren't any clear records remaining.
-ITEM_20150717_005669	After the Medis Diena, the equipment that were used for the hunting and the adventures are receiving the spotlight. As the number of violent monsters increases, the adventurous hunting which was unique before is becoming daily lives.
+ITEM_20150717_005669	After Medis Diena, the equipment that were used for the hunting and the adventures are receiving the spotlight. As the number of violent monsters increases, the adventurous hunting which was unique before is becoming daily lives.
 ITEM_20150717_005670	Its appearance looks good since it was used for the designs of the court guards and its defensive rate is also great.
 ITEM_20150717_005671	From long time ago, many wizards bought this equipment when they accumulated enough money. This equipment fulfills the needs of performance as well as the needs of designs.
 ITEM_20150717_005672	This equipment possesses more privacy than it looks. Also, the light reflection is weak in the night times so the scouts have used this equipment often.
 ITEM_20150717_005673	The pattern of the foot soldiers that was adopted from the beggining of the kingdom has been continued until now. At some times in the past, the kingdom soldiers wore this and aligned in front of 3 layer castle walls.
 ITEM_20150717_005674	This equipment possesses the passion of the wizards' wish to improve themselves to the next level.
-ITEM_20150717_005675	The previous Skirmisher equipment is being crafted with improved qualities as the monsters go rampant since the Medis Diena.
+ITEM_20150717_005675	The previous Skirmisher equipment is being crafted with improved qualities as the monsters go rampant since Medis Diena.
 ITEM_20150717_005676	This equipment was once adopted as the official equipment of the foot soldiers inside the castle of the capital city. As the time passed by after that, this equipment was used constantly even in the periods when it wasn't adopted by the kingdom.
 ITEM_20150717_005677	According to a folklore, the source of this craft manual was leaked from the library of the goddesses.
 ITEM_20150717_005678	This is the equipment with the pattern that was mainly worn at the outer areas of the kingdom. It is believed to be used in the southern part of Orsha for about hundred years.
@@ -5746,14 +5746,14 @@ ITEM_20150717_005745	This necklace said to bring misfortune, but that is untrue.
 ITEM_20150717_005746	Even when Kepas were harvested as crops, before turning into monsters, They were known to be good for your strength. 
 ITEM_20150717_005747	It was originally made for Miners working in the dark underground but people of various jobs benefited from this necklace. It was first made in Klaipeda. 
 ITEM_20150717_005748	This necklace protected its owner until his last moment. We hope the new owner of this necklace always receives the protection from it.
-ITEM_20150717_005749	Since the Medis Diena, new monsters brought new skills that were used to craft items such as this. It is a premier product.
+ITEM_20150717_005749	Since Medis Diena, new monsters brought new skills that were used to craft items such as this. It is a premier product.
 ITEM_20150717_005750	It contains a royal grace from Goddess Zemyna who doesn't enjoy fighting. It provides users with an amazing defense effect, but it isn't good during attacks.
 ITEM_20150717_005751	Klaipeda has been known for its handicrafts. Fedimian handicrafts has evolved from using silver to other materials, but Klaipeda handicrafts has always been related to the use of crystals.
 ITEM_20150717_005752	You might think it's an ordinary item, made of light wood, but woods are not ordinary in this world. 
 ITEM_20150717_005753	Vubbes using this equipment proves that a very strong existence is behind them. Some people think that it could be Mirtis. 
 ITEM_20150717_005754	The people who've equipped it before said their Spirit goes up. As a result, it is true that their resistance to Magic increases.
 ITEM_20150717_005755	Gathering some makes one effective. Don't divide for using.
-ITEM_20150717_005756	It is styled after the noble families in the world after the Medis Diena.
+ITEM_20150717_005756	It is styled after the noble families in the world after Medis Diena.
 ITEM_20150717_005757	There are lots of products named like this crafted firstly in the Grand Forest Land. Shelter of the Grand Forest Land had not a chance to gather at various people under a different situation.
 ITEM_20150717_005758	Mining is the famous industry in Klaipeda, and lots of product based on this industry has been manufactured.
 ITEM_20150717_005759	Sometimes, disappeared skills and styles has been rediscovered in the Valley area. This discovery remake like these new type products.
@@ -5763,10 +5763,10 @@ ITEM_20150717_005762	Like these types Pearl is a decoration purpose since it is 
 ITEM_20150717_005763	Priests who communicated directly with Goddess also don't know lots of parts. However, known up to now can endow a lot of abilities.
 ITEM_20150717_005764	The origin of this bracelet is connecting to Lydia Schaffen and Schaffenstar formed by her. However, There is not restriction to use this bracelet for people who not came from Star Tower.
 ITEM_20150717_005765	Goddess Jurate evicted demons living in the sea from her territory. As Merregina roams on land, its use as material is becoming known. 
-ITEM_20150717_005766	The study of strong demons and the creation of new magical weapons has become more important after the Medis Diena.
+ITEM_20150717_005766	The study of strong demons and the creation of new magical weapons has become more important after Medis Diena.
 ITEM_20150717_005767	Its name reflects that the item is easy to get, not that the item is shabby. 
-ITEM_20150717_005768	During the Millenary 90 years ago, many items were crafted to celebrate the Great King Zachariel's founding of the kingdom. The items' necessity only increased after the Medis Diena.
-ITEM_20150717_005769	Some avoid it for the source of its power but such thoughts are considered a luxury afte Medis Diena.
+ITEM_20150717_005768	During the Millenary 90 years ago, many items were crafted to celebrate the Great King Zachariel's founding of the kingdom. The items' necessity only increased after Medis Diena.
+ITEM_20150717_005769	Some avoid it for the source of its power but such thoughts are considered a luxury after Medis Diena.
 ITEM_20150717_005770	Lapasape Mushroom
 ITEM_20150717_005771	Lapasape is a mushroom that grows on bodies. It smells very foul. It can be obtained from Lapasapes.
 ITEM_20150717_005772	Party Quest Reward Chest
@@ -5828,41 +5828,41 @@ ITEM_20150717_005827	Kingdom Army Guard's Breastplate
 ITEM_20150717_005828	{memo X}Kingdom Army Guard's Equipped Armor
 ITEM_20150717_005829	Bomb
 ITEM_20150717_005830	{memo X}Bomb crafted to protect the camp from monster's attack
-ITEM_20150729_005831	While initially unpopular during the Medis Diena, the resurgence of strongly armored monsters is proving its value.
-ITEM_20150729_005832	This widely used weapon was mostly sought after as a decoration or collectible item prior to the Medis Diena.
-ITEM_20150729_005833	In the wake of the Medis Diena, the Winterspoon family disclosed the crafting recipe for this weapon to all alchemists.
-ITEM_20150729_005834	Although some people dismiss this weapon as a "tree cutting axe", its actual user will tell you that the Medis Diena would have resulted in far worse losses without it.
+ITEM_20150729_005831	While initially unpopular during Medis Diena, the resurgence of strongly armored monsters is proving its value.
+ITEM_20150729_005832	This widely used weapon was mostly sought after as a decoration or collectible item prior to Medis Diena.
+ITEM_20150729_005833	In the wake of Medis Diena, the Winterspoon family disclosed the crafting recipe for this weapon to all alchemists.
+ITEM_20150729_005834	Although some people dismiss this weapon as a "tree cutting axe", its actual user will tell you that Medis Diena would have resulted in far worse losses without it.
 ITEM_20150729_005835	Used to be given to magicians who enlisted to the army. There is an abundant supply after Medis Diena. 
-ITEM_20150729_005836	Wizards have been discovering new facts from monsters emerging from the Medis Diena and applying them to varying situations.
-ITEM_20150729_005837	The increase in demons after the Medis Diena increased the price of this already-expensive rod.
-ITEM_20150729_005838	This bow, popular among hunters, became even more widespread after the Medis Diena.
+ITEM_20150729_005836	Wizards have been discovering new facts from monsters emerging from Medis Diena and applying them to varying situations.
+ITEM_20150729_005837	The increase in demons after Medis Diena increased the price of this already-expensive rod.
+ITEM_20150729_005838	This bow, popular among hunters, became even more widespread after Medis Diena.
 ITEM_20150729_005839	A Bow used by Hunter upgraded more strongly for battle.
-ITEM_20150729_005840	Due to increase in demand for high quality bows since the Medis Diena, this bow is being crafted quite frequently.
-ITEM_20150729_005841	Prior to the Medis Diena, hunters rarely used this bow. It might sound strange, but the bow would cause excessive damage to the prey.
-ITEM_20150729_005842	A new bow designed and developed through joint cooperation of master bowcrafters. It was conceived with the hope of overcoming the Medis Diena.
-ITEM_20150729_005843	Although it is hard to find wood for crafting since the Medis Diena, this weapon is not hard to make.
-ITEM_20150729_005844	Weapons based on alchemy are in great demand since the Medis Diena.
+ITEM_20150729_005840	Due to increase in demand for high quality bows since Medis Diena, this bow is being crafted quite frequently.
+ITEM_20150729_005841	Prior to Medis Diena, hunters rarely used this bow. It might sound strange, but the bow would cause excessive damage to the prey.
+ITEM_20150729_005842	A new bow designed and developed through joint cooperation of master bowcrafters. It was conceived with the hope of overcoming Medis Diena.
+ITEM_20150729_005843	Although it is hard to find wood for crafting since Medis Diena, this weapon is not hard to make.
+ITEM_20150729_005844	Weapons based on alchemy are in great demand since Medis Diena.
 ITEM_20150729_005845	The weapon is specialized in taking down well-equipped enemies.
-ITEM_20150729_005846	The Ranger Master developed this weapon based on research data on the monsters in the Kateen Forest after the Medis Diena. However, she recommends that no one uses it.
-ITEM_20150729_005847	In the old days it was readily available to Pardoners at an affordable price, but since the Medis Diena those days are long gone.
-ITEM_20150729_005848	New possibilities have been discovered for weaponcrafting thanks to the emergence of new monsters since the Medis Diena.
-ITEM_20150729_005849	This weapon used to be only obtainable by clerics with permission from the royal household. Such restrictions have become meaningless since the Medis Diena.
+ITEM_20150729_005846	The Ranger Master developed this weapon based on research data on the monsters in the Kateen Forest after Medis Diena. However, she recommends that no one uses it.
+ITEM_20150729_005847	In the old days it was readily available to Pardoners at an affordable price, but since Medis Diena those days are long gone.
+ITEM_20150729_005848	New possibilities have been discovered for weaponcrafting thanks to the emergence of new monsters since Medis Diena.
+ITEM_20150729_005849	This weapon used to be only obtainable by clerics with permission from the royal household. Such restrictions have become meaningless since Medis Diena.
 ITEM_20150729_005850	Minotaur Shield
-ITEM_20150729_005851	{memo X}The recipe for this shild has only been discovered recently. It may not be possible to craft it after the Medis Diena.
+ITEM_20150729_005851	{memo X}The recipe for this shild has only been discovered recently. It may not be possible to craft it after Medis Diena.
 ITEM_20150729_005852	Since the Day of Goddess, many recipes were found through the use of altenative ingredients from monsters.
-ITEM_20150729_005853	Crafters say that it has become easier to empower a wooden wand's attributes since the Medis Diena.
-ITEM_20150729_005854	Prior to the Medis Diena, there was nobody who would use this weapon because it used demonic powers, However, with the vanishing of the Goddesses, desperate people have begun using it.
+ITEM_20150729_005853	Crafters say that it has become easier to empower a wooden wand's attributes since Medis Diena.
+ITEM_20150729_005854	Prior to Medis Diena, there was nobody who would use this weapon because it used demonic powers, However, with the vanishing of the Goddesses, desperate people have begun using it.
 ITEM_20150729_005855	Rumor has it that supplies of leather increased after Medis Diena.
-ITEM_20150729_005856	One of the benefits of the Medis Diena is that crafters have found ways to reuse monsters's remains for stronger armor.
-ITEM_20150729_005857	Since the Medis Diena, many equipment crafted from new material, like these pants, are replacing traditional ones.
-ITEM_20150729_005858	Standard armor given to Royal Guards prior to the Medis Diena.
-ITEM_20150729_005859	Since its inauguration prior to the Medis Diena, the Cryomancer Master has stopped the tradition of awarding this pendant to people. Now this pendant must be either obtained or crafted by users themselves.
-ITEM_20150729_005860	Many new magical items that uses the power of monsters have been invented since the Medis Diena.
+ITEM_20150729_005856	One of the benefits of Medis Diena is that crafters have found ways to reuse monsters's remains for stronger armor.
+ITEM_20150729_005857	Since Medis Diena, many equipment crafted from new material, like these pants, are replacing traditional ones.
+ITEM_20150729_005858	Standard armor given to Royal Guards prior to Medis Diena.
+ITEM_20150729_005859	Since its inauguration prior to Medis Diena, the Cryomancer Master has stopped the tradition of awarding this pendant to people. Now this pendant must be either obtained or crafted by users themselves.
+ITEM_20150729_005860	Many new magical items that uses the power of monsters have been invented since Medis Diena.
 ITEM_20150729_005861	- Electric impact effect to ememies with damage 405 by 15% random when receive the electric attribute attack
-ITEM_20150729_005862	This item has been crafted with various poisons since its origin and, with the Medis Diena, materials have been become even easier to find.
+ITEM_20150729_005862	This item has been crafted with various poisons since its origin and, with Medis Diena, materials have been become even easier to find.
 ITEM_20150729_005863	Originally from demons who passed the recipe down to the Vubbes, this recipe was released by human warriors who stole it from the Vubbes.
 ITEM_20150729_005864	- Plant Collection Effect{nl}, when defeat Plant types - Herb items can be droped when the Plant Collection Effect overlapped 15 times.
-ITEM_20150729_005865	The new monsters appeared since the Medis Diena, the name was made according to the a scholar woh devoted to find ways.
+ITEM_20150729_005865	The new monsters appeared since Medis Diena, the name was made according to the a scholar woh devoted to find ways.
 ITEM_20150729_005866	- Frenzy Effect during 5 seconds{nl}, when you avoid - Increases Physical damage to 235 during 35 seconds,movement speed to 10 and decreases Physical Defense 88
 ITEM_20150729_005867	{memo X}Adds 2814 EXP and 2166 Class EXP. {nl}There is a chance of receiving additional EXP. {nl}Right-click to use. 
 ITEM_20150729_005868	Lv3 EXP Card (Deletion)
@@ -7065,7 +7065,7 @@ ITEM_20151001_007064	Damp Piece of Paper
 ITEM_20151001_007065	Only obtainable by killing monsters.
 ITEM_20151001_007066	This will help you find sacred items.
 ITEM_20151001_007067	Glass Bottle with Ink
-ITEM_20151001_007068	A special ink contained within a glass bottle. This special ink was vital for important documents. When important documents needed to be hidden, this ink was used. It's been tossed away and buried since the Medis Diena.
+ITEM_20151001_007068	A special ink contained within a glass bottle. This special ink was vital for important documents. When important documents needed to be hidden, this ink was used. It's been tossed away and buried since Medis Diena.
 ITEM_20151001_007069	
 ITEM_20151001_007070	
 ITEM_20151001_007071	Trap

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -2687,7 +2687,7 @@ QUEST_20151001_002694	A false revelation.. Are you using it to lure me?{nl}It's 
 QUEST_20151001_002695	But, you can't do anything for me with your preparation.{nl}I'm smiling because of your foolishness and your gap of absolute power.
 QUEST_20151001_002696	Good. I can feel the real revelation place.{nl}Once again, trying to struggle.
 QUEST_20151001_002697	Just here to be hiddend the revelation.
-QUEST_20151001_002698	$Demon Lord Magnox
+QUEST_20151001_002698	$Demon Lord Magnoxd
 QUEST_20151001_002699	The ones who follow the Goddess are always stupid.{nl}Still doesn't know me!{nl}I'm waiting for you guys to come over here by yourself.
 QUEST_20151001_002700	After I defeat you, I will continously disturb the priest until he opens the box himself.
 QUEST_20151001_002701	I was able to retrieve my soul thanks to you.. Isn't this the reverting chain that shredded my soul?

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -118,7 +118,7 @@ QUEST_20150317_000117	Supply Base Soldier
 QUEST_20150317_000118	I've never been in a real fight before so I'm a bit nervous.
 QUEST_20150317_000119	Farm Sentinel
 QUEST_20150317_000120	My colleague is in the middle of a battle at the Miners' Village. {nl}I've thought of going to help, but the Eastern Woods is in trouble as well, so all I can do is worry.
-QUEST_20150317_000121	I think this mission's shown me enough monsters for a lifetime. {nl}It used to be just groups of Vubbes.
+QUEST_20150317_000121	I think this mission has shown me enough monsters for a lifetime. {nl}It used to be just groups of Vubbes.
 QUEST_20150317_000122	{memo X}Chupacabras are fond of the streams and lush vegetation of the northern area.
 QUEST_20150317_000123	Klaipeda Guard Captain
 QUEST_20150317_000124	You're the…
@@ -1979,8 +1979,8 @@ QUEST_20150428_001982	{memo X}$Dina Bee Farm is in danger of monster attacks. {n
 QUEST_20150511_001983	$It's better to use the cable car than to fight past the monsters.
 QUEST_20150511_001984	$Just don't believe everything he says. {nl}He was known for being quite the show-off back at home.
 QUEST_20150511_001985	$It would be nice if all these Revelators being here meant that the Goddesses are back.
-QUEST_20150511_001986	$Power is the most important stat for swordsmen. {nl}You could also train yourself to be agile and possess strong stamina. {nl}You should take a moment to decide on what to prioritize from now on.
-QUEST_20150511_001987	$Power is the most important stat for archers. {nl}But, of course you can't ignore agile movement. {nl}You should take a moment to decide on what to prioritize from now on.
+QUEST_20150511_001986	$Strength is the most important stat for swordsmen. {nl}You could also train yourself to be agile and possess strong stamina. {nl}You should take a moment to decide on what to prioritize from now on.
+QUEST_20150511_001987	$Strength is the most important stat for archers. {nl}But, of course you can't ignore agile movement. {nl}You should take a moment to decide on what to prioritize from now on.
 QUEST_20150511_001988	$Intelligence is the most important stat for clerics. {nl}But sometimes you may need more strength or a stronger spirit. {nl}You should take a moment to decide what to prioritize from now on.
 QUEST_20150511_001989	$Helping reconstruct Fedimian may be more meaningful than pottery. {nl}But people need something to soothe their hearts.
 QUEST_20150511_001990	$If I had the diary, I could continue my adventure, but I wasn't chosen… {nl}But for you things might be different…
@@ -2687,7 +2687,7 @@ QUEST_20151001_002694	A false revelation.. Are you using it to lure me?{nl}It's 
 QUEST_20151001_002695	But, you can't do anything for me with your preparation.{nl}I'm smiling because of your foolishness and your gap of absolute power.
 QUEST_20151001_002696	Good. I can feel the real revelation place.{nl}Once again, trying to struggle.
 QUEST_20151001_002697	Just here to be hiddend the revelation.
-QUEST_20151001_002698	$Demon Lord Magnoxd
+QUEST_20151001_002698	$Demon Lord Magnox
 QUEST_20151001_002699	The ones who follow the Goddess are always stupid.{nl}Still doesn't know me!{nl}I'm waiting for you guys to come over here by yourself.
 QUEST_20151001_002700	After I defeat you, I will continously disturb the priest until he opens the box himself.
 QUEST_20151001_002701	I was able to retrieve my soul thanks to you.. Isn't this the reverting chain that shredded my soul?

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -2395,7 +2395,7 @@ QUEST_20150908_002402	{memo X}Obtained the wood
 QUEST_20150918_002403	There are no missions for today.
 QUEST_20150918_002404	$There are only missions that seem difficult to you.{nl} Please come again another time.
 QUEST_20150918_002405	Historic Site Ruins
-QUEST_20150918_002406	Historic Site Ruins (Recommended LV : 90). Only you and your party members can enter together.{nl}Are you sure you want to enter?
+QUEST_20150918_002406	Historic Site Ruins (Recommended Lv : 90){nl}Only you and your party members can enter together.{nl}Are you sure you want to enter?
 QUEST_20150918_002407	Right. Goddess Laima is the strangest of them all.{nl}No one knows when she disappeared. To be honest, I don't know if she really is a Goddess.{nl}
 QUEST_20150918_002408	Even if they say the world is doomed, our soldiers will guard this place until the end. {nl}However, we won't be responsible for you getting yourself into trouble, so be careful.
 QUEST_20150918_002409	${memo Uska is a knight}Welcome. Sir Uska is waiting for you in the central square of Klaipeda. {nl}Well, is there anything that you are unsure of?
@@ -2437,21 +2437,21 @@ QUEST_20150918_002444	$Let's check the barrel over there.
 QUEST_20150918_002445	Looks like there is something like a wing of a Goddess Statue over there.
 QUEST_20150918_002446	Huh? How did you get up here?
 QUEST_20151001_002447	Amazing.{nl}It must be created 100 years ago..{nl}It looks tell you by staying.{nl}
-QUEST_20151001_002448	But, I don't feel any evil energy nor the determination.{nl}So then, this revelation is really Laima's... That's right.{nl}
+QUEST_20151001_002448	But, I don't feel any evil energy nor the determination.{nl}So then, this revelation is really of Goddess Laima's... That's right.{nl}
 QUEST_20151001_002449	We are more surprised about the savior.{nl}
-QUEST_20151001_002450	Among many revelators, the one who can save this world and the goddesses...{nl}The revelation says that you are the savior.{nl}
+QUEST_20151001_002450	Among many Revelators, the one who can save this world and the Goddesses...{nl}The revelation says that you are the savior.{nl}
 QUEST_20151001_002451	You better not tell the world about it.{nl}If you don't want the demons to go look for you.{nl}
-QUEST_20151001_002452	The revelation doesn't want to me mention about the savior I guess.{nl}Okay, please go back to meet Uska.{nl}
-QUEST_20151001_002453	He will tell you where to go.{nl}May the goddess bless you in the future.
-QUEST_20151001_002454	Receptionist Riam
-QUEST_20151001_002455	Which request are you looking for?
+QUEST_20151001_002452	The revelation doesn't want me to mention about the savior, I guess.{nl}Okay, please go back to meet Uska.{nl}
+QUEST_20151001_002453	He will tell you where to go.{nl}May the Goddess bless you in the future.
+QUEST_20151001_002454	Receptionist Liam
+QUEST_20151001_002455	What kind of request are you looking for?
 QUEST_20151001_002456	Please be with someone you can trust.
-QUEST_20151001_002457	We don't have a suitable request.{nl}Please look for it next time.
+QUEST_20151001_002457	We don't have a suitable request for you.{nl}Please look for it next time.
 QUEST_20151001_002458	There's a request that is being progressed.{nl}Come see me again after finishing the request.
-QUEST_20151001_002459	A request can be accepted by the party leader.
-QUEST_20151001_002460	Thorn Vine Forest Dungeon
-QUEST_20151001_002461	You can only enter Thorny Vines Forest (recommended level: 175) with players that are in the same party with you.{nl}Are you going to enter?
-QUEST_20151001_002462	It was a disaster… Many people were either injured or killed. {nl}Once gentle creatures grew fierce and many new monsters emerged.{nl}
+QUEST_20151001_002459	The request can be accepted by the party leader.
+QUEST_20151001_002460	Thorny Vines Forest Dungeon
+QUEST_20151001_002461	Thorny Vines Forest (Recommended Lv : 175){nl}Only you and your party members can enter together.{nl}Do you want to enter?
+QUEST_20151001_002462	It was a disaster… Many people were either injured or killed. {nl}Gentle creatures grew fierce and many new monsters emerged.{nl}
 QUEST_20151001_002463	I think the best weapons and the armors are the ones that you get used to over a long period time. In order to do so, you must start first by buying good items.
 QUEST_20151001_002464	The things I sell are good both in price and quality.
 QUEST_20151001_002465	A lot of people seem to be coming thanks to Sir Uska's recruitment notice.{nl}Take a look around slowly without feeling pressure.
@@ -2664,34 +2664,34 @@ QUEST_20151001_002671
 QUEST_20151001_002672	
 QUEST_20151001_002673	
 QUEST_20151001_002674	
-QUEST_20151001_002675	This land got blessing by Zemyna, so they thought they should make a will of the Goddess.{nl}How can I stop it.
+QUEST_20151001_002675	This land is blessed by Goddess Zemyna, so they thought they should make a will of the Goddess.{nl}How can I stop it.
 QUEST_20151001_002676	Fake Box
-QUEST_20151001_002677	Not this box
-QUEST_20151001_002678	It is not enough to destory the holy relics of the church order, you did release Karail..{nl}
+QUEST_20151001_002677	It doesn't seem to be this box.
+QUEST_20151001_002678	It is not enough to destroy the holy relics of the church order, you did release Karail..{nl}
 QUEST_20151001_002679	You have to pay your life!
 QUEST_20151001_002680	Truth Token
 QUEST_20151001_002681	The divine energy decreased when the truth token was lighting.
-QUEST_20151001_002682	The mysterious girn shown up with light. Let's talk.
-QUEST_20151001_002683	The mysterious girl run without any comments. Follow her.
+QUEST_20151001_002682	The mysterious girl with the light has appeared. Talk to her.
+QUEST_20151001_002683	The mysterious girl ran away without saying anything. Follow her.
 QUEST_20151001_002684	Suspicous Basket
-QUEST_20151001_002685	An offensive smell greeted my nose. It seems old foods.
-QUEST_20151001_002686	The mysterious girl shown with the light again.
-QUEST_20151001_002687	Welcome! There is no time!{nl} My strength is to here!
+QUEST_20151001_002685	The offensive smell is unpleasant to your nose. It seems to be old food after it was hidden.
+QUEST_20151001_002686	The mysterious girl with the light has appeared once again.
+QUEST_20151001_002687	Welcome! There is no time!{nl} My strength is over here!
 QUEST_20151001_002688	Aldona! Giderone!{nl}Now!
-QUEST_20151001_002689	Aldona and Giderone..{nl}I'm sorry for burdened you due to the feebleness.{nl}
-QUEST_20151001_002690	But time is not enoug.{nl}You guys brought the Revelator.. He has a power to remove the disaster at here.{nl}
-QUEST_20151001_002691	I will ask a revelator to help me.{nl}You guys shoud to ready to make the key of evening sky quickly.{nl}
+QUEST_20151001_002689	Aldona and Giderone..{nl}I'm sorry for being a burden to you because of my feebleness.{nl}
+QUEST_20151001_002690	However, let's not waste any time.{nl}You brought the Savior.. who has the power to get rid of this disaster here.{nl}
+QUEST_20151001_002691	I will ask the Savior to help me.{nl}You guys should be ready to quickly make the Evening Star Key.{nl}
 QUEST_20151001_002692	The many deaths of demons could not fill the emptiness in my heart. {nl}Once the Goddess's great mission for me is over, I will be left with a long life full of boring moments.
-QUEST_20151001_002693	Damn, I thought it would die after getting its throat cut.{nl}I hope it can just behave and die slowly now.
-QUEST_20151001_002694	Lie revelation..you want to lure me just using it?{nl}It's so worried the preparation what Laima was prepared at best.
-QUEST_20151001_002695	But, you can't do anything for me with the your preparation.{nl}I smile since your foolish that the gap of strengthen absoultely.
+QUEST_20151001_002693	Ugh, I thought it would die after getting its throat cut.{nl}I hope it can just behave now and die slowly.
+QUEST_20151001_002694	A false revelation.. Are you using it to lure me?{nl}It's so worried the preparation what Laima was prepared at best.
+QUEST_20151001_002695	But, you can't do anything for me with your preparation.{nl}I'm smiling because of your foolishness and your gap of absolute power.
 QUEST_20151001_002696	Good. I can feel the real revelation place.{nl}Once again, trying to struggle.
 QUEST_20151001_002697	Just here to be hiddend the revelation.
-QUEST_20151001_002698	Morch Marknox
-QUEST_20151001_002699	All guys who followed Goddess are always foolish{nl}Still doesn't know me!{nl}I'm waiting you guys come here yourself.
-QUEST_20151001_002700	After defeating you, I will continously disturb the priest untill opening the box himself.
-QUEST_20151001_002701	I was able to gather my soul thanks to you.. Isn't this the reverting chain that shredded my soul?
-QUEST_20151001_002702	Obtaing the shiny moss!
-QUEST_20151001_002703	Obtained the shiny moss!
+QUEST_20151001_002698	$Demon Lord Magnox
+QUEST_20151001_002699	The ones who follow the Goddess are always stupid.{nl}Still doesn't know me!{nl}I'm waiting for you guys to come over here by yourself.
+QUEST_20151001_002700	After I defeat you, I will continously disturb the priest until he opens the box himself.
+QUEST_20151001_002701	I was able to retrieve my soul thanks to you.. Isn't this the reverting chain that shredded my soul?
+QUEST_20151001_002702	Collecting the Shiny Moss
+QUEST_20151001_002703	Obtained Shiny Moss!
 QUEST_20151001_002704	Failed to obtain the moss!
-QUEST_20151001_002705	Obtained the nazi mushroom!
+QUEST_20151001_002705	Obtained Nachi Mushroom!

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -2683,12 +2683,12 @@ QUEST_20151001_002690	However, let's not waste any time.{nl}You brought the Savi
 QUEST_20151001_002691	I will ask the Savior to help me.{nl}You guys should be ready to quickly make the Evening Star Key.{nl}
 QUEST_20151001_002692	The many deaths of demons could not fill the emptiness in my heart. {nl}Once the Goddess's great mission for me is over, I will be left with a long life full of boring moments.
 QUEST_20151001_002693	Ugh, I thought it would die after getting its throat cut.{nl}I hope it can just behave now and die slowly.
-QUEST_20151001_002694	A false revelation.. Are you using it to lure me?{nl}It's so worried the preparation what Laima was prepared at best.
-QUEST_20151001_002695	But, you can't do anything for me with your preparation.{nl}I'm smiling because of your foolishness and your gap of absolute power.
+QUEST_20151001_002694	A false prophecy.. all this so you can lure me out to get rid of me?{nl}It's disappointing to see that such trickery is the best Lamia can prepare.
+QUEST_20151001_002695	But for all you preparations, you are powerless against me..{nl}It's amusing how your foolishness blinds you from the insurmountable gap of power between us.
 QUEST_20151001_002696	Good. I can feel the real revelation place.{nl}Once again, trying to struggle.
 QUEST_20151001_002697	Just here to be hiddend the revelation.
 QUEST_20151001_002698	$Demon Lord Magnox
-QUEST_20151001_002699	The ones who follow the Goddess are always stupid.{nl}Still doesn't know me!{nl}I'm waiting for you guys to come over here by yourself.
+QUEST_20151001_002699	Such is the fools who follow the Goddess..{nl}Have you not witnessed enough to know me?{nl}All this time I've been waiting for you all to come at your own will.
 QUEST_20151001_002700	After I defeat you, I will continously disturb the priest until he opens the box himself.
 QUEST_20151001_002701	I was able to retrieve my soul thanks to you.. Isn't this the reverting chain that shredded my soul?
 QUEST_20151001_002702	Collecting the Shiny Moss

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -567,10 +567,10 @@ QUEST_20150317_000566	Warning
 QUEST_20150317_000567	This is the entrance to Kateen Forest. {nl}Travelling is ill-advised because of the vicious monsters inhabiting the area.
 QUEST_20150317_000568	We're carrying out the plan to get through the Gate Route. {nl}Dangerous monsters are showing up so pedestrians should be careful. {nl} - Commander Julian
 QUEST_20150317_000569	There are rumors that ghosts show up, so please refrain from passing through.
-QUEST_20150317_000570	$You are entering the Thorn Forest Area from here on. {nl}It is very dangerous so please refrain from passing through. {nl} - Liaison Niels
+QUEST_20150317_000570	$You are entering the Thorn Forest area from here on. {nl}It is very dangerous so please refrain from passing through. {nl} - Liaison Officer Niels
 QUEST_20150317_000571	Warning! Keep out! {nl}Your safety is not guaranteed.
 QUEST_20150317_000572	Warning! Keep out! {nl}Stay away if you want to live.
-QUEST_20150317_000573	Restricted Area. {nl}This area is restricted due to cursed stones and dangerous monsters. {nl} - Commander Venas
+QUEST_20150317_000573	Restricted Area. {nl}This area is restricted due to cursed stones and dangerous monsters. {nl} - Commander Benas
 QUEST_20150317_000574	{memo X}Wife of a Refugee Family
 QUEST_20150317_000575	{memo X}I took refuge, following my husband, but it's scarier than I thought.
 QUEST_20150317_000576	Old Man of a Refugee Family
@@ -1020,7 +1020,7 @@ QUEST_20150317_001019	I can feel Laima's power.
 QUEST_20150317_001020	{memo X}The pain I haven't felt for a long time...
 QUEST_20150317_001021	{memo X}Even so, I will not waste my power on you.
 QUEST_20150317_001022	{memo X}I guess the real revelation is in the chapel? {nl}That Laima could only prepare this much. Such a pity.
-QUEST_20150317_001023	This is the Crest of Space...
+QUEST_20150317_001023	This is the Seal of Space...
 QUEST_20150317_001024	We will need the Revelator.
 QUEST_20150317_001025	The Revelator came here alone. {nl}Exactly what I wanted.
 QUEST_20150317_001026	{memo X}For what purpose did you come to this cursed city? {nl}Please go back if you don't have a particular purpose.
@@ -1987,7 +1987,7 @@ QUEST_20150511_001990	$If I had the diary, I could continue my adventure, but I 
 QUEST_20150511_001991	{memo X}$If you cleverly use the dry air that forms around areas of severe cold, you'd be able to freeze any object even in a desert. {nl}However, if you can't receive the blessing from the Goddess, it won't be possible to make that kind of air.
 QUEST_20150511_001992	$I'll report the damages. {nl}Chasing a Sparnas, a gigantic bird-type creature, will be hard. Despite being large, they are rather agile. {nl}It usually goes after the supplies, but I can't imagine nor find out why. I'm guessing someone's playing a trick.
 QUEST_20150511_001993	$Grain pocket was discovered in the ashes of the supplies. {nl}They smell so bad and old they can't be used for food at all. {nl}Please check the supplies for anything missing.
-QUEST_20150511_001994	$Defeat all the monsters nearby. {nl}The vicious energy in the vine forest is constantly creating new monsters. {nl}But you should first defeat most of them before you face Ironbaum. {nl}Even a small factor could ruin the big task. {nl}Also, you could try threatening the monsters so they can't do what they want to do.
+QUEST_20150511_001994	$Defeat all the monsters nearby. {nl}The vicious energy in the thorn forest is constantly creating new monsters. {nl}But you should first defeat most of them before you face Ironbaum. {nl}Even a small factor could ruin the big task. {nl}Also, you could try threatening the monsters so they can't do what they want to do.
 QUEST_20150511_001995	$(Everything is scribbled so poorly that they can't be distinguished from letters or drawings.)
 QUEST_20150511_001996	$The facility that belonged to the workers who worked on the Mausoleum of Zachariel suddenly shut down. {nl}It's not like they left because finishing it was hopeless, but they just vanished all at once. {nl}Maybe it is related to the irregularly big size of the tomb and its complicated composition {nl}even after considering the fact that it was the grave to commemorate the greatest king in history.
 QUEST_20150511_001997	$King Zachariel had made many arrangements for future generations. {nl}We and the Jonas family were one of them. {nl}But the meaning of the arrangements is only known by the Goddess. {nl}At least we know that the will of the king that we are protecting and the secret of the tomb indicates one person.

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -565,7 +565,7 @@ QUEST_20150317_000564	Compass
 QUEST_20150317_000565	Select Information
 QUEST_20150317_000566	Warning
 QUEST_20150317_000567	This is the entrance to Kateen Forest. {nl}Travelling is ill-advised because of the vicious monsters inhabiting the area.
-QUEST_20150317_000568	We're carrying out the plan to get through the Gate Route. {nl}Dangerous monsters are showing up so pedestrians should be careful. {nl} - Commander Julian
+QUEST_20150317_000568	We are carrying out the plan to get through the Gate Route. {nl}Dangerous monsters are showing up, so pedestrians should be careful. {nl} - Commander Julian
 QUEST_20150317_000569	There are rumors that ghosts show up, so please refrain from passing through.
 QUEST_20150317_000570	$You are entering the Thorn Forest area from here on. {nl}It is very dangerous so please refrain from passing through. {nl} - Liaison Officer Niels
 QUEST_20150317_000571	Warning! Keep out! {nl}Your safety is not guaranteed.
@@ -674,14 +674,14 @@ QUEST_20150317_000673	Magic, at the beginning, began from the investigation of m
 QUEST_20150317_000674	After that, the basic senses, religious belief of the Goddess, {nl}and mathematical approaches were mixed to find areas for expansion.
 QUEST_20150317_000675	The research twisted previous notions of time and space, {nl}which were beyond the changes of the body, {nl}and the rules of physics and the elements progressed significantly.
 QUEST_20150317_000676	The Report of the High Barrier Magic
-QUEST_20150317_000677	The barrier in this tower could not have possibly been created by the demon lord.
+QUEST_20150317_000677	The barrier in this tower could not have possibly been created by the Demon Lord.
 QUEST_20150317_000678	It is like a tight-knit net. {nl}Someone with a normal level of divine power cannot escape from it.
 QUEST_20150317_000679	For what reason was this barrier created?{nl}Is it related to the fact that the Goddess who controls the flames of this world is staying here?
 QUEST_20150317_000680	Agailla Flurry called Gabija to this tower, so this barrier is not meant to lock Gabija in. {nl}To find out the reason for this, we first have to understand the composition of the barrier.
 QUEST_20150317_000681	After a long investigation, we've found that this barrier was {nl}not only created by the power of Helgasercle, but also with other kinds of mana.
 QUEST_20150317_000682	We've also found that mana was composed by aligning the foundation stones in a certain position.
 QUEST_20150317_000683	We were able to retrieve some of those foundation stones from various areas in the kingdom. {nl}The new information that we found here with them was astonishing.
-QUEST_20150317_000684	The mana provided to use barrier magic wasn't voluntary. {nl}We theorize that the levels of the demon lords were divided and sealed into the foundation stones and aligned into a position.
+QUEST_20150317_000684	The mana provided to use barrier magic wasn't voluntary. {nl}We theorize that the levels of the Demon Lords were divided and sealed into the foundation stones and aligned into a position.
 QUEST_20150317_000685	The key to unlock this barrier is in the foundation. {nl}We'll continue to search for the answer after we block Helgasercle's invasion.
 QUEST_20150317_000686	The Understanding of Mana
 QUEST_20150317_000687	Unlike priests who control the blessing of the Goddess directly, {nl}the wizard is defined as a person who releases various magic information or the blessing of the Goddess.
@@ -1572,11 +1572,11 @@ QUEST_20150323_001572	{memo X}$Ready? Another group will be coming soon.
 QUEST_20150323_001573	Demon Lord Hauberk
 QUEST_20150323_001574	{memo X}$You must have a lot of questions. Ask, Revelator…
 QUEST_20150323_001575	{memo X}$Vakarine is fighting Valtrus in the Demon Prison across the portal. {nl}She won't be able hold it for much longer unless someone helps.
-QUEST_20150323_001576	{memo X}$Men under the command of the Baron have been here though they weren't able to make it back. {nl}I watched everything with the wizard's eyes. {nl}Even the screams of Vakarine and her Cupols.
+QUEST_20150323_001576	{memo X}$Men under the command of the Baron have been here though they weren't able to make it back. {nl}I watched everything with the wizard's eyes. {nl}Even the screams of Vakarine and her Kupoles.
 QUEST_20150323_001577	{memo X}$That depends on whether or not you have the will to save the Goddess. {nl}We can take time to talk about it. 
 QUEST_20150323_001578	{memo X}$The limbs of Nuaelle were all cut off. {nl}Now go find Aldona. {nl}She will take you and Hauberk to Nuaelle's territory.
 QUEST_20150323_001579	$We're entering Nuaelle's area now. {nl}Get ready. 
-QUEST_20150323_001580	{memo X}$Once Nuaelle is gone, we'll be able to fight the demons easily even with only the Cupols. 
+QUEST_20150323_001580	{memo X}$Once Nuaelle is gone, we'll be able to fight the demons easily even with only the Kupoles. 
 QUEST_20150323_001581	{memo X}$Our biggest problem aside from the corruption breach was Nuaelle. {nl}Now we can focus on the former. {nl}Go to Prison District 3. The Goddess awaits your support.
 QUEST_20150323_001582	$Keep your guard up. {nl}It's the secret to the last key but the demons are still watching.
 QUEST_20150323_001583	$You will enter the special room once you get all five keys of Maven. {nl}In there, you will be tested to see if you're eligible for the revelation. 
@@ -1740,7 +1740,7 @@ QUEST_20150401_001741	$I feel dizzy. Is the medicine working?
 QUEST_20150401_001742	Feels like the hunger went away.
 QUEST_20150401_001743	$You must have a lot of questions. Ask, Revelator…
 QUEST_20150401_001744	$Vakarine is fighting Valtrus in the Demon Prison across the portal. {nl}She won't be able hold it for much longer unless someone helps.
-QUEST_20150401_001745	{memo X}$Men under the command of the Baron have been here though they weren't able to make it back. {nl}I watched everything with the wizard's eyes. {nl}Even the screams of Vakarine and her Cupols.
+QUEST_20150401_001745	{memo X}$Men under the command of the Baron have been here though they weren't able to make it back. {nl}I watched everything with the wizard's eyes. {nl}Even the screams of Vakarine and her Kupoles.
 QUEST_20150401_001746	{memo X}$That depends on whether or not you have the will to save the Goddess. {nl}We can take time to talk about it. 
 QUEST_20150401_001747	{memo X}$I hear the demons that crossed the corruption breach are gathered in Ausros Chapel. {nl}I wish you luck in the name of the Goddess. 
 QUEST_20150401_001748	Royal Mausoleum Construction Fee
@@ -1820,7 +1820,7 @@ QUEST_20150414_001823	$It's no joke.
 QUEST_20150414_001824	{memo X}$Someone's Memo
 QUEST_20150414_001825	{memo X}$This place is insane. {nl}The only way to get rid of this cursed Tree Root Crystal is to burn the place down. {nl}It should all be burned.
 QUEST_20150414_001826	$The Baron's greed had him send his men into this area. {nl}None of them made it back.
-QUEST_20150414_001827	$I watched everything with the wizard's eyes. {nl}Even the screams of Vakarine and her Cupols. 
+QUEST_20150414_001827	$I watched everything with the wizard's eyes. {nl}Even the screams of Vakarine and her Kupoles. 
 QUEST_20150414_001828	$That depends on whether or not you have the will to save the Goddess. {nl}We can take time to talk about it. 
 QUEST_20150414_001829	$Isn't there a more effective way to block the monsters?
 QUEST_20150414_001830	$Freshly cultivating the farm isn't easy though at least there are less monsters than before.
@@ -1962,13 +1962,13 @@ QUEST_20150428_001965	$The Diary of Baron Soldier, Chagos
 QUEST_20150428_001966	$The magician, who appeared from somewhere, told the ignorant baron that the object is located here.
 QUEST_20150428_001967	$The way to eternal youth. {nl}I can't find the way there: the place where only death awaits.
 QUEST_20150428_001968	$The Crumbling Document
-QUEST_20150428_001969	$The demon lord, Helgasercle, divided the spirit of the demon lord, Hauberk. {nl}This was used to power the barrier that now surrounds the Mage Tower and then was scattered throughout the kingdom.
+QUEST_20150428_001969	$The Demon Lord, Helgasercle, divided the spirit of the Demon Lord, Hauberk. {nl}This was used to power the barrier that now surrounds the Mage Tower and then was scattered throughout the kingdom.
 QUEST_20150428_001970	$Many magicians came to break the barrier, but they could not succeed with just the foundations stones that were gathered at the tower.
 QUEST_20150428_001971	$To all adventurers of the kingdom, {nl}the Mage Tower offers gold to those who bring back the fragments of Hauberk's spirit.
 QUEST_20150428_001972	$The Order to Defeat the Demons
 QUEST_20150428_001973	$I hereby order in the name of Vakarine! {nl}After Medis Diena, they can no longer be forgiven. {nl}They are trying to expand their power by penetrating into the crack that was created in the barrier.
-QUEST_20150428_001974	$All the Cupols here shall defeat demon lords Boolut, Nuaelle, and Baltrus first. {nl}The enemy will panic without their commanders and will be easier to defeat.
-QUEST_20150428_001975	$Cupols who can't attack should concentrate on blocking the crack. {nl}We can't allow more demons from going to the demon lords.
+QUEST_20150428_001974	$All the Kupoles here shall defeat Demon Lords Boolut, Nuaelle, and Baltrus first. {nl}The enemy will panic without their commanders and will be easier to defeat.
+QUEST_20150428_001975	$Kupoles who can't attack should concentrate on blocking the crack. {nl}We can't allow more demons from going to the Demon Lords.
 QUEST_20150428_001976	$How should I live from now on? {nl}I should have moved to Klaipeda.
 QUEST_20150428_001977	{memo X}$Since you've placed them into the inventory, you can read them anytime.
 QUEST_20150428_001978	$Mirtis' power was so overwhelming that Cunningham had to make an important decision.

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -2683,7 +2683,7 @@ QUEST_20151001_002690	However, let's not waste any time.{nl}You brought the Savi
 QUEST_20151001_002691	I will ask the Savior to help me.{nl}You guys should be ready to quickly make the Evening Star Key.{nl}
 QUEST_20151001_002692	The many deaths of demons could not fill the emptiness in my heart. {nl}Once the Goddess's great mission for me is over, I will be left with a long life full of boring moments.
 QUEST_20151001_002693	Ugh, I thought it would die after getting its throat cut.{nl}I hope it can just behave now and die slowly.
-QUEST_20151001_002694	A false prophecy.. all this so you can lure me out to get rid of me?{nl}It's disappointing to see that such trickery is the best Lamia can prepare.
+QUEST_20151001_002694	A false revelation.. all this so you can lure me out to get rid of me?{nl}It's disappointing to see that such trickery is the best Lamia can prepare.
 QUEST_20151001_002695	But for all you preparations, you are powerless against me..{nl}It's amusing how your foolishness blinds you from the insurmountable gap of power between us.
 QUEST_20151001_002696	Good. I can feel the real revelation place.{nl}Once again, trying to struggle.
 QUEST_20151001_002697	Just here to be hiddend the revelation.

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -25,7 +25,7 @@ QUEST_JOBSTEP_20150317_000024	{memo X}This will be enough. {nl}My magic is not e
 QUEST_JOBSTEP_20150317_000025	Your will to learn from me is good, but first I have a favor to ask. {nl}We can continue our talk if you say you're up to it. {nl}
 QUEST_JOBSTEP_20150317_000026	Lydia Schaffen's stuff is like divine materials to us archers. {nl}I would give up everything just to have it.
 QUEST_JOBSTEP_20150317_000027	I never imagined that I would see this myself. {nl}Thank you. I will teach you thoroughly from now on, so you better be prepared. 
-QUEST_JOBSTEP_20150317_000028	I heard the lost telescope lens from Star Tower is in the 1st floor of the Crystal Mine. {nl}Get me that lens before the other masters find out and I'll teach you my skills. 
+QUEST_JOBSTEP_20150317_000028	I heard the lost telescope lens from the Star Tower is in the 1st floor of the Crystal Mine. {nl}Get me that lens before the other masters find out and I'll teach you my skills. 
 QUEST_JOBSTEP_20150317_000029	{memo X}So you want to learn the way of the arrow from me...Then I have a mission for you. {nl}I will base my decision on how well you accomplish the mission. 
 QUEST_JOBSTEP_20150317_000030	Evoniphon...I will never forgive him.
 QUEST_JOBSTEP_20150317_000031	Hunter Master
@@ -406,7 +406,7 @@ QUEST_JOBSTEP_20150317_000405	You need to show your bravery if you want to learn
 QUEST_JOBSTEP_20150317_000406	Are you brave enough to turn the enemy's blade to you when your allies are in danger?
 QUEST_JOBSTEP_20150317_000407	I can picture them full of anger. {nl}You've passed the test. You're good enough to learn from me.
 QUEST_JOBSTEP_20150317_000408	{memo X}You want to learn from me? Then there's something you should do for me. {nl}Teach the Hackapell Master who believes that there's something in the world that can't be penetrated.
-QUEST_JOBSTEP_20150317_000409	{memo X}The spear is unbeatable and invincible. {nl}I want to see the face of poor Shadow Gaoler when it's defeated.
+QUEST_JOBSTEP_20150317_000409	{memo X}The spear is unbeatable and invincible. {nl}I want to see the face of poor Shadowgaler when it's defeated.
 QUEST_JOBSTEP_20150317_000410	{memo X}If that fellow asks, I'll proudly tell him that our skilled Hoplite took it down. {nl}I will acknowledge you with this.
 QUEST_JOBSTEP_20150317_000411	{memo X}You want to learn from me? {nl}Then you have to pass a test. {nl}
 QUEST_JOBSTEP_20150317_000412	{memo X}I heard the other Masters are sending their disciples to defeat Yekub in the Cathedral. {nl}But that is what you must bring an end to. Go now.
@@ -1338,7 +1338,7 @@ QUEST_JOBSTEP_20150317_001337	Collected all the books for the Ranger Master. Tal
 QUEST_JOBSTEP_20150317_001338	Talk to Sculptor Tesla
 QUEST_JOBSTEP_20150317_001339	{memo X}Meet Sculptor Tesla at Rhombuspaving Dale.
 QUEST_JOBSTEP_20150317_001340	Defeat Yekub and get Blue Crystal
-QUEST_JOBSTEP_20150317_001341	Sculptor Tesla says he'll help you become Dievdirbys if you get him sculpting materials. Get Blue Crystal from the Yekub in Crystal Mine 2nd Floor.
+QUEST_JOBSTEP_20150317_001341	Sculptor Tesla says he'll help you become a Dievdirbys if you get him sculpting materials. Get Blue Crystal from the Yekub in Crystal Mine 2F.
 QUEST_JOBSTEP_20150317_001342	Give Blue Crystal to Sculptor Tesla
 QUEST_JOBSTEP_20150317_001343	Found the Blue Crystal Tesla wanted. Take it to him.
 QUEST_JOBSTEP_20150317_001344	Defeat Yekub and get %s
@@ -1732,7 +1732,7 @@ QUEST_JOBSTEP_20150317_001731	Go to the Ranger Master
 QUEST_JOBSTEP_20150317_001732	Meet the Ranger Master in Klaipeda
 QUEST_JOBSTEP_20150317_001733	Extract the fluids from Moyas at the Great Cathedral
 QUEST_JOBSTEP_20150317_001734	The Ranger Master says he'll teach you if you help him. Collect fluid samples from Moyas hiding in the Cathedral.
-QUEST_JOBSTEP_20150317_001735	Deliver to the Ranger Master
+QUEST_JOBSTEP_20150317_001735	Deliver it to the Ranger Master
 QUEST_JOBSTEP_20150317_001736	Collect fluid samples of Moya. Give it to the Ranger Master.
 QUEST_JOBSTEP_20150317_001737	Monster Fluid
 QUEST_JOBSTEP_20150317_001738	Find the Sapper Master
@@ -1757,7 +1757,7 @@ QUEST_JOBSTEP_20150317_001756	Go to the Wugushi Master
 QUEST_JOBSTEP_20150317_001757	{memo X}Meet the Wugushi Master in Fedimian
 QUEST_JOBSTEP_20150317_001758	{memo X}Collect the composite poison
 QUEST_JOBSTEP_20150317_001759	{memo X}The Wugushi Master gave you an assignment to collect the poison. Collect the poison from Stoulets in the Great Cathedral using temporal tube.
-QUEST_JOBSTEP_20150317_001760	Deliver to the Wugushi Master
+QUEST_JOBSTEP_20150317_001760	Deliver it to the Wugushi Master
 QUEST_JOBSTEP_20150317_001761	Gathered enough combined poison. Give it to the Wugushi Master,
 QUEST_JOBSTEP_20150317_001762	Get Combined Poison
 QUEST_JOBSTEP_20150317_001763	Go to the Scout Master
@@ -1770,7 +1770,7 @@ QUEST_JOBSTEP_20150317_001769	{memo X}Defeat the monsters
 QUEST_JOBSTEP_20150317_001770	Go to the Quarrel Shooter Master
 QUEST_JOBSTEP_20150317_001771	Get the rubbings of Lydia Schaffen's Gravestone
 QUEST_JOBSTEP_20150317_001772	The Quarrel Shooter Master wants the rubbings of Lydia Schaffen's Gravestone as a test. Get it from the Courtyard of the Goddess.
-QUEST_JOBSTEP_20150317_001773	Deliver to the Master Quarrelsooter Master
+QUEST_JOBSTEP_20150317_001773	Deliver it to the Master Quarrel Shooter Master
 QUEST_JOBSTEP_20150317_001774	Got the rubbings. Give it to the Quarrel Shooter Master
 QUEST_JOBSTEP_20150317_001775	Go to the Rogue Master
 QUEST_JOBSTEP_20150317_001776	Go to the Rogue Master in Fedimian
@@ -1780,11 +1780,11 @@ QUEST_JOBSTEP_20150317_001779	Report to the Rogue Master
 QUEST_JOBSTEP_20150317_001780	You passed all the test from the Rogue Master. Report back to the Rogue Master.
 QUEST_JOBSTEP_20150317_001781	Go to the Hoplite Master
 QUEST_JOBSTEP_20150317_001782	Find the Hoplite Master in West Siauliai Woods.
-QUEST_JOBSTEP_20150317_001783	{memo X}Defeat Shadow Gaoler in the main chamber of the Great Cathedral
-QUEST_JOBSTEP_20150317_001784	{memo X}Before you learn from the Hoplite Master, he wants you to defeat Shadow Gaoler before the Hackapell Master. As she wishes, defeat Shadow Gaoler in the main chamber of the Great Cathedral and return.
+QUEST_JOBSTEP_20150317_001783	{memo X}Defeat Shadowgaler in the main chamber of the Great Cathedral
+QUEST_JOBSTEP_20150317_001784	{memo X}Before you learn from the Hoplite Master, he wants you to defeat Shadowgaler before the Hackapell Master. As she wishes, defeat Shadowgaler in the main chamber of the Great Cathedral and return.
 QUEST_JOBSTEP_20150317_001785	Report to the Hoplite Master
-QUEST_JOBSTEP_20150317_001786	You have defeated Shadow Gaoler. Report back to the Hoplite Master.
-QUEST_JOBSTEP_20150317_001787	Defeat Shadow Gaoler
+QUEST_JOBSTEP_20150317_001786	You have defeated Shadowgaler. Report back to the Hoplite Master.
+QUEST_JOBSTEP_20150317_001787	Defeat Shadowgaler
 QUEST_JOBSTEP_20150317_001788	Meet the Barbarian Master
 QUEST_JOBSTEP_20150317_001789	Talk to the Barbarian Master in East Siauliai Woods
 QUEST_JOBSTEP_20150317_001790	{memo X}Defeat Yekubs in the main chamber of the Great Cathedral
@@ -1879,7 +1879,7 @@ QUEST_JOBSTEP_20150317_001878	Gathered Wildflower Stamen. Give it to the Cleric 
 QUEST_JOBSTEP_20150317_001879	Wildflower Stamen
 QUEST_JOBSTEP_20150317_001880	Retrieve the lost Holy Materials in the Town Center
 QUEST_JOBSTEP_20150317_001881	The Krivis Master says the Holy Materials were stolen during a raid on its way to Fedimian. Find the lost Holy Materials in the Town Center and bring it to the Krivis Master.
-QUEST_JOBSTEP_20150317_001882	Deliver to the Krivis Master
+QUEST_JOBSTEP_20150317_001882	Deliver it to the Krivis Master
 QUEST_JOBSTEP_20150317_001883	Found the lost Holy Materials. Give it to the Krivis Master.
 QUEST_JOBSTEP_20150317_001884	Find %s from the Town Center
 QUEST_JOBSTEP_20150317_001885	Defeat Tutu
@@ -1890,7 +1890,7 @@ QUEST_JOBSTEP_20150317_001889	Removed the source of evil aura in Ruklys Street. 
 QUEST_JOBSTEP_20150317_001890	Remove the Source of Evil Aura
 QUEST_JOBSTEP_20150317_001891	{memo X}Obtain the essences of the petrified whales from Lonesome Marketplace
 QUEST_JOBSTEP_20150317_001892	{memo X}The Bokor Master will test you by checking whether you would be able to bring the essences of the petrified whales. Defeat the petrified whales that roam around in Lonesome Marketplace and bring the essences of the petrified whales.
-QUEST_JOBSTEP_20150317_001893	Deliver to the Bokor Master
+QUEST_JOBSTEP_20150317_001893	Deliver it to the Bokor Master
 QUEST_JOBSTEP_20150317_001894	Got the essence of Stone Whale. Bring it to the Bokor Master.
 QUEST_JOBSTEP_20150317_001895	Defeat Stone Whale and get %s
 QUEST_JOBSTEP_20150317_001896	{memo X}Meet the Sculptor Tesla in Rhombuspaving Dale
@@ -2188,13 +2188,13 @@ QUEST_JOBSTEP_20150317_002187	Vaidotas says learning is not difficult but you ha
 QUEST_JOBSTEP_20150317_002188	Report to Vaidotas
 QUEST_JOBSTEP_20150317_002189	You've defeated the Werewolf. Report back to Vaidotas.
 QUEST_JOBSTEP_20150317_002190	Talk to the Quarrel Shooter Master in Klaipeda.
-QUEST_JOBSTEP_20150317_002191	Find the lens in Crystal Mine 1st Floor.
-QUEST_JOBSTEP_20150317_002192	Quarrel Shooter says he's been looking through the telescope in Star Tower and he found clues to the lens. Go to Crystal Mine 1st Floor and look for the lens.
+QUEST_JOBSTEP_20150317_002191	Find the lens in Crystal Mine 1F
+QUEST_JOBSTEP_20150317_002192	The Quarrel Shooter says he's been looking through the telescope in the Star Tower and he found clues to the lens. Go to Crystal Mine 1F and look for the lens.
 QUEST_JOBSTEP_20150317_002193	Found the lens. Give it to the Quarrel Shooter Master.
-QUEST_JOBSTEP_20150317_002194	Defeat Shadow Gaoler and get %s
+QUEST_JOBSTEP_20150317_002194	Defeat Shadowgaler and get %s
 QUEST_JOBSTEP_20150317_002195	Go to the Ranger Master in Klaipeda.
 QUEST_JOBSTEP_20150317_002196	Collect Bat Venom Sample
-QUEST_JOBSTEP_20150317_002197	The Ranger Master mentioned an assassin named Evonipon and wants the venom sample he used. Collect samples of venoms from the bats in Crystal Mine 1st Floor.
+QUEST_JOBSTEP_20150317_002197	The Ranger Master mentioned an assassin named Evonipon and wants the venom sample he used. Collect samples of venoms from the bats in Crystal Mine 1F.
 QUEST_JOBSTEP_20150317_002198	Colleted all the poison samples needed. Take it to the Ranger Master.
 QUEST_JOBSTEP_20150317_002199	Defeat the bats and get %s
 QUEST_JOBSTEP_20150323_002200	{memo X}The leather of Glizardon and the canine of Galok in Tenet Chapel B1.{nl}And black powders of Egnome from the 2F. Please bring those to me.
@@ -2272,7 +2272,7 @@ QUEST_JOBSTEP_20150323_002271	{memo X}This is the rope to tie people up.{nl}Prac
 QUEST_JOBSTEP_20150323_002272	{memo X}Bitereginas are threatening people at Owls' Village.{nl}What do you think? I want you defeat them as compensation for my lessons.
 QUEST_JOBSTEP_20150323_002273	{memo X}With the name of Master, I should help others around, but I just don't have the time.{nl}Anyways, I will teach you my skills as I promised to you.
 QUEST_JOBSTEP_20150323_002274	{memo X}If you tell me like that, I can tell you there is a solution.{nl}If you could defeat Moas at the outer edge of Fedimian, who destroyed all my ingredients, I will change your turn.
-QUEST_JOBSTEP_20150323_002275	I heard the Hackapell Master will defeat Shadow Gaoler at Owls' Village...{nl}It will be good to see if you could defeat them first.
+QUEST_JOBSTEP_20150323_002275	I heard the Hackapell Master will defeat Shadowgaler at Owls' Village...{nl}It will be good to see if you could defeat them first.
 QUEST_JOBSTEP_20150323_002276	A skilled person like you could defeat Reaverpede at Roxona Marketplace easily.{nl}If you can't do this, I can't accept you as a Ranger applicant.
 QUEST_JOBSTEP_20150323_002277	{memo X}Some idiot baron opened a portal that was connected to the Demons' Prison.{nl}I heard that the demons there keep trying to come out.{nl}
 QUEST_JOBSTEP_20150323_002278	{memo X}Defeat Deadborn which is the most dangerous demon there.{nl}It will be a good hunt, don't you think?
@@ -2435,8 +2435,8 @@ QUEST_JOBSTEP_20150323_002434	Find the hidden monsters using flash bombs and def
 QUEST_JOBSTEP_20150323_002435	{memo X}Find the hidden monsters at Saknis Plains using flash bombs and defeat them.
 QUEST_JOBSTEP_20150323_002436	{memo X}Defeat the detected monsters
 QUEST_JOBSTEP_20150323_002437	The Rogue Master told you that you need to take a test before he can teach you his skills. At the training field of the entrance of Kateen Forest, use smoke bombs to the monsters that are rushing in and defeat them.
-QUEST_JOBSTEP_20150323_002438	Defeat Shadow Gaoler at the Owl Burial Ground
-QUEST_JOBSTEP_20150323_002439	{memo X}The Hoplite Master told you that before you learn a lesson, he wants you to defeat Shadow Gaoler first before the Hackapell Master defeates them. As she requested, defeat Shadow Gaoler at the Owl Burial Ground and come back.
+QUEST_JOBSTEP_20150323_002438	Defeat Shadowgaler at the Owl Burial Ground
+QUEST_JOBSTEP_20150323_002439	{memo X}The Hoplite Master told you that before you learn a lesson, he wants you to defeat Shadowgaler first before the Hackapell Master defeates them. As she requested, defeat Shadowgaler at the Owl Burial Ground and come back.
 QUEST_JOBSTEP_20150323_002440	Defeat Yekub at the Owl Burial Ground
 QUEST_JOBSTEP_20150323_002441	The Barbarian Master wants you to defeat Yekubs faster than anybody. Defeat Yekubs at the Owl Burial Ground.
 QUEST_JOBSTEP_20150323_002442	{memo X}The Squire Master told you that you should continuously practice until the skill becomes yours. Practice the skill against the monsters at Poslinkis Forest.
@@ -2716,7 +2716,7 @@ QUEST_JOBSTEP_20150714_002715	Rogues should be fast.{nl}Fight against the monste
 QUEST_JOBSTEP_20150714_002716	Elusiveness is the most attractive property of Rogue.{nl}With swift movements, Rogue makes it's enemies dizzy.
 QUEST_JOBSTEP_20150714_002717	The perfect stage of Hoplite destroys everything.{nl}Unfortunately, my colleague the Hackapell Master does not believe in such thing.
 QUEST_JOBSTEP_20150714_002718	If you could help instead of me, he will realize something.{nl}How about it?
-QUEST_JOBSTEP_20150714_002719	{memo X}Spears are mighty and never lose.{nl}I want to see the guy's pitiful face after Shadow Gaoler is dead.
+QUEST_JOBSTEP_20150714_002719	{memo X}Spears are mighty and never lose.{nl}I want to see the guy's pitiful face after Shadowgaler is dead.
 QUEST_JOBSTEP_20150714_002720	If the friend asks us, I will tell him that our competent Hoplite defeated it.{nl}You reached the level of a master, but if you need any help, you can come to me.
 QUEST_JOBSTEP_20150714_002721	You want to become the greatest Barbarian.{nl}There's something you should do.{nl}
 QUEST_JOBSTEP_20150714_002722	The other masters sent the disciples to Manacle Grave to eliminate Yekubs.{nl}But, that should be done by you. Destroy them and return.
@@ -2855,7 +2855,7 @@ QUEST_JOBSTEP_20150714_002854	%s of Forest of Prayer
 QUEST_JOBSTEP_20150714_002855	Go to the Wugushi Master in Gateway to Great King
 QUEST_JOBSTEP_20150714_002856	Go to the Scout Master in Gateway to Great King
 QUEST_JOBSTEP_20150714_002857	Use Flares to find the hidden monsters in Apsimesti Crossroads and defeat them.
-QUEST_JOBSTEP_20150714_002858	The Hoplite Master wants you to find and defeat Shadow Gaoler which the Hackapell Master promised to defeat. As she wishes, come back after defeating Shadow Gaoler at Manacle Grave.
+QUEST_JOBSTEP_20150714_002858	The Hoplite Master wants you to find and defeat Shadowgaler which the Hackapell Master promised to defeat. As she wishes, come back after defeating Shadowgaler at Manacle Grave.
 QUEST_JOBSTEP_20150714_002859	The Squire Master asked you to practice Arrest rope as much as you can so you can control it without any problem. Practice to use the rope on three mosnter at once in Poslinkis Forest. 
 QUEST_JOBSTEP_20150714_002860	Go to the Centurion Master in Forest of Prayer.
 QUEST_JOBSTEP_20150714_002861	The Wugushi Master is waiting for you in the Gateway of Great King.

--- a/QUEST_JOBSTEP.tsv
+++ b/QUEST_JOBSTEP.tsv
@@ -667,7 +667,7 @@ QUEST_JOBSTEP_20150317_000666	{memo X}Good. You skills are enough.{nl}I am happy
 QUEST_JOBSTEP_20150317_000667	{memo X}If you want to be a Cataphract, you should be able to defeat Gaigalas at the Flowerless Forest.{nl}Come back after defeating it.
 QUEST_JOBSTEP_20150317_000668	{memo X}There has been nothing that could obstruct my path since I decided to become a Catapract. {nl}Just peirce through anything that would block us. Don't you think so?
 QUEST_JOBSTEP_20150317_000669	{memo X}You are more than I expected.{nl}Good. Let's continue our good relationship.
-QUEST_JOBSTEP_20150317_000670	{memo X}I am sorry, but I am too busy to accept you at the moment.{nl}I heard someone saw our family's symbol, which was lost on the Medis Diena, so I am looking for it.
+QUEST_JOBSTEP_20150317_000670	{memo X}I am sorry, but I am too busy to accept you at the moment.{nl}I heard someone saw our family's symbol, which was lost on Medis Diena, so I am looking for it.
 QUEST_JOBSTEP_20150317_000671	I am the only one left in the Legwyn family, so each symbol is important to me.
 QUEST_JOBSTEP_20150317_000672	{memo X}This... is the symbol of Legwyn Family.{nl}Thanks. As I promised you, I will help you reach a higher level.
 QUEST_JOBSTEP_20150317_000673	{memo X}If you want to learn from me, it is courtesy to show your own skills first. {nl}Defeating the Honeypin at Deep Indigo Forest would be enough. 

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -32,7 +32,7 @@ QUEST_LV_0100_20150317_000031	$Take it. I made some bait from old grains in the 
 QUEST_LV_0100_20150317_000032	$We may not get a second chance if we don't defeat it this time.{nl}It doesn't seem like they're idiots.
 QUEST_LV_0100_20150317_000033	${memo X}I heard the sound of fighting so I came in a hurry. Did you defeat it?{nl}I only spotted Shaulems at my spot.{nl}Thank you. You have performed a meritorious deed.
 QUEST_LV_0100_20150317_000034	$Adjutant Paulina
-QUEST_LV_0100_20150317_000035	$We should recover the stolen supplies.{nl}We can't call ourselves soldiers of the Kingdom if we don't do anything about it.{nl}
+QUEST_LV_0100_20150317_000035	$We should recover the stolen supplies.{nl}We can't call ourselves soldiers of the kingdom if we don't do anything about it.{nl}
 QUEST_LV_0100_20150317_000036	$The stolen supplies were taken by the Shaulems in every Supply Warehouse, recover the supplies and bring them to Volda.
 QUEST_LV_0100_20150317_000037	$I feel so fed up having to endure this all the time.{nl}Reinforcements should be coming soon, but what can we expect from such an incompetent kingdom?
 QUEST_LV_0100_20150317_000038	$Adjutant Volda
@@ -278,7 +278,7 @@ QUEST_LV_0100_20150317_000273	{memo X}$I do worry that the monsters might harm t
 QUEST_LV_0100_20150317_000274	$I am happy that the statue is unharmed.{nl}The monsters here know to fear the Goddess.{nl}
 QUEST_LV_0100_20150317_000275	$Go down the Shadow Forest Road and you should arrive at Klaipeda shortly.{nl}Well then, may the blessings of the Goddess be with you.
 QUEST_LV_0100_20150317_000276	{memo X}$Please do me a favor if you are headed to Klaipeda.{nl}It's not easy to go back and forth from Klaipeda because of the Infrorocktors nowadays.
-QUEST_LV_0100_20150317_000277	$Maybe taking care of the Statues will make the Goddesses return sooner...
+QUEST_LV_0100_20150317_000277	$Maybe taking care of the statues will make the Goddesses return sooner...
 QUEST_LV_0100_20150317_000278	{memo X}$Follow the road on the left at the camp crossroads.{nl}{-scp SCR_DIALOG_NPC_ANIM(
 QUEST_LV_0100_20150317_000279	$)} You'll meet the troops right away.
 QUEST_LV_0100_20150317_000280	$)}Alright, good job.{nl}You'll arrive at Klaipeda shortly if you follow the Shadow Forest Road.{nl}Don't forget to drop by Sir Uska.
@@ -333,13 +333,13 @@ QUEST_LV_0100_20150317_000328	{memo X}$Finding the cause of the monsters is impo
 QUEST_LV_0100_20150317_000329	$The movement of Weavers in the lower areas of the stream seems suspicious.{nl}Seems like they're trying to interfere with supplies to the Miners' Village.
 QUEST_LV_0100_20150317_000330	$We might have to give up our current supplies and support ourselves until the next batch of supplies arrive.
 QUEST_LV_0100_20150317_000331	$Thank you.{nl}With you helping us out like this, we will not be defeated.
-QUEST_LV_0100_20150317_000332	$Your next mission is to find the cause of the increasing number of monsters.{nl}Popolions have a big appetite so I hope we can find a clue.
+QUEST_LV_0100_20150317_000332	$Your next mission is to find the cause of the increasing number of monsters.{nl}Popolions have a big appetite, so I hope we can find a clue.
 QUEST_LV_0100_20150317_000333	$Although the Miners' Village is in trouble, given that the situation has reached the Eastern Woods,{nl}we can't assure the safety of Klaipeda.{nl}We can just hope that Klaipeda is doing well.
 QUEST_LV_0100_20150317_000334	$Operations Officer
 QUEST_LV_0100_20150317_000335	$Were you sent by Aras?{nl}This is a piece of Vubbe clothing. Ah... I see...
 QUEST_LV_0100_20150317_000336	I think the Vubbes of the Miners' Village have made their way into the woods.{nl}Maybe that's the reason behind the abnormal surge in monsters too.{nl}
 QUEST_LV_0100_20150317_000337	$I better ask Aras to search for Vubbes in other regions too.{nl}In the meantime, I would like you to take a look at the upper areas.
-QUEST_LV_0100_20150317_000338	$We haven't searched the upper areas yet.{nl}Of course, we should be sending troops but I ask for your help as this is an urgent matter.
+QUEST_LV_0100_20150317_000338	$We haven't searched the upper areas yet.{nl}Of course we should be sending troops, but I ask for your help as this is an urgent matter.
 QUEST_LV_0100_20150317_000339	$You saw a Vubbe Fighter but missed it?{nl}We also got a report of Vubbe Fighter appearing in the Southern area.{nl}
 QUEST_LV_0100_20150317_000340	$First, talk to the Search Scout by the bridge in the lower area of Bulvjes Farm.{nl}This will become a tedious drawn out campaign if we that Vubbe Fighter run loose.
 QUEST_LV_0100_20150317_000341	{memo X}$So the Vubbe Fighters are the reason behind the growing number of monsters.{nl}Please find out how many Vubbe Fighters there are.{nl}
@@ -362,8 +362,8 @@ QUEST_LV_0100_20150317_000357	$You mean you really defeated the Vubbe Fighter?{n
 QUEST_LV_0100_20150317_000358	$Of course. As promised, I will grant you access to the Miners' Village.{nl}Please wait.
 QUEST_LV_0100_20150317_000359	$If you find any clues, let the Operations Officer in the northern area know about it.
 QUEST_LV_0100_20150317_000360	$I think the battle at the Miners' Village is in a very bad situation.{nl}It's too late to move the troops so please go on ahead to support the Miners' Village.
-QUEST_LV_0100_20150317_000361	$They have low IQ, but these monsters build groups and live as a community.{nl}They used to appear only occasionally in the deeper areas of the mines... Could they be expanding their forces?{nl}
-QUEST_LV_0100_20150317_000362	$Whatever the reason is, Vubbes expanding their territory is a big problem.{nl}Monsters that lose their territory to Vubbes will be forced to make their way into our base.
+QUEST_LV_0100_20150317_000361	$They have low IQ, but these monsters build groups and live as a community.{nl}They used to appear only occasionally in the deeper areas of the mines...{nl}Could they be expanding their forces?{nl}
+QUEST_LV_0100_20150317_000362	$Whatever the reason is, the Vubbes expanding their territory is a big problem.{nl}Monsters that lose their territory to the Vubbes will be forced to make their way into our base.
 QUEST_LV_0100_20150317_000363	It's a single road from here on so you'll be able to find the people easily.{nl}
 QUEST_LV_0100_20150317_000364	{memo X}Oh, let me give you some helpful information in return for your your help.{nl}The evidence of salvation that the Revelators are looking for can be found in the Closed Area.
 QUEST_LV_0100_20150317_000365	One thing, there's something that keeps bothering me.{nl}A vague feeling of something alien.
@@ -537,7 +537,7 @@ QUEST_LV_0100_20150317_000532	What? Tutu?{nl}I don't have time to think about th
 QUEST_LV_0100_20150317_000533	$When you level up, you can increase a status of your choice and become stronger. {nl} Would you like to try doing so now?
 QUEST_LV_0100_20150317_000534	It's important to keep in mind what you would want to be. {nl} That's never an easy thing.
 QUEST_LV_0100_20150317_000535	{memo X}Yes. That's how you do it. {nl} Pretty simple, huh?
-QUEST_LV_0100_20150317_000536	Aras is in the center area of the Woods. {nl} But there has been a tremendous increase in monsters around here so I suggest you don't go in.
+QUEST_LV_0100_20150317_000536	Aras is in the center area of the woods. {nl} But there has been a tremendous increase in monsters around here, so I suggest you don't go in.
 QUEST_LV_0100_20150317_000537	Somehow Klaipeda has managed to hold back the monsters for now,{nl}but we have to find and remove the cause or we won't hold out for long.{nl}
 QUEST_LV_0100_20150317_000538	That strange feeling I had in Crystal Mine 3F,{nl}it keeps occurring to me that it might be related to that girl the town people are talking about.{nl}
 QUEST_LV_0100_20150317_000539	I just feel bad that I wasn't able to meet
@@ -567,7 +567,7 @@ QUEST_LV_0100_20150317_000562	Archeologist Friedka
 QUEST_LV_0100_20150317_000563	I'm looking for a certain unique stone pillar. But as a scholar, getting it is beyond my skill.{nl}If you help me, you will be handsomely rewarded. Are you interested?
 QUEST_LV_0100_20150317_000564	I know that we received an order to withdraw, but know this,{nl}the reward will be well worth your time. You won't regret it.
 QUEST_LV_0100_20150317_000565	Okay. First collect amulets from the Hogmas.{nl}After that, put those amulets on the stone pillar at the bottom of Geltonas Highland.
-QUEST_LV_0100_20150317_000566	We have to get out of here quickly before something bigger and worse finds us.{nl}Well, so far so good, but coming in so far is not without danger.{nl}I hope the Kingdom pays more attention to rescuing people than they do to these kinds of experiments.
+QUEST_LV_0100_20150317_000566	We have to get out of here quickly before something bigger and worse finds us.{nl}Well, so far so good, but coming in so far is not without danger.{nl}I hope the kingdom pays more attention to rescuing people than they do to these kinds of experiments.
 QUEST_LV_0100_20150317_000567	Are you asking me how come a technician is at a place like this?{nl}As an advisor, of course. {nl} You'll need a technician like me to find out how this gigantic structure stood still for hundreds of years.
 QUEST_LV_0100_20150317_000568	Looking at equations is one thing, but being out here...{nl}We will find the true nature of this place soon enough.
 QUEST_LV_0100_20150317_000569	According to this map, the thing we are looking for is in Stone Pillar Hill.{nl}Alright then. Would you please make a rubber copy of it?{nl}{nl}
@@ -876,7 +876,7 @@ QUEST_LV_0100_20150317_000871	It is an honor to fight with you, Revelator. {nl} 
 QUEST_LV_0100_20150317_000872	If you don't mind, can you get Eyes of Madness from Rodelins?{nl}They are handy when you want to hide yourself from demons.
 QUEST_LV_0100_20150317_000873	I don't want those filthy things to be near me either.{nl}But, it's worse to face against those demons alone.
 QUEST_LV_0100_20150317_000874	Thanks.{nl}I will share them with the other brothers before the demons find out.
-QUEST_LV_0100_20150317_000875	You are indeed the revelator.{nl}Now, we can concentrate on protecting the altar.
+QUEST_LV_0100_20150317_000875	You are indeed the Revelator.{nl}Now, we can concentrate on protecting the altar.
 QUEST_LV_0100_20150317_000876	Don't worry, the barrier at the main entrance to the 1st floor can be offset by the chapel's power. {nl}That's what the altars are for. {nl}
 QUEST_LV_0100_20150317_000877	Let's take care of the Unknocker first. {nl} I'll lure the Unknocker, giving you a chance to attack it.
 QUEST_LV_0100_20150317_000878	{memo X}I want to request to you to defeat Pawndel and Pawnd.{nl}They are demon sisters and they give us headaches.
@@ -965,7 +965,7 @@ QUEST_LV_0100_20150317_000960	$While I prepare to do the rubbings, please put th
 QUEST_LV_0100_20150317_000961	I will follow you soon. Just a moment.
 QUEST_LV_0100_20150317_000962	$After we finish the rubbings, we can say farewell to this place.{nl}Can you help me a bit more?
 QUEST_LV_0100_20150317_000963	The capital may already be in ruins, but I will protect Klaipeda.
-QUEST_LV_0100_20150317_000964	Using all your power to crush any enemy that would threaten the Kingdom. {nl} That's how Highlanders fight in battle. {nl}
+QUEST_LV_0100_20150317_000964	Using all your power to crush any enemy that would threaten the kingdom. {nl} That's how Highlanders fight in battle. {nl}
 QUEST_LV_0100_20150317_000965	Good work, guys. {nl} Actually, I was also an adventure but the results seem to be fine. {nl} You just need to tell it like that to Kayetonas in Flower hill.
 QUEST_LV_0100_20150317_000966	Seems like even the Auka Altar lost its powers. {nl} There were stories about its powers wiping out dozens of demons in the past.
 QUEST_LV_0100_20150317_000967	It's hard to watch the Egnomes running around the Atgaila Chapel.{nl} Please clean up the Egnomes.
@@ -1010,7 +1010,7 @@ QUEST_LV_0100_20150317_001005	{memo X}It's almost done. Yes..
 QUEST_LV_0100_20150317_001006	{memo X}You gathered everything.{nl}Give them to me. Including the Jewel.{nl}I know the way to fully stabilize it so let's go to the Laboratory.
 QUEST_LV_0100_20150317_001007	$I hope the device is still okay..
 QUEST_LV_0100_20150317_001008	{memo X}Good! We can activate the device now.
-QUEST_LV_0100_20150317_001009	{memo X}You are the revelator who helped the Paladin Master right?{nl}My name is Grita. I came from the Mage Tower.
+QUEST_LV_0100_20150317_001009	{memo X}You are the Revelator who helped the Paladin Master right?{nl}My name is Grita. I came from the Mage Tower.
 QUEST_LV_0100_20150317_001010	{memo X}Help me. Gabija is in danger.{nl}We are gonna lose the tower to the demons if we don't receive any help.
 QUEST_LV_0100_20150317_001011	{memo X}
 QUEST_LV_0100_20150317_001012	{memo X}This is the entrance to the tower.{nl}I became unconscious at the tower and lost all my power somehow.{nl}
@@ -1357,7 +1357,7 @@ QUEST_LV_0100_20150317_001352	{memo X}Thank you for the regards from Laimonas. {
 QUEST_LV_0100_20150317_001353	Don't forget to send my regards to the Klaipeda Chief Commander.
 QUEST_LV_0100_20150317_001354	When you are ready, please go to Aras in the Eastern Woods.
 QUEST_LV_0100_20150317_001355	Welcome! {nl} Oh, you're the Revelator. I really wanted to meet you. {nl}
-QUEST_LV_0100_20150317_001356	This is a warp scroll. {nl} You can go to any Goddess Statue or return to previous location by using it. {nl}
+QUEST_LV_0100_20150317_001356	This is a Warp Scroll. {nl} You can go to any Goddess Statue or return to previous location by using it. {nl}
 QUEST_LV_0100_20150317_001357	{memo X}We'll give you more than what the Knights asked for so please help us find the Goddesses.
 QUEST_LV_0100_20150317_001358	{memo X}I think Large Kepa is still out there. {nl} Would you take a look?
 QUEST_LV_0100_20150317_001359	{memo X}It was there right? {nl} My senses are never wrong. 
@@ -1366,7 +1366,7 @@ QUEST_LV_0100_20150317_001361	{memo X}My men should have returned by now but the
 QUEST_LV_0100_20150317_001362	My men said they were going to Delon Shelter. {nl} The Golem may appear anytime and yet they are so carefree. 
 QUEST_LV_0100_20150317_001363	$Rocktortuga is coming this way. {nl}Please lend us your strength to make sure it doesn't break through our defenses. 
 QUEST_LV_0100_20150317_001364	Have you seen any baby Poata? {nl} We better drive them out quickly so that the mother Poata won't keep showing up. 
-QUEST_LV_0100_20150317_001365	Vubbes have built their base outside the village. {nl} Now that we don't even have troops, {nl}something serious might happen if we don't drive them out of their base. 
+QUEST_LV_0100_20150317_001365	The Vubbes have built their base outside the village. {nl} Now that we don't even have troops, something serious might happen if we don't drive them out of their base. 
 QUEST_LV_0100_20150317_001366	Thank you so much for your bravery. 
 QUEST_LV_0100_20150317_001367	How can I express my gratitude. {nl}I'm sure the Goddess sent you to us.
 QUEST_LV_0100_20150317_001368	This patient told us that Chafer has appeared. {nl} Can you help us out and go check on it?
@@ -1430,7 +1430,7 @@ QUEST_LV_0100_20150317_001425	Enough... Don't ask any more questions. {nl} I don
 QUEST_LV_0100_20150317_001426	From here, it's Zachariel's Royal Mausoleum.{nl}You can freely enter, but please be careful not to disturb the research.
 QUEST_LV_0100_20150317_001427	$Niels is the one who is in charge of this place.{nl}If you need to ask something, go find him at the Research Camp.
 QUEST_LV_0100_20150317_001428	$We won't block anyone's entrance past here, but we can't guarantee one's safety.
-QUEST_LV_0100_20150317_001429	$The researchers here receive support from the Kingdom.{nl}The person in charge is Niels, so if have any questions talk to him at the Research Camp.
+QUEST_LV_0100_20150317_001429	$The researchers here receive support from the kingdom.{nl}The person in charge is Niels, so if have any questions talk to him at the Research Camp.
 QUEST_LV_0100_20150317_001430	The Royal Mausoleum should be protected.{nl}If it can't be protected, it will be destroyed itself.
 QUEST_LV_0100_20150317_001431	$Fedimian is a very old city, and is surrounded by countless ruins and wonders. {nl} This includes the Mage Tower, the Cursed City and the Cathedral.
 QUEST_LV_0100_20150317_001432	$Hundreds of years ago a great witch by the name of Agailla Flurry built that tower. {nl} Many of the magics used today saw their beginnings within that tower, and haven't changed much since.
@@ -1444,7 +1444,7 @@ QUEST_LV_0100_20150317_001439	We are still reviving the city, but since it's too
 QUEST_LV_0100_20150317_001440	Follower Alvydas
 QUEST_LV_0100_20150317_001441	Since follow believe the Goddess Saule, you'll be able to accept this as a high difficulty such. {nl} impiety to, do you think want to who stay like this terrible place?
 QUEST_LV_0100_20150317_001442	Follower Raminta
-QUEST_LV_0100_20150317_001443	$If that evil aura spreads to other forests..{nl}Those forests will also change, like Kvailas Forest.{nl}And then the entire Kingdom may also... It scares me.
+QUEST_LV_0100_20150317_001443	$If that evil aura spreads to other forests..{nl}Those forests will also change, like Kvailas Forest.{nl}And then the entire kingdom may also... It scares me.
 QUEST_LV_0100_20150317_001444	Follower Evaldas
 QUEST_LV_0100_20150317_001445	$Everyone is tired, but the evil aura never stops. So, we at least try to stay happy. {nl} However, I don't know how long I can keep feeling happy.
 QUEST_LV_0100_20150317_001446	Follower Zanetta
@@ -1565,7 +1565,7 @@ QUEST_LV_0100_20150317_001560	$Mine Manager
 QUEST_LV_0100_20150317_001561	$I'm hanging on somehow but I'm losing strength in my arms.
 QUEST_LV_0100_20150317_001562	$I should have been more careful. {nl} It's all my fault.
 QUEST_LV_0100_20150317_001563	$I have my roots deep in hunting. {nl} Don't worry about me. Go look after the others.
-QUEST_LV_0100_20150317_001564	$As the Mayor, I can't just leave the village like this. {nl} How could the Goddesses be so indifferent?
+QUEST_LV_0100_20150317_001564	$As the mayor, I cannot just leave the village like this. {nl} How could the Goddesses be so indifferent?
 QUEST_LV_0100_20150317_001565	{memo X}$Aren't you a Revelator? The Goddess must've sent help. {nl} In order to enter the mine, you must save a young man name Vaidotas first. {nl}He was kidnapped and brought to the Vubbe Outpost. {nl} Please, I'm begging for your help.
 QUEST_LV_0100_20150317_001566	Kind Owl Sculptor
 QUEST_LV_0100_20150317_001567	There are so many wandering spirits these days.{nl}This really..
@@ -1579,7 +1579,7 @@ QUEST_LV_0100_20150317_001574	There is an owl that knows well about this problem
 QUEST_LV_0100_20150317_001575	Ah, I can't concentrate.{nl}While I am remembering it, can you take care of that Ellogua?{nl}I just can't remember easily.
 QUEST_LV_0100_20150317_001576	We are made of ordinary wood so we are scared of moist and insects.{nl}We are keen to be broken as well.{nl}It would have been better if we were made of iron.
 QUEST_LV_0100_20150317_001577	Thank you!{nl}I can't scratch my head because I am a tree..Hehe..{nl}
-QUEST_LV_0100_20150317_001578	Hm! Yes, I finally remembered it! {nl}Go find instabilized owl.{nl}That owl was so close to Sequoia so it must know the method.
+QUEST_LV_0100_20150317_001578	Hm! Yes, I finally remembered it! {nl}Find instabilized owl.{nl}That owl was so close to Sequoia so it must know the method.
 QUEST_LV_0100_20150317_001579	Instabilized Owl Sculpture
 QUEST_LV_0100_20150317_001580	I will tell you as I promised. I mean Sequoia. {nl}
 QUEST_LV_0100_20150317_001581	Sequoia is obsessed with vicious power.{nl}You face vicious power with divine power.{nl}Yes. We should face it!{nl}
@@ -1653,7 +1653,7 @@ QUEST_LV_0100_20150317_001648	Damn. The materials and the equipments should come
 QUEST_LV_0100_20150317_001649	How should I scold Malt?
 QUEST_LV_0100_20150317_001650	That's enough!{nl}I feel sorry to you.
 QUEST_LV_0100_20150317_001651	So, does this mean that you can help me?{nl}Please get some claws from Velwrigglers at Rajuma Curved Path.
-QUEST_LV_0100_20150317_001652	{memo X}Our revelator is so kind.{nl}Isn't he?
+QUEST_LV_0100_20150317_001652	{memo X}Our Revelator is so kind.{nl}Isn't he?
 QUEST_LV_0100_20150317_001653	Darn, it just grazed, but it hurts so bad.{nl}Well done.
 QUEST_LV_0100_20150317_001654	{memo X}It will be completed if I have Truffle poison mushrooms at Ajidu intersection.{nl}I am counting on you.
 QUEST_LV_0100_20150317_001655	Where are the mushrooms from Truffles?{nl}Look closely at their horns. That is in fact a mushroom.
@@ -1857,7 +1857,7 @@ QUEST_LV_0100_20150317_001852	Thank you!{nl}Fortunately, he is breathing again.{
 QUEST_LV_0100_20150317_001853	We'll rest a little more and return when he regains his strength.{nl}May the Goddess bless you.
 QUEST_LV_0100_20150317_001854	$The Revelator is here?! Thank the Goddess.{nl}I am Rexipher, a historian. I am studying the Royal Mausoleum.{nl}
 QUEST_LV_0100_20150317_001855	$We already have most of the answers.{nl}But for the last answer, I need to borrow your power as the Revelator.
-QUEST_LV_0100_20150317_001856	{memo X}There are things that only revelator could see.{nl}The questions from the owner of the tomb..
+QUEST_LV_0100_20150317_001856	{memo X}There are things that only Revelator could see.{nl}The questions from the owner of the tomb..
 QUEST_LV_0100_20150317_001857	It is so good to meet a person like you, I guess this is the blessing of the god.
 QUEST_LV_0100_20150317_001858	$Good.{nl}The next epitaph is at Shirnas Highland. Let's go.
 QUEST_LV_0100_20150317_001859	$I wonder what they tried to protect by building the Royal Mausoleum.{nl}I'd like to see it with my own eyes.
@@ -2158,7 +2158,7 @@ QUEST_LV_0100_20150317_002153	{memo X}
 QUEST_LV_0100_20150317_002154	I just feel sorry to my brother.
 QUEST_LV_0100_20150317_002155	$Old Man of Andale village
 QUEST_LV_0100_20150317_002156	God is looking after our village so our village has clear water and air. And there are no disasters here.
-QUEST_LV_0100_20150317_002157	So finally the revelator has come.{nl}Very healthy and reliable. I gues we can do it this time.
+QUEST_LV_0100_20150317_002157	So finally the Revelator has come.{nl}Very healthy and reliable. I gues we can do it this time.
 QUEST_LV_0100_20150317_002158	Aren't you the Revelator? {nl} So, what brings you to our village? {nl}
 QUEST_LV_0100_20150317_002159	Goddess Saule? {nl} We haven't seen her for a long time. {nl}
 QUEST_LV_0100_20150317_002160	The portal leading to Goddess Saule just won't open. {nl}I think it's all because the diving pond is contaminated.
@@ -2168,7 +2168,7 @@ QUEST_LV_0100_20150317_002163	Our village serves Goddess Saule who overlooks the
 QUEST_LV_0100_20150317_002164	{memo X}I haved carved the owls for a long time.{nl}At one point in time, they got their lives and determination.{nl}
 QUEST_LV_0100_20150317_002165	{memo X}When I gained my conciousness, a few hundreds of years have passed.
 QUEST_LV_0100_20150317_002166	{memo X}Carvers should be careful not to exaggerate their skills. They should be humble.
-QUEST_LV_0100_20150317_002167	It is a good sign that you, the revelator came here.{nl}We've been waiting for you for a long time.
+QUEST_LV_0100_20150317_002167	It is a good sign that you, the Revelator came here.{nl}We've been waiting for you for a long time.
 QUEST_LV_0100_20150317_002168	Please come to our village.{nl}Villagers will really like you.{nl}For sure.
 QUEST_LV_0100_20150317_002169	The god guides us to meet together.
 QUEST_LV_0100_20150317_002170	Don't think it's a pain. We received a blessing.
@@ -2961,7 +2961,7 @@ QUEST_LV_0100_20150317_002956	Let's gather the force of the guardians and find t
 QUEST_LV_0100_20150317_002957	Not interested
 QUEST_LV_0100_20150317_002958	{memo X}Notice /The royal guardian of the spell has opened his mouth. #7
 QUEST_LV_0100_20150317_002959	$Hidden Place (2)
-QUEST_LV_0100_20150317_002960	Go find the royal spell
+QUEST_LV_0100_20150317_002960	Find the royal spell
 QUEST_LV_0100_20150317_002961	Quit
 QUEST_LV_0100_20150317_002962	$Emergency (1)
 QUEST_LV_0100_20150317_002963	Gather the spell
@@ -3221,7 +3221,7 @@ QUEST_LV_0100_20150317_003216	One Step Closer to the King's Legacy
 QUEST_LV_0100_20150317_003217	Research of Historian Rexipher (1)
 QUEST_LV_0100_20150317_003218	{memo X}Observing the Pillar/LOOK/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003219	Research of Historian Rexipher (2)
-QUEST_LV_0100_20150317_003220	Go find the next inscription
+QUEST_LV_0100_20150317_003220	Find the next inscription
 QUEST_LV_0100_20150317_003221	Research of Historian Rexipher (3)
 QUEST_LV_0100_20150317_003222	Go to where the inscription is
 QUEST_LV_0100_20150317_003223	Research of Historian Rexipher (4)
@@ -3435,7 +3435,7 @@ QUEST_LV_0100_20150317_003430	Release Goddess Saule (4)
 QUEST_LV_0100_20150317_003431	{memo X}Releasing the barrier/MAKING/3/TRACK_BEFORE/None/None/1/BOT/F_ground051/0.5/BOT
 QUEST_LV_0100_20150317_003432	Goddess Saule
 QUEST_LV_0100_20150317_003433	{memo X}Removing restraining sphere
-QUEST_LV_0100_20150317_003434	To the Gateway of the Great King
+QUEST_LV_0100_20150317_003434	To the Gateway of Great King
 QUEST_LV_0100_20150317_003435	Show the revelation
 QUEST_LV_0100_20150317_003436	{memo X}Notice/Use the portal and move to the gateway of the Great King #5
 QUEST_LV_0100_20150317_003437	Searching for Goddess Saule
@@ -3854,7 +3854,7 @@ QUEST_LV_0100_20150317_003849	{memo X}Persuasion of the Battle Commander
 QUEST_LV_0100_20150317_003850	$The Battle Commander says he will tell his men to do the rest. Report back to Knight Titas.
 QUEST_LV_0100_20150317_003851	Report to Knight Titas
 QUEST_LV_0100_20150317_003852	{memo X}Please be prepared to now go to the Klaipeda.
-QUEST_LV_0100_20150317_003853	$Find Search Scout in the marked area
+QUEST_LV_0100_20150317_003853	$Find the Search Scout in the marked area
 QUEST_LV_0100_20150317_003854	$You were asked to inform the troops to assemble before heading to Klaipeda. Inform the Search Scout about the assembly.
 QUEST_LV_0100_20150317_003855	$Inform the Search Scout about the order.
 QUEST_LV_0100_20150317_003856	$A Large Kepa suddenly appeared. Defeat it.
@@ -3922,7 +3922,7 @@ QUEST_LV_0100_20150317_003917	$Listen to the Sentinel's Chupacabra extermination
 QUEST_LV_0100_20150317_003918	$Let's help the Sentinel exterminate Chupacabras who threaten the troops.
 QUEST_LV_0100_20150317_003919	$Hunt Chupacabras
 QUEST_LV_0100_20150317_003920	$Walk around the woods and defeat the Chupacabras endangering the soldiers.
-QUEST_LV_0100_20150317_003921	$Return and report to Sentinel
+QUEST_LV_0100_20150317_003921	$Return and report to the Sentinel
 QUEST_LV_0100_20150317_003922	$Report to the Eastern Woods Sentinel that the Chupacabras have been exterminated.
 QUEST_LV_0100_20150317_003923	$Listen to the Sentinel about the supplies camp
 QUEST_LV_0100_20150317_003924	$Listen to the Sentinel about the monster that attacked the supplies camp.
@@ -3976,7 +3976,7 @@ QUEST_LV_0100_20150317_003971	$Defeat the Pokubus interfering with the Supply Of
 QUEST_LV_0100_20150317_003972	$Talk to the Supply Soldier
 QUEST_LV_0100_20150317_003973	$Tell the Supply Soldier that you defeated the Pokubus.
 QUEST_LV_0100_20150317_003974	$Defeat Pokubus
-QUEST_LV_0100_20150317_003975	$Go find the Search Scout
+QUEST_LV_0100_20150317_003975	$Find the Search Scout
 QUEST_LV_0100_20150317_003976	$The Operations Officer said that the Search Scout in the lower area found the Vubbe Fighter. Meet the Search Scout near the bridge in the lower area of Bulvjes Farm.
 QUEST_LV_0100_20150317_003977	$Search for the Vubbe Fighter
 QUEST_LV_0100_20150317_003978	{memo X}The Search Scout says the Vubbe Fighter is in the Nudegi Felled area but seems better to wait for additional troops. You need to get in the Crystal Mine as soon as possible, so let's just go ahead and defeat the Vubbe Fighter.
@@ -4108,7 +4108,7 @@ QUEST_LV_0100_20150317_004103	$Report to Officer Luders
 QUEST_LV_0100_20150317_004104	$Successfully defeated Sparnas. Report back to Officer Liudas. 
 QUEST_LV_0100_20150317_004105	$Defeat the lured Sparnas. 
 QUEST_LV_0100_20150317_004106	$Talk to Liaison Officer Niels
-QUEST_LV_0100_20150317_004107	$Arrived safely at the Gateway of the Great King. Find the person in charge. 
+QUEST_LV_0100_20150317_004107	$Arrived safely at the Gateway of Great King. Find the person in charge. 
 QUEST_LV_0100_20150317_004108	$Find the missing archivist, Jonas.
 QUEST_LV_0100_20150317_004109	$Liaison Officer Niels is looking for an old man named Jonas. Be sure to bring him back when you find him.
 QUEST_LV_0100_20150317_004110	$Find Archivist Jonas
@@ -4504,10 +4504,10 @@ QUEST_LV_0100_20150317_004499	$Tell the Healer Lady to go back to the village ag
 QUEST_LV_0100_20150317_004500	$Defeat the monsters
 QUEST_LV_0100_20150317_004501	$The lady says she can't go back with her patients because there are too many monsters. Defeat the monsters for her. 
 QUEST_LV_0100_20150317_004502	$Defeated the monsters. Tell the lady to go back to the village. 
-QUEST_LV_0100_20150317_004503	$Talk to Miners' Village Mayor
+QUEST_LV_0100_20150317_004503	$Talk to the Miners' Village Mayor
 QUEST_LV_0100_20150317_004504	$Talk to the mayor again to enter the Crystal Mines. 
 QUEST_LV_0100_20150317_004505	$Rescue Vaidotas who is kidnapped by the Vubbes
-QUEST_LV_0100_20150317_004506	$The Revelation of the Goddess is important but you can't leave the kidnapped villagers. To save the villagers trapped in the Mines, go to the Vubbe Outpost and save Vaidotas first.
+QUEST_LV_0100_20150317_004506	$The Revelation of the Goddess is important but you can't leave the kidnapped villagers. To save the villagers trapped in the Crystal Mine, go to the Vubbe Outpost and save Vaidotas first.
 QUEST_LV_0100_20150317_004507	$Intercept the Vubbe raid
 QUEST_LV_0100_20150317_004508	$The Mayor seems to have a problem. Talk to him.
 QUEST_LV_0100_20150317_004509	$Defeat the Vubbes that are occupying the village
@@ -4943,7 +4943,7 @@ QUEST_LV_0100_20150317_004938	$Grita told you that since Antares did research on
 QUEST_LV_0100_20150317_004939	$It seems that you found information on the flow of magic. Talk to Grita.
 QUEST_LV_0100_20150317_004940	{memo X}You found the way to destroy the magic safely. Talk to Grita.
 QUEST_LV_0100_20150317_004941	$Find the 2nd Valve in the Central Control Room
-QUEST_LV_0100_20150317_004942	{memo X}Most of the monsters would receive tremendous damages if you could destroy all the valves to explode the magic. Go find the 2nd valve in the central control room which is the only one remaining.
+QUEST_LV_0100_20150317_004942	{memo X}Most of the monsters would receive tremendous damages if you could destroy all the valves to explode the magic. Find the 2nd valve in the central control room which is the only one remaining.
 QUEST_LV_0100_20150317_004943	{memo X}Antares left a trap. Talk to Grita.
 QUEST_LV_0100_20150317_004944	$Check the Immobile Mineloader
 QUEST_LV_0100_20150317_004945	$There is a Mineloader at the Mage Tower that acts as a guard. Check the immobile Mineloader.
@@ -5235,7 +5235,7 @@ QUEST_LV_0100_20150317_005230	{memo X}
 QUEST_LV_0100_20150317_005231	$Read the epitaph of Isvalyta Historic Site
 QUEST_LV_0100_20150317_005232	$Historian Rexipher is asking for your cooperation for the common objective of getting to the Royal Mausoleum. Follow his guide and read the epitaph of Isvalyta Historic Site.
 QUEST_LV_0100_20150317_005233	{memo X}Got the clues to the King's dilemma. Talk to Rexipher. 
-QUEST_LV_0100_20150317_005234	{memo X}The epitaph mentions about the dilemma on proving the revelator. Talk to Rexipher about the location of next epitaph. 
+QUEST_LV_0100_20150317_005234	{memo X}The epitaph mentions about the dilemma on proving the Revelator. Talk to Rexipher about the location of next epitaph. 
 QUEST_LV_0100_20150317_005235	$Read the epitaph at Shirnas Highland
 QUEST_LV_0100_20150317_005236	Rexipher says the next epitaph is in Shirnas Highland. Go there and check the next epitaph. 
 QUEST_LV_0100_20150317_005237	{memo X}
@@ -5752,7 +5752,7 @@ QUEST_LV_0100_20150317_005747	$Report the to the Old Man
 QUEST_LV_0100_20150317_005748	$Purified the Holy Pond. Return to the Old Man and ask about the portal mentioned in the revelation.
 QUEST_LV_0100_20150317_005749	$Talk to the Old Man
 QUEST_LV_0100_20150317_005750	$Find the villager sent by the Old Man
-QUEST_LV_0100_20150317_005751	$The Old Man says he sent a villager to Nugria Sanctum to see of the portal is working but he has not heard since. Go find the villager who was sent to Nugria Sanctum.
+QUEST_LV_0100_20150317_005751	$The Old Man says he sent a villager to Nugria Sanctum to see of the portal is working but he has not heard since. Find the villager who was sent to Nugria Sanctum.
 QUEST_LV_0100_20150317_005752	Talk to the injured villager
 QUEST_LV_0100_20150317_005753	Defeated the monster that attacked the villager. Talk to the villager.
 QUEST_LV_0100_20150317_005754	$Defeat the monster that attacked the villager
@@ -5899,7 +5899,7 @@ QUEST_LV_0100_20150317_005894	{memo X}Knight Commander Uska thinks the high gard
 QUEST_LV_0100_20150317_005895	Interferance of Lepus blocking the way
 QUEST_LV_0100_20150317_005896	Defeat Lepus that is blocking the way
 QUEST_LV_0100_20150317_005897	Talk to soldier Moody
-QUEST_LV_0100_20150317_005898	Commander Liudas is asking Moody to bring the report on Sparnas. Go find Soldier Moody in Amzina Curved Path. 
+QUEST_LV_0100_20150317_005898	Commander Liudas is asking Moody to bring the report on Sparnas. Find Soldier Moody in Amzina Curved Path. 
 QUEST_LV_0100_20150317_005899	Retrieve the report that Siaulambs took away
 QUEST_LV_0100_20150317_005900	Moody says he lost the report while fighting against the Siaulambs. Find the report for him.
 QUEST_LV_0100_20150317_005901	Give it to Officer Liudas
@@ -6421,7 +6421,7 @@ QUEST_LV_0100_20150323_006416	$This is one of the devices the first Paladin set 
 QUEST_LV_0100_20150323_006417	{memo X}$You must find Goddess Saule...{nl}The colorful stream mentioned in the revelation may refer to the upper region of Veja Ravine. {nl}Well then, may the blessings of Goddess be with you.
 QUEST_LV_0100_20150323_006418	$This is the holy weapon used to fight against Gesti in Nefritas Cliff. {nl}It has been handed down since the times of the first Paladin.
 QUEST_LV_0100_20150323_006419	{memo X}$Go. Tenet Chapel is located in Tenet Garden.{nl}You must prevent the revelation from falling into the hands of Gesti.
-QUEST_LV_0100_20150323_006420	$Go find Gesti. {nl}Tenet Chapel is located in Tenet Garden.
+QUEST_LV_0100_20150323_006420	$Find Gesti. {nl}Tenet Chapel is located in Tenet Garden.
 QUEST_LV_0100_20150323_006421	{memo X}There is a way to stop it but only you can do it. {nl}Please, come to Karsta battlefield in Fedimian outskirt.
 QUEST_LV_0100_20150323_006422	You need to use the cable car to go from Srautas Gorge to Gele Plateau. {nl}I heard people used to hang baskets on ropes in the past, and use those to traverse the gorge. {nl}Well the cable car is scary enough for me. 
 QUEST_LV_0100_20150323_006423	$I came to protect this divine land from the demons. {nl}I heard that the Paladin Master is also in Gele Plateau. It must surely be a big problem. {nl}
@@ -6744,7 +6744,7 @@ QUEST_LV_0100_20150428_006739	{memo X}Ah, the stabilization has come to an end.{
 QUEST_LV_0100_20150428_006740	$The Jewel of Prominence has stopped behaving erratically.{nl}But, in order to fully stabilize it, we need the Flame Crystals from the tower's Center Large Brazier.
 QUEST_LV_0100_20150428_006741	{memo X}You gathered everything.{nl}Give them to me. Including the Jewel.{nl}I know the way to stabilize it fully so let's go to Laboratory.
 QUEST_LV_0100_20150428_006742	$Good! Now we can activate the device.
-QUEST_LV_0100_20150428_006743	{memo X}You..are the revelator who helped the Paladin Master right?{nl}My name is Grita. I came from the Mage Tower.
+QUEST_LV_0100_20150428_006743	{memo X}You..are the Revelator who helped the Paladin Master right?{nl}My name is Grita. I came from the Mage Tower.
 QUEST_LV_0100_20150428_006744	{memo X}Help me. Gabija is in danger.{nl}We are gonna lose the tower to the demons if we don't receive help.
 QUEST_LV_0100_20150428_006745	$Only you can stop all that from happening. {nl}Please, come to the Karsta Hall Site at the Fedimian Suburbs.
 QUEST_LV_0100_20150428_006746	{memo X}This is then entrance to the tower.{nl}I became unconscious at the tower and lost all the power somehow.{nl}
@@ -6789,7 +6789,7 @@ QUEST_LV_0100_20150428_006784	$So this is the Jewel of Prominence. I can feel it
 QUEST_LV_0100_20150428_006785	$To find the Jewel of Prominence, just use this detector.{nl}When you use this detector near Jewel's location, the Jewel will appear.
 QUEST_LV_0100_20150428_006786	{memo X}The portal that you tried to open is the gate of lies.{nl}The villagers hear are the tricks of Demons' lord, Bramble.
 QUEST_LV_0100_20150428_006787	{memo X}I am Saule, the Goddess of the sun.{nl}Everything is just like how Lamia has forseen.
-QUEST_LV_0100_20150428_006788	{memo X}It's true that I am looking for the revelator, but I need someone skillful.{nl}I am sorry, but you don't look like the revelator I am looking for.
+QUEST_LV_0100_20150428_006788	{memo X}It's true that I am looking for the Revelator, but I need someone skillful.{nl}I am sorry, but you don't look like the Revelator I am looking for.
 QUEST_LV_0100_20150428_006789	$Welcome. {nl} Only hard-to-find stuff here.
 QUEST_LV_0100_20150428_006790	{memo X}I'm sorry but can you burn this oration in front of the epitaph in Rukas Plateau? {nl}You have explored different areas of the valley. {nl}I think you are more than qualified to comfort their souls. 
 QUEST_LV_0100_20150428_006791	This place is like a grave for many explorers and historians. {nl} And we study to find more factual history on top of their graves.
@@ -6851,7 +6851,7 @@ QUEST_LV_0100_20150428_006846	Talk to Goddess Saule
 QUEST_LV_0100_20150428_006847	It was Goddess Saule who was restrained by the demons. Talk to Goddess Saule.
 QUEST_LV_0100_20150428_006848	As written on the revelation, go through Naslaite Cliff Path and arrive at Veja Ravine.
 QUEST_LV_0100_20150428_006849	Reduce the monster's life under 50% and bring it near the Tree Root Crystal, and they will start to react.
-QUEST_LV_0100_20150428_006850	The assistant commander Volda asked you to defeat the dumble ball which Siaulambs consume. Go find the dumble ball at the old wooden box in the 4th supplies' warehouse.
+QUEST_LV_0100_20150428_006850	The assistant commander Volda asked you to defeat the dumble ball which Siaulambs consume. Find the dumble ball at the old wooden box in the 4th supplies' warehouse.
 QUEST_LV_0100_20150428_006851	Find the person who knows about the epitaph of Agailla Flurry and listen to his request.
 QUEST_LV_0100_20150428_006852	You found the Villager's Bag. Return the Villager's Bag and ask him about the contents in the epitaph.
 QUEST_LV_0100_20150428_006853	Defeat Blue Woodspirits that appeared near Obelisk
@@ -6877,7 +6877,7 @@ QUEST_LV_0100_20150511_006872	I feel happy to see them being defeated.{nl}But, I
 QUEST_LV_0100_20150511_006873	You should get ready before you take the Light Crystal to the entrance.{nl}It could attract a powerful monster.
 QUEST_LV_0100_20150511_006874	I feel relieved to have you here.{nl}I feel that the fact that Laima has chosen you is very fortunate. 
 QUEST_LV_0100_20150511_006875	$That explosion was too dangerous.{nl}Let's find a safer way to destroy these valves.
-QUEST_LV_0100_20150511_006876	There are many things we need to concentrate on protecting, {nl}so we should defeat the demons quietly without causing alarm.{nl}I feel so relieved to have you here, revelator.
+QUEST_LV_0100_20150511_006876	There are many things we need to concentrate on protecting, {nl}so we should defeat the demons quietly without causing alarm.{nl}I feel so relieved to have you here, Revelator.
 QUEST_LV_0100_20150511_006877	{memo X}There are rumors about Golems appearing so don't go far too deep. {nl} It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
 QUEST_LV_0100_20150511_006878	You are easily exposed to enemies' attacks when you are using a bow.{nl}So my strategy is to use anything such as a shield or a stone to protect myself.
 QUEST_LV_0100_20150511_006879	I have already memorized most of them, but the ones left are really important.{nl}They contain information on how to enter the Royal Mausoleum and such.
@@ -7029,7 +7029,7 @@ QUEST_LV_0100_20150714_007024	A small village becomes a big village and then a c
 QUEST_LV_0100_20150714_007025	I told you a while ago, but if possible, I would have pulled it out.{nl}Please beware of the surroundings near you.
 QUEST_LV_0100_20150714_007026	Difficult, difficult...{nl}The words are hard to understand.
 QUEST_LV_0100_20150714_007027	I guess it was the gold plate.{nl}It was lucky that the well was dried... If not, it could have been horrible.{nl}
-QUEST_LV_0100_20150714_007028	I will organize them and show you later.{nl}You are the revelator. They will help your journey to find the Goddesses.
+QUEST_LV_0100_20150714_007028	I will organize them and show you later.{nl}You are the Revelator. They will help your journey to find the Goddesses.
 QUEST_LV_0100_20150714_007029	It seems that the gold plates that you've brought can't be worked due to the rusts.{nl}Why did they record on the gold plate...
 QUEST_LV_0100_20150714_007030	In fact, I didn't know what this gold plate was.{nl}Since this place is the hometown of Demetrius, I came here expecting something may be present.{nl{
 QUEST_LV_0100_20150714_007031	Nothing was engraved on it, rather it was full of rusts.
@@ -7133,9 +7133,9 @@ QUEST_LV_0100_20150714_007128	If it goes wrong, the demons would come out to thi
 QUEST_LV_0100_20150714_007129	We can't do anything if the portal completely opens.{nl}What the hell is happening at Aqueduct region?
 QUEST_LV_0100_20150714_007130	Succeeded?{nl}I think there's something that connects to the other world at Aqueduct region.{nl}What the hell is that...
 QUEST_LV_0100_20150714_007131	Disciple Ramelie
-QUEST_LV_0100_20150714_007132	The sealed tower that was protected by the revelator is being attacked again.{nl}But, it can't be protected by us and the villagers.
+QUEST_LV_0100_20150714_007132	The sealed tower that was protected by the Revelator is being attacked again.{nl}But, it can't be protected by us and the villagers.
 QUEST_LV_0100_20150714_007133	The first seal of the sealed tower is already destroyed by the attacks from the demons.{nl}The second seal still remains, but I don't know how long we can hold up.
-QUEST_LV_0100_20150714_007134	The Goddess asked us to protect the seal. {nl}Now, only one we can trust is you, the revelator.
+QUEST_LV_0100_20150714_007134	The Goddess asked us to protect the seal. {nl}Now, only one we can trust is you, the Revelator.
 QUEST_LV_0100_20150714_007135	Is the seal okay?{nl}I don't know how many times I've prayed to wish that you are okay.
 QUEST_LV_0100_20150714_007136	Now is the time to restore the first seal.{nl}I know it's going to be hard, but I can't seek help for this.
 QUEST_LV_0100_20150714_007137	Are you really going to help? How grateful...{nl}First fill the crest of Austeja Goddess with the sacred energy near the altar.{nl}
@@ -8113,7 +8113,7 @@ QUEST_LV_0100_20150918_008108	$It's not like there weren't any monsters at all f
 QUEST_LV_0100_20150918_008109	That's it, that's how you do it. Easy, right?{nl}There is no way to tell what is going to become of this world now that the Goddesses have left,{nl}so we have to steadily put effort into it ourselves.
 QUEST_LV_0100_20150918_008110	A shield that is advanced to level 4 will be enough.{nl}The determination should be checked.
 QUEST_LV_0100_20150918_008111	You are so determined unlike other guys nowadays.{nl}You can come to learn from me anytime you want.
-QUEST_LV_0100_20150918_008112	$During your travels you might discover Goddess Statues scattered all over the Kingdom.{nl}Worship these statues and you will certainly receive their blessings.
+QUEST_LV_0100_20150918_008112	$During your travels you might discover Goddess Statues scattered all over the kingdom.{nl}Worship these statues and you will certainly receive their blessings.
 QUEST_LV_0100_20150918_008113	Press {img F10 40 40} to open the Help menu for more information.
 QUEST_LV_0100_20150918_008114	The Writings on the Wall
 QUEST_LV_0100_20150918_008115	Which factors are decisive for determining outcomes of battles?{nl}If you just continue to attack thoughtlessly, then you may get attacked instead.
@@ -8168,7 +8168,7 @@ QUEST_LV_0100_20151001_008163	You mean you want to enter the Crystal Mines to fi
 QUEST_LV_0100_20151001_008164	But that's tough at the moment. {nl}There is a swamp of Vubbes rushing out of the Crystal Mines.{nl}
 QUEST_LV_0100_20151001_008165	And there's an increase of the monsters here in the Easter Woods that are now threatening even Klaipeda. {nl}The Miners' Village in the middle has turned into a battlefied. {nl}
 QUEST_LV_0100_20151001_008166	We have divided the troops into two. {nl}Half of the troops are guarding the Miners' Village {nl}and the other half are searching why the number of monsters increased in Eastern Woods.  
-QUEST_LV_0100_20151001_008167	So we are not in the situation to spare our troops for guarding revelators while they check the evidence of salvation. {nl}But we also can't go against the order of the Bishop and Knight Commander either. {nl}
+QUEST_LV_0100_20151001_008167	So we are not in the situation to spare our troops for guarding Revelators while they check the evidence of salvation. {nl}But we also can't go against the order of the Bishop and Knight Commander either. {nl}
 QUEST_LV_0100_20151001_008168	Hmm, what about this? {nl}
 QUEST_LV_0100_20151001_008169	To test whether you can safely reach Miners' Village even without the aid of guards... {nl}Why don't you help us in our search? 
 QUEST_LV_0100_20151001_008170	Good job. {nl}Now, let get to the main task.
@@ -8176,7 +8176,7 @@ QUEST_LV_0100_20151001_008171	Oh, let me give you some helpful information in re
 QUEST_LV_0100_20151001_008172	It wasn't so long ago. {nl}I felt a strange energy while experimenting near the Closed Area. {nl}It was quite different from the spell we know of. It was very warm.{nl}
 QUEST_LV_0100_20151001_008173	The Miners' Village is under siege and dangerous.{nl}Please wait in Klaipeda until the siege is over. 
 QUEST_LV_0100_20151001_008174	Thank you for your determination to learn my swordsmanship, but I am not sure if you would follow well.{nl}I will test you by seeing how you face the Vubbes at Crystal Mine 1F.
-QUEST_LV_0100_20151001_008175	Have you met Jonas in the Gateway of the Great King? {nl}It definitely isn't a sickness. {nl}But it also isn't magic of the present times. 
+QUEST_LV_0100_20151001_008175	Have you met Jonas in the Gateway of Great King? {nl}It definitely isn't a sickness. {nl}But it also isn't magic of the present times. 
 QUEST_LV_0100_20151001_008176	If this note is true, we might die any time.{nl}By the way, what happened to the person who wrote it?
 QUEST_LV_0100_20151001_008177	Because of that, a few disciples have died.{nl}But, it's strange. It seems that it never happened.
 QUEST_LV_0100_20151001_008178	Well done.{nl}Now, is this going to be the last lesson...
@@ -8230,10 +8230,10 @@ QUEST_LV_0100_20151001_008225	Just as I thought. The monsters in this forest wer
 QUEST_LV_0100_20151001_008226	If it was my hometown, if a demon occupied the Mines, everyone would have attacked it and celebrated. {nl}Anyway, I don't know who that Revelator is but this weak kingdom finally found someone useful. 
 QUEST_LV_0100_20151001_008227	A sacred chapel had to go through such bad things. The clerics of this kingdom is planning something unusual. {nl}But it's a good thing to have protected the Tenet Chapel. It means they have the guts, don't you think? {nl}{nl}
 QUEST_LV_0100_20151001_008228	The Vubbes suddenly rushed out of the Mines. {nl}I have no idea what's going on. Do you have anything that comes to mind? 
-QUEST_LV_0100_20151001_008229	We won't know if the revelators really dreamed of the Goddess. It could even be a trick of the Demons. {nl}But didn't someone among them save the Tenet Chapel. {nl}From the Demon Lord even. 
-QUEST_LV_0100_20151001_008230	It's a relief a revelator drove away the Demon Lord from the mines. I was scared another Medis Diena would happen. {nl}But I felt something warm... Was it just my delusion? {nl}It was a pure and good energy. 
-QUEST_LV_0100_20151001_008231	It's such good news that a revelator helped drive away the Demon Lord of Crystal Mines.{nl}But a strange and sacred enery was felt... Could it have been just a delusion? {nl}It is very vague.  
-QUEST_LV_0100_20151001_008232	Do you think Medis Diena and the Demons are related? {nl}I mean the Tenet Chapel. It was as if the demons were waiting for that moment...{nl}Come to think of it, the revelators could have been ones prepared for such situation. 
+QUEST_LV_0100_20151001_008229	We won't know if the Revelators really dreamed of the Goddess. It could even be a trick of the Demons. {nl}But didn't someone among them save the Tenet Chapel. {nl}From the Demon Lord even. 
+QUEST_LV_0100_20151001_008230	It's a relief a Revelator drove away the Demon Lord from the mines. I was scared another Medis Diena would happen. {nl}But I felt something warm... Was it just my delusion? {nl}It was a pure and good energy. 
+QUEST_LV_0100_20151001_008231	It's such good news that a Revelator helped drive away the Demon Lord of Crystal Mines.{nl}But a strange and sacred enery was felt... Could it have been just a delusion? {nl}It is very vague.  
+QUEST_LV_0100_20151001_008232	Do you think Medis Diena and the Demons are related? {nl}I mean the Tenet Chapel. It was as if the demons were waiting for that moment...{nl}Come to think of it, the Revelators could have been ones prepared for such situation. 
 QUEST_LV_0100_20151001_008233	I made it through the wild monsters and you made through the Thorn Forest. {nl}I'm sure you're not looking for the Goddess... Then what's the matter? 
 QUEST_LV_0100_20151001_008234	I heard the historians were attacked by the Demon Lord in King's Plateau. {nl}So it means the disaster was forewarned a thousand years ago? {nl}Anyway, it's a relief the Revelator was able to block it. 
 QUEST_LV_0100_20151001_008235	In between this Valley area and Klaipeda is the Thorn Forest that is full of evil energy. {nl}It was just a normal and peaceful forest before but..{nl}You making it through the forest... Does it mean the forest is now purified? 
@@ -8241,7 +8241,7 @@ QUEST_LV_0100_20151001_008236	There is still so much left unrevealed about the G
 QUEST_LV_0100_20151001_008237	I heard the source of the evil energy deep in the Thorn Forest recently disappeared. {nl}But it will need a long time for the forest to return to its previous state...
 QUEST_LV_0100_20151001_008238	Did you hear that a Revelator stopped the Demon Lord's plan in Royal Mausoleum? {nl}I heard that Demon Lord was going around destroying the ruins in King's Plateau. Now we finally taught him a lesson. 
 QUEST_LV_0100_20151001_008239	How did you come here? Did you make it through the Thorn Forest? {nl}Hmm. Are you saying you can't tell me about it.
-QUEST_LV_0100_20151001_008240	The Demon Lord that was messing the King's Plateau seems to have been the reason behind all the cases of people missing. {nl}It serves him right that a revelator stopped all his plans from going through. 
+QUEST_LV_0100_20151001_008240	The Demon Lord that was messing the King's Plateau seems to have been the reason behind all the cases of people missing. {nl}It serves him right that a Revelator stopped all his plans from going through. 
 QUEST_LV_0100_20151001_008241	Since Goddess Saule disappeared, areas centering around Kvailas Forest was filled with evil energy and thorns. {nl}But you made it through the Thorn Forest? Can we say that it's a good sign? {nl}
 QUEST_LV_0100_20151001_008242	A Revelator saved the Royal Mausoleum of King Zachariel. {nl}But why would the demons go after the ruins that's over a thousand years old? {nl}There is too much that we don't know about. {nl}
 QUEST_LV_0100_20151001_008243	I heard the monsters keep attacking the ruins and the historians keep disappearing. {nl}But also, nobody remembers. How funny. 
@@ -8250,14 +8250,14 @@ QUEST_LV_0100_20151001_008245	If the Demon Lord invaded the Royal Mausoleum, the
 QUEST_LV_0100_20151001_008246	Now the demons even wear the mask of a human. {nl}I heard some Revelator stopped the Demon Lord in the Royal Mausoleum but I wonder how many demons are now hiding amongst humans. 
 QUEST_LV_0100_20151001_008247	This place holds records of the hidden side of history. {nl}Time is an absolute thing. It just depends on how you look at it. 
 QUEST_LV_0100_20151001_008248	I heard a Revelator stopped the Demon Lord that was eyeing the Royal Mausoleum. {nl}It may be a bit overboard to make a connection between Medis Diena and a king from a thousand years ago... {nl}But I'm sure there is something that we are all forgot.
-QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before the Medis Diena.{nl}Thanks to the Goddess sending us the revelator, we finally make an end to the long battle. 
+QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before the Medis Diena.{nl}Thanks to the Goddess sending us the Revelator, we finally make an end to the long battle. 
 QUEST_LV_0100_20151001_008250	The weight of history feels greatly heavy when you stand in this place. {nl}Maybe you can find a clue about Medis Diena. 
 QUEST_LV_0100_20151001_008251	I keep getting the though that Medis Diena might have just been a process.{nl}If not, then why would the demons go after a mausoleum that is over a thousand years old? {nl}It's a good some thing some Revelator stopped it. 
 QUEST_LV_0100_20151001_008252	Everyone know that Helgasercle showed an obsession towards the Mage Tower since centuries ago. {nl}Whatever is in that tower, we can finally see the end of it. {nl}That's a great thing. 
-QUEST_LV_0100_20151001_008253	From Tenet Chapel and now to the Cathedral... But they say it was resolved well by the Revelator so I hope things get better. {nl}Not minding the talks of the world and doing what you must is what's good for the Goddess and the Kingdom. 
+QUEST_LV_0100_20151001_008253	From Tenet Chapel and now to the Cathedral... But they say it was resolved well by the Revelator so I hope things get better. {nl}Not minding the talks of the world and doing what you must is what's good for the Goddess and the kingdom. 
 QUEST_LV_0100_20151001_008254	The story that a Revelator saved the Mage Tower is something that even someone like me, who is not interest in the gossips of the world, can hear. {nl}It's a surprise that there was a least one person who was good enough from anybody there. 
 QUEST_LV_0100_20151001_008255	Hergasercle was an incarnation of obsession. {nl}The chain of obsession was broken thanks to the Revelator but its souls is not something that can be saved. 
-QUEST_LV_0100_20151001_008256	I heard a revelator defeated the Demon Lord that dirtied the teachings of save Maven. {nl}Now it is time for us clergies to come forward. {nl}We should put away our regrets about failing to protect the Cathedral and atone our sins. 
+QUEST_LV_0100_20151001_008256	I heard a Revelator defeated the Demon Lord that dirtied the teachings of save Maven. {nl}Now it is time for us clergies to come forward. {nl}We should put away our regrets about failing to protect the Cathedral and atone our sins. 
 QUEST_LV_0100_20151001_008257	My colleague is dead?{nl}That can't be. Only if I had not tempted him...{nl}
 QUEST_LV_0100_20151001_008258	This map is useless now since my colleague is dead.{nl}Please pray that my colleague would go to the Goddess safely.
 QUEST_LV_0100_20151001_008259	I can't leave with everything behind...
@@ -8267,20 +8267,20 @@ QUEST_LV_0100_20151001_008262	This is all because of the dream of the bishop of 
 QUEST_LV_0100_20151001_008263	I'm not sure if that is the reason but the Vubbes suddenly rushed out of the Crystal Mines. {nl}Those Vubbes took all the villagers they see into the mines. {nl}
 QUEST_LV_0100_20151001_008264	Please... Save the villagers. {nl}I beg of you!
 QUEST_LV_0100_20151001_008265	Let's go to the Crystal Mines. {nl}I will tell you the rest of the story in the Crystal Mine entrance. 
-QUEST_LV_0100_20151001_008266	Hold on! There is something you should know. {nl}We went into the mines to save the kidnapped villagers too.{nl}But the purifiers were broken and the mine was filled with toxic fumes so we failed every time. {nl}
+QUEST_LV_0100_20151001_008266	Hold on! There is something you should know. {nl}We went into the mines to save the kidnapped villagers too.{nl}But the purifiers were broken and the mine was filled with toxic fumes, so we failed every time. {nl}
 QUEST_LV_0100_20151001_008267	Ye..Yes..{nl}Find a young man named Vaidotas!{nl}
 QUEST_LV_0100_20151001_008268	That fellow knows well about the purifiers in Crystal Mines. {nl}It hasn't been long since he was taken away by the Vubbes so he must be in the Vubbe Outpost. 
 QUEST_LV_0100_20151001_008269	{memo X}You want to learn my skills?{nl}It's not hard for me to teach you, but would you be able to handle it?
 QUEST_LV_0100_20151001_008270	The Goddess always told us to help those around us.{nl}By helping others near you, you will help your spirit as well.
 QUEST_LV_0100_20151001_008271	Zachariel's ordeal is not easy.{nl}With the skill you have, he should have acknowledged you.
 QUEST_LV_0100_20151001_008272	The kingdom has lost all its hope. {nl}It does not have any will to stand back anymore and is just crying out for the Goddess.{nl}
-QUEST_LV_0100_20151001_008273	It is during this time that the people came forward saying they dreamed of the Goddess. {nl}It is you, the revelators. {nl}
+QUEST_LV_0100_20151001_008273	It is during this time that the people came forward saying they dreamed of the Goddess. {nl}It is you, the Revelator. {nl}
 QUEST_LV_0100_20151001_008274	Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the Goddess told him the evidence of salvation will be found in the Crystal Mines. {nl}
 QUEST_LV_0100_20151001_008275	Knight Aras in the Eastern Woods is in charge of it so go and meet him. 
-QUEST_LV_0100_20151001_008276	Why is the Goddess sending us revelators now, four years after the incident... {nl}A peasant like me may no tbe able to understand the deeper meaning of the Goddess' will.
-QUEST_LV_0100_20151001_008277	But at least, I know that the Revelators are our only hope.{nl}
+QUEST_LV_0100_20151001_008276	Four years ago after the incident, why is the Goddess sending us Revelators now... {nl}A peasant like me may not be able to understand the deeper meaning of the Goddess' will.
+QUEST_LV_0100_20151001_008277	But, at least I know that the Revelators are our only hope.{nl}
 QUEST_LV_0100_20151001_008278	Well then, go on to the Eastern Woods. {nl}Don't forget to worship the Statue of Goddess Ausrine in the central plaza before you leave. {nl}
-QUEST_LV_0100_20151001_008279	Also, be sure to drop by the Tools Merchant.{nl}I have left some warp scrolls for the revelators. 
+QUEST_LV_0100_20151001_008279	Also, be sure to drop by the Tools Merchant.{nl}I have left some warp scrolls for the Revelators. 
 QUEST_LV_0100_20151001_008280	I can feel Bramble suffering.{nl}He is getting retribution for extracting all vigor from this land.
 QUEST_LV_0100_20151001_008281	I am not afraid of dying.{nl}The Goddess Saule will guide me well.
 QUEST_LV_0100_20151001_008282	The portal that you tried to open is the gate of lies.{nl}That portal leads to where all the knowledge of the world is. 
@@ -8302,17 +8302,17 @@ QUEST_LV_0100_20151001_008297	As I have told you before, the revelation is in th
 QUEST_LV_0100_20151001_008298	But Bramble is also not in its usual condition due to the previous battle. {nl}It is recovering by turning the forest into a thorn forest and extracting nourishments. 
 QUEST_LV_0100_20151001_008299	My disciples are waiting for you in Gate Route. {nl}Please take back the revelation from him. 
 QUEST_LV_0100_20151001_008300	I haved carved many owls for a long time to help Goddess Arusine.{nl}At one point in time, they got their lives and determination.{nl}
-QUEST_LV_0100_20151001_008301	Was Medis Diena just the beginning. {nl}A forest far away from the capital such as this one is also starting to soak its way into the evil energy. {nl} 
+QUEST_LV_0100_20151001_008301	Medis Diena was just the beginning. {nl}A forest far away from the capital such as this one is also starting to soak its way into the evil energy. {nl} 
 QUEST_LV_0100_20151001_008302	I will be able to guide you to the revelation if I use all the strength left in me. {nl}That is why you should release me. 
 QUEST_LV_0100_20151001_008303	But please don't reveal my existence for now. {nl}It is in nature of humans to want to depend on somewhere. {nl}If they find out about the helplessness of the Goddess, the world will be full of moans and confusion. 
 QUEST_LV_0100_20151001_008304	That portal is.. a fantasy... No. A portal going to Goddess Saule. {nl} Anyway, opening the portal is very important.
-QUEST_LV_0100_20151001_008305	If the armors protect you from physical attacks, accessories protect you from magic attacks. {nl} I hope it would be useful for you.{nl}Nice to meet you!{nl}Are you the Revelator who dreamed of the Goddess? {nl}
-QUEST_LV_0100_20151001_008306	Everyone in Klaipeda is talking about that. {nl}I wonder if the revelators really saw the disappeared Goddesses in their dreams... and where is that dream... {nl}
-QUEST_LV_0100_20151001_008307	I am curious to know more about the dream but I'm sure they can't tell me about it.{nl}But it's ok. {nl}I believe that the revelators are people who will find the Goddesses. {nl}
-QUEST_LV_0100_20151001_008308	Please take this accessory. {nl}If the armors protect you from physical attacks, accessories protect you from magic attacks. {nl} 
-QUEST_LV_0100_20151001_008309	I hope you it will be useful for you. {nl}May the blessings of Goddess be with you...
+QUEST_LV_0100_20151001_008305	If armor protect you from physical attacks, accessories protect you from magic attacks. {nl} I hope it would be useful for you.{nl}Nice to meet you!{nl}Are you the Revelator who dreamed of the Goddess? {nl}
+QUEST_LV_0100_20151001_008306	Everyone in Klaipeda is talking about it. {nl}I wonder if the Revelators really saw the disappeared Goddesses in their dreams... and where is that dream... {nl}
+QUEST_LV_0100_20151001_008307	I am curious to know more about the dream but I'm sure they can't tell me about it.{nl}But that's fine since I believe that the Revelators are people who will find the Goddesses. {nl}
+QUEST_LV_0100_20151001_008308	Please take this accessory. {nl}If the armor protects you from physical attacks, accessories protect you from magic attacks. {nl} 
+QUEST_LV_0100_20151001_008309	I hope it will be useful for you. {nl}May the blessings of Goddess be with you...
 QUEST_LV_0100_20151001_008310	The poison of Scorpio, it was somewhat strange.{nl}Well. It already happened so what can I do anyway. I won't mind as long as it doesn't threaten my life.
-QUEST_LV_0100_20151001_008311	Oh I'm causing such trouble.. Thank you for hleping me. {nl}You just have to make a magic circle with the firewood I give you and burn the Shaman doll on top of it.
+QUEST_LV_0100_20151001_008311	Oh I'm causing such trouble.. Thank you for helping me. {nl}You just have to make a magic circle with the firewood I give you and burn the Shaman doll on top of it.
 QUEST_LV_0100_20151001_008312	The crops died when you did what you were told to do? {nl}It's okay. I was told that the bad aura within the crops will go away like that. {nl}
 QUEST_LV_0100_20151001_008313	This is tough. {nl}Many might be killed..
 QUEST_LV_0100_20151001_008314	Huh? You killed it because it tried to eat people? {nl}Ah.. well then, nevermind. I will report it to the Baron myself.
@@ -8327,7 +8327,7 @@ QUEST_LV_0100_20151001_008322	{nl}If it is alright with you, can you set up some
 QUEST_LV_0100_20151001_008323	Thank you. {nl}That would be good enough. 
 QUEST_LV_0100_20151001_008324	Serapinas
 QUEST_LV_0100_20151001_008325	I am Serapinas, one of the new members of the Kedolaomer Merchants. {nl}I am in charge of promoting the merchants. {nl}If you have time, can you help me in one of my promotion agenda? 
-QUEST_LV_0100_20151001_008326	{nl}It's nothing difficult. You just have to go near Orsha or Klaipeda and help the revelators who just began their adventures. {nl}I will give you a scroll. If you use it on them, it will help them and promote the merchants as well. 
+QUEST_LV_0100_20151001_008326	{nl}It's nothing difficult. You just have to go near Orsha or Klaipeda and help the Revelators who just began their adventures. {nl}I will give you a scroll. If you use it on them, it will help them and promote the merchants as well. 
 QUEST_LV_0100_20151001_008327	You must use it near the fields of Orsha or Klaipeda. {nl}And it must be someone who just began their adventure. {nl}I will not work on people who have seen the promotion material already. 
 QUEST_LV_0100_20151001_008328	Thank you for stepping up to help.
 QUEST_LV_0100_20151001_008329	Oh, you're back already. {nl}Revelators sure are different. 
@@ -8364,7 +8364,7 @@ QUEST_LV_0100_20151001_008359	Now it's time to make the sanctuary. {nl}Try to ma
 QUEST_LV_0100_20151001_008360	You can make it here. 
 QUEST_LV_0100_20151001_008361	Good work. {nl}I have a feeling that Gierda, in the northern area, also needs your help.
 QUEST_LV_0100_20151001_008362	Gierda
-QUEST_LV_0100_20151001_008363	You're the revelator. {nl}I am Giedra of Rud order. {nl}If you're here to meet Antanas, I'm sure you've already heard about our order so I won't talk so much about it. 
+QUEST_LV_0100_20151001_008363	You're the Revelator. {nl}I am Giedra of Rud order. {nl}If you're here to meet Antanas, I'm sure you've already heard about our order so I won't talk so much about it. 
 QUEST_LV_0100_20151001_008364	{nl}I am collecting the materials needed to make the Scriptures of Goddess. {nl}Normal paper turns yellow and decays quickly... So I'm looking for materials that won't get wet nor be discolored easily. {nl}The transparent shell of the monsters are great for it. If you polish it well before writing on it, it will last a long time. {nl}Can you get me those? {nl}
 QUEST_LV_0100_20151001_008365	It's a pretty common material so it will be easily to collect. 
 QUEST_LV_0100_20151001_008366	Bring it to me when you collect them all. 
@@ -8387,7 +8387,7 @@ QUEST_LV_0100_20151001_008382	{nl}Anyway, now I'll really go to Orsha now. {nl}T
 QUEST_LV_0100_20151001_008383	Chisel?{nl}The tools merchant should have it. {nl}Go on over there.
 QUEST_LV_0100_20151001_008384	It's a long way back with the tool... {nl}Be careful.
 QUEST_LV_0100_20151001_008385	A Chisel? {nl}You will use it to repair the sanctuary? 
-QUEST_LV_0100_20151001_008386	{nl}Well, I just bought some old chisels from other revelators... {nl}If you need, you can take one of it. 
+QUEST_LV_0100_20151001_008386	{nl}Well, I just bought some old chisels from other Revelators... {nl}If you need, you can take one of it. 
 QUEST_LV_0100_20151001_008387	Did you get the chisel? 
 QUEST_LV_0100_20151001_008388	Oh, you got them all. 
 QUEST_LV_0100_20151001_008389	It's a long way to Gernas Plains... {nl}Go on.
@@ -9047,18 +9047,18 @@ QUEST_LV_0100_20151001_009042
 QUEST_LV_0100_20151001_009043	
 QUEST_LV_0100_20151001_009044	
 QUEST_LV_0100_20151001_009045	
-QUEST_LV_0100_20151001_009046	
+QUEST_LV_0100_20151001_009046	Helping Hand
 QUEST_LV_0100_20151001_009047	
-QUEST_LV_0100_20151001_009048	
+QUEST_LV_0100_20151001_009048	The Mysterious Girl (1)
 QUEST_LV_0100_20151001_009049	
-QUEST_LV_0100_20151001_009050	
+QUEST_LV_0100_20151001_009050	Reclaiming Food
 QUEST_LV_0100_20151001_009051	
 QUEST_LV_0100_20151001_009052	
-QUEST_LV_0100_20151001_009053	
+QUEST_LV_0100_20151001_009053	The Mysterious Girl (2)
 QUEST_LV_0100_20151001_009054	
 QUEST_LV_0100_20151001_009055	
 QUEST_LV_0100_20151001_009056	
-QUEST_LV_0100_20151001_009057	
+QUEST_LV_0100_20151001_009057	The Mysterious Girl (3)
 QUEST_LV_0100_20151001_009058	
 QUEST_LV_0100_20151001_009059	
 QUEST_LV_0100_20151001_009060	
@@ -9068,25 +9068,25 @@ QUEST_LV_0100_20151001_009063
 QUEST_LV_0100_20151001_009064	
 QUEST_LV_0100_20151001_009065	
 QUEST_LV_0100_20151001_009066	
-QUEST_LV_0100_20151001_009067	
+QUEST_LV_0100_20151001_009067	Statue of Peace (1)
 QUEST_LV_0100_20151001_009068	
 QUEST_LV_0100_20151001_009069	
-QUEST_LV_0100_20151001_009070	
+QUEST_LV_0100_20151001_009070	Statue of Peace (2)
 QUEST_LV_0100_20151001_009071	
 QUEST_LV_0100_20151001_009072	
 QUEST_LV_0100_20151001_009073	
 QUEST_LV_0100_20151001_009074	
-QUEST_LV_0100_20151001_009075	
-QUEST_LV_0100_20151001_009076	
-QUEST_LV_0100_20151001_009077	
-QUEST_LV_0100_20151001_009078	
-QUEST_LV_0100_20151001_009079	
-QUEST_LV_0100_20151001_009080	
+QUEST_LV_0100_20151001_009075	The Missing Girl (1)
+QUEST_LV_0100_20151001_009076	The Missing Girl (2)
+QUEST_LV_0100_20151001_009077	The Missing Girl (3)
+QUEST_LV_0100_20151001_009078	Talk to Knight Aras to inquire about the Miners' Village
+QUEST_LV_0100_20151001_009079	Knight Commander Uska has told you to speak with Knight Aras who is in charge of the Crystal Mine. Talk to Knight Aras.
+QUEST_LV_0100_20151001_009080	Go to Knight Aras
 QUEST_LV_0100_20151001_009081	
-QUEST_LV_0100_20151001_009082	
-QUEST_LV_0100_20151001_009083	
-QUEST_LV_0100_20151001_009084	
-QUEST_LV_0100_20151001_009085	
+QUEST_LV_0100_20151001_009082	Investigate in the Eastern Woods.{nl}By defeating Popolions, you might find a clue about the increasing number of monsters.
+QUEST_LV_0100_20151001_009083	Return to Knight Aras
+QUEST_LV_0100_20151001_009084	Return to Knight Aras and tell him that you have defeated the Vubbe Fighter.
+QUEST_LV_0100_20151001_009085	Talk to Knight Aras about the Miners' Village
 QUEST_LV_0100_20151001_009086	
 QUEST_LV_0100_20151001_009087	
 QUEST_LV_0100_20151001_009088	

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -149,7 +149,7 @@ QUEST_LV_0100_20150317_000148	$I lost my important research materials at the Aba
 QUEST_LV_0100_20150317_000149	$I am so glad I get to see the Royal Mausoleum myself, but the monsters... They are scary.
 QUEST_LV_0100_20150317_000150	$Thank you so much.{nl}You should also check the Records Repository.
 QUEST_LV_0100_20150317_000151	$The entrance to the Royal Mausoleum is hidden within this gigantic canyon somewhere.{nl}The start of the canyon begins here.
-QUEST_LV_0100_20150317_000152	$Many experts have come here to conduct research on the Royal Mausoleum.{nl}Maybe we can find some clues about the Medis Diena here.
+QUEST_LV_0100_20150317_000152	$Many experts have come here to conduct research on the Royal Mausoleum.{nl}Maybe we can find some clues about Medis Diena here.
 QUEST_LV_0100_20150317_000153	$Why are there so many monsters in the canyon when there is so little plant life around?
 QUEST_LV_0100_20150317_000154	$What happened to my request? Is it not done yet?
 QUEST_LV_0100_20150317_000155	$Look closely at the ground.{nl}It may have fallen down.
@@ -192,7 +192,7 @@ QUEST_LV_0100_20150317_000191	$Go to the Abandoned Old Workshop.{nl}Some old man
 QUEST_LV_0100_20150317_000192	$What is that? It smells like mead!
 QUEST_LV_0100_20150317_000193	{memo X}I feel dizzy.{nl}What am I doing here anyway?
 QUEST_LV_0100_20150317_000194	$Best of luck on the search.{nl}I lost all the supplies and my belongings while the monsters were chasing after me.{nl}Can you find the scattered supplies first?
-QUEST_LV_0100_20150317_000195	$I don't have much to say to the humble mercenary.{nl}Although I was okay even on the Medis Diena, I am certain this place is cursed.{nl}
+QUEST_LV_0100_20150317_000195	$I don't have much to say to the humble mercenary.{nl}Although I was okay even on Medis Diena, I am certain this place is cursed.{nl}
 QUEST_LV_0100_20150317_000196	$How long has it been since I came here?{nl}Where is Mirta and who are you?
 QUEST_LV_0100_20150317_000197	$I'm trying to remember something but it keeps fading whenever I get close.
 QUEST_LV_0100_20150317_000198	$Vaidotas
@@ -1420,7 +1420,7 @@ QUEST_LV_0100_20150317_001415	{memo X}The device is at the left end of this hall
 QUEST_LV_0100_20150317_001416	{memo X}Good!{nl}There wouldn't be more monsters now.{nl}
 QUEST_LV_0100_20150317_001417	{memo X}Let's go to the next floor soon. {nl} Goddess Gabija is awaiting us. {nl}
 QUEST_LV_0100_20150317_001418	Refugee
-QUEST_LV_0100_20150317_001419	I lost everything. {nl} I don't know how I can go on anymore. {nl} Would my life have become this miserable if not for the Medis Diena?
+QUEST_LV_0100_20150317_001419	I lost everything. {nl} I don't know how I can go on anymore. {nl} Would my life have become this miserable if not for Medis Diena?
 QUEST_LV_0100_20150317_001420	Four years ago, it was on the eve of the so called 'Medis Diena'. {nl} Suddenly, a huge tree emerged in the middle of the capital and the earth and sky reversed. {nl}
 QUEST_LV_0100_20150317_001421	I never knew a tree could grow that big. {nl} And the destruction of the capital began. {nl}
 QUEST_LV_0100_20150317_001422	Everything happened so fast, and nobody knew what to do. {nl} We didn't know whether to run away or try to stop it... Our minds just became blank.
@@ -8205,7 +8205,7 @@ QUEST_LV_0100_20151001_008200	I heard the first Paladin promised three things in
 QUEST_LV_0100_20151001_008201	Our Shaman dolls are different from Bokor's Shaman dolls. {nl}
 QUEST_LV_0100_20151001_008202	You can summon the shaman doll with this summon scroll. {nl}
 QUEST_LV_0100_20151001_008203	Understanding the root of everything becomes the power of Elementalist. {nl}Wind, Water, Fire, Earth. We pull the strongest powers from the simplest forms. 
-QUEST_LV_0100_20151001_008204	This forest is also growing dark. {nl}Many people should realize that the Medis Diena is the start of a disaster. {nl}
+QUEST_LV_0100_20151001_008204	This forest is also growing dark. {nl}Many people should realize that Medis Diena is the start of a disaster. {nl}
 QUEST_LV_0100_20151001_008205	Too bad that Gesti wasn't killed, but still you did a great job.{nl}It will end soon..
 QUEST_LV_0100_20151001_008206	Without Irene, I would have died.{nl}Of course, I really appreciate for your help.
 QUEST_LV_0100_20151001_008207	It's all my fault.{nl}Schmid is dead.. what should I do alone.
@@ -8249,10 +8249,10 @@ QUEST_LV_0100_20151001_008244	I heard a Revelator drove out the Demon Lord that 
 QUEST_LV_0100_20151001_008245	If the Demon Lord invaded the Royal Mausoleum, then the symptoms of Jonas in Gate Route also becomes clear. {nl}If King Zachariel erased the memory of the workers in the Mausoleum, then it must be a side effect of the old magic. {nl}What do you think he was planning to do? 
 QUEST_LV_0100_20151001_008246	Now the demons even wear the mask of a human. {nl}I heard some Revelator stopped the Demon Lord in the Royal Mausoleum but I wonder how many demons are now hiding amongst humans. 
 QUEST_LV_0100_20151001_008247	This place holds records of the hidden side of history. {nl}Time is an absolute thing. It just depends on how you look at it. 
-QUEST_LV_0100_20151001_008248	I heard a Revelator stopped the Demon Lord that was eyeing the Royal Mausoleum. {nl}It may be a bit overboard to make a connection between the Medis Diena and a king from a thousand years ago... {nl}But I'm sure there is something that we are all forgot.
-QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before the Medis Diena.{nl}Thanks to the Goddess sending us the Revelator, we finally make an end to the long battle. 
-QUEST_LV_0100_20151001_008250	The weight of history feels greatly heavy when you stand in this place. {nl}Maybe you can find a clue about the Medis Diena. 
-QUEST_LV_0100_20151001_008251	I keep getting the thought that the Medis Diena might have just been a process.{nl}If not, then why would the demons go after a mausoleum that is over a thousand years old? {nl}It's a good some thing some Revelator stopped it. 
+QUEST_LV_0100_20151001_008248	I heard a Revelator stopped the Demon Lord that was eyeing the Royal Mausoleum. {nl}It may be a bit overboard to make a connection between Medis Diena and a king from a thousand years ago... {nl}But I'm sure there is something that we are all forgot.
+QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before Medis Diena.{nl}Thanks to the Goddess sending us the Revelator, we finally make an end to the long battle. 
+QUEST_LV_0100_20151001_008250	The weight of history feels greatly heavy when you stand in this place. {nl}Maybe you can find a clue about Medis Diena. 
+QUEST_LV_0100_20151001_008251	I keep getting the thought that Medis Diena might have just been a process.{nl}If not, then why would the demons go after a mausoleum that is over a thousand years old? {nl}It's a good some thing some Revelator stopped it. 
 QUEST_LV_0100_20151001_008252	Everyone know that Helgasercle showed an obsession towards the Mage Tower since centuries ago. {nl}Whatever is in that tower, we can finally see the end of it. {nl}That's a great thing. 
 QUEST_LV_0100_20151001_008253	From Tenet Chapel and now to the Cathedral... But they say it was resolved well by the Revelator so I hope things get better. {nl}Not minding the talks of the world and doing what you must is what's good for the Goddess and the kingdom. 
 QUEST_LV_0100_20151001_008254	The story that a Revelator saved the Mage Tower is something that even someone like me, who is not interest in the gossips of the world, can hear. {nl}It's a surprise that there was a least one person who was good enough from anybody there. 
@@ -8285,7 +8285,7 @@ QUEST_LV_0100_20151001_008280	I can feel Bramble suffering.{nl}He is getting ret
 QUEST_LV_0100_20151001_008281	I am not afraid of dying.{nl}The Goddess Saule will guide me well.
 QUEST_LV_0100_20151001_008282	The portal that you tried to open is the gate of lies.{nl}That portal leads to where all the knowledge of the world is. 
 QUEST_LV_0100_20151001_008283	I have been fighting Demon Lord Bramble that tried to take over the revelation. {nl}I have fought with it nights and days to hand the revelation to you. {nl}
-QUEST_LV_0100_20151001_008284	But, the Medis Diena broke the balance of strength. {nl}The Goddesses has lost most of their strength since that day. {nl}
+QUEST_LV_0100_20151001_008284	But, Medis Diena broke the balance of strength. {nl}The Goddesses has lost most of their strength since that day. {nl}
 QUEST_LV_0100_20151001_008285	Bramble took that chance to steal the revelation and seal me in this place. {nl}Because only I know how to interpret the revelation.{nl} 
 QUEST_LV_0100_20151001_008286	But I did not give into Bramble's order to interpret the revelation.{nl}That is why he made a plot to open a portal that leads to where all knowledge of the world is. {nl}
 QUEST_LV_0100_20151001_008287	The residents of this area is the plot to open that portal. {nl}To find a way to get the revelation using your power as the savior... Something brutal was done. {nl}
@@ -8337,7 +8337,7 @@ QUEST_LV_0100_20151001_008332	{nl}Let's take time to talk later but first, pleas
 QUEST_LV_0100_20151001_008333	It would also be nice to take care of the monsters on your way there too. 
 QUEST_LV_0100_20151001_008334	It won't be that dangerous.
 QUEST_LV_0100_20151001_008335	Oh, you brought it. {nl}This is a divine object known as the Incense of Goddess.
-QUEST_LV_0100_20151001_008336	Did I tell you? {nl}Oh, it was a long day... {nl}We faced the Medis Diena right here while we were transporting the divine objects to Orsha. 
+QUEST_LV_0100_20151001_008336	Did I tell you? {nl}Oh, it was a long day... {nl}We faced Medis Diena right here while we were transporting the divine objects to Orsha. 
 QUEST_LV_0100_20151001_008337	{nl}The wagon flipped and the divine objects scattered around. {nl}That's why we are going through this excavation to find it. {nl}But people are hesitating to excavate that area because of the monsters... Please help us. 
 QUEST_LV_0100_20151001_008338	I wonder if it was eaten by the monster...
 QUEST_LV_0100_20151001_008339	Looks like the monsters ripped it to shreds but here. {nl}Let me try to have it back.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -201,7 +201,7 @@ QUEST_LV_0100_20150317_000200	$Do you know about the Legend of Cunningham?{nl}Th
 QUEST_LV_0100_20150317_000201	{memo X}$Anyway, my guess is that the demon is re-awakening and is controlling the Vubbes.{nl}The Bishop's dream and the Legend of Cunningham... I feel they may be a sign that something huge is about to happen.{nl}
 QUEST_LV_0100_20150317_000202	$Only the Goddess would know if it will be hope or despair.{nl}
 QUEST_LV_0100_20150317_000203	$The purifier can be easily fixed by anyone, but it may be hard to find the parts needed.{nl}In that case, use the compass that I gave you to search for them.{nl}
-QUEST_LV_0100_20150317_000204	$Well then, I have some things to do so I will meet you at the Crystal Mine 3F.{nl}In the name of the Goddess, I pray for success in your struggles.
+QUEST_LV_0100_20150317_000204	$Well then, I have some things to do so I will meet you at 3F of the Crystal Mine.{nl}In the name of the Goddess, I pray for success in your struggles.
 QUEST_LV_0100_20150317_000205	$If you can't find the parts needed to repair the purifier, use the compass I gave you.{nl}It'll help you find them.
 QUEST_LV_0100_20150317_000206	$Village Aunt
 QUEST_LV_0100_20150317_000207	$You've come to save us? Right?
@@ -397,7 +397,7 @@ QUEST_LV_0100_20150317_000392	There seems to be a gap in the rock where you can 
 QUEST_LV_0100_20150317_000393	Let's search Bulvjes Farm first.{nl}But don't chase them or something as it can be dangerous.
 QUEST_LV_0100_20150317_000394	It makes me wonder if you're an envoy of the Goddess.{nl}Anyway, the supply camp is located further below the farm.
 QUEST_LV_0100_20150317_000395	{memo X}
-QUEST_LV_0100_20150317_000396	The Crystal Mines have become infested with Vubbes, so be sure to stay together in groups of five.
+QUEST_LV_0100_20150317_000396	The Crystal Mine has become infested with Vubbes, so be sure to stay together in groups of five.
 QUEST_LV_0100_20150317_000397	Equipment Merchant
 QUEST_LV_0100_20150317_000398	Even at times like this, I struggle to find the best items I can. You can't go easy in terms of dealing with your customers.
 QUEST_LV_0100_20150317_000399	Monsters attack and steal from people who buy items from me. I think they know I can tell which items are good.{nl}I feel sorry for those who were attacked but it also proves that the items are worth it.
@@ -505,8 +505,8 @@ QUEST_LV_0100_20150317_000500	$You must be brave in order to protect the kingdom
 QUEST_LV_0100_20150317_000501	{memo X}The Goddesses may be all gone but my powers are still doing fine, right?{nl}I'm sure it must be proof that Goddess Gabija is at least safe somewhere.
 QUEST_LV_0100_20150317_000502	{memo X}
 QUEST_LV_0100_20150317_000503	{memo X}
-QUEST_LV_0100_20150317_000504	Quarrelshooter Master
-QUEST_LV_0100_20150317_000505	It's painful to see people come to Klaipeda seeking refuge from the monsters.{nl}If they were Quarrelshooters they wouldn't have to.
+QUEST_LV_0100_20150317_000504	Quarrel Shooter Master
+QUEST_LV_0100_20150317_000505	It's painful to see people come to Klaipeda seeking refuge from the monsters.{nl}If they were Quarrel Shooters they wouldn't have to.
 QUEST_LV_0100_20150317_000506	Ranger Master
 QUEST_LV_0100_20150317_000507	{memo X}I heard monsters swarm in flocks outside of Klaipeda.{nl}If I could improve my skill instead of attacking them one by one...
 QUEST_LV_0100_20150317_000508	Sapper Master
@@ -1754,7 +1754,7 @@ QUEST_LV_0100_20150317_001749	We should ask for more when we are in times like t
 QUEST_LV_0100_20150317_001750	Good. Good. This will be enough.
 QUEST_LV_0100_20150317_001751	$Now go get lime from the monsters that swallowed some.
 QUEST_LV_0100_20150317_001752	After finish making this, I am outta of this town.{nl}I stayed here so long.
-QUEST_LV_0100_20150317_001753	Good. Go meet my partner at Garden of Poles with this.{nl}He is called Vincent and he is very skillful.
+QUEST_LV_0100_20150317_001753	Good. Meet my partner at Garden of Poles with this.{nl}He is called Vincent and he is very skillful.
 QUEST_LV_0100_20150317_001754	Ah. Welcome.{nl}There aren't any people in this world who can make counterfeits well like us.{nl}
 QUEST_LV_0100_20150317_001755	I needed someone to do some errands.{nl}Get some firewoods that are scattered on the ground.
 QUEST_LV_0100_20150317_001756	Vincent
@@ -4275,7 +4275,7 @@ QUEST_LV_0100_20150317_004270	$Observe the Eyes of the Great King besides the Ar
 QUEST_LV_0100_20150317_004271	$Archivist Jonas is asking you to prove that you are qualified for his task by using the Eyes of the Great King.
 QUEST_LV_0100_20150317_004272	$The Eyes of the Great King have responded. Talk to Archivist Jonas.
 QUEST_LV_0100_20150317_004273	$Talk to the Medicine Dealer
-QUEST_LV_0100_20150317_004274	$Merchant Davio told you that he needs one more herb to complete the medicine, but he already sent off the Medicine Dealer to get the herb. Go meet the Medicine Dealer at Kapas Highway.
+QUEST_LV_0100_20150317_004274	$Merchant Davio told you that he needs one more herb to complete the medicine, but he already sent off the Medicine Dealer to get the herb. Meet the Medicine Dealer at Kapas Highway.
 QUEST_LV_0100_20150317_004275	$Collect Canyon Metos.
 QUEST_LV_0100_20150317_004276	$The Medicine Dealer told you that all other ingredients is ready, except for Canyon Metos. Collect Canyon Metoses in Metos Field in order to complete the medicine that will bring back Jonas' mind.
 QUEST_LV_0100_20150317_004277	$You have enough Canyon Metos. Return to the Medicine Dealer and complete the medicine that will bring back Jonas' mind.
@@ -4307,15 +4307,15 @@ QUEST_LV_0100_20150317_004302	{memo X}You found a part for the Entrance Purifier
 QUEST_LV_0100_20150317_004303	{memo X} Find %s on the floor
 QUEST_LV_0100_20150317_004304	$Retrieve Purifier Parts
 QUEST_LV_0100_20150317_004305	$Retrieve Purifier Parts from the Vubbe with a question mark on its head.
-QUEST_LV_0100_20150317_004306	$Repair the Entrance Purifier on the 1st Floor
+QUEST_LV_0100_20150317_004306	$Repair the Entrance Purifier on 1F
 QUEST_LV_0100_20150317_004307	$Found the missing parts of the Entrance Purifier. Try to assemble and activate it.
 QUEST_LV_0100_20150317_004308	{memo X}Search for Purifier parts on the floor
-QUEST_LV_0100_20150317_004309	$Repair the Purifiers on the 2nd Floor
-QUEST_LV_0100_20150317_004310	$Repair all the Purifiers on the 2nd Floor
+QUEST_LV_0100_20150317_004309	$Repair the Purifiers on 2F
+QUEST_LV_0100_20150317_004310	$Repair all the Purifiers on 2F
 QUEST_LV_0100_20150317_004311	$Inspect the Central Purifier
-QUEST_LV_0100_20150317_004312	$The Mine Compass is pointing towards the Central Purifier on the 1st floor. Inspect the purifier. 
+QUEST_LV_0100_20150317_004312	$The Mine Compass is pointing towards the Central Purifier on 1F. Inspect the purifier. 
 QUEST_LV_0100_20150317_004313	$Use the Mine Compass
-QUEST_LV_0100_20150317_004314	$Use the Mine Compass to find the Spare Purifier located somewhere on the 1st floor.
+QUEST_LV_0100_20150317_004314	$Use the Mine Compass to find the Spare Purifier located somewhere on 1F.
 QUEST_LV_0100_20150317_004315	$Search District 4 for the Spare Purifier
 QUEST_LV_0100_20150317_004316	$The Mine Compass is pointing towards District 4. Follow its lead and find the Spare Purifier that can be used to repair the Purifier.
 QUEST_LV_0100_20150317_004317	$Get parts from the Spare Purifier in District 4.
@@ -4324,13 +4324,13 @@ QUEST_LV_0100_20150317_004319	$Obtained spare parts for the Central Purifier. Re
 QUEST_LV_0100_20150317_004320	$Defeat Cyclops in the Crystal Mine
 QUEST_LV_0100_20150317_004321	$Cyclops is rampaging in the Crystal Mine. Defeat Cyclops. 
 QUEST_LV_0100_20150317_004322	$Defeat Cyclops
-QUEST_LV_0100_20150317_004323	$Inspect the Passage Purifier on the 1st Floor
+QUEST_LV_0100_20150317_004323	$Inspect the Passage Purifier on 1F
 QUEST_LV_0100_20150317_004324	$There is a problem with the purifier on the path to Crystal Mine 2F. Go and inspect it.
 QUEST_LV_0100_20150317_004325	$Use the Mine Compass to find the parts needed to repair the purifier.
 QUEST_LV_0100_20150317_004326	$Search District 6 for Purifier Parts
 QUEST_LV_0100_20150317_004327	$The Mine Compass is pointing towards District 6. Follow it and find parts to repair the purifier.
 QUEST_LV_0100_20150317_004328	 Retrieve %s from Specter Monarch
-QUEST_LV_0100_20150317_004329	$Repair the Passage Purifier on the 1st Floor
+QUEST_LV_0100_20150317_004329	$Repair the Passage Purifier on 1F
 QUEST_LV_0100_20150317_004330	$Found the parts needed to repair the Passage Purifier. Try to assemble and activate it.
 QUEST_LV_0100_20150317_004331	$Inspect the Circulation Purifier
 QUEST_LV_0100_20150317_004332	$The Circulation Purifier on the 2nd Floor is not working. Figure out what the problem is.
@@ -4343,7 +4343,7 @@ QUEST_LV_0100_20150317_004338	$Check if the Purifier Pipe in District 2 is funct
 QUEST_LV_0100_20150317_004339	$Defeat Carapace
 QUEST_LV_0100_20150317_004340	$Activate the Circulation Purifier
 QUEST_LV_0100_20150317_004341	$All Purifier Pipes seems to be working properly. Activate the Circulation Purifier.
-QUEST_LV_0100_20150317_004342	$Inspect the Auxiliary Purifier on the 2nd Floor
+QUEST_LV_0100_20150317_004342	$Inspect the Auxiliary Purifier on 2F
 QUEST_LV_0100_20150317_004343	$The Auxiliary Purifier on the 2nd Floor is halted. Find out why it is halted.
 QUEST_LV_0100_20150317_004344	$Use the Mine Compass
 QUEST_LV_0100_20150317_004345	$Use the Mine Compass to check what you need to fix the Auxiliary Purifier.
@@ -4354,7 +4354,7 @@ QUEST_LV_0100_20150317_004349	$Search for tools to remove rust
 QUEST_LV_0100_20150317_004350	$Follow the Mine Compass's lead and find a way to remove the rust.
 QUEST_LV_0100_20150317_004351	$Restore the Magic Supply Device in District 4
 QUEST_LV_0100_20150317_004352	$Seems like you can fix the Magic Supply Device in District 4 with lubricant.
-QUEST_LV_0100_20150317_004353	$Activate the Auxiliary Purifier on the 2nd Floor
+QUEST_LV_0100_20150317_004353	$Activate the Auxiliary Purifier on 2F
 QUEST_LV_0100_20150317_004354	$The Magic Supply Device seems to be working well. Activate the Auxiliary Purifier.
 QUEST_LV_0100_20150317_004355	$Check the Main Purifier
 QUEST_LV_0100_20150317_004356	$The Main Purifier is not working. Go and inspect it.
@@ -4384,7 +4384,7 @@ QUEST_LV_0100_20150317_004379	There are still many seals left before you go to t
 QUEST_LV_0100_20150317_004380	Unleash the seal device
 QUEST_LV_0100_20150317_004381	You have to unleash all seals to enter into the sanctum that will lead you to the inheritance of Zachariel. Unleash the 2nd seal that is on the middle of the way to the Broken Sanctum. Be careful of monsters' attacks.
 QUEST_LV_0100_20150317_004382	Talk to Gustas Jonas
-QUEST_LV_0100_20150317_004383	You have unleashed the 2nd seal. Go meet Gustas Jonas to listen to the guides for the next seal to get to the inheritance of Zachariel.
+QUEST_LV_0100_20150317_004383	You have unleashed the 2nd seal. Meet Gustas Jonas to listen to the guides for the next seal to get to the inheritance of Zachariel.
 QUEST_LV_0100_20150317_004384	Talk with Mercenary Toby
 QUEST_LV_0100_20150317_004385	Mercenary Todou is looking for someone who can help him. Talk with Todou
 QUEST_LV_0100_20150317_004386	Get your skills tested
@@ -4398,8 +4398,8 @@ QUEST_LV_0100_20150317_004393	You picked up an equipment for excavation. Return 
 QUEST_LV_0100_20150317_004394	Talk to the Owl Sculpture of Forecasts
 QUEST_LV_0100_20150317_004395	Talk to the Owl Sculpture of Forecasts
 QUEST_LV_0100_20150317_004396	Defeat Necroventer
-QUEST_LV_0100_20150317_004397	Talk to the Archeologist, Laudi
-QUEST_LV_0100_20150317_004398	Lausi is looking for someone who is stronger than anyone. Go talk to Laudi.
+QUEST_LV_0100_20150317_004397	Talk to Archeologist Laudi
+QUEST_LV_0100_20150317_004398	Archeologist Laudi is looking for someone who is stronger than anyone. Talk to Archeologist Laudi.
 QUEST_LV_0100_20150317_004399	$Obtain the fragment of the ruins by{nl} defeating Denoptic
 QUEST_LV_0100_20150317_004400	$Laudi said that he can not continue his research due to the charcoal-eating Denoptic. Please bring him the fragments of the ruins that haven't been digested inside Denoptic beyond Apynys Camp. When you take a look at the charcoal, Denoptic should appear.
 QUEST_LV_0100_20150317_004401	Give the fragments to Laudi
@@ -5011,7 +5011,7 @@ QUEST_LV_0100_20150317_005006	The herb broker told you that you need the secreti
 QUEST_LV_0100_20150317_005007	Hand it over to the herb broker
 QUEST_LV_0100_20150317_005008	You obtained all the fluids of Tinis. Hand them over to the herb broker.
 QUEST_LV_0100_20150317_005009	Obtain the secreting fluids of Tinis.
-QUEST_LV_0100_20150317_005010	It seems that the herbicide is all completed. Go talk to the herb broker.
+QUEST_LV_0100_20150317_005010	It seems that the herbicide is all completed. Talk to the herb broker.
 QUEST_LV_0100_20150317_005011	Use the herbicide on the thorny bushes
 QUEST_LV_0100_20150317_005012	The herb broker gave you the herbicide that he made. Use it on the place below where thorny bushes are located.
 QUEST_LV_0100_20150317_005013	A gigantic monster appeared as you used the herbicide, but you were able to defeat it. Talk to the soldier, Bran.
@@ -5040,7 +5040,7 @@ QUEST_LV_0100_20150317_005035	Report to the commander Raimondas
 QUEST_LV_0100_20150317_005036	Spion who was definitely dead became violent because of the herb broker so you had no other choice,  but to defeat him. Return to Raimondas and tell him what happened. 
 QUEST_LV_0100_20150317_005037	Defeat Bebraspion
 QUEST_LV_0100_20150317_005038	You should now return to meet Raimondas since you obtained the symbol. Talk to Alryus before you meet Raimondas.
-QUEST_LV_0100_20150317_005039	It seems that you are qualifed to become an official soldier since you obtained the symbol. Go meet Raimondas and show him the symbol.
+QUEST_LV_0100_20150317_005039	It seems that you are qualifed to become an official soldier since you obtained the symbol. Meet Raimondas and show him the symbol.
 QUEST_LV_0100_20150317_005040	Talk to Follower Vaidutis
 QUEST_LV_0100_20150317_005041	Meet Follower Vaidutis on the 1st floor of Tenet Chapel
 QUEST_LV_0100_20150317_005042	Collect the Power Crystals
@@ -6813,7 +6813,7 @@ QUEST_LV_0100_20150428_006808	You dreamed about the Goddess telling you to go to
 QUEST_LV_0100_20150428_006809	Extinguished the research diary on the fire place
 QUEST_LV_0100_20150428_006810	You burned all diaries to calm his soul. Talk to the spirit of the adventurer, Varkis.
 QUEST_LV_0100_20150428_006811	Meet Blacksmith of Klaipeda
-QUEST_LV_0100_20150428_006812	Go meet the Blacksmith of Klaipeda as Pipoti has told you.
+QUEST_LV_0100_20150428_006812	Meet the Blacksmith of Klaipeda as Pipoti has told you.
 QUEST_LV_0100_20150428_006813	Before you release the important seal at Ramstis Ridge, you should first talk to the disciple of Gustas.
 QUEST_LV_0100_20150428_006814	As the Goddess told you in the dream of the bishop, you should first go to Crystal Mine, but you can't just see and ignore the villagers who are evacuating. Let's help the angry hunter.
 QUEST_LV_0100_20150428_006815	Talk to Vaidotas at Crystal Mine 1F
@@ -6866,7 +6866,7 @@ QUEST_LV_0100_20150428_006861	To the 1st zone of Demons' Prison
 QUEST_LV_0100_20150428_006862	Move to the 1st zone of Demons' Prison
 QUEST_LV_0100_20150428_006863	Move to the 1st zone of Demons' Prison
 QUEST_LV_0100_20150428_006864	In order to go to Demons' Prison, you should go past Gitise settlement area. Help the ones that are in trouble to go to Gitese settlement area past Klaipeda.
-QUEST_LV_0100_20150511_006865	$Anyway, my guess is that the demon is re-awakening and is controlling the Vubbes.{nl}The Bishop's dream and the Legend of Cunningham... I feel they may be a sign that something huge is about to happen.{nl}
+QUEST_LV_0100_20150511_006865	$Anyway, my guess is that the demon is re-awakening and is controlling the Vubbes.{nl}The Bishop's dream and the legend of Cunningham... I feel they may be a sign that something huge is about to happen.{nl}
 QUEST_LV_0100_20150511_006866	$Finding the cause of the monsters is important,{nl}but I'm more worried about supplies not making it to the Miners' Village.
 QUEST_LV_0100_20150511_006867	$Vubbe Fighter is hiding deep in the Nudegi Felled Area. {nl} We got the orders to kill but it may be safer to wait for additional troops.
 QUEST_LV_0100_20150511_006868	$If you ever face us as enemies, you should be careful not to lose your legs.{nl}Swords are still able to lash out from under our shields.{nl}
@@ -7518,7 +7518,7 @@ QUEST_LV_0100_20150714_007513	Meet Alruida, the assistant of Justas. He is on th
 QUEST_LV_0100_20150714_007514	Use the reagent to find the real gold plates
 QUEST_LV_0100_20150714_007515	Alruida told you find the real ones among the gold plates that are scattered across the great hall. Use the reagent that Alruida gave to you to find the real gold plates.
 QUEST_LV_0100_20150714_007516	Hand over the gold plates to Alruida
-QUEST_LV_0100_20150714_007517	You've found the real gold plates. Go meet Alruida to hand them over.
+QUEST_LV_0100_20150714_007517	You've found the real gold plates. Meet Alruida to hand them over.
 QUEST_LV_0100_20150714_007518	Talk with Alruida if there are other gold plates.
 QUEST_LV_0100_20150714_007519	Retrieve the gold plates that are under the vines
 QUEST_LV_0100_20150714_007520	At the corner of Apsuba Hall, the gold plates are under the vines. Pull the plates out from the vines.
@@ -7532,7 +7532,7 @@ QUEST_LV_0100_20150714_007527	Search for the gold plates using the detection sti
 QUEST_LV_0100_20150714_007528	Alruida told you that there is one place that he hasn't explored. Use the detection stick that Alruida gave to you to explore Polsas Highway.
 QUEST_LV_0100_20150714_007529	Alruida found the gold plate that he hasn't found before. Take the gold plate to Alruida.
 QUEST_LV_0100_20150714_007530	Alruida is happy since all the plates are gathered. Talk to Alruida again.
-QUEST_LV_0100_20150714_007531	Go meet Justas
+QUEST_LV_0100_20150714_007531	Meet Justas
 QUEST_LV_0100_20150714_007532	Alruida told you to hand over all gold plates that were discovered to Justas. Hand over all the plates to Justas and receive the research records of Demetrius.
 QUEST_LV_0100_20150714_007533	$Remaining Danger
 QUEST_LV_0100_20150714_007534	$Vaidotas in Miners' Village is looking for you. Talk to Vaidotas.
@@ -8035,7 +8035,7 @@ QUEST_LV_0100_20150908_008030	You've collected all the resin of the trees.{nl}Go
 QUEST_LV_0100_20150908_008031	Combining the ingredients
 QUEST_LV_0100_20150908_008032	The dye has been completed!{nl}Go to the altar and obtain the dye
 QUEST_LV_0100_20150908_008033	Go back to the new officer of Andail village
-QUEST_LV_0100_20150908_008034	Go meet the priest of Andail village at Cobalt Forest!
+QUEST_LV_0100_20150908_008034	Meet the priest of Andail village at Cobalt Forest!
 QUEST_LV_0100_20150908_008035	Moldyhorn has appeared!
 QUEST_LV_0100_20150908_008036	Combining the ingredients
 QUEST_LV_0100_20150908_008037	Defeat the monsters that reacted to the ominous energy!
@@ -8043,7 +8043,7 @@ QUEST_LV_0100_20150908_008038	Blue Woodspirit has appeared!
 QUEST_LV_0100_20150908_008039	Obtain Languid Herb from Narvas Crooked Road
 QUEST_LV_0100_20150908_008040	Look for spiritual flowers with the strong fragrance Dvyni Swamp
 QUEST_LV_0100_20150908_008041	You've obtained the spiritual flowers that possess strong fragrance!{nl}Go back to the priest of the village
-QUEST_LV_0100_20150908_008042	Go meet the elder of the village
+QUEST_LV_0100_20150908_008042	Meet the elder of the village
 QUEST_LV_0100_20150908_008043	Bring the bombs from the bomb container which is located at the upper side of the village
 QUEST_LV_0100_20150908_008044	Look for tools that can be used to pull out the object in the well!
 QUEST_LV_0100_20150908_008045	Pulling out the object
@@ -8150,9 +8150,9 @@ QUEST_LV_0100_20150918_008145	$Stonemason Canolyn told you that a monster called
 QUEST_LV_0100_20150918_008146	$Find Historian Rexipher
 QUEST_LV_0100_20150918_008147	$Collect Hogma Teeth
 QUEST_LV_0100_20150918_008148	Pursue Rexipher at the Royal Mausoleum Entrance
-QUEST_LV_0100_20151001_008149	Do you know the legend of Cunningham? {nl}It's a legend about how a great demon was trapped in the Crystal Mines in the past. {nl}
+QUEST_LV_0100_20151001_008149	Do you know the legend of Cunningham? {nl}It's a legend about how a great demon was trapped in the Crystal Mine in the past. {nl}
 QUEST_LV_0100_20151001_008150	I assume that the trapped demon has finally woken up to control the Vubbes. {nl}The dream of the Bishop and the Legend of Cunningham... {nl}I wonder if it is a forewarning of a great event that's about to happen.{nl}
-QUEST_LV_0100_20151001_008151	Only the Goddess knows if it will be hope or despair. {nl}You can read the details about it in a book found at Mine Worker's Resting Place in 2F.
+QUEST_LV_0100_20151001_008151	Only the Goddess knows if it will be hope or despair. {nl}You can read the details about it in a book found at Mine Worker's Resting Place on 2F.
 QUEST_LV_0100_20151001_008152	Anyway, it seems like the Vubbes surely destroyed the purifiers. {nl}You better fix it first before the hostages run out of air. 
 QUEST_LV_0100_20151001_008153	I will protect this village for my dead comrades.
 QUEST_LV_0100_20151001_008154	If the Bokor Master told you that I would know it..{nl}There's one place that comes to mind.{nl}

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -8151,15 +8151,15 @@ QUEST_LV_0100_20150918_008146	$Find Historian Rexipher
 QUEST_LV_0100_20150918_008147	$Collect Hogma Teeth
 QUEST_LV_0100_20150918_008148	Pursue Rexipher at the Royal Mausoleum Entrance
 QUEST_LV_0100_20151001_008149	Do you know the legend of Cunningham? {nl}It's a legend about how a great demon was trapped in the Crystal Mines in the past. {nl}
-QUEST_LV_0100_20151001_008150	I assumption is that the trapped demon finally woke up to control the Vubbes. {nl}The dream of the Bishop and the Legend of Cunningham... {nl}I wonder if it is a forewarning of a great event that's about to happen.{nl}
-QUEST_LV_0100_20151001_008151	Only the Goddess knows if it will be hope or despair. {nl}You can read the details about it in the book found in Miners' Resting Area in 2F.
+QUEST_LV_0100_20151001_008150	I assume that the trapped demon has finally woken up to control the Vubbes. {nl}The dream of the Bishop and the Legend of Cunningham... {nl}I wonder if it is a forewarning of a great event that's about to happen.{nl}
+QUEST_LV_0100_20151001_008151	Only the Goddess knows if it will be hope or despair. {nl}You can read the details about it in a book found at Mine Worker's Resting Place in 2F.
 QUEST_LV_0100_20151001_008152	Anyway, it seems like the Vubbes surely destroyed the purifiers. {nl}You better fix it first before the hostages run out of air. 
 QUEST_LV_0100_20151001_008153	I will protect this village for my dead comrades.
 QUEST_LV_0100_20151001_008154	If the Bokor Master told you that I would know it..{nl}There's one place that comes to mind.{nl}
 QUEST_LV_0100_20151001_008155	You're saying something that's really hard to believe. {nl}You mean this revelation is Goddess Laima and we have to collect all these for the Goddess to return?{nl}
-QUEST_LV_0100_20151001_008156	Goddess Laima is often called the recorded Goddess. {nl}When King Zachariel formed this kingdom, the only record about it is that Goddess Laima blessed it.  {nl}
+QUEST_LV_0100_20151001_008156	Goddess Laima is often called the recorded Goddess. {nl}When the Great King Zachariel formed this kingdom, the only record about it is that Goddess Laima blessed it.  {nl}
 QUEST_LV_0100_20151001_008157	I'd like to ask you a favor. {nl}I have sinned because I was not able to fulfill my duties of guarding the kingdom on Medis Diena. {nl}
-QUEST_LV_0100_20151001_008158	But I am not a Revelator. {nl}Even if I want to make up for my sins, my duty  at the moment is to protect the many citizens of Klaipeda. {nl}
+QUEST_LV_0100_20151001_008158	But I am not a Revelator. {nl}Even if I want to make up for my sins, my duty at the moment is to protect the many citizens of Klaipeda. {nl}
 QUEST_LV_0100_20151001_008159	So please find all the revelations. {nl}I will put my position as the Knight Commander of Klaipeda on the line and help you deal with it. 
 QUEST_LV_0100_20151001_008160	If you're on your way to Klaipeda, let me ask you a favor. {nl}It's not easy to go to Klaipeda because of the Infrorocktors.
 QUEST_LV_0100_20151001_008161	I feel so relieved to be stationed in the Western Woods.{nl}There are some places where you'd rather die than to be stationed.
@@ -8176,7 +8176,7 @@ QUEST_LV_0100_20151001_008171	Oh, let me give you some helpful information in re
 QUEST_LV_0100_20151001_008172	It wasn't so long ago. {nl}I felt a strange energy while experimenting near the Closed Area. {nl}It was quite different from the spell we know of. It was very warm.{nl}
 QUEST_LV_0100_20151001_008173	The Miners' Village is under siege and dangerous.{nl}Please wait in Klaipeda until the siege is over. 
 QUEST_LV_0100_20151001_008174	Thank you for your determination to learn my swordsmanship, but I am not sure if you would follow well.{nl}I will test you by seeing how you face the Vubbes at Crystal Mine 1F.
-QUEST_LV_0100_20151001_008175	Have you met Jonas in the Gateway of Great King? {nl}It definitely isn't a sickness. {nl}But it also isn't magic of the present times. 
+QUEST_LV_0100_20151001_008175	Have you met Jonas in the Gateway of the Great King? {nl}It definitely isn't a sickness. {nl}But it also isn't magic of the present times. 
 QUEST_LV_0100_20151001_008176	If this note is true, we might die any time.{nl}By the way, what happened to the person who wrote it?
 QUEST_LV_0100_20151001_008177	Because of that, a few disciples have died.{nl}But, it's strange. It seems that it never happened.
 QUEST_LV_0100_20151001_008178	Well done.{nl}Now, is this going to be the last lesson...

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -90,7 +90,7 @@ QUEST_LV_0100_20150317_000089	$You are pretty good for a rookie.{nl}It's disorga
 QUEST_LV_0100_20150317_000090	$Get to know our soldiers while I make preparations for the battle.{nl}I will call you before we confront Gaigalas.
 QUEST_LV_0100_20150317_000091	$When we burn the Ducky Fat, Gaigalas will appear after smelling the odor.{nl}Lengvas Garden will be a good place to burn it.
 QUEST_LV_0100_20150317_000092	$My heart is pounding.{nl}I feel like my soul is throbbing with it.
-QUEST_LV_0100_20150317_000093	$Old Owl Statue
+QUEST_LV_0100_20150317_000093	$Old Owl Sculpture
 QUEST_LV_0100_20150317_000094	$There's no one in this forest. Why are you here?{nl}
 QUEST_LV_0100_20150317_000095	$Gaigalas?{nl}Defeating it without any assistance will be difficult.
 QUEST_LV_0100_20150317_000096	$I have seen many deaths here.{nl}And I don't want to see any more sacrifices.
@@ -170,7 +170,7 @@ QUEST_LV_0100_20150317_000169	$I will lead the way and you will handle any monst
 QUEST_LV_0100_20150317_000170	$The time is now. Please go on ahead to Beacon Hill Pass.
 QUEST_LV_0100_20150317_000171	{memo X}I am sure that you are qualified for this.{nl}Goddess Laima has led all these.
 QUEST_LV_0100_20150317_000172	$Finally the hidden treasure can be passed down to someone.{nl}I regret not recognizing you sooner due to my senility.
-QUEST_LV_0100_20150317_000173	$Zachariel told us to bestow his hidden treasure upon a qualified person.{nl}You can check whether you are qualified with the Eyes of the Great King.
+QUEST_LV_0100_20150317_000173	$Great King Zachariel told us to bestow his hidden treasure upon a qualified person.{nl}You can check whether you are qualified with the Eyes of the Great King.
 QUEST_LV_0100_20150317_000174	$We have one more responsibility besides protecting the Royal Mausoleum.{nl}And that is to protect the inheritance until a qualified person comes.{nl}
 QUEST_LV_0100_20150317_000175	$We have no idea what exactly the hidden treasure is.{nl}The king just told us to protect it so we are just following his order.
 QUEST_LV_0100_20150317_000176	$Medicine Dealer
@@ -183,7 +183,7 @@ QUEST_LV_0100_20150317_000182	$I brought that old man's medicine. {nl}But we spe
 QUEST_LV_0100_20150317_000183	{memo X}The gold that Lichenclops have in this town will be enough.{nl}Bring those to the Medicine Dealer in Kapas Highway.
 QUEST_LV_0100_20150317_000184	$This will be enough. Davio sent you, right?{nl} I still need one more ingredient to make the medicine truly effective.
 QUEST_LV_0100_20150317_000185	$To make the medicine, I needed to find the cause of Jonas' symptoms and it drove me crazy.{nl}Funnily enough, it was caused by a spell that was used long ago.{nl}
-QUEST_LV_0100_20150317_000186	$I heard a rumor that Zachariel erased the memories of all workers after building the Mausoleum.{nl}That should be the spell casted on Jonas, though he is also a bit senile.
+QUEST_LV_0100_20150317_000186	$I heard a rumor that the Great King Zachariel erased the memories of all workers after building the Royal Mausoleum.{nl}That should be the spell casted on Jonas, though he is also a bit senile.
 QUEST_LV_0100_20150317_000187	$It was tough to get that old man's medicine.{nl}But, there's nothing I cannot get.
 QUEST_LV_0100_20150317_000188	$It will be completed once you melt it in the honey that you have. Take it with you.
 QUEST_LV_0100_20150317_000189	$That medicine works well. Make him swallow it somehow.
@@ -197,7 +197,7 @@ QUEST_LV_0100_20150317_000196	$How long has it been since I came here?{nl}Where 
 QUEST_LV_0100_20150317_000197	$I'm trying to remember something but it keeps fading whenever I get close.
 QUEST_LV_0100_20150317_000198	$Vaidotas
 QUEST_LV_0100_20150317_000199	{memo X}$That smell.. I think the purifying device in the mine is broken.{nl}We better repair it quickly. The kidnapped villagers might suffocate.
-QUEST_LV_0100_20150317_000200	$Do you know about the Legend of Cunningham?{nl}The legend states that a great demon was sealed here in the Crystal Mine.{nl}There is a book with more details about it at the Mine Worker's Resting Place in Crystal Mine 2F.{nl}
+QUEST_LV_0100_20150317_000200	$Do you know about the legend of Cunningham?{nl}The legend states that a great demon was sealed here in the Crystal Mine.{nl}There is a book with more details about it at the Mine Worker's Resting Place in Crystal Mine 2F.{nl}
 QUEST_LV_0100_20150317_000201	{memo X}$Anyway, my guess is that the demon is re-awakening and is controlling the Vubbes.{nl}The Bishop's dream and the Legend of Cunningham... I feel they may be a sign that something huge is about to happen.{nl}
 QUEST_LV_0100_20150317_000202	$Only the Goddess would know if it will be hope or despair.{nl}
 QUEST_LV_0100_20150317_000203	$The purifier can be easily fixed by anyone, but it may be hard to find the parts needed.{nl}In that case, use the compass that I gave you to search for them.{nl}
@@ -546,7 +546,7 @@ QUEST_LV_0100_20150317_000541	Let's remove the last seal at the left side of her
 QUEST_LV_0100_20150317_000542	Demons are approaching. It's not good.{nl}It is sealed tightly, but I don't feel safe.
 QUEST_LV_0100_20150317_000543	I caught the smell of Biteregina.{nl}I'm glad that you're safe.
 QUEST_LV_0100_20150317_000544	All right. The hidden door to the sanctum is now open and you may enter it.{nl}You will see one of the two seals that protect the legacy of Zachariel, the Great King.
-QUEST_LV_0100_20150317_000545	Now, we just have to see Zachariel the Great King's eternal sleep.{nl}It was a real honor for me to meet you.
+QUEST_LV_0100_20150317_000545	Now, we just have to see Great King Zachariel's eternal sleep.{nl}It was a real honor for me to meet you.
 QUEST_LV_0100_20150317_000546	Well done.{nl}Morkus is waiting for you at Overlong Bridge Valley. You must hurry.
 QUEST_LV_0100_20150317_000547	There are people who are after Zachariel's inheritance.{nl}If they weren't sealed, those people must have taken them by now.
 QUEST_LV_0100_20150317_000548	{memo X}Because of that, a few disciples have died.{nl}But, that's strange. It seems that it never happened.
@@ -892,17 +892,17 @@ QUEST_LV_0100_20150317_000887	Good job. {nl} If there are any good demons left, 
 QUEST_LV_0100_20150317_000888	The Central Altar that suppresses the power of the demons suddenly stopped. {nl} Could you take a look at what's going on?
 QUEST_LV_0100_20150317_000889	Strange, it was definitely working.
 QUEST_LV_0100_20150317_000890	It was an ambush. {nl} We would have been in big trouble without your help.
-QUEST_LV_0100_20150317_000891	You need the Crest of Space in order to enter the hidden sanctum. {nl} It's hidden in the Sventove Central Altar, but I just hope it's not too late.
+QUEST_LV_0100_20150317_000891	You need the Seal of Space in order to enter the hidden sanctuary. {nl} It's hidden in the Sventove Central Altar, but I just hope it's not too late.
 QUEST_LV_0100_20150317_000892	Structures in the Tenet Chapel are placed to ward against the demons. {nl} Each one in itself is a small barrier that contributes to a huge barrier. {nl}
 QUEST_LV_0100_20150317_000893	The most powerful barrier is on the 2nd floor. {nl} I heard that it can exert the greatest force when the Divine Sphere is there.
 QUEST_LV_0100_20150317_000894	Gesti made the first move. {nl} It will be difficult to approach secretly.
 QUEST_LV_0100_20150317_000895	I must change the plan. {nl} First, you need to go watch Gesti's actions. {nl}
 QUEST_LV_0100_20150317_000896	Let's start by occupying the Bell Tower.
 QUEST_LV_0100_20150317_000897	From here, we can see what Gesti is going to do.
-QUEST_LV_0100_20150317_000898	Alright, bring the Crest of Space from the Sventove Central Altar. {nl} You can do it, right?
-QUEST_LV_0100_20150317_000899	You must know that the revelation is hidden in the sanctuary. {nl} The Crest of Space is the only key that will get you to the sanctuary. {nl}
+QUEST_LV_0100_20150317_000898	Alright, bring the Seal of Space from the Sventove Central Altar. {nl} You can do it, right?
+QUEST_LV_0100_20150317_000899	You must know that the revelation is hidden in the sanctuary. {nl} The Seal of Space is the only key that will get you to the sanctuary. {nl}
 QUEST_LV_0100_20150317_000900	It's not just the Tenet Chapel. {nl} You can enter all the places that the Goddess hid.
-QUEST_LV_0100_20150317_000901	The Crest of Space can only be used by the Revelator, so you won't be able to find the revelation right away. {nl}
+QUEST_LV_0100_20150317_000901	The Seal of Space can only be used by the Revelator, so you won't be able to find the revelation right away. {nl}
 QUEST_LV_0100_20150317_000902	But the enemy is the Demon Queen. Even the Paladin Master couldn't defeat her.{nl}I should use the power of the Broken Altar.
 QUEST_LV_0100_20150317_000903	We can't do anything about the destroyed altar, but the fragments still have power. {nl} Gather the pieces and insert them in the 8 pillars of the Sventove Central Hall.
 QUEST_LV_0100_20150317_000904	When you are done, I will be able to restrict Gesti through the power of the Divine Sphere and the chapel. {nl} It may be for a short while but that's the best option we have.
@@ -911,7 +911,7 @@ QUEST_LV_0100_20150317_000906	Demons are going around the second floor searching
 QUEST_LV_0100_20150317_000907	{memo X}I'm relieved you're beside me. {nl} I think it was a good thing that Laima chose you.
 QUEST_LV_0100_20150317_000908	Good job. {nl} When this is over, I should gather all brothers and drive them away at once.
 QUEST_LV_0100_20150317_000909	I'll ring the bell and let you know when Gesti shows up, so have a safe trip on your way.
-QUEST_LV_0100_20150317_000910	{memo X}So you found the crest of space. {nl}Use the crest on the pillar beside me to go to the sanctuary. {nl} It is prepared for the Revelator only.
+QUEST_LV_0100_20150317_000910	{memo X}So you found the Seal of Space. {nl}Use the crest on the pillar beside me to go to the sanctuary. {nl} It is prepared for the Revelator only.
 QUEST_LV_0100_20150317_000911	May the blessings of the Goddess be with you.
 QUEST_LV_0100_20150317_000912	So Gesti just ran away. {nl} Fine. Since you got the revelation, we've completed the mission. {nl}
 QUEST_LV_0100_20150317_000913	{memo X}
@@ -1286,7 +1286,7 @@ QUEST_LV_0100_20150317_001281	Mercenary Eta
 QUEST_LV_0100_20150317_001282	I will come back soon so don't worry.{nl}This was an easy thing when I was young.
 QUEST_LV_0100_20150317_001283	How would the commander scold us this time..
 QUEST_LV_0100_20150317_001284	Archeologist Laudi
-QUEST_LV_0100_20150317_001285	The Goddess and the demons.. Zachariel's Mausoleum and the secret of the artifacts...
+QUEST_LV_0100_20150317_001285	The Goddess and the demons.. Zachariel's Royal Mausoleum and the secret of the artifacts...
 QUEST_LV_0100_20150317_001286	Morkus Jonas
 QUEST_LV_0100_20150317_001287	$That guy the Old Man kept talking about, is he going to come at all??
 QUEST_LV_0100_20150317_001288	$The Old Man told us.{nl}When you go against your destiny, that also is a part of your destiny.{nl}Maybe the reason why we are trying hard is because that's our destiny.
@@ -1441,15 +1441,15 @@ QUEST_LV_0100_20150317_001436	$How many times must we pray to the Goddess Zemyna
 QUEST_LV_0100_20150317_001437	$This is the holy district of the city of Fedimian. {nl} The commercial district is currently closed, please accept that inconvenience.
 QUEST_LV_0100_20150317_001438	$The divine city, Fedimian also has a business district besides the holy district here.{nl}But, on the Medis Diena, the business district was completely destroyed due to the earthquake.
 QUEST_LV_0100_20150317_001439	We are still reviving the city, but since it's too old..{nl}At least, the holy district is still left intact due to Zemyna's blessing.
-QUEST_LV_0100_20150317_001440	Follower Alvydas
+QUEST_LV_0100_20150317_001440	Believer Alvydas
 QUEST_LV_0100_20150317_001441	Since follow believe the Goddess Saule, you'll be able to accept this as a high difficulty such. {nl} impiety to, do you think want to who stay like this terrible place?
-QUEST_LV_0100_20150317_001442	Follower Raminta
+QUEST_LV_0100_20150317_001442	Believer Raminta
 QUEST_LV_0100_20150317_001443	$If that evil aura spreads to other forests..{nl}Those forests will also change, like Kvailas Forest.{nl}And then the entire kingdom may also... It scares me.
-QUEST_LV_0100_20150317_001444	Follower Evaldas
+QUEST_LV_0100_20150317_001444	Believer Evaldas
 QUEST_LV_0100_20150317_001445	$Everyone is tired, but the evil aura never stops. So, we at least try to stay happy. {nl} However, I don't know how long I can keep feeling happy.
-QUEST_LV_0100_20150317_001446	Follower Zanetta
+QUEST_LV_0100_20150317_001446	Believer Zanetta
 QUEST_LV_0100_20150317_001447	$I want to tell to the people out there that we are still here.{nl}The Goddess always tells us that everything will be alright when the revelation comes.
-QUEST_LV_0100_20150317_001448	Follower Simas
+QUEST_LV_0100_20150317_001448	Believer Simas
 QUEST_LV_0100_20150317_001449	{memo X}
 QUEST_LV_0100_20150317_001450	{memo X}There are rumors about Golems appearing so don't go far too deep. {nl} It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
 QUEST_LV_0100_20150317_001451	So, I guess there is actually someone good among those who say they've dreamed of the Goddess.
@@ -1596,7 +1596,7 @@ QUEST_LV_0100_20150317_001591	I sometimes miss it. The old Sequoia.{nl}Why was i
 QUEST_LV_0100_20150317_001592	Something's wrong. {nl}The Guide Owl is not in a good mood. I hope you go there fast.{nl}
 QUEST_LV_0100_20150317_001593	Take that stick with you. They are my friends.{nl}I think you will need it from now on.
 QUEST_LV_0100_20150317_001594	It will be okay. That owl is strong.{nl}It will be okay. It will be okay.
-QUEST_LV_0100_20150317_001595	Guide Owl Statue
+QUEST_LV_0100_20150317_001595	Guide Owl Sculpture
 QUEST_LV_0100_20150317_001596	I almost fell into eternal sleep if it weren't you.{nl}Sequoia is our enemy now. Enemy!
 QUEST_LV_0100_20150317_001597	Sequoia is not only owls' problem.{nl}It is attacking any living creatures!{nl}Please help us to defeat it.{nl}
 QUEST_LV_0100_20150317_001598	If we let Sequoia act like now, all owls will be destroyed.{nl}Many people will die as well...{nl}There will be full of wandering spirits and we won't have any owls to guide us.{nl}
@@ -1638,7 +1638,7 @@ QUEST_LV_0100_20150317_001633	There are some purifying devices that doesn't acti
 QUEST_LV_0100_20150317_001634	$There is a shopping plaza in the lower part of Klaipeda. {nl} Stop by and look around if you need anything.
 QUEST_LV_0100_20150317_001635	I just want him to run away far. {nl}Nah, in fact, I don't know. He was a really good friend of me..
 QUEST_LV_0100_20150317_001636	Okay.{nl}Please find the Grave Protector Owl from the grave of the unknown warrior.{nl}If he could lend us his power, it will be a good chance to defeat Sequioa.
-QUEST_LV_0100_20150317_001637	Follower Adele
+QUEST_LV_0100_20150317_001637	Believer Adele
 QUEST_LV_0100_20150317_001638	Thorny vines are also plants so they must be weak to strong acid.{nl}What do you think? Isn't that a good idea?
 QUEST_LV_0100_20150317_001639	Filibo?{nl}I wouldn't worry if it only steals food.{nl}
 QUEST_LV_0100_20150317_001640	It bites on any wooden materials on military equipments and it also breaks medicine jars.{nl}It makes holes to tents.{nl}And it is not afraid of anything. It attacks people.
@@ -1664,12 +1664,12 @@ QUEST_LV_0100_20150317_001659	What was your impression of seeing the altar?{nl}I
 QUEST_LV_0100_20150317_001660	Anyway, the acidic solution will be completed after mixing them!
 QUEST_LV_0100_20150317_001661	Please melt the thorny vines with this acidic solution.{nl}The thorny vines are located on the upper side of Isdidu Fork.
 QUEST_LV_0100_20150317_001662	I hope Thorny Forest returns to what it used to look like.{nl}Birds are nowhere to be found right now.
-QUEST_LV_0100_20150317_001663	Thorny Forest was once a very beautiful forest.{nl}We, the followers, used to hold sacred prayer ceremonies here.{nl}
+QUEST_LV_0100_20150317_001663	Thorny Forest was once a very beautiful forest.{nl}We, the believers, used to hold sacred prayer ceremonies here.{nl}
 QUEST_LV_0100_20150317_001664	It turned out like this after Demon Lord Bramble came to our forest.{nl}I can't remember the last time hearing the sounds of birds. I miss the old and beautiful forest...
 QUEST_LV_0100_20150317_001665	Sometimes I miss the old forest.{nl}I also miss listening to the words of Goddess Saule.
-QUEST_LV_0100_20150317_001666	Follower Birgis
+QUEST_LV_0100_20150317_001666	Believer Virgis
 QUEST_LV_0100_20150317_001667	There's nothing that we can't do with our religious faith.{nl}If there is anything that we can't do, then that's because our religious faith is not big enough.
-QUEST_LV_0100_20150317_001668	Follower Noyus
+QUEST_LV_0100_20150317_001668	Believer Noyus
 QUEST_LV_0100_20150317_001669	{memo X}
 QUEST_LV_0100_20150317_001670	Supplies Officer
 QUEST_LV_0100_20150317_001671	I am the supplies officer here.{nl}I received the list of supplies that is needed, but look at the number of supplies here.{nl}I can't manage them myself.{nl}
@@ -1771,7 +1771,7 @@ QUEST_LV_0100_20150317_001766	I am smarter than you guys think!{nl}Do you think 
 QUEST_LV_0100_20150317_001767	$It is a real honor to be chosen as a member of the research team, but I am afraid of making mistakes.
 QUEST_LV_0100_20150317_001768	The man with silver hair requested me something, what was it?{nl}Or was it blonde hair?
 QUEST_LV_0100_20150317_001769	Forecastor Owl
-QUEST_LV_0100_20150317_001770	Necroventer has obstructed the road to the forest of thorns. {nl} You must defeat the Necroventer to enter the forest of thorns.
+QUEST_LV_0100_20150317_001770	Necroventer has obstructed the road to the Thorn Forest. {nl} You must defeat the Necroventer to enter the Thorn Forest.
 QUEST_LV_0100_20150317_001771	The Owl Sculpture with anger
 QUEST_LV_0100_20150317_001772	Die all those who are resistant to Necroventer.
 QUEST_LV_0100_20150317_001773	{memo X}
@@ -1866,7 +1866,7 @@ QUEST_LV_0100_20150317_001861	The god is quiet. {nl}I think the tomb will be the
 QUEST_LV_0100_20150317_001862	It was dangerous.{nl}But, we can't stop.
 QUEST_LV_0100_20150317_001863	{memo X}
 QUEST_LV_0100_20150317_001864	$What do I want to obtain from the Royal Mausoleum?{nl}That is a secret.
-QUEST_LV_0100_20150317_001865	{memo X}$The trial of the Great King Zachariel is not easy.{nl}With the skill you have, he should have recognized you.
+QUEST_LV_0100_20150317_001865	{memo X}$The ordeal of the Great King Zachariel is not easy.{nl}With the skill you have, he should have recognized you.
 QUEST_LV_0100_20150317_001866	$The last epitaph is at Apati Cliff.{nl}I hope the Great King Zachariel will understand our sincerity.
 QUEST_LV_0100_20150317_001867	{memo X}Soon we should have all clues.{nl}I am looking forward to it.
 QUEST_LV_0100_20150317_001868	{memo X}
@@ -1981,7 +1981,7 @@ QUEST_LV_0100_20150317_001976	$Crutches from Moses the Old Man..{nl}I really don
 QUEST_LV_0100_20150317_001977	$I didn't say it's over.{nl}Please get me the leather of Flying Frogs near this camp.{nl}
 QUEST_LV_0100_20150317_001978	I don't wanna know its use.
 QUEST_LV_0100_20150317_001979	Darn, it's worse than the lumber that you brought me a while ago{nl}Wait, I haven't told you to leave yet.
-QUEST_LV_0100_20150317_001980	Follower Domas
+QUEST_LV_0100_20150317_001980	Believer Domas
 QUEST_LV_0100_20150317_001981	{memo X}I am going to burn the thorny vines that are blocking the road.{nl}Can you help me?
 QUEST_LV_0100_20150317_001982	Please get me the remains of Thornball first. {nl}There are many of them at Rustebi Woods.
 QUEST_LV_0100_20150317_001983	{memo X}There's a demon that I want you to defeat.{nl}The monster is called Likaous at Thorny Pole Garden. It brings vicious atmosphere with him.
@@ -1990,9 +1990,9 @@ QUEST_LV_0100_20150317_001985	Flames will never catch on these thorny vines here
 QUEST_LV_0100_20150317_001986	You brought it well.{nl}I was worried that you would hurt, but I guess I didn't have to worry.
 QUEST_LV_0100_20150317_001987	Four years ago, this forest was a normal forest.{nl}But it turned out like this after Bramble came deep into the forest.
 QUEST_LV_0100_20150317_001988	Who knew that they would use the power of our altar?{nl}I can't see the Goddess.
-QUEST_LV_0100_20150317_001989	Follower Bronius
+QUEST_LV_0100_20150317_001989	Believer Bronius
 QUEST_LV_0100_20150317_001990	$I only survived because of you.{nl}I should warn the other followers to be careful.
-QUEST_LV_0100_20150317_001991	Follower Jurga
+QUEST_LV_0100_20150317_001991	Believer Jurga
 QUEST_LV_0100_20150317_001992	{memo X}$I can feel Bramble is suffering.{nl}He is getting retribution for extracting all vigor from this land.
 QUEST_LV_0100_20150317_001993	You're the Savior the Goddess sent. What an honor. {nl} Are you ready to fight Bramble?
 QUEST_LV_0100_20150317_001994	You need to be prepared if you want to defeat Bramble. {nl} First, take this.
@@ -2052,20 +2052,20 @@ QUEST_LV_0100_20150317_002047	That ring is full of divine energy so it will be h
 QUEST_LV_0100_20150317_002048	You found my ring! {nl}Thanks. Thank you so much!
 QUEST_LV_0100_20150317_002049	{memo X}$The priests are having hard time due to thorny vines.{nl}Can you help them?
 QUEST_LV_0100_20150317_002050	$I will write down the process for you.{nl}How about you start by recharging the mana of the magic crystal?
-QUEST_LV_0100_20150317_002051	$Okay, show me that you can stand against those thorny vines with your religious faith.{nl}You can't say you are a follower if you are weak to that.
+QUEST_LV_0100_20150317_002051	$Okay, show me that you can stand against those thorny vines with your religious faith.{nl}You can't say you are a believer if you are weak to that.
 QUEST_LV_0100_20150317_002052	{memo X}
 QUEST_LV_0100_20150317_002053	$I don't know if it's the thorny vines or the evil aura, but... {nl}this forest makes people very depressed.
 QUEST_LV_0100_20150317_002054	$I personally believe that one day this forest will be okay again.
 QUEST_LV_0100_20150317_002055	Are you okay?{nl}I almost lost my conciousness due to that voice.{nl}Who is he anyways..
 QUEST_LV_0100_20150317_002056	{memo X}
-QUEST_LV_0100_20150317_002057	$The evil aura is becoming stronger and the followers are getting tired. It's a bad situation.
+QUEST_LV_0100_20150317_002057	$The evil aura is becoming stronger and the believers are getting tired. It's a bad situation.
 QUEST_LV_0100_20150317_002058	$Thanks.{nl}I wonder what would have happened if you weren't here.
 QUEST_LV_0100_20150317_002059	$As the Merog Shamans are undertaking their rituals, I will give that a shot.{nl}Can you take care of them?
 QUEST_LV_0100_20150317_002060	$Thank you for your help.{nl}Now the demons won't be able to act so freely.
 QUEST_LV_0100_20150317_002061	$I did not know those demons could use summoning crystals.{nl}They may overwhelm us.
 QUEST_LV_0100_20150317_002062	I want to receive all the information about that demon summoning circle.{nl}Please be careful not to break the precious sample.
 QUEST_LV_0100_20150317_002063	$We would be able to find a way to use it.{nl}Those demons used our altar, so we can use it too.
-QUEST_LV_0100_20150317_002064	Follower Onute
+QUEST_LV_0100_20150317_002064	Believer Onute
 QUEST_LV_0100_20150317_002065	They are waiting for Archon to be summoned.{nl}They will be frightened if you destroy all the summoning circles along with Archon.
 QUEST_LV_0100_20150317_002066	Thanks.{nl}They will not be able to attack us easily now.{nl}
 QUEST_LV_0100_20150317_002067	{memo X}Thanks.{nl}The believers are distributed to their areas so find them and help them.
@@ -2079,21 +2079,21 @@ QUEST_LV_0100_20150317_002074	$Goddess Saule said to absolutely not speak of our
 QUEST_LV_0100_20150317_002075	{memo X}This is all my fault. I shouldn't have underestimated it.
 QUEST_LV_0100_20150317_002076	{memo X}
 QUEST_LV_0100_20150317_002077	I am okay about the sample so just break it so that it won't activate.{nl}I am gonna take a look at it myself.
-QUEST_LV_0100_20150317_002078	$I get angry every time I enter that forest of thorns.{nl}How could such dirty things happen to the Goddess' sacred forest?
+QUEST_LV_0100_20150317_002078	$I get angry every time I enter that Thorn Forest.{nl}How could such dirty things happen to the Goddess' sacred forest?
 QUEST_LV_0100_20150317_002079	{memo X}$Help me. Merogs are after me.{nl}When they are grouped up like that, I can't face them.
 QUEST_LV_0100_20150317_002080	Good. {nl} Now, we're going to destroy the roots of Bramble.
-QUEST_LV_0100_20150317_002081	Follower Samanta
+QUEST_LV_0100_20150317_002081	Believer Samanta
 QUEST_LV_0100_20150317_002082	Whenever I tried to purify Thornbush Rest Place, those monsters attack.{nl}Is there some way to avoid them?
-QUEST_LV_0100_20150317_002083	Monsters are becoming more violent as they enter deeper into the forest of thorns.{nl}Maybe that is because of the vicious energy.
+QUEST_LV_0100_20150317_002083	Monsters are becoming more violent as they enter deeper into the Thorn Forest.{nl}Maybe that is because of the vicious energy.
 QUEST_LV_0100_20150317_002084	I can relax now and purify Thornbush Rest Place.{nl}Thank you so much.
 QUEST_LV_0100_20150317_002085	I can rely on you.{nl}Please protect the altar until the fountain is purified.
 QUEST_LV_0100_20150317_002086	{memo X}$Put Merog saliva in this potion and shake it. {nl} It will help you withstand the muddy aura of Bramble.
-QUEST_LV_0100_20150317_002087	$Bramble is recovering by embedding his roots around the forest of thorns. {nl} Cutting those roots will hurt him.
+QUEST_LV_0100_20150317_002087	$Bramble is recovering by embedding his roots around the Thorn Forest. {nl} Cutting those roots will hurt him.
 QUEST_LV_0100_20150317_002088	$You mustn't let your guard down, even if Bramble is weakened. {nl}After all, it is a Demon Lord, no matter how injured it is.
 QUEST_LV_0100_20150317_002089	$Now we can make a full-scale attack on Bramble. {nl} I'll go to Giliaii Courtyard to watch Bramble first, so follow me.
 QUEST_LV_0100_20150317_002090	$The most important roots are at Sviesa Hill Areas and Tankinta Vacant Lot. {nl} Cut them both.
 QUEST_LV_0100_20150317_002091	$Even after all of the vicious aura is removed, this forest will remain as it is.{nl}But someday, we will also end it that way.
-QUEST_LV_0100_20150317_002092	Follower Kazis
+QUEST_LV_0100_20150317_002092	Believer Kazis
 QUEST_LV_0100_20150317_002093	Somewhere in the single road Caracas has hidden Honeypin, but I can't find it. {nl} The purification work has been delayed because of the monster.
 QUEST_LV_0100_20150317_002094	You just need to activate the altar of purification.{nl}Do this without letting Honeypin know.
 QUEST_LV_0100_20150317_002095	You aren't hurt?{nl}I heard the Honeypin's wing sound, but I am relieved to see you are okay.
@@ -2148,7 +2148,7 @@ QUEST_LV_0100_20150317_002143	{memo X}
 QUEST_LV_0100_20150317_002144	It's the key. {nl} Please let me free.
 QUEST_LV_0100_20150317_002145	{memo X}Thank you in the name of Saule, Goddess of the Sun. {nl}
 QUEST_LV_0100_20150317_002146	{memo X}It's a shame but the revelation is in the hands of Bramble. {nl} The reason he imprisoned me instead of killing me is to use my divinity to interpret the revelation. {nl}
-QUEST_LV_0100_20150317_002147	{memo X}But the Bramble is also not in its normal condition due to the previous battle. {nl} Please stop the Bramble in the gateway with my followers and get the revelation back.
+QUEST_LV_0100_20150317_002147	{memo X}But the Bramble is also not in its normal condition due to the previous battle. {nl} Please stop the Bramble in the gateway with my believers and get the revelation back.
 QUEST_LV_0100_20150317_002148	Please show me the Revelation. {nl} I will show you its meaning.
 QUEST_LV_0100_20150317_002149	If any divine power is still contained within the shrine offering tools, then we can surely use it to find Clymen. {nl}
 QUEST_LV_0100_20150317_002150	Lyliana
@@ -2547,7 +2547,7 @@ QUEST_LV_0100_20150317_002542	$I'm not a new recruit
 QUEST_LV_0100_20150317_002543	$Trivial Honor (2)
 QUEST_LV_0100_20150317_002544	$I'll burn the Ducky Fat
 QUEST_LV_0100_20150317_002545	{memo X}Setting up firewood .../FIRE/3/TRACK_BEFORE
-QUEST_LV_0100_20150317_002546	$Old Owl Statue's Aid
+QUEST_LV_0100_20150317_002546	$Old Owl Sculpture's Aid
 QUEST_LV_0100_20150317_002547	$Ask what to do
 QUEST_LV_0100_20150317_002548	$Ignore the Owl
 QUEST_LV_0100_20150317_002549	$Truth and Spirit
@@ -3153,10 +3153,10 @@ QUEST_LV_0100_20150317_003148	Hide first
 QUEST_LV_0100_20150317_003149	Occupy the Bell Tower
 QUEST_LV_0100_20150317_003150	Begin immediately
 QUEST_LV_0100_20150317_003151	Gesti might still be around
-QUEST_LV_0100_20150317_003152	Stolen Crest of Space
+QUEST_LV_0100_20150317_003152	Stolen Seal of Space
 QUEST_LV_0100_20150317_003153	I will bring it secretly
 QUEST_LV_0100_20150317_003154	I'll observe the situation a little more
-QUEST_LV_0100_20150317_003155	About the Crest of space
+QUEST_LV_0100_20150317_003155	About the Seal of Space
 QUEST_LV_0100_20150317_003156	Cat and Mouse
 QUEST_LV_0100_20150317_003157	I'll be cautious on my way
 QUEST_LV_0100_20150317_003158	Check Gesti's action and go
@@ -3687,7 +3687,7 @@ QUEST_LV_0100_20150317_003682	{memo X}Visible gateway to pick up/FIRE/3/TRACK_BE
 QUEST_LV_0100_20150317_003683	Fight Poison with Poison (1)
 QUEST_LV_0100_20150317_003684	I think that's a good idea
 QUEST_LV_0100_20150317_003685	Doesn't sound so good
-QUEST_LV_0100_20150317_003686	About the Followers
+QUEST_LV_0100_20150317_003686	About the Believers
 QUEST_LV_0100_20150317_003687	My Ring!
 QUEST_LV_0100_20150317_003688	I'll get you the ring if I pick it up 
 QUEST_LV_0100_20150317_003689	It's probably digested by now
@@ -3696,14 +3696,14 @@ QUEST_LV_0100_20150317_003691	Fight Poison with Poison (2)
 QUEST_LV_0100_20150317_003692	I'll get it ASAP
 QUEST_LV_0100_20150317_003693	Fight Poison with Poison (3)
 QUEST_LV_0100_20150317_003694	I'll combine it
-QUEST_LV_0100_20150317_003695	About the forest of thorns in the past
+QUEST_LV_0100_20150317_003695	About the Thorn Forest in the past
 QUEST_LV_0100_20150317_003696	{memo X}Combining/MAKING/3/TRACK_BEFORE/None
 QUEST_LV_0100_20150317_003697	Fight Poison with Poison (4)
 QUEST_LV_0100_20150317_003698	Go to melt the thorn vines
 QUEST_LV_0100_20150317_003699	In the name of Faith (1)
 QUEST_LV_0100_20150317_003700	I'll help if I can
 QUEST_LV_0100_20150317_003701	I have nothing to do with it
-QUEST_LV_0100_20150317_003702	About the evil aura in the the forest of thorns
+QUEST_LV_0100_20150317_003702	About the evil aura in the the Thorn Forest
 QUEST_LV_0100_20150317_003703	In the name of Faith (2)
 QUEST_LV_0100_20150317_003704	In the name of Faith (3)
 QUEST_LV_0100_20150317_003705	{memo X}$Purifying??MAKING/2/TRACK_BEFORE/None
@@ -4165,20 +4165,20 @@ QUEST_LV_0100_20150317_004160	$Light fire in the marked area
 QUEST_LV_0100_20150317_004161	$Weiz says Gaigalas will appear when it smells the Ducky Fat burning. Light fire to burn the Ducky Fat in an airy area in Lengvas Garden. 
 QUEST_LV_0100_20150317_004162	$Report to Soldier Weiz
 QUEST_LV_0100_20150317_004163	$You burned the Ducky Fat and Gaigalas appeared. Quickly return to Weiz and let him know that Gaigalas appeared.
-QUEST_LV_0100_20150317_004164	$Talk to the Old Owl Statue
-QUEST_LV_0100_20150317_004165	$During the battle with Gaigalas, the owl statue was looking at you strangely. Talk to the Old Owl Statue. 
+QUEST_LV_0100_20150317_004164	$Talk to the Old Owl Sculpture
+QUEST_LV_0100_20150317_004165	$During the battle with Gaigalas, the Owl Sculpture was looking at you strangely. Talk to the Old Owl Sculpture. 
 QUEST_LV_0100_20150317_004166	$Collect Infroholder's Horn
-QUEST_LV_0100_20150317_004167	$The Old Owl Statue says you can't defeat Gaigalas fighting the way you did. Gather Infroholder's horn to make a Memory Fragment.
-QUEST_LV_0100_20150317_004168	$Deliver to the Old Owl Statue
-QUEST_LV_0100_20150317_004169	$Collected the Infroholder's Horn needed. Give them to Old Owl Statue.
+QUEST_LV_0100_20150317_004167	$The Old Owl Sculpture says you can't defeat Gaigalas fighting the way you did. Gather Infroholder's horn to make a Memory Fragment.
+QUEST_LV_0100_20150317_004168	$Deliver to the Old Owl Sculpture
+QUEST_LV_0100_20150317_004169	$Collected the Infroholder's Horn needed. Give them to Old Owl Sculpture.
 QUEST_LV_0100_20150317_004170	$Defeat Infroholder and obtain %s
 QUEST_LV_0100_20150317_004171	$Defeat Infroholder
-QUEST_LV_0100_20150317_004172	$The Old Owl Statue seems to have sensed something and is tilting its head. Talk to the Owl Statue.
-QUEST_LV_0100_20150317_004173	$The Old Owl Statue showed you a scene from the past where soldiers who tried hunting Gaigalas were wiped out. Talk to the Owl Statue.
-QUEST_LV_0100_20150317_004174	$Talk to the Worrying Owl Statue.
-QUEST_LV_0100_20150317_004175	$Heed the words of the Old Owl Statue and bring the Memory Fragment to the Statue of the Worrying Owl in Bandyma Crossroad.
-QUEST_LV_0100_20150317_004176	$Awaken the Memories of the Sleeping Owl Statues
-QUEST_LV_0100_20150317_004177	$In order to defeat Gaigalas, you need power of the Owl Statues that fell asleep without completing their magic. Awaken the memory of sleeping Owl Statues to complete the magic that will weaken Gaigalas.
+QUEST_LV_0100_20150317_004172	$The Old Owl Sculpture seems to have sensed something and is tilting its head. Talk to the Owl Sculpture.
+QUEST_LV_0100_20150317_004173	$The Old Owl Sculpture showed you a scene from the past where soldiers who tried hunting Gaigalas were wiped out. Talk to the Owl Sculpture.
+QUEST_LV_0100_20150317_004174	$Talk to the Worrying Owl Sculpture.
+QUEST_LV_0100_20150317_004175	$Heed the words of the Old Owl Sculpture and bring the Memory Fragment to the Statue of the Worrying Owl in Bandyma Crossroad.
+QUEST_LV_0100_20150317_004176	$Awaken the Memories of the Sleeping Owl Sculptures
+QUEST_LV_0100_20150317_004177	$In order to defeat Gaigalas, you need power of the Owl Sculptures that fell asleep without completing their magic. Awaken the memory of sleeping Owl Sculptures to complete the magic that will weaken Gaigalas.
 QUEST_LV_0100_20150317_004178	$Report to the Statue of the Worrying Owl
 QUEST_LV_0100_20150317_004179	$Completed the magic that will weaken Gaigalas. Return and tell it to the Statue of the Worrying Owl.
 QUEST_LV_0100_20150317_004180	$Summon and Defeat Gaigalas
@@ -4470,9 +4470,9 @@ QUEST_LV_0100_20150317_004465	Defeat the monsters that are rushing in
 QUEST_LV_0100_20150317_004466	Talk to Vio
 QUEST_LV_0100_20150317_004467	Eta told you that he will return to the camp. Tell this to Vio.
 QUEST_LV_0100_20150317_004468	Eta promised you that he will return to the camp. Tell this to Vio.
-QUEST_LV_0100_20150317_004469	Finally, it seems that you can enter into the sanctum that will lead you to the inheritance of Zachariel. Talk to Gustas Jonas.
+QUEST_LV_0100_20150317_004469	Finally, it seems that you can enter into the sanctum that will lead you to the inheritance of the Great King Zachariel. Talk to Gustas Jonas.
 QUEST_LV_0100_20150317_004470	Remove the seal inside the sanctum
-QUEST_LV_0100_20150317_004471	The santum was the first seal to protect the inheritance of Zachariel. Go into the santum and unleash the seal.
+QUEST_LV_0100_20150317_004471	The santum was the first seal to protect the inheritance of the Great King Zachariel. Go into the santum and unleash the seal.
 QUEST_LV_0100_20150317_004472	You finally unleased the first seal. Talk to Gustas Jonas.
 QUEST_LV_0100_20150317_004473	{memo X}
 QUEST_LV_0100_20150317_004474	{memo X}
@@ -5122,11 +5122,11 @@ QUEST_LV_0100_20150317_005117	Go to the Bell Tower
 QUEST_LV_0100_20150317_005118	Saw Gesti scolding her subordinates
 QUEST_LV_0100_20150317_005119	Almost got caught by Gesti, but you found out something good. Gesti hasn't found the revelation yet. Ask Follower Algis about what to do next.
 QUEST_LV_0100_20150317_005120	Gesti disappeared to the Central hall. Talk to Follower Algis.
-QUEST_LV_0100_20150317_005121	Follower Algis says that in order to enter the hidden sanctum, you need the Crest of Space, which is hidden in the Central Altar, but Gesti is roaming around the area and it is too dangerous. Occupy the Bell Tower, a good observation point. 
+QUEST_LV_0100_20150317_005121	Follower Algis says that in order to enter the hidden sanctuary, you need the Seal of Space, which is hidden in the Central Altar, but Gesti is roaming around the area and it is too dangerous. Occupy the Bell Tower, a good observation point. 
 QUEST_LV_0100_20150317_005122	Occupied the Bell Tower. Talk to Follower Algis. 
 QUEST_LV_0100_20150317_005123	Occupied the Bell Tower. Ask Follower Algis what to do next. 
 QUEST_LV_0100_20150317_005124	Gesti destroyed the Sventove Central Altar!
-QUEST_LV_0100_20150317_005125	Gesti destroyed the Sventove Central Altar and stole the Crest of Space. You can't get the revelation this way and you'll be killed if you run into Gesti. Talk to Follower Algis about how to solve the situation. 
+QUEST_LV_0100_20150317_005125	Gesti destroyed the Sventove Central Altar and stole the Seal of Space. You can't get the revelation this way and you'll be killed if you run into Gesti. Talk to Follower Algis about how to solve the situation. 
 QUEST_LV_0100_20150317_005126	Make a trap at Sventove Central Hall
 QUEST_LV_0100_20150317_005127	Follower Algis suggested using the pieces of destroyed altar to restrict Gesti. Collect the pieces of altar and place them on the eight pillars of Sventove Central Hall.
 QUEST_LV_0100_20150317_005128	Placed the altar pieces on the eight pillars. Return to Follower Algis.
@@ -5145,7 +5145,7 @@ QUEST_LV_0100_20150317_005140	Weakened Gesti with the power of central altar and
 QUEST_LV_0100_20150317_005141	Failed to defeat Gesti but she ran away with serious injury. Talk to Follower Algis. 
 QUEST_LV_0100_20150317_005142	Gesti got away, but there are still more things left to do in the chapel. Talk to Follower Algis again.
 QUEST_LV_0100_20150317_005143	Find the revelation in the hidden sanctum
-QUEST_LV_0100_20150317_005144	Use the Crest of Space on the pillar to enter the sanctuary and find the revelation.
+QUEST_LV_0100_20150317_005144	Use the Seal of Space on the pillar to enter the sanctuary and find the revelation.
 QUEST_LV_0100_20150317_005145	Tell the Paladin Master about the story so far
 QUEST_LV_0100_20150317_005146	{memo X}
 QUEST_LV_0100_20150317_005147	$Talk to Guard Allen
@@ -5174,7 +5174,7 @@ QUEST_LV_0100_20150317_005169	$Minotaur appeared from the sky like Follower Kaye
 QUEST_LV_0100_20150317_005170	$Defeated Minotaur together with Follower Kayetonas. Talk to Follower Kayetonas.
 QUEST_LV_0100_20150317_005171	{memo X}
 QUEST_LV_0100_20150317_005172	Listen to Follower Algis' explanations
-QUEST_LV_0100_20150317_005173	The Paladin Master told you to listen to Follower Algis about the Tenet Chapel, the first Paladin, and the Crest of Space. Listen to Follower Algis before he leaves. 
+QUEST_LV_0100_20150317_005173	The Paladin Master told you to listen to Follower Algis about the Tenet Chapel, the first Paladin, and the Seal of Space. Listen to Follower Algis before he leaves. 
 QUEST_LV_0100_20150317_005174	Listened to Follower Algis' explanations. Report to the Paladin Master and follow the next orders. 
 QUEST_LV_0100_20150317_005175	The Paladin Master is looking for you
 QUEST_LV_0100_20150317_005176	Help the Paladin Master
@@ -5383,7 +5383,7 @@ QUEST_LV_0100_20150317_005378	Barely defeated Cactusvel. Check if Cyrenia Odell 
 QUEST_LV_0100_20150317_005379	Defeat Rexipher's summon
 QUEST_LV_0100_20150317_005380	Tell Cyrenia Odell about what happened.
 QUEST_LV_0100_20150317_005381	{memo X}Follow Rexipher and enter Mausoleum
-QUEST_LV_0100_20150317_005382	Cyrenia Odell says Rexipher's objective is the thing hidden in the Royal Mausoleum by King Zachariel for the Goddess. Follow Rexipher and enter the Royal Mausoleum.
+QUEST_LV_0100_20150317_005382	Cyrenia Odell says Rexipher's objective is the thing hidden in the Royal Mausoleum by the Great King Zachariel for the Goddess. Follow Rexipher into the Royal Mausoleum.
 QUEST_LV_0100_20150317_005383	Defeat Rexipher's subordinates
 QUEST_LV_0100_20150317_005384	Talk to Epigraphist Schmid
 QUEST_LV_0100_20150317_005385	{memo X}
@@ -5771,7 +5771,7 @@ QUEST_LV_0100_20150317_005766	$The pollution in the Holy Pond seems serious. Che
 QUEST_LV_0100_20150317_005767	Defeat Merregina
 QUEST_LV_0100_20150317_005768	$Go to the altar of Nugria Sanctum
 QUEST_LV_0100_20150317_005769	{memo X}
-QUEST_LV_0100_20150317_005770	Use the Crest of Space
+QUEST_LV_0100_20150317_005770	Use the Seal of Space
 QUEST_LV_0100_20150317_005771	{memo X}
 QUEST_LV_0100_20150317_005772	Hidden Royal Mausoleum Book appeared
 QUEST_LV_0100_20150317_005773	A book hidden somewhere in Royal Mausoleum 5F appeared. Talk to it.
@@ -6136,45 +6136,45 @@ QUEST_LV_0100_20150317_006131	$Collected enough leather of Flying Frogs. Moses b
 QUEST_LV_0100_20150317_006132	$Moses is dissatisfied even with the leather. Control your anger and talk to him again.
 QUEST_LV_0100_20150317_006133	$Give crutches to Villager Cahill
 QUEST_LV_0100_20150317_006134	$Moses the Old Man was actually making crutches for Villager Cahill. Give Moses the Old Man's wooden crutches to Villager Cahill.
-QUEST_LV_0100_20150317_006135	Talk to Follower Domas
-QUEST_LV_0100_20150317_006136	Goddess Saule's Follower Domas needs help in Gate Route.
+QUEST_LV_0100_20150317_006135	Talk to Believer Domas
+QUEST_LV_0100_20150317_006136	Goddess Saule's Believer Domas needs help in Gate Route.
 QUEST_LV_0100_20150317_006137	Defeat Thornball and get its remains.
 QUEST_LV_0100_20150317_006138	{memo X}
-QUEST_LV_0100_20150317_006139	Give it to Follower Domas
-QUEST_LV_0100_20150317_006140	Got the remains of Thornball to use for burning the forest. But won't the whole forest burn like this? Anyway, give it to Follower Domas.
+QUEST_LV_0100_20150317_006139	Give it to Believer Domas
+QUEST_LV_0100_20150317_006140	Got the remains of Thornball to use for burning the forest. But won't the whole forest burn like this? Anyway, give it to Believer Domas.
 QUEST_LV_0100_20150317_006141	Defeat Thornball and get %s
 QUEST_LV_0100_20150317_006142	Defeat Cauliflower and get its sap.
 QUEST_LV_0100_20150317_006143	{memo X}
-QUEST_LV_0100_20150317_006144	$I collected all the saps of the Cauliflower. I should give them to Follower Domas.
+QUEST_LV_0100_20150317_006144	$I collected all the saps of the Cauliflower. I should give them to Believer Domas.
 QUEST_LV_0100_20150317_006145	Defeat Cauliflower and fill the Thornball Pouch with Cauliflower Sap
 QUEST_LV_0100_20150317_006146	Burn the thorny vines covering the gate.
 QUEST_LV_0100_20150317_006147	Everything is finally ready. Burn the thorny vines covering the gate.
 QUEST_LV_0100_20150317_006148	$Burning the thorny vines covering the gate.
-QUEST_LV_0100_20150317_006149	Talk to Goddess Saule Follower Adele
-QUEST_LV_0100_20150317_006150	Goddess Saule's Follower Adele needs your help in Gate Route.
+QUEST_LV_0100_20150317_006149	Talk to Goddess Saule Believer Adele
+QUEST_LV_0100_20150317_006150	Goddess Saule's Believer Adele needs your help in Gate Route.
 QUEST_LV_0100_20150317_006151	Collect the Velwriggler Claws.
-QUEST_LV_0100_20150317_006152	$Follower Adele want to melt the thorny vines with acid solution. First, gather Velwriggler's claws in Rajuma Curved Path in order to make the acid solution.
-QUEST_LV_0100_20150317_006153	Give the claws to Follower Adele.
-QUEST_LV_0100_20150317_006154	$Collected all the Velwriggler claws needed. Give them to Follower Adele.
-QUEST_LV_0100_20150317_006155	Talk to Follower Adele
-QUEST_LV_0100_20150317_006156	Goddess Saule Follower Adele needs help.
-QUEST_LV_0100_20150317_006157	Find Follower Adele's ring.
-QUEST_LV_0100_20150317_006158	Follower Adele lost her precious ring along with her leather pouch. Find the ring for her.
-QUEST_LV_0100_20150317_006159	Give the ring to Follower Adele
+QUEST_LV_0100_20150317_006152	$Believer Adele want to melt the thorny vines with acid solution. First, gather Velwriggler's claws in Rajuma Curved Path in order to make the acid solution.
+QUEST_LV_0100_20150317_006153	Give the claws to Believer Adele.
+QUEST_LV_0100_20150317_006154	$Collected all the Velwriggler claws needed. Give them to Believer Adele.
+QUEST_LV_0100_20150317_006155	Talk to Believer Adele
+QUEST_LV_0100_20150317_006156	Goddess Saule Believer Adele needs help.
+QUEST_LV_0100_20150317_006157	Find Believer Adele's ring.
+QUEST_LV_0100_20150317_006158	Believer Adele lost her precious ring along with her leather pouch. Find the ring for her.
+QUEST_LV_0100_20150317_006159	Give the ring to Believer Adele
 QUEST_LV_0100_20150317_006160	$The ring's holiness prevented it from being swallowed by the monster. Return the ring to Adele.
 QUEST_LV_0100_20150317_006161	Defeat Chafer and get %s
-QUEST_LV_0100_20150317_006162	Goddess Saule's Follower Adele needs your help.
+QUEST_LV_0100_20150317_006162	Goddess Saule's Believer Adele needs your help.
 QUEST_LV_0100_20150317_006163	Collect Truffle's poisonous mushrooms.
-QUEST_LV_0100_20150317_006164	Follower Adele says she needs poisonous mushrooms of Truffles for the acid solution. Defeat the Truffles in Isdidu Fork and gather the mushrooms.
-QUEST_LV_0100_20150317_006165	Give the poisonous mushrooms to Follower Adele
-QUEST_LV_0100_20150317_006166	Gathered enough poisonous mushrooms from Truffles. Give them to Follower Adele so that she can make the acid solution. 
+QUEST_LV_0100_20150317_006164	Believer Adele says she needs poisonous mushrooms of Truffles for the acid solution. Defeat the Truffles in Isdidu Fork and gather the mushrooms.
+QUEST_LV_0100_20150317_006165	Give the poisonous mushrooms to Believer Adele
+QUEST_LV_0100_20150317_006166	Gathered enough poisonous mushrooms from Truffles. Give them to Believer Adele so that she can make the acid solution. 
 QUEST_LV_0100_20150317_006167	$Combined the mixed solution at the Altar of Harmony.
 QUEST_LV_0100_20150317_006168	$Gathered all the materials. Approach the Altar of Harmony in Isdidu Fork, then combine Truffle's poisonous mushrooms and the Velwriggler's claws to make a mixed solution.
-QUEST_LV_0100_20150317_006169	Give the mixed solution to Follower Adele
-QUEST_LV_0100_20150317_006170	You have successfully made the mixed solution at the Altar of Harmony. Give it to Follower Adele.
+QUEST_LV_0100_20150317_006169	Give the mixed solution to Believer Adele
+QUEST_LV_0100_20150317_006170	You have successfully made the mixed solution at the Altar of Harmony. Give it to Believer Adele.
 QUEST_LV_0100_20150317_006171	Melt the thorny vines using the acidic solution.
-QUEST_LV_0100_20150317_006172	Follower Adele made acid solution with the mix solution you brought. Bring the solution to Gate Route and melt the thorny vines.
-QUEST_LV_0100_20150317_006173	Talk to Follower Virgis
+QUEST_LV_0100_20150317_006172	Believer Adele made acid solution with the mix solution you brought. Bring the solution to Gate Route and melt the thorny vines.
+QUEST_LV_0100_20150317_006173	Talk to Believer Virgis
 QUEST_LV_0100_20150317_006174	Virgis wants your help.
 QUEST_LV_0100_20150317_006175	$Charge the magic crystal in the condensed magic spots.
 QUEST_LV_0100_20150317_006176	$Virgis's Memo: First, charge the magic crystal I gave you. Look for the condensed magic spots in Pavydo Woodland.
@@ -6187,84 +6187,84 @@ QUEST_LV_0100_20150317_006182	$Get the refined magic crystal
 QUEST_LV_0100_20150317_006183	$Use the refined magic crystal to remove the thorny vines
 QUEST_LV_0100_20150317_006184	$Virgis's Memo: Very good. Now use the refined magic crystal and show those thorny vines the power of Goddess Saule's followers.
 QUEST_LV_0100_20150317_006185	$Virgis's Memo: Very good. Now use the refined magic crystal and show those thorny vines the power of Goddess Saule's followers.
-QUEST_LV_0100_20150317_006186	Talk to Follower Nojus
-QUEST_LV_0100_20150317_006187	Goddess Saule Follower Nojus is anxiously waiting for you.
+QUEST_LV_0100_20150317_006186	Talk to Believer Nojus
+QUEST_LV_0100_20150317_006187	Goddess Saule Believer Nojus is anxiously waiting for you.
 QUEST_LV_0100_20150317_006188	$Find the 'ominous voice'
 QUEST_LV_0100_20150317_006189	$Nojus told you where the ominous voice is coming from. Go and find it.
 QUEST_LV_0100_20150317_006190	{memo X}
-QUEST_LV_0100_20150317_006191	$Defeated the Poata summoned by the Beholder. Go deep into the forest of thorns to find Bramble.
+QUEST_LV_0100_20150317_006191	$Defeated the Poata summoned by the Beholder. Go deep into the Thorn Forest to find Bramble.
 QUEST_LV_0100_20150317_006192	Defeat the summoned Poata
-QUEST_LV_0100_20150317_006193	Talk to Follower Alvydas
-QUEST_LV_0100_20150317_006194	$Goddess Saule Follower Alvydas is watching you.
-QUEST_LV_0100_20150317_006195	Look for Goddess Saule Followers
+QUEST_LV_0100_20150317_006193	Talk to Believer Alvydas
+QUEST_LV_0100_20150317_006194	$Goddess Saule Believer Alvydas is watching you.
+QUEST_LV_0100_20150317_006195	Look for Goddess Saule Believers
 QUEST_LV_0100_20150317_006196	{memo X}
-QUEST_LV_0100_20150317_006197	$Helped all the followers of Goddess Saule. Talk to Follower Alvydas.
-QUEST_LV_0100_20150317_006198	Talk to Follower Raminta
-QUEST_LV_0100_20150317_006199	$Goddess Saule Follower Raminta needs your help.
+QUEST_LV_0100_20150317_006197	$Helped all the followers of Goddess Saule. Talk to Believer Alvydas.
+QUEST_LV_0100_20150317_006198	Talk to Believer Raminta
+QUEST_LV_0100_20150317_006199	$Goddess Saule Believer Raminta needs your help.
 QUEST_LV_0100_20150317_006200	Defeat the source of evil aura. 
-QUEST_LV_0100_20150317_006201	$Follower Raminta says she found the demon spreading the evil aura around. Defeat Rikaus for her. 
-QUEST_LV_0100_20150317_006202	Report to Follower Raminta
-QUEST_LV_0100_20150317_006203	Defeated Rikaus that was spreading evil aura. Report to Follower Raminta.
+QUEST_LV_0100_20150317_006201	$Believer Raminta says she found the demon spreading the evil aura around. Defeat Rikaus for her. 
+QUEST_LV_0100_20150317_006202	Report to Believer Raminta
+QUEST_LV_0100_20150317_006203	Defeated Rikaus that was spreading evil aura. Report to Believer Raminta.
 QUEST_LV_0100_20150317_006204	Defeat Rikaus
-QUEST_LV_0100_20150317_006205	Talk to Follower Evaldas
-QUEST_LV_0100_20150317_006206	$Goddess Saule Follower Evaldas needs your help.
+QUEST_LV_0100_20150317_006205	Talk to Believer Evaldas
+QUEST_LV_0100_20150317_006206	$Goddess Saule Believer Evaldas needs your help.
 QUEST_LV_0100_20150317_006207	$Defeat the Merog Shamans
-QUEST_LV_0100_20150317_006208	$Follower Evaldas asked you to defeat the Shamans. Stop their rituals and defeat them.
+QUEST_LV_0100_20150317_006208	$Believer Evaldas asked you to defeat the Shamans. Stop their rituals and defeat them.
 QUEST_LV_0100_20150317_006209	Report to Evaldas
-QUEST_LV_0100_20150317_006210	$Defeat the Merog Shamans. Tell Evaldas about it.
+QUEST_LV_0100_20150317_006210	$Defeat the Merog Shamans. Tell Believer Evaldas about it.
 QUEST_LV_0100_20150317_006211	$Defeat the Merog Shaman performing a ritual
-QUEST_LV_0100_20150317_006212	Talk to Follower Zaneta
-QUEST_LV_0100_20150317_006213	$Goddess Saule Follower Zaneta needs your help.
+QUEST_LV_0100_20150317_006212	Talk to Believer Zaneta
+QUEST_LV_0100_20150317_006213	$Goddess Saule Believer Zaneta needs your help.
 QUEST_LV_0100_20150317_006214	Destroy the demon summoning crystal
 QUEST_LV_0100_20150317_006215	$Those Merogs prepared a demon summoning circle that summons demons in Goddess Saule's Altar. Destroy the summoning crystal in the center and stop the demons.
-QUEST_LV_0100_20150317_006216	Report to Follower Zaneta
-QUEST_LV_0100_20150317_006217	$Destroyed all the summoning crystals. Go and comfort Zaneta.
-QUEST_LV_0100_20150317_006218	Talk to Follower Simas
-QUEST_LV_0100_20150317_006219	Goddess Saule Follower Simas needs your help.
+QUEST_LV_0100_20150317_006216	Report to Believer Zaneta
+QUEST_LV_0100_20150317_006217	$Destroyed all the summoning crystals. Comfort Believer Zaneta.
+QUEST_LV_0100_20150317_006218	Talk to Believer Simas
+QUEST_LV_0100_20150317_006219	Goddess Saule Believer Simas needs your help.
 QUEST_LV_0100_20150317_006220	Destroy the demon summoning circle fuming a murky aura.
-QUEST_LV_0100_20150317_006221	Follower Simas says the the demon summoning circle is fuming evil energy along with demons and it is worth a research. Destroy the summoning circle just enough for Simas to research.
-QUEST_LV_0100_20150317_006222	Report to Follower Simas
+QUEST_LV_0100_20150317_006221	Believer Simas says the the demon summoning circle is fuming evil energy along with demons and it is worth a research. Destroy the summoning circle just enough for Simas to research.
+QUEST_LV_0100_20150317_006222	Report to Believer Simas
 QUEST_LV_0100_20150317_006223	The summoning circle does not seem to work anymore. Tell Simas that he can study it.
 QUEST_LV_0100_20150317_006224	Destroy the Summoning Crystal
-QUEST_LV_0100_20150317_006225	Talk to Follower Onute
-QUEST_LV_0100_20150317_006226	Goddess Saule Follower Onute needs your help.
+QUEST_LV_0100_20150317_006225	Talk to Believer Onute
+QUEST_LV_0100_20150317_006226	Goddess Saule Believer Onute needs your help.
 QUEST_LV_0100_20150317_006227	Defeat Archon and the demon summoning circle.
-QUEST_LV_0100_20150317_006228	$Follower Onute is angry that the altar turned into a demon summoning circle. Defeat Archon and destroy the demon summoning circle to teach them a lesson about the Goddess' powers.
-QUEST_LV_0100_20150317_006229	Report to Follower Onute
-QUEST_LV_0100_20150317_006230	Got rid of all the ominous things Onute mentioned. Report to Follower Onute.
-QUEST_LV_0100_20150317_006231	Talk to Follower Bronius
-QUEST_LV_0100_20150317_006232	Goddess Saule Follower Bronius is in hiding and anxiously waiting for your help.
+QUEST_LV_0100_20150317_006228	$Believer Onute is angry that the altar turned into a demon summoning circle. Defeat Archon and destroy the demon summoning circle to teach them a lesson about the Goddess' powers.
+QUEST_LV_0100_20150317_006229	Report to Believer Onute
+QUEST_LV_0100_20150317_006230	Got rid of all the ominous things Onute mentioned. Report to Believer Onute.
+QUEST_LV_0100_20150317_006231	Talk to Believer Bronius
+QUEST_LV_0100_20150317_006232	Goddess Saule Believer Bronius is in hiding and anxiously waiting for your help.
 QUEST_LV_0100_20150317_006233	{memo X}Defeat the Merogs
-QUEST_LV_0100_20150317_006234	$Follower Bronius says the monsters are after him. Defeat the monsters.
-QUEST_LV_0100_20150317_006235	Defeated the monsters. Talk to Bronius.
-QUEST_LV_0100_20150317_006236	Defeat the monster that tried to kill the followers
-QUEST_LV_0100_20150317_006237	Talk to Follower Samantha
+QUEST_LV_0100_20150317_006234	$Believer Bronius says the monsters are after him. Defeat the monsters.
+QUEST_LV_0100_20150317_006235	Defeated the monsters. Talk to Believer Bronius.
+QUEST_LV_0100_20150317_006236	Defeat the monster that tried to kill the believer
+QUEST_LV_0100_20150317_006237	Talk to Believer Samantha
 QUEST_LV_0100_20150317_006238	{memo X}
 QUEST_LV_0100_20150317_006239	{memo X}Protect the altar from the monsters
-QUEST_LV_0100_20150317_006240	Follower Samantha is worried because the monsters attack whenever she tries to purify. Protect the Altar of Purification in Thornbush Rest Place from the monsters.
-QUEST_LV_0100_20150317_006241	$Protected the altar from the monsters. Return to Follower Samantha.
+QUEST_LV_0100_20150317_006240	Believer Samantha is worried because the monsters attack whenever she tries to purify. Protect the Altar of Purification in Thornbush Rest Place from the monsters.
+QUEST_LV_0100_20150317_006241	$Protected the altar from the monsters. Return to Believer Samantha.
 QUEST_LV_0100_20150317_006242	Check Sviesa Hill Areas
-QUEST_LV_0100_20150317_006243	$Follower Jurga says one of Bramble's roots is in Sviesa Hill Areas. Check Sviesa Hill Areas.
+QUEST_LV_0100_20150317_006243	$Believer Jurga says one of Bramble's roots is in Sviesa Hill Areas. Check Sviesa Hill Areas.
 QUEST_LV_0100_20150317_006244	Cut Bramble's Roots.
 QUEST_LV_0100_20150317_006245	Approached the Bramble's roots but Gaigalas appeared. You must defeat Gaigalas before destroying Bramble's roots.
-QUEST_LV_0100_20150317_006246	Talk to Follower Jurga
-QUEST_LV_0100_20150317_006247	You cut off Bramble's roots. Return and talk to Follower Jurga.
+QUEST_LV_0100_20150317_006246	Talk to Believer Jurga
+QUEST_LV_0100_20150317_006247	You cut off Bramble's roots. Return and talk to Believer Jurga.
 QUEST_LV_0100_20150317_006248	Defeat Gaigalas guarding Bramble's Root
 QUEST_LV_0100_20150317_006249	Destroy Bramble's Root
-QUEST_LV_0100_20150317_006250	Follower Jurga is following the Goddess in watching over Bramble and is waiting for you. 
+QUEST_LV_0100_20150317_006250	Believer Jurga is following the Goddess in watching over Bramble and is waiting for you. 
 QUEST_LV_0100_20150317_006251	{memo X}Get Merog's stinger and make Thorn Flower stimulant
 QUEST_LV_0100_20150317_006252	{memo X}Bramble says he needs to make medication for withstanding the evil aura before getting into the battle. Go to Kruva swell and get Merog's stingers. 
 QUEST_LV_0100_20150317_006253	{memo X}Collect all of Merog's stingers needed. Return to Jurga.
 QUEST_LV_0100_20150317_006254	$Check Tankinta Vacant Lot
-QUEST_LV_0100_20150317_006255	$Follower Jurga says one of Bramble's roots is in Tankinta Vacant Lot. Check out Tankinta Vacant Lot.
+QUEST_LV_0100_20150317_006255	$Believer Jurga says one of Bramble's roots is in Tankinta Vacant Lot. Check out Tankinta Vacant Lot.
 QUEST_LV_0100_20150317_006256	Defeat Molich guarding the roots of Bramble.
 QUEST_LV_0100_20150317_006257	Defeat Molich guarding Bramble's Root
-QUEST_LV_0100_20150317_006258	Talk to Follower Kazis
-QUEST_LV_0100_20150317_006259	Goddess Saule Follower Kazis needs your help.
+QUEST_LV_0100_20150317_006258	Talk to Believer Kazis
+QUEST_LV_0100_20150317_006259	Goddess Saule Believer Kazis needs your help.
 QUEST_LV_0100_20150317_006260	Purifying the Caradas rail.
-QUEST_LV_0100_20150317_006261	$Follower Kazis says Honeypin is making it difficult to do purifying works. Activate the altar for Follower Kazis.
-QUEST_LV_0100_20150317_006262	$Defeated Honeypin. Return to Follower Kazis.
-QUEST_LV_0100_20150317_006263	$You agreed to meet Follower Jurga in Giliaii courtyard to plan a fight against Bramble.
+QUEST_LV_0100_20150317_006261	$Believer Kazis says Honeypin is making it difficult to do purifying works. Activate the altar for Believer Kazis.
+QUEST_LV_0100_20150317_006262	$Defeated Honeypin. Return to Believer Kazis.
+QUEST_LV_0100_20150317_006263	$You agreed to meet Believer Jurga in Giliaii Courtyard to plan a fight against Bramble.
 QUEST_LV_0100_20150317_006264	Defeat Bramble and retrieve the Revelation.
 QUEST_LV_0100_20150317_006265	Arrived at Giliaii Courtyard where Bramble is in. Defeat it and retrieve the Revelation!
 QUEST_LV_0100_20150317_006266	Obtain the Revelation.
@@ -6336,17 +6336,17 @@ QUEST_LV_0100_20150317_006331	{memo X}
 QUEST_LV_0100_20150317_006332	{memo X}
 QUEST_LV_0100_20150317_006333	Beholder's Careful Trick
 QUEST_LV_0100_20150317_006334	A mysterious beholder appeared to share the belief of Goddess. Let's hear what he has to say. 
-QUEST_LV_0100_20150317_006335	Follower Jurga says there are more things to do other than making the stimulant. Talk to Follower Jurga.
+QUEST_LV_0100_20150317_006335	Believer Jurga says there are more things to do other than making the stimulant. Talk to Believer Jurga.
 QUEST_LV_0100_20150317_006336	Destroy Bramble's roots.
 QUEST_LV_0100_20150317_006337	$Jurga says we must destroy the roots placed to heal Bramble's wound. The roots are in Sviesa Hill Areas and Tankinta Vacant Lot.
-QUEST_LV_0100_20150317_006338	Removed all of Bramble's roots. Talk to Follower Jurga.
+QUEST_LV_0100_20150317_006338	Removed all of Bramble's roots. Talk to Believer Jurga.
 QUEST_LV_0100_20150317_006339	{memo X}Seems like the Item Merchant has something left to say. Talk to the Item Merchant.
 QUEST_LV_0100_20150317_006340	Talk to the Accessory Merchant
 QUEST_LV_0100_20150317_006341	The Accessory Merchant has given the Relevator an accessory gift. Please accept it graciously.
 QUEST_LV_0100_20150317_006342	Listen to Gustas Jonas for the next step.
 QUEST_LV_0100_20150317_006343	Meet Morkus Jonas in Overlong Bridge Valley.
 QUEST_LV_0100_20150317_006344	You'll know what to do next when you meet Morkus Jonas in Overlong Bridge Valley.
-QUEST_LV_0100_20150317_006345	Goddess Saule says that Bramble stole the revelation in the forest of thorns. Move to the forest of thorns.
+QUEST_LV_0100_20150317_006345	Goddess Saule says that Bramble stole the revelation in the Thorn Forest. Move to the Thorn Forest.
 QUEST_LV_0100_20150317_006346	{memo X}
 QUEST_LV_0100_20150317_006347	{memo X}
 QUEST_LV_0100_20150317_006348	Talk to Soldier Jace
@@ -6444,9 +6444,9 @@ QUEST_LV_0100_20150323_006439	$They were created to remind people of the five si
 QUEST_LV_0100_20150323_006440	{memo X}Looks like the necklace belongs to you. {nl}If it wasn't for you, the teachings of Maven would have been left as a curse.
 QUEST_LV_0100_20150323_006441	$To be honest, I'd like go to Kvailas Forest rather than staying here. {nl}I want to see the source of evil with my own two eyes.
 QUEST_LV_0100_20150323_006442	$Thank you. The tools are sold by the blacksmith in Klaipeda. {nl}But before that, there are stones in Stele Road that are known for their quality. I ask for you to retrieve some for me. 
-QUEST_LV_0100_20150323_006443	$Done. Please place this at the entrance of Royal Mausoleum in Zachariel Crossroad. {nl}This should bring comfort to their souls.
+QUEST_LV_0100_20150323_006443	$Done. Please place this at the entrance of Royal Mausoleum in Zachariel Crossroads. {nl}This should bring comfort to their souls.
 QUEST_LV_0100_20150323_006444	{memo X}Hmm. You're really as good as they say. {nl}Rolandas is waiting for you in Akmens Ridge.
-QUEST_LV_0100_20150323_006445	{memo X}Please be careful. {nl}A dark aura similar to the voice a while ago is covering the forest of thorns. {nl}Especially the Kvailas Forest.. I have sharp ears for things like this..
+QUEST_LV_0100_20150323_006445	{memo X}Please be careful. {nl}A dark aura similar to the voice a while ago is covering the Thorn Forest. {nl}Especially the Kvailas Forest.. I have sharp ears for things like this..
 QUEST_LV_0100_20150323_006446	$The Necroventer that occupied Kule Peak is gone. {nl}Kule Peak should become peaceful again.
 QUEST_LV_0100_20150323_006447	$This was prepared for releasing the seals in Tiltas Valley. {nl}The sap was collected little by little over centuries. {nl}So please handle it with care. 
 QUEST_LV_0100_20150323_006448	$This is it. {nl}Bring the Seal Release Crystal to Ramstis Ridge. {nl}The Disciples of Gustas will welcome you there. 
@@ -6586,8 +6586,8 @@ QUEST_LV_0100_20150323_006581	$Talk to the Wandering Spirit of Escanciu Village.
 QUEST_LV_0100_20150323_006582	$I found a written order while checking the military backpack of the Wandering Spirit in Escanciu Village. Check the details of the order.
 QUEST_LV_0100_20150323_006583	$Complete Operation Wooden Village for the Wandering Spirit of Escanciu Village.
 QUEST_LV_0100_20150323_006584	Move to Kvailas Forest
-QUEST_LV_0100_20150323_006585	Find the followers of Goddess Saule in Sirdgela Forest and help them.
-QUEST_LV_0100_20150323_006586	Goddess Saule's Follower Samantha is waiting for your help in Kvailas Forest.
+QUEST_LV_0100_20150323_006585	Find the believers of Goddess Saule in Sirdgela Forest and help them.
+QUEST_LV_0100_20150323_006586	Goddess Saule's Believer Samantha is waiting for your help in Kvailas Forest.
 QUEST_LV_0100_20150323_006587	Villagers told you to go to the elderly of Andale Village. Go to the elderly of Andale Village in Vieta Gorge.
 QUEST_LV_0100_20150323_006588	Go to the Ershike Altar
 QUEST_LV_0100_20150323_006589	Collected all the materials needed to restore the obelisk. Go to the Ershike Altar to combine it.
@@ -6602,7 +6602,7 @@ QUEST_LV_0100_20150323_006597	Check the old well in Coblat Forest.
 QUEST_LV_0100_20150323_006598	Move to Akmens Ridge
 QUEST_LV_0100_20150323_006599	Morkus Jonas says you can listen to the next story from Rolandas Jonas in Akmens Ridge.
 QUEST_LV_0100_20150323_006600	Go and meet Rolandas Jonas in Akmens Ridge.
-QUEST_LV_0100_20150323_006601	{memo X}Goddess Saule says Bramble of Kvailas Forest is in the forest of thorns. Pass through Gate Route and Spine Heart Dale to Kvailas Forest to find the revelation. 
+QUEST_LV_0100_20150323_006601	{memo X}Goddess Saule says Bramble of Kvailas Forest is in the Thorn Forest. Pass through Gate Route and Spine Heart Dale to Kvailas Forest to find the revelation. 
 QUEST_LV_0100_20150323_006602	Kvailas Forest
 QUEST_LV_0100_20150323_006603	Travel to Gele Plateau
 QUEST_LV_0100_20150323_006604	Gele Plateau
@@ -6697,8 +6697,8 @@ QUEST_LV_0100_20150414_006692	{memo X}Cetek altar was destroyed but Sevia altar 
 QUEST_LV_0100_20150414_006693	Defeat Experimental Slime
 QUEST_LV_0100_20150414_006694	There are more seal stones. Defeat the Experimental Slime that is guarding it to find other seal stones by talking to it.
 QUEST_LV_0100_20150414_006695	The Tzedej Altar in Plateau of Rex is not yet activated. Activate it.
-QUEST_LV_0100_20150414_006696	Domas, a follower of Goddess Saule, is planning to burn the thorny vines. Get the remains of Thornball at Geisma Access Road.
-QUEST_LV_0100_20150414_006697	Follower Domas says he needs Cauliflower Sap because of the rain. Get the sap from Cauliflowers at Rustybe Dead Tree Area.
+QUEST_LV_0100_20150414_006696	Goddess Saule's Believer Domas is planning to burn the thorny vines. Get the remains of Thornball at Geisma Access Road.
+QUEST_LV_0100_20150414_006697	Believer Domas says he needs Cauliflower Sap because of the rain. Get the sap from Cauliflowers at Rustybe Dead Tree Area.
 QUEST_LV_0100_20150414_006698	{memo X}Combine Ridimed leaf and detox solvent to make antidote.
 QUEST_LV_0100_20150428_006699	I heard the sound of figthing so I cam here in a hurry..Have you defeated it?{nl}I only spotted Siaulambs.{nl}Well done. You have performanced a meritorious deed.
 QUEST_LV_0100_20150428_006700	I feel stuffy.
@@ -6855,7 +6855,7 @@ QUEST_LV_0100_20150428_006850	The assistant commander Volda asked you to defeat 
 QUEST_LV_0100_20150428_006851	Find the person who knows about the epitaph of Agailla Flurry and listen to his request.
 QUEST_LV_0100_20150428_006852	You found the Villager's Bag. Return the Villager's Bag and ask him about the contents in the epitaph.
 QUEST_LV_0100_20150428_006853	Defeat Blue Woodspirits that appeared near Obelisk
-QUEST_LV_0100_20150428_006854	$Goddess Saule lost the revelation from Bramble at the forest of thorns within Kvailas Forest. Help the priests at Gate Route and Sirdgela Forest and look for the revelation at Kvailas Forest.
+QUEST_LV_0100_20150428_006854	$Goddess Saule lost the revelation from Bramble at the Thorn Forest within Kvailas Forest. Help the priests at Gate Route and Sirdgela Forest and look for the revelation at Kvailas Forest.
 QUEST_LV_0100_20150428_006855	Go down from Twin Bridge at Miners' Village to get to Srautas Gorge, and then take the cable car from Srautas Gorge and go up a bit to get to Gele Plateau.
 QUEST_LV_0100_20150428_006856	Move to Starving Demon's Road
 QUEST_LV_0100_20150428_006857	Move to Starving Demon's Road
@@ -6950,7 +6950,7 @@ QUEST_LV_0100_20150714_006945	$A monster in disguise as a Goddess Statue. I pity
 QUEST_LV_0100_20150714_006946	$We didn't just stay put when we were held down by the monsters. {nl}We sent out Scouts to look for ways out of here but no one came back. {nl}
 QUEST_LV_0100_20150714_006947	$If you are okay with it, I want you to search for them.{nl}
 QUEST_LV_0100_20150714_006948	$It's going to be hard.{nl}The Thorny Forest keeps growing.
-QUEST_LV_0100_20150714_006949	$A dark aura similar to the voice a while ago is covering the forest of thorns. {nl}Especially Kvailas Forest.. Please be careful.
+QUEST_LV_0100_20150714_006949	$A dark aura similar to the voice a while ago is covering the Thorn Forest. {nl}Especially Kvailas Forest.. Please be careful.
 QUEST_LV_0100_20150714_006950	Good. {nl}First, defeat the Big Blue Grivas up the hills.
 QUEST_LV_0100_20150714_006951	$When you throw this bomb at the Long-Branched Trees, they will light up.{nl}When you feel they are burnt enough, destroy them to get charcoals.{nl}
 QUEST_LV_0100_20150714_006952	$Be careful. This place is full of evil energy from Bramble.{nl}You better go back to be safe.
@@ -6991,12 +6991,12 @@ QUEST_LV_0100_20150714_006986	You will know how to handle it when you control it
 QUEST_LV_0100_20150714_006987	With the warp magic field under me, you could quickly go to the room of rituals.{nl}I hope you are successful...
 QUEST_LV_0100_20150714_006988	The magic generating stones in the room of rituals affect the other magic generating stones nearby.{nl}We could start over with Balyus' magic.
 QUEST_LV_0100_20150714_006989	The magical power that was supplied to the magical stone of the interaction has been completely shut off... {nl}Do you think we can really wish for the salvation.
-QUEST_LV_0100_20150714_006990	We are all ready. But, that Akorn is different from the Akorn from your era. {nl}It may be better to leave it like that.
+QUEST_LV_0100_20150714_006990	We are all ready. But, that Archon is different from the Archon from your era. {nl}It may be better to leave it like that.
 QUEST_LV_0100_20150714_006991	We have an other way. The sealed artifact among Balryus artifacts...{nl}I heard there are some of them in Uzdaromo stone chamber that were created to suppress the demons.
 QUEST_LV_0100_20150714_006992	I already gave up the hope that I would be free a few hundreds years ago.{nl}In fact, I still can't believe it.
 QUEST_LV_0100_20150714_006993	The seal that is suppressing the demonic energy... that's it.{nl}Now everything is ready.
-QUEST_LV_0100_20150714_006994	Now, when the magical stone of the interaction stops, I will be free with Akorn.{nl}
-QUEST_LV_0100_20150714_006995	I will tell you one more time. You should not think of Akorn that was present in your era.{nl}It will be hard without using the seal.
+QUEST_LV_0100_20150714_006994	Now, when the magical stone of the interaction stops, I will be free with Archon.{nl}
+QUEST_LV_0100_20150714_006995	I will tell you one more time. You should not think of Archon that was present in your era.{nl}It will be hard without using the seal.
 QUEST_LV_0100_20150714_006996	In fact, I am okay even if I disappear like this.{nl}It's so thankful that you care for me, but I don't want you to get hurt.
 QUEST_LV_0100_20150714_006997	We are almost at the moment of being released from the restraint that was on us for hundreds of years.{nl}
 QUEST_LV_0100_20150714_006998	I can be saved. I... finally...{nl}I can't thank you enough.{nl}
@@ -7246,7 +7246,7 @@ QUEST_LV_0100_20150714_007241	Unseal the broken seal of Pasaga Cliff in Ramstis 
 QUEST_LV_0100_20150714_007242	{memo X}Notice/Return to Klaipeda and talk to Knight Commander Uska
 QUEST_LV_0100_20150714_007243	I will think about it little more
 QUEST_LV_0100_20150714_007244	{memo X}Notice/GetItem /Monsters suddenly smelled something and appeared!#5
-QUEST_LV_0100_20150714_007245	{memo X}Notice/!/Mushwort Appeared! It must have broken the Owl Statue!#5
+QUEST_LV_0100_20150714_007245	{memo X}Notice/!/Mushwort Appeared! It must have broken the Owl Sculpture!#5
 QUEST_LV_0100_20150714_007246	Looking for the oil
 QUEST_LV_0100_20150714_007247	{memo X}Notice/!/The fire is dying.{nl}Steal the arrows from High Vubbe archer and throw it in the fire!#5
 QUEST_LV_0100_20150714_007248	Making a rubber copy
@@ -7277,7 +7277,7 @@ QUEST_LV_0100_20150714_007272	{memo X}Notice/Move to Giliai Courtyard!#5
 QUEST_LV_0100_20150714_007273	Inseparable Spirit
 QUEST_LV_0100_20150714_007274	Ask him to tell you the story
 QUEST_LV_0100_20150714_007275	There is a Way (1)
-QUEST_LV_0100_20150714_007276	Tell him to find the way to defeat Akorn together
+QUEST_LV_0100_20150714_007276	Tell him to find the way to defeat Archon together
 QUEST_LV_0100_20150714_007277	I will think little more
 QUEST_LV_0100_20150714_007278	There is a Way (2)
 QUEST_LV_0100_20150714_007279	Ask him if there's a way to obtain the magical power of Balryus
@@ -7423,11 +7423,11 @@ QUEST_LV_0100_20150714_007418	Obtained the Mysterious Slate
 QUEST_LV_0100_20150714_007419	You've obtained the Mysterious Slate that was inside the Crystal Pillar. When you bring it to Sir Uska in Klaipeda, you may find out the identity of the slate.
 QUEST_LV_0100_20150714_007420	Defeat Infroholders that rushed in.
 QUEST_LV_0100_20150714_007421	Get Matsum's Flower Stamen to create a Thorn Flower Stimulant.
-QUEST_LV_0100_20150714_007422	Jurga told you that before you fight against Bramble, you should make the medicine that would help you endure the musky aura. Obtain Matsum's Flower Stamen at Rankena Hill.
-QUEST_LV_0100_20150714_007423	Collect all of Matsum's Flower Stamen. Return to Follower Jurga.
+QUEST_LV_0100_20150714_007422	Believer Jurga told you that before you fight against Bramble, you should make the medicine that would help you endure the musky aura. Obtain Matsum's Flower Stamen at Rankena Hill.
+QUEST_LV_0100_20150714_007423	Collect all of Matsum's Flower Stamen. Return to Believer Jurga.
 QUEST_LV_0100_20150714_007424	Defeat Matsums
 QUEST_LV_0100_20150714_007425	Talk with the spirit of Jane
-QUEST_LV_0100_20150714_007426	Jane's spirit is not leaving from dangerous Akorn. Ask her why.
+QUEST_LV_0100_20150714_007426	Jane's spirit is not leaving from dangerous Achorn. Ask her why.
 QUEST_LV_0100_20150714_007427	Listen from Jane's spirit
 QUEST_LV_0100_20150714_007428	It seems that something complicated is going on with Jane. Listen from Jane's spirit what's the matter.
 QUEST_LV_0100_20150714_007429	There is always a way
@@ -7450,12 +7450,12 @@ QUEST_LV_0100_20150714_007445	You've stopped all magic generating stones in the 
 QUEST_LV_0100_20150714_007446	What's bad about being careful
 QUEST_LV_0100_20150714_007447	You've blocked the magical power that is going into the magical stones of interaction by stopping all magic generating stones. Talk to Jane's spirit again.
 QUEST_LV_0100_20150714_007448	Search for the keepstakes of sealed Balryus in Uzdaromo stone chamber
-QUEST_LV_0100_20150714_007449	Jane told you that when the magical stones of the interaction completely stop, Akorn will be released with you. To defeat the released Akorn easily, look for usable objects that Balryus created when he was alive.
+QUEST_LV_0100_20150714_007449	Jane told you that when the magical stones of the interaction completely stop, Archon will be released with you. To defeat the released Archon easily, look for usable objects that Balryus created when he was alive.
 QUEST_LV_0100_20150714_007450	You've unleashed the seal and obtained the stamp that suppresses the demonic energy. Return to Jane's spirit with this.
-QUEST_LV_0100_20150714_007451	You are ready to fight against Akorn. Talk to Jane's spirit if this will be enough.
+QUEST_LV_0100_20150714_007451	You are ready to fight against Archon. Talk to Jane's spirit if this will be enough.
 QUEST_LV_0100_20150714_007452	Stop the magical stones of the interaction
-QUEST_LV_0100_20150714_007453	{memo X}When you stop the magical stone of the interaction, Akorn will be released along with Jane's spirit. Stop the magical stone of the interaction and defeat Akorn.
-QUEST_LV_0100_20150714_007454	You've defeated Akorn. Talk to Jane what's she going to do next.
+QUEST_LV_0100_20150714_007453	{memo X}When you stop the magical stone of the interaction, Archon will be released along with Jane's spirit. Stop the magical stone of the interaction and defeat Archon.
+QUEST_LV_0100_20150714_007454	You've defeated Archon. Talk to Jane what's she going to do next.
 QUEST_LV_0100_20150714_007455	Gold Spoon Life
 QUEST_LV_0100_20150714_007456	Ask Adriyus
 QUEST_LV_0100_20150714_007457	Ask Adriyus if there are other tombstones that he found in other regions
@@ -7770,7 +7770,7 @@ QUEST_LV_0100_20150730_007765	{memo X}Yuta told you that he came here to look fo
 QUEST_LV_0100_20150730_007766	{memo X}I am not interested.
 QUEST_LV_0100_20150730_007767	The spell doll of the grave guard
 QUEST_LV_0100_20150730_007768	{memo X}Talking/TALK/2/TRACK_BEFORE/None
-QUEST_LV_0100_20150730_007769	Suspicious believers
+QUEST_LV_0100_20150730_007769	Suspicious Believers
 QUEST_LV_0100_20150730_007770	{memo X}Accroding to Yuta, the corpses came our from the coffins that soared.{nl}Destroy the coffins that came out from the ground.
 QUEST_LV_0100_20150730_007771	Pull out the spell doll from the box of the grave guard
 QUEST_LV_0100_20150730_007772	{memo X}The grave guard, Sigis asked you to pull out the spell doll from the box of the grave guard.
@@ -7869,18 +7869,18 @@ QUEST_LV_0100_20150803_007864	Go to the place where the sprit of the soldier wit
 QUEST_LV_0100_20150803_007865	Go to the place where the sprit of the soldier with resentment told you to go
 QUEST_LV_0100_20150803_007866	{memo X}Rescue the desperate man
 QUEST_LV_0100_20150803_007867	{memo X}Rescue the desperate man
-QUEST_LV_0100_20150803_007868	Talk with the believer, Gintas
+QUEST_LV_0100_20150803_007868	Talk with Believer Gintas
 QUEST_LV_0100_20150803_007869	You've rescued the desperate man. Talk with him.
 QUEST_LV_0100_20150804_007870	$You are better than I expected.{nl}I have another request for you... How about it?
 QUEST_LV_0100_20150804_007871	I can't move at all due to the barrier.{nl}Please do something about it.
 QUEST_LV_0100_20150804_007872	$Shoot. I think the monsters are rushing back here.{nl}They probably found out that I have been freed.
 QUEST_LV_0100_20150804_007873	Where is the master. I am so scared because I am worried.
-QUEST_LV_0100_20150804_007874	$This trial was indeed the one that can be only passed by the Revelator.{nl}The trial that was prepared by the owner of the Royal Mausoleum.
-QUEST_LV_0100_20150804_007875	$Are you hurt somewhere?{nl}Oh, that's the second symbol of trial of the Great King.
-QUEST_LV_0100_20150804_007876	$So, soon all of the symbols of the trials will be collected.{nl}I'll be looking forward to it.
-QUEST_LV_0100_20150804_007877	$Finally, you have collected all the symbols of the trials.{nl}Give me the symbols, please. I will start the interpretations.
+QUEST_LV_0100_20150804_007874	$This ordeal was indeed the one that can be only passed by the Revelator.{nl}The ordeal that was prepared by the owner of the Royal Mausoleum.
+QUEST_LV_0100_20150804_007875	$Are you hurt somewhere?{nl}Oh, that's the second symbol of ordeal of the Great King.
+QUEST_LV_0100_20150804_007876	$So, soon all of the symbols of the ordeals will be collected.{nl}I'll be looking forward to it.
+QUEST_LV_0100_20150804_007877	$Finally, you have collected all the symbols of the ordeals.{nl}Give me the symbols, please. I will start the interpretations.
 QUEST_LV_0100_20150804_007878	$Wispy Floating Words
-QUEST_LV_0100_20150804_007879	$I prepared 4 trials, so that our enemies can't touch on it.{nl}But if you are not prepared, even you won't be able to overcome those trials.{nl}
+QUEST_LV_0100_20150804_007879	$I prepared 4 ordeals, so that our enemies can't touch on it.{nl}But if you are not prepared, even you won't be able to overcome those ordeals.{nl}
 QUEST_LV_0100_20150804_007880	$Look for it. {nl}The way will be opened when you prove yourself as a true savior.{nl}
 QUEST_LV_0100_20150804_007881	$Oh my, so that was the case...{nl}The symbols are covered with something, so it is difficult for me to examine them.{nl}
 QUEST_LV_0100_20150804_007882	$I will be waiting patiently.{nl}Why would we have to be in a hurry when we already have the symbols?
@@ -7894,18 +7894,18 @@ QUEST_LV_0100_20150804_007889	$Technician Heinen asked you to defeat the monster
 QUEST_LV_0100_20150804_007890	$You have destroyed the barrier on the west side as Technician Heinen requested you too. Talk to him again.
 QUEST_LV_0100_20150804_007891	Collect %s by destroying the Stone Pillar
 QUEST_LV_0100_20150804_007892	Put the stones with vigor at Alkune Stairway
-QUEST_LV_0100_20150804_007893	$You have obtained the symbols of the trial of the Great King. Talk to Historian Rexipher.
-QUEST_LV_0100_20150804_007894	$The epitaph tells you about the trial which relates to the authentication of the Revelator. Talk to Historian Rexipher about the location of the next epitaph.
-QUEST_LV_0100_20150804_007895	$It is the third trial that was prepared by the Great King Zachariel. Read the epitaph on the left side of Dykyne Fork to obtain the third symbol of the trial.
-QUEST_LV_0100_20150804_007896	$You have obtained the third symbol of the trial. Return to Historian Rexipher and talk to him.
+QUEST_LV_0100_20150804_007893	$You have obtained the symbols of the ordeal of the Great King. Talk to Historian Rexipher.
+QUEST_LV_0100_20150804_007894	$The epitaph tells you about the ordeal which relates to the authentication of the Revelator. Talk to Historian Rexipher about the location of the next epitaph.
+QUEST_LV_0100_20150804_007895	$It is the third ordeal that was prepared by the Great King Zachariel. Read the epitaph on the left side of Dykyne Fork to obtain the third symbol of the ordeal.
+QUEST_LV_0100_20150804_007896	$You have obtained the third symbol of the ordeal. Return to Historian Rexipher and talk to him.
 QUEST_LV_0100_20150804_007897	{memo X}Obtain %s
-QUEST_LV_0100_20150804_007898	$There is only one epitaph remaining until you pass all the trials. Talk to Historian Rexipher about the location of the epitaph.
-QUEST_LV_0100_20150804_007899	$This is the last trial prepared by the Great King Zachariel. Read the epitaph at Apati Cliff and obtain the fourth symbol.
-QUEST_LV_0100_20150804_007900	$You have obtained the fourth symbol of the trial. Return to Historian Rexipher and talk to him again.
+QUEST_LV_0100_20150804_007898	$There is only one epitaph remaining until you pass all the ordeals. Talk to Historian Rexipher about the location of the epitaph.
+QUEST_LV_0100_20150804_007899	$This is the last ordeal prepared by the Great King Zachariel. Read the epitaph at Apati Cliff and obtain the fourth symbol.
+QUEST_LV_0100_20150804_007900	$You have obtained the fourth symbol of the ordeal. Return to Historian Rexipher and talk to him again.
 QUEST_LV_0100_20150804_007901	$Historian Rexipher is thinking deeply about something as he sees the symbols. Talk to him again.
 QUEST_LV_0100_20150804_007902	$Historian Rexipher says that the symbols are covered with something so he asked you to get the teeth of Hogma that will be used as abrasives. Obtain Hogma's Tooth.
-QUEST_LV_0100_20150804_007903	$Historian Rexipher disappeared with the symbols of the trial. Talk to Liaison Officer Bale at Plateau of Rex to ask about his whereabouts.
-QUEST_LV_0100_20150804_007904	$You must somehow find Rexipher since he has all the symbols of the trial. Ask him again.
+QUEST_LV_0100_20150804_007903	$Historian Rexipher disappeared with the symbols of the ordeal. Talk to Liaison Officer Bale at Plateau of Rex to ask about his whereabouts.
+QUEST_LV_0100_20150804_007904	$You must somehow find Rexipher since he has all the symbols of the ordeal. Ask him again.
 QUEST_LV_0100_20150804_007905	When you were about to remove the seal of the cliffs, the monsters suddenly appeared. Defeat the monsters!
 QUEST_LV_0100_20150908_007906	Check the map by pressing M
 QUEST_LV_0100_20150908_007907	You can avoid the attacks of large Kepa using jump!
@@ -8185,17 +8185,17 @@ QUEST_LV_0100_20151001_008180	It's time for you to enhance the qualities of Mana
 QUEST_LV_0100_20151001_008181	It is a shame to look back once a man starts his journey.{nl}My brother will rather choose to die than look back.
 QUEST_LV_0100_20151001_008182	I'm sure my brother stood firm and accepted his final moments. However, I still think he could've lived more meaningfully if he had just turned away from his ambition...
 QUEST_LV_0100_20151001_008183	I'm thinking of converting the Demons using the power of the altar. {nl} The converted Demons will absorb the divine power and slowly start to die. {nl}
-QUEST_LV_0100_20151001_008184	So you found the seal of space. {nl}Honestly, I did not believe it when my friend, Paladin Master, said a Savior would come. {nl}
-QUEST_LV_0100_20151001_008185	That's how bad the situation was. {nl}My family and friends all went to the Goddess... {nl}It seemed like there was no hope naymore in this world. {nl}
+QUEST_LV_0100_20151001_008184	So you found the Seal of Space. {nl}Honestly, I did not believe it when my friend, the Paladin Master, said a Savior would come. {nl}
+QUEST_LV_0100_20151001_008185	That's how bad the situation was. {nl}My family and friends all went to the Goddess... {nl}It seemed like there was no hope anymore in this world. {nl}
 QUEST_LV_0100_20151001_008186	Here, use the Seal of Space on the pillar beside me and go to the sanctuary. {nl}It is prepared only for the Revelator. 
-QUEST_LV_0100_20151001_008187	I was there when the Divine Tree was destroying the capital. {nl}But I was not able to stop it. I was not able to save everyone.{nl}This will remain in my heart like a needle and hurt me forever. 
-QUEST_LV_0100_20151001_008188	But you were different. You have the power to save everyone. {nl}All the followers, the guards, even the wishes that me and the first paladin longed for... {nl} 
+QUEST_LV_0100_20151001_008187	I was there when the Divine Tree was destroying the capital. {nl}But I was not able to stop it. I was not able to save everyone.{nl}This will remain in my heart like a needle and it hurts me forever. 
+QUEST_LV_0100_20151001_008188	But you were different. You have the power to save everyone. {nl}All the followers, the guards, even the wishes that me and the first Paladin longed for... {nl} 
 QUEST_LV_0100_20151001_008189	Right. {nl}Did you mention that you need to find Goddess Saule? {nl}
 QUEST_LV_0100_20151001_008190	The colorful stream mentioned in the revelation starts at above the Veja Ravine. {nl}Well then, may the blessings of Goddess be with you.
 QUEST_LV_0100_20151001_008191	When you find the revelation, tell Mater Paladin of the story you've been through so far. {nl}He must be the one most anxious about it. {nl}
 QUEST_LV_0100_20151001_008192	I will gather all the prayers for my fammily and friends and offer it to you. {nl}May the blessings of Goddess be with you...
 QUEST_LV_0100_20151001_008193	But his old body of mine does not follow my will anymore. {nl}Now I can only trust my old friend Algis and you. {nl}
-QUEST_LV_0100_20151001_008194	Go. Tenet Cathedral is in Tenet Garden.{nl}My lifelong wish.. Be sure to stop the revelation from falling into the hands of Gesti.
+QUEST_LV_0100_20151001_008194	Go. The Tenet Cathedral is in Tenet Garden.{nl}My lifelong wish.. Be sure to stop the revelation from falling into the hands of Gesti.
 QUEST_LV_0100_20151001_008195	Please bring me the Mali seeds in the way to Labure roads. {nl} They would be a good source of magic for the shaman doll. {nl} {nl}
 QUEST_LV_0100_20151001_008196	Won't you help me purify Labure road? {nl} The shaman doll finds the evil force but we have to purify it ourselves.
 QUEST_LV_0100_20151001_008197	We need the rope for ceremony to make the shaman doll. {nl} It's on the waist of the Panto Shaman in the Cottage. {nl} Bring it to me.
@@ -8208,7 +8208,7 @@ QUEST_LV_0100_20151001_008203	Understanding the root of everything becomes the p
 QUEST_LV_0100_20151001_008204	This forest is also growing dark. {nl}Many people should realize that the Medis Diena is the start of a disaster. {nl}
 QUEST_LV_0100_20151001_008205	Too bad that Gesti wasn't killed, but still you did a great job.{nl}It will end soon..
 QUEST_LV_0100_20151001_008206	Without Irene, I would have died.{nl}Of course, I really appreciate for your help.
-QUEST_LV_0100_20151001_008207	It's all my fault.{nl}Smid is dead.. what should I do alone.
+QUEST_LV_0100_20151001_008207	It's all my fault.{nl}Schmid is dead.. what should I do alone.
 QUEST_LV_0100_20151001_008208	I don't think prayers and ceremonies are the only way to serve the Goddess. {nl}Serving the world through physical training is also an important mission of the cleric. 
 QUEST_LV_0100_20151001_008209	There are two ways to approach the Goddess. {nl}Strong belief for the Goddess and the sound of silver dropping on the offering box. Just that. 
 QUEST_LV_0100_20151001_008210	The magic to control time is the essence of all magics.{nl}It's what Agailla Flurry told me.
@@ -8217,13 +8217,13 @@ QUEST_LV_0100_20151001_008212	The Bishop is praying in closure. {nl}When you are
 QUEST_LV_0100_20151001_008213	I'll give you more than what the Knights asked for so please help us find the Goddesses. {nl}{nl}Welcome!{nl}Oh, you're the Revelator. I really wanted to meet you.{nl}
 QUEST_LV_0100_20151001_008214	Klaipeda is full of hope and expectations for the Revelators who dreamed of the Goddess. {nl}I am also one of them. {nl}
 QUEST_LV_0100_20151001_008215	We'll give you more than what the Knights asked for. {nl}Since we have many Revelators, things will get better, right? 
-QUEST_LV_0100_20151001_008216	You mean you actually drove away the Demon Lord from Crystal Mines... {nl}Thank you for reminding me of something that I have forgotten for a while. A hope. 
-QUEST_LV_0100_20151001_008217	The first Paladin and Tenet Chapel fulfilled their duties. {nl}Right.. The time has finally come. Together with the Revelator. 
-QUEST_LV_0100_20151001_008218	I heard the monsters in Kateen Forest is eating up the Owl Statues I've made. {nl}I'm sure it is trying to use the souls for something else. Like using it for nourishments... 
-QUEST_LV_0100_20151001_008219	Did you know? A Revelator defeated the Demon Lord in Crystal Mines. {nl}Do you think that disaster also comes with hope? 
-QUEST_LV_0100_20151001_008220	When I first saw the Revelators, I wondered if they were worthy of that name. {nl}But they saved Crystal Mines and Tenet Chapel. {nl}There is definitely a savior whom the Goddess sent. 
-QUEST_LV_0100_20151001_008221	I heard some Revelator defeated the Demon Lord in Crystal Mines. {nl}That's incredible. Aren't Demon Lords the greatest among the demons? 
-QUEST_LV_0100_20151001_008222	Did you hear about the Revelator who blocked the Demon Lord in Tenet Chapel? {nl}It would have been better if it was killed for good {nl}but it was a Demon Lord that even the Paladin Master wasn't able to defeat. {nl}That is awesome enough. 
+QUEST_LV_0100_20151001_008216	You mean you actually drove away the Demon Lord from the Crystal Mine... {nl}Thank you for reminding me of something that I have forgotten for a while. Hope. 
+QUEST_LV_0100_20151001_008217	The first Paladin and the Tenet Chapel fulfilled their duties. {nl}Right.. The time has finally come. Together with the Revelator. 
+QUEST_LV_0100_20151001_008218	I heard the monsters in Kateen Forest is eating up the Owl Sculptures I've made. {nl}I'm sure it is trying to use the souls for something else. Like using it for nourishments... 
+QUEST_LV_0100_20151001_008219	Did you know? A Revelator defeated the Demon Lord in the Crystal Mine. {nl}Do you think that disaster also comes with hope? 
+QUEST_LV_0100_20151001_008220	When I first saw the Revelators, I wondered if they were worthy of that name. {nl}But they saved the Crystal Mine and the Tenet Chapel. {nl}There is definitely a savior whom the Goddess sent. 
+QUEST_LV_0100_20151001_008221	I heard some Revelator defeated the Demon Lord in Crystal Mine. {nl}That's incredible. Aren't Demon Lords the greatest among the demons? 
+QUEST_LV_0100_20151001_008222	Did you hear about the Revelator who blocked the Demon Lord in the Tenet Chapel? {nl}It would have been better if it was killed for good {nl}but it was a Demon Lord that even the Paladin Master wasn't able to defeat. {nl}That is awesome enough. 
 QUEST_LV_0100_20151001_008223	As a Hunter, my instinct says the monsters in this forest is showing unusual movements. {nl}As if pushed by something. 
 QUEST_LV_0100_20151001_008224	I feel ashamed that I wasn't able to join the squad in Tenet Chapel. {nl}But isn't it amazing? The Tenet Chapel was saved from that Demon Lord. 
 QUEST_LV_0100_20151001_008225	Just as I thought. The monsters in this forest were chased by the Vubbes. {nl}And to see that the Revelator actually defeated the Demon Lord that planned all this.{nl}I really wonder who that is. 
@@ -8232,16 +8232,16 @@ QUEST_LV_0100_20151001_008227	A sacred chapel had to go through such bad things.
 QUEST_LV_0100_20151001_008228	The Vubbes suddenly rushed out of the Mines. {nl}I have no idea what's going on. Do you have anything that comes to mind? 
 QUEST_LV_0100_20151001_008229	We won't know if the Revelators really dreamed of the Goddess. It could even be a trick of the Demons. {nl}But didn't someone among them save the Tenet Chapel. {nl}From the Demon Lord even. 
 QUEST_LV_0100_20151001_008230	It's a relief a Revelator drove away the Demon Lord from the mines. I was scared another Medis Diena would happen. {nl}But I felt something warm... Was it just my delusion? {nl}It was a pure and good energy. 
-QUEST_LV_0100_20151001_008231	It's such good news that a Revelator helped drive away the Demon Lord of Crystal Mines.{nl}But a strange and sacred enery was felt... Could it have been just a delusion? {nl}It is very vague.  
+QUEST_LV_0100_20151001_008231	It's such good news that a Revelator helped drive away the Demon Lord of the Crystal Mine.{nl}But a strange and sacred enery was felt... Could it have been just a delusion? {nl}It is very vague.  
 QUEST_LV_0100_20151001_008232	Do you think Medis Diena and the Demons are related? {nl}I mean the Tenet Chapel. It was as if the demons were waiting for that moment...{nl}Come to think of it, the Revelators could have been ones prepared for such situation. 
 QUEST_LV_0100_20151001_008233	I made it through the wild monsters and you made through the Thorn Forest. {nl}I'm sure you're not looking for the Goddess... Then what's the matter? 
-QUEST_LV_0100_20151001_008234	I heard the historians were attacked by the Demon Lord in King's Plateau. {nl}So it means the disaster was forewarned a thousand years ago? {nl}Anyway, it's a relief the Revelator was able to block it. 
-QUEST_LV_0100_20151001_008235	In between this Valley area and Klaipeda is the Thorn Forest that is full of evil energy. {nl}It was just a normal and peaceful forest before but..{nl}You making it through the forest... Does it mean the forest is now purified? 
+QUEST_LV_0100_20151001_008234	I heard the historians were attacked by the Demon Lord at Plateau of Rex. {nl}So it means the disaster was forewarned a thousand years ago? {nl}Anyway, it's a relief the Revelator was able to block it. 
+QUEST_LV_0100_20151001_008235	In between this valley area and Klaipeda is the Thorn Forest that is full of evil energy. {nl}It was just a normal and peaceful forest before but..{nl}You making it through the forest... Does it mean the forest is now purified? 
 QUEST_LV_0100_20151001_008236	There is still so much left unrevealed about the Great King Zachariel.{nl}But since the demons lived longer than us... This must have been what they were preying at. {nl}I don't know who it is but it's a good thing the Revelator stopped it. We might even have had another Medis Diena.
 QUEST_LV_0100_20151001_008237	I heard the source of the evil energy deep in the Thorn Forest recently disappeared. {nl}But it will need a long time for the forest to return to its previous state...
-QUEST_LV_0100_20151001_008238	Did you hear that a Revelator stopped the Demon Lord's plan in Royal Mausoleum? {nl}I heard that Demon Lord was going around destroying the ruins in King's Plateau. Now we finally taught him a lesson. 
+QUEST_LV_0100_20151001_008238	Did you hear that a Revelator stopped the Demon Lord's plan in Royal Mausoleum? {nl}I heard that Demon Lord was going around destroying the ruins in Plateau of Rex. Now we finally taught him a lesson. 
 QUEST_LV_0100_20151001_008239	How did you come here? Did you make it through the Thorn Forest? {nl}Hmm. Are you saying you can't tell me about it.
-QUEST_LV_0100_20151001_008240	The Demon Lord that was messing the King's Plateau seems to have been the reason behind all the cases of people missing. {nl}It serves him right that a Revelator stopped all his plans from going through. 
+QUEST_LV_0100_20151001_008240	The Demon Lord that was messing the Plateau of Rex seems to have been the reason behind all the cases of people missing. {nl}It serves him right that a Revelator stopped all his plans from going through. 
 QUEST_LV_0100_20151001_008241	Since Goddess Saule disappeared, areas centering around Kvailas Forest was filled with evil energy and thorns. {nl}But you made it through the Thorn Forest? Can we say that it's a good sign? {nl}
 QUEST_LV_0100_20151001_008242	A Revelator saved the Royal Mausoleum of King Zachariel. {nl}But why would the demons go after the ruins that's over a thousand years old? {nl}There is too much that we don't know about. {nl}
 QUEST_LV_0100_20151001_008243	I heard the monsters keep attacking the ruins and the historians keep disappearing. {nl}But also, nobody remembers. How funny. 
@@ -8249,10 +8249,10 @@ QUEST_LV_0100_20151001_008244	I heard a Revelator drove out the Demon Lord that 
 QUEST_LV_0100_20151001_008245	If the Demon Lord invaded the Royal Mausoleum, then the symptoms of Jonas in Gate Route also becomes clear. {nl}If King Zachariel erased the memory of the workers in the Mausoleum, then it must be a side effect of the old magic. {nl}What do you think he was planning to do? 
 QUEST_LV_0100_20151001_008246	Now the demons even wear the mask of a human. {nl}I heard some Revelator stopped the Demon Lord in the Royal Mausoleum but I wonder how many demons are now hiding amongst humans. 
 QUEST_LV_0100_20151001_008247	This place holds records of the hidden side of history. {nl}Time is an absolute thing. It just depends on how you look at it. 
-QUEST_LV_0100_20151001_008248	I heard a Revelator stopped the Demon Lord that was eyeing the Royal Mausoleum. {nl}It may be a bit overboard to make a connection between Medis Diena and a king from a thousand years ago... {nl}But I'm sure there is something that we are all forgot.
+QUEST_LV_0100_20151001_008248	I heard a Revelator stopped the Demon Lord that was eyeing the Royal Mausoleum. {nl}It may be a bit overboard to make a connection between the Medis Diena and a king from a thousand years ago... {nl}But I'm sure there is something that we are all forgot.
 QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before the Medis Diena.{nl}Thanks to the Goddess sending us the Revelator, we finally make an end to the long battle. 
-QUEST_LV_0100_20151001_008250	The weight of history feels greatly heavy when you stand in this place. {nl}Maybe you can find a clue about Medis Diena. 
-QUEST_LV_0100_20151001_008251	I keep getting the though that Medis Diena might have just been a process.{nl}If not, then why would the demons go after a mausoleum that is over a thousand years old? {nl}It's a good some thing some Revelator stopped it. 
+QUEST_LV_0100_20151001_008250	The weight of history feels greatly heavy when you stand in this place. {nl}Maybe you can find a clue about the Medis Diena. 
+QUEST_LV_0100_20151001_008251	I keep getting the thought that the Medis Diena might have just been a process.{nl}If not, then why would the demons go after a mausoleum that is over a thousand years old? {nl}It's a good some thing some Revelator stopped it. 
 QUEST_LV_0100_20151001_008252	Everyone know that Helgasercle showed an obsession towards the Mage Tower since centuries ago. {nl}Whatever is in that tower, we can finally see the end of it. {nl}That's a great thing. 
 QUEST_LV_0100_20151001_008253	From Tenet Chapel and now to the Cathedral... But they say it was resolved well by the Revelator so I hope things get better. {nl}Not minding the talks of the world and doing what you must is what's good for the Goddess and the kingdom. 
 QUEST_LV_0100_20151001_008254	The story that a Revelator saved the Mage Tower is something that even someone like me, who is not interest in the gossips of the world, can hear. {nl}It's a surprise that there was a least one person who was good enough from anybody there. 
@@ -8263,19 +8263,19 @@ QUEST_LV_0100_20151001_008258	This map is useless now since my colleague is dead
 QUEST_LV_0100_20151001_008259	I can't leave with everything behind...
 QUEST_LV_0100_20151001_008260	What do we do? {nl}The Vubbes rushed in and kidnapped the villagers!
 QUEST_LV_0100_20151001_008261	You are the Revelator, right? {nl}The Goddess must have helped. {nl}
-QUEST_LV_0100_20151001_008262	This is all because of the dream of the bishop of Klaipeda. {nl}What is he talking about evidence of salvation in Crystal Mines. I have never seen such thing. {nl}
-QUEST_LV_0100_20151001_008263	I'm not sure if that is the reason but the Vubbes suddenly rushed out of the Crystal Mines. {nl}Those Vubbes took all the villagers they see into the mines. {nl}
+QUEST_LV_0100_20151001_008262	This is all because of the dream of the bishop of Klaipeda. {nl}What is he talking about evidence of salvation in the Crystal Mine. I have never seen such thing. {nl}
+QUEST_LV_0100_20151001_008263	I'm not sure if that is the reason but the Vubbes suddenly rushed out of the Crystal Mine. {nl}Those Vubbes took all the villagers they see into the mines. {nl}
 QUEST_LV_0100_20151001_008264	Please... Save the villagers. {nl}I beg of you!
-QUEST_LV_0100_20151001_008265	Let's go to the Crystal Mines. {nl}I will tell you the rest of the story in the Crystal Mine entrance. 
+QUEST_LV_0100_20151001_008265	Let's go to the Crystal Mine. {nl}I will tell you the rest of the story in the Crystal Mine entrance. 
 QUEST_LV_0100_20151001_008266	Hold on! There is something you should know. {nl}We went into the mines to save the kidnapped villagers too.{nl}But the purifiers were broken and the mine was filled with toxic fumes, so we failed every time. {nl}
 QUEST_LV_0100_20151001_008267	Ye..Yes..{nl}Find a young man named Vaidotas!{nl}
-QUEST_LV_0100_20151001_008268	That fellow knows well about the purifiers in Crystal Mines. {nl}It hasn't been long since he was taken away by the Vubbes so he must be in the Vubbe Outpost. 
+QUEST_LV_0100_20151001_008268	That fellow knows well about the purifiers in the Crystal Mine. {nl}It hasn't been long since he was taken away by the Vubbes so he must be in the Vubbe Outpost. 
 QUEST_LV_0100_20151001_008269	{memo X}You want to learn my skills?{nl}It's not hard for me to teach you, but would you be able to handle it?
 QUEST_LV_0100_20151001_008270	The Goddess always told us to help those around us.{nl}By helping others near you, you will help your spirit as well.
-QUEST_LV_0100_20151001_008271	Zachariel's ordeal is not easy.{nl}With the skill you have, he should have acknowledged you.
+QUEST_LV_0100_20151001_008271	Great King Zachariel's ordeal is not easy.{nl}With the skill you have, he should have acknowledged you.
 QUEST_LV_0100_20151001_008272	The kingdom has lost all its hope. {nl}It does not have any will to stand back anymore and is just crying out for the Goddess.{nl}
 QUEST_LV_0100_20151001_008273	It is during this time that the people came forward saying they dreamed of the Goddess. {nl}It is you, the Revelator. {nl}
-QUEST_LV_0100_20151001_008274	Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the Goddess told him the evidence of salvation will be found in the Crystal Mines. {nl}
+QUEST_LV_0100_20151001_008274	Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the Goddess told him the evidence of salvation will be found in the Crystal Mine. {nl}
 QUEST_LV_0100_20151001_008275	Knight Aras in the Eastern Woods is in charge of it so go and meet him. 
 QUEST_LV_0100_20151001_008276	Four years ago after the incident, why is the Goddess sending us Revelators now... {nl}A peasant like me may not be able to understand the deeper meaning of the Goddess' will.
 QUEST_LV_0100_20151001_008277	But, at least I know that the Revelators are our only hope.{nl}
@@ -8285,7 +8285,7 @@ QUEST_LV_0100_20151001_008280	I can feel Bramble suffering.{nl}He is getting ret
 QUEST_LV_0100_20151001_008281	I am not afraid of dying.{nl}The Goddess Saule will guide me well.
 QUEST_LV_0100_20151001_008282	The portal that you tried to open is the gate of lies.{nl}That portal leads to where all the knowledge of the world is. 
 QUEST_LV_0100_20151001_008283	I have been fighting Demon Lord Bramble that tried to take over the revelation. {nl}I have fought with it nights and days to hand the revelation to you. {nl}
-QUEST_LV_0100_20151001_008284	But Medis Diena broke the balance of strength. {nl}The Goddesses has lost most of their strength since that day. {nl}
+QUEST_LV_0100_20151001_008284	But, the Medis Diena broke the balance of strength. {nl}The Goddesses has lost most of their strength since that day. {nl}
 QUEST_LV_0100_20151001_008285	Bramble took that chance to steal the revelation and seal me in this place. {nl}Because only I know how to interpret the revelation.{nl} 
 QUEST_LV_0100_20151001_008286	But I did not give into Bramble's order to interpret the revelation.{nl}That is why he made a plot to open a portal that leads to where all knowledge of the world is. {nl}
 QUEST_LV_0100_20151001_008287	The residents of this area is the plot to open that portal. {nl}To find a way to get the revelation using your power as the savior... Something brutal was done. {nl}
@@ -8300,7 +8300,7 @@ QUEST_LV_0100_20151001_008295	Please bring me the sacrifice tools in the Grand C
 QUEST_LV_0100_20151001_008296	I am finally free. {nl}I will prepare to interpret the revelation from this point on. {nl}
 QUEST_LV_0100_20151001_008297	As I have told you before, the revelation is in the hands of Demon Lord Bramble. {nl}I feel sorry that I have to burden you, but your strength is the only thing I can rely on.{nl}
 QUEST_LV_0100_20151001_008298	But Bramble is also not in its usual condition due to the previous battle. {nl}It is recovering by turning the forest into a thorn forest and extracting nourishments. 
-QUEST_LV_0100_20151001_008299	My disciples are waiting for you in Gate Route. {nl}Please take back the revelation from him. 
+QUEST_LV_0100_20151001_008299	My believers are waiting for you in Gate Route. {nl}Please take back the revelation from him. 
 QUEST_LV_0100_20151001_008300	I haved carved many owls for a long time to help Goddess Arusine.{nl}At one point in time, they got their lives and determination.{nl}
 QUEST_LV_0100_20151001_008301	Medis Diena was just the beginning. {nl}A forest far away from the capital such as this one is also starting to soak its way into the evil energy. {nl} 
 QUEST_LV_0100_20151001_008302	I will be able to guide you to the revelation if I use all the strength left in me. {nl}That is why you should release me. 
@@ -8332,12 +8332,12 @@ QUEST_LV_0100_20151001_008327	You must use it near the fields of Orsha or Klaipe
 QUEST_LV_0100_20151001_008328	Thank you for stepping up to help.
 QUEST_LV_0100_20151001_008329	Oh, you're back already. {nl}Revelators sure are different. 
 QUEST_LV_0100_20151001_008330	Jurate
-QUEST_LV_0100_20151001_008331	I am Jurate, the leader of Divine object excavation team. {nl}Are you here to help? {nl}We need some. 
+QUEST_LV_0100_20151001_008331	I am Jurate, the leader of divine object excavation team. {nl}Are you here to help? {nl}We need some. 
 QUEST_LV_0100_20151001_008332	{nl}Let's take time to talk later but first, please help excavate the area I tell you . 
 QUEST_LV_0100_20151001_008333	It would also be nice to take care of the monsters on your way there too. 
 QUEST_LV_0100_20151001_008334	It won't be that dangerous.
-QUEST_LV_0100_20151001_008335	Oh, you brought it. {nl}This is a Divine object known as the Incense of Goddess.
-QUEST_LV_0100_20151001_008336	Did I tell you? {nl}Oh, it was a long day... {nl}We faced Medis Diena right here while we were transporting the Divine objects to Orsha. 
+QUEST_LV_0100_20151001_008335	Oh, you brought it. {nl}This is a divine object known as the Incense of Goddess.
+QUEST_LV_0100_20151001_008336	Did I tell you? {nl}Oh, it was a long day... {nl}We faced the Medis Diena right here while we were transporting the divine objects to Orsha. 
 QUEST_LV_0100_20151001_008337	{nl}The wagon flipped and the divine objects scattered around. {nl}That's why we are going through this excavation to find it. {nl}But people are hesitating to excavate that area because of the monsters... Please help us. 
 QUEST_LV_0100_20151001_008338	I wonder if it was eaten by the monster...
 QUEST_LV_0100_20151001_008339	Looks like the monsters ripped it to shreds but here. {nl}Let me try to have it back.
@@ -8348,7 +8348,7 @@ QUEST_LV_0100_20151001_008343	Locate the area and then carefully dig that area. 
 QUEST_LV_0100_20151001_008344	Carefully use the detector as you go north. 
 QUEST_LV_0100_20151001_008345	Oh, you found it. 
 QUEST_LV_0100_20151001_008346	{nl}Let's see...
-QUEST_LV_0100_20151001_008347	{nl}This Divine object is an ink bottle. {nl}It contains the secret ink that was used for important records and documents. {nl}I assume this ink was used when they needed to hide the record. 
+QUEST_LV_0100_20151001_008347	{nl}This divine object is an ink bottle. {nl}It contains the secret ink that was used for important records and documents. {nl}I assume this ink was used when they needed to hide the record. 
 QUEST_LV_0100_20151001_008348	{nl}Ah, I think that's about all the work we need to do for the day. {nl}Thank you for your help.
 QUEST_LV_0100_20151001_008349	Marzelius
 QUEST_LV_0100_20151001_008350	Hello. {nl}I am the Record leader Marzelius. 

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -8150,290 +8150,290 @@ QUEST_LV_0100_20150918_008145	$Stonemason Canolyn told you that a monster called
 QUEST_LV_0100_20150918_008146	$Find Historian Rexipher
 QUEST_LV_0100_20150918_008147	$Collect Hogma Teeth
 QUEST_LV_0100_20150918_008148	Pursue Rexipher at the Royal Mausoleum Entrance
-QUEST_LV_0100_20151001_008149	
-QUEST_LV_0100_20151001_008150	
-QUEST_LV_0100_20151001_008151	
-QUEST_LV_0100_20151001_008152	
-QUEST_LV_0100_20151001_008153	
-QUEST_LV_0100_20151001_008154	
-QUEST_LV_0100_20151001_008155	
-QUEST_LV_0100_20151001_008156	
-QUEST_LV_0100_20151001_008157	
-QUEST_LV_0100_20151001_008158	
-QUEST_LV_0100_20151001_008159	
-QUEST_LV_0100_20151001_008160	
-QUEST_LV_0100_20151001_008161	
-QUEST_LV_0100_20151001_008162	
-QUEST_LV_0100_20151001_008163	
-QUEST_LV_0100_20151001_008164	
-QUEST_LV_0100_20151001_008165	
-QUEST_LV_0100_20151001_008166	
-QUEST_LV_0100_20151001_008167	
-QUEST_LV_0100_20151001_008168	
-QUEST_LV_0100_20151001_008169	
-QUEST_LV_0100_20151001_008170	
-QUEST_LV_0100_20151001_008171	
-QUEST_LV_0100_20151001_008172	
-QUEST_LV_0100_20151001_008173	
-QUEST_LV_0100_20151001_008174	
-QUEST_LV_0100_20151001_008175	
-QUEST_LV_0100_20151001_008176	
-QUEST_LV_0100_20151001_008177	
-QUEST_LV_0100_20151001_008178	
-QUEST_LV_0100_20151001_008179	
-QUEST_LV_0100_20151001_008180	
-QUEST_LV_0100_20151001_008181	
+QUEST_LV_0100_20151001_008149	Do you know the legend of Cunningham? {nl}It's a legend about how a great demon was trapped in the Crystal Mines in the past. {nl}
+QUEST_LV_0100_20151001_008150	I assumption is that the trapped demon finally woke up to control the Vubbes. {nl}The dream of the Bishop and the Legend of Cunningham... {nl}I wonder if it is a forewarning of a great event that's about to happen.{nl}
+QUEST_LV_0100_20151001_008151	Only the Goddess knows if it will be hope or despair. {nl}You can read the details about it in the book found in Miners' Resting Area in 2F.
+QUEST_LV_0100_20151001_008152	Anyway, it seems like the Vubbes surely destroyed the purifiers. {nl}You better fix it first before the hostages run out of air. 
+QUEST_LV_0100_20151001_008153	I will protect this village for my dead comrades.
+QUEST_LV_0100_20151001_008154	If the Bokor Master told you that I would know it..{nl}There's one place that comes to mind.{nl}
+QUEST_LV_0100_20151001_008155	You're saying something that's really hard to believe. {nl}You mean this revelation is Goddess Laima and we have to collect all these for the Goddess to return?{nl}
+QUEST_LV_0100_20151001_008156	Goddess Laima is often called the recorded Goddess. {nl}When King Zachariel formed this kingdom, the only record about it is that Goddess Laima blessed it.  {nl}
+QUEST_LV_0100_20151001_008157	I'd like to ask you a favor. {nl}I have sinned because I was not able to fulfill my duties of guarding the kingdom on Medis Diena. {nl}
+QUEST_LV_0100_20151001_008158	But I am not a Revelator. {nl}Even if I want to make up for my sins, my duty  at the moment is to protect the many citizens of Klaipeda. {nl}
+QUEST_LV_0100_20151001_008159	So please find all the revelations. {nl}I will put my position as the Knight Commander of Klaipeda on the line and help you deal with it. 
+QUEST_LV_0100_20151001_008160	If you're on your way to Klaipeda, let me ask you a favor. {nl}It's not easy to go to Klaipeda because of the Infrorocktors.
+QUEST_LV_0100_20151001_008161	I feel so relieved to be stationed in the Western Woods.{nl}There are some places where you'd rather die than to be stationed.
+QUEST_LV_0100_20151001_008162	Aren't you hurt?{nl}I appreciate that you got rid of the Poatas but what were you thinking? 
+QUEST_LV_0100_20151001_008163	You mean you want to enter the Crystal Mines to find the evidence of Salvation? {nl}
+QUEST_LV_0100_20151001_008164	But that's tough at the moment. {nl}There is a swamp of Vubbes rushing out of the Crystal Mines.{nl}
+QUEST_LV_0100_20151001_008165	And there's an increase of the monsters here in the Easter Woods that are now threatening even Klaipeda. {nl}The Miners' Village in the middle has turned into a battlefied. {nl}
+QUEST_LV_0100_20151001_008166	We have divided the troops into two. {nl}Half of the troops are guarding the Miners' Village {nl}and the other half are searching why the number of monsters increased in Eastern Woods.  
+QUEST_LV_0100_20151001_008167	So we are not in the situation to spare our troops for guarding revelators while they check the evidence of salvation. {nl}But we also can't go against the order of the Bishop and Knight Commander either. {nl}
+QUEST_LV_0100_20151001_008168	Hmm, what about this? {nl}
+QUEST_LV_0100_20151001_008169	To test whether you can safely reach Miners' Village even without the aid of guards... {nl}Why don't you help us in our search? 
+QUEST_LV_0100_20151001_008170	Good job. {nl}Now, let get to the main task.
+QUEST_LV_0100_20151001_008171	Oh, let me give you some helpful information in return for your your help.{nl}The evidence of salvation that the Revelators are looking for might be found in the Closed Area.
+QUEST_LV_0100_20151001_008172	It wasn't so long ago. {nl}I felt a strange energy while experimenting near the Closed Area. {nl}It was quite different from the spell we know of. It was very warm.{nl}
+QUEST_LV_0100_20151001_008173	The Miners' Village is under siege and dangerous.{nl}Please wait in Klaipeda until the siege is over. 
+QUEST_LV_0100_20151001_008174	Thank you for your determination to learn my swordsmanship, but I am not sure if you would follow well.{nl}I will test you by seeing how you face the Vubbes at Crystal Mine 1F.
+QUEST_LV_0100_20151001_008175	Have you met Jonas in the Gateway of Great King? {nl}It definitely isn't a sickness. {nl}But it also isn't magic of the present times. 
+QUEST_LV_0100_20151001_008176	If this note is true, we might die any time.{nl}By the way, what happened to the person who wrote it?
+QUEST_LV_0100_20151001_008177	Because of that, a few disciples have died.{nl}But, it's strange. It seems that it never happened.
+QUEST_LV_0100_20151001_008178	Well done.{nl}Now, is this going to be the last lesson...
+QUEST_LV_0100_20151001_008179	Bring me hard shell of Varvs and rigid horns of Zinutekas from the Royal Mausoleum 1F.{nl}It shouldn't be hard since you are my disciple.
+QUEST_LV_0100_20151001_008180	It's time for you to enhance the qualities of Manas that you possess as a Linker.{nl}Any magic is okay. I will test you by dueling.
+QUEST_LV_0100_20151001_008181	It is a shame to look back once a man starts his journey.{nl}My brother will rather choose to die than look back.
 QUEST_LV_0100_20151001_008182	I'm sure my brother stood firm and accepted his final moments. However, I still think he could've lived more meaningfully if he had just turned away from his ambition...
-QUEST_LV_0100_20151001_008183	
-QUEST_LV_0100_20151001_008184	
-QUEST_LV_0100_20151001_008185	
-QUEST_LV_0100_20151001_008186	
-QUEST_LV_0100_20151001_008187	
-QUEST_LV_0100_20151001_008188	
-QUEST_LV_0100_20151001_008189	
-QUEST_LV_0100_20151001_008190	
-QUEST_LV_0100_20151001_008191	
-QUEST_LV_0100_20151001_008192	
-QUEST_LV_0100_20151001_008193	
-QUEST_LV_0100_20151001_008194	
-QUEST_LV_0100_20151001_008195	
-QUEST_LV_0100_20151001_008196	
-QUEST_LV_0100_20151001_008197	
-QUEST_LV_0100_20151001_008198	
-QUEST_LV_0100_20151001_008199	
-QUEST_LV_0100_20151001_008200	
-QUEST_LV_0100_20151001_008201	
-QUEST_LV_0100_20151001_008202	
-QUEST_LV_0100_20151001_008203	
-QUEST_LV_0100_20151001_008204	
-QUEST_LV_0100_20151001_008205	
-QUEST_LV_0100_20151001_008206	
-QUEST_LV_0100_20151001_008207	
-QUEST_LV_0100_20151001_008208	
-QUEST_LV_0100_20151001_008209	
-QUEST_LV_0100_20151001_008210	
-QUEST_LV_0100_20151001_008211	
-QUEST_LV_0100_20151001_008212	
-QUEST_LV_0100_20151001_008213	
-QUEST_LV_0100_20151001_008214	
-QUEST_LV_0100_20151001_008215	
-QUEST_LV_0100_20151001_008216	
-QUEST_LV_0100_20151001_008217	
-QUEST_LV_0100_20151001_008218	
-QUEST_LV_0100_20151001_008219	
-QUEST_LV_0100_20151001_008220	
-QUEST_LV_0100_20151001_008221	
-QUEST_LV_0100_20151001_008222	
-QUEST_LV_0100_20151001_008223	
-QUEST_LV_0100_20151001_008224	
-QUEST_LV_0100_20151001_008225	
-QUEST_LV_0100_20151001_008226	
-QUEST_LV_0100_20151001_008227	
-QUEST_LV_0100_20151001_008228	
-QUEST_LV_0100_20151001_008229	
-QUEST_LV_0100_20151001_008230	
-QUEST_LV_0100_20151001_008231	
-QUEST_LV_0100_20151001_008232	
-QUEST_LV_0100_20151001_008233	
-QUEST_LV_0100_20151001_008234	
-QUEST_LV_0100_20151001_008235	
-QUEST_LV_0100_20151001_008236	
-QUEST_LV_0100_20151001_008237	
-QUEST_LV_0100_20151001_008238	
-QUEST_LV_0100_20151001_008239	
-QUEST_LV_0100_20151001_008240	
-QUEST_LV_0100_20151001_008241	
-QUEST_LV_0100_20151001_008242	
-QUEST_LV_0100_20151001_008243	
-QUEST_LV_0100_20151001_008244	
-QUEST_LV_0100_20151001_008245	
-QUEST_LV_0100_20151001_008246	
-QUEST_LV_0100_20151001_008247	
-QUEST_LV_0100_20151001_008248	
-QUEST_LV_0100_20151001_008249	
-QUEST_LV_0100_20151001_008250	
-QUEST_LV_0100_20151001_008251	
-QUEST_LV_0100_20151001_008252	
-QUEST_LV_0100_20151001_008253	
-QUEST_LV_0100_20151001_008254	
-QUEST_LV_0100_20151001_008255	
-QUEST_LV_0100_20151001_008256	
-QUEST_LV_0100_20151001_008257	
-QUEST_LV_0100_20151001_008258	
-QUEST_LV_0100_20151001_008259	
-QUEST_LV_0100_20151001_008260	
-QUEST_LV_0100_20151001_008261	
-QUEST_LV_0100_20151001_008262	
-QUEST_LV_0100_20151001_008263	
-QUEST_LV_0100_20151001_008264	
-QUEST_LV_0100_20151001_008265	
-QUEST_LV_0100_20151001_008266	
-QUEST_LV_0100_20151001_008267	
-QUEST_LV_0100_20151001_008268	
-QUEST_LV_0100_20151001_008269	
-QUEST_LV_0100_20151001_008270	
-QUEST_LV_0100_20151001_008271	
-QUEST_LV_0100_20151001_008272	
-QUEST_LV_0100_20151001_008273	
-QUEST_LV_0100_20151001_008274	
-QUEST_LV_0100_20151001_008275	
-QUEST_LV_0100_20151001_008276	
-QUEST_LV_0100_20151001_008277	
-QUEST_LV_0100_20151001_008278	
-QUEST_LV_0100_20151001_008279	
-QUEST_LV_0100_20151001_008280	
-QUEST_LV_0100_20151001_008281	
-QUEST_LV_0100_20151001_008282	
-QUEST_LV_0100_20151001_008283	
-QUEST_LV_0100_20151001_008284	
-QUEST_LV_0100_20151001_008285	
-QUEST_LV_0100_20151001_008286	
-QUEST_LV_0100_20151001_008287	
-QUEST_LV_0100_20151001_008288	
-QUEST_LV_0100_20151001_008289	
-QUEST_LV_0100_20151001_008290	
-QUEST_LV_0100_20151001_008291	
-QUEST_LV_0100_20151001_008292	
-QUEST_LV_0100_20151001_008293	
-QUEST_LV_0100_20151001_008294	
-QUEST_LV_0100_20151001_008295	
-QUEST_LV_0100_20151001_008296	
-QUEST_LV_0100_20151001_008297	
-QUEST_LV_0100_20151001_008298	
-QUEST_LV_0100_20151001_008299	
-QUEST_LV_0100_20151001_008300	
-QUEST_LV_0100_20151001_008301	
-QUEST_LV_0100_20151001_008302	
-QUEST_LV_0100_20151001_008303	
-QUEST_LV_0100_20151001_008304	
-QUEST_LV_0100_20151001_008305	
-QUEST_LV_0100_20151001_008306	
-QUEST_LV_0100_20151001_008307	
-QUEST_LV_0100_20151001_008308	
-QUEST_LV_0100_20151001_008309	
-QUEST_LV_0100_20151001_008310	
-QUEST_LV_0100_20151001_008311	
-QUEST_LV_0100_20151001_008312	
-QUEST_LV_0100_20151001_008313	
-QUEST_LV_0100_20151001_008314	
-QUEST_LV_0100_20151001_008315	
-QUEST_LV_0100_20151001_008316	
-QUEST_LV_0100_20151001_008317	
-QUEST_LV_0100_20151001_008318	
-QUEST_LV_0100_20151001_008319	
-QUEST_LV_0100_20151001_008320	
-QUEST_LV_0100_20151001_008321	
-QUEST_LV_0100_20151001_008322	
-QUEST_LV_0100_20151001_008323	
-QUEST_LV_0100_20151001_008324	
-QUEST_LV_0100_20151001_008325	
-QUEST_LV_0100_20151001_008326	
-QUEST_LV_0100_20151001_008327	
-QUEST_LV_0100_20151001_008328	
-QUEST_LV_0100_20151001_008329	
-QUEST_LV_0100_20151001_008330	
-QUEST_LV_0100_20151001_008331	
-QUEST_LV_0100_20151001_008332	
-QUEST_LV_0100_20151001_008333	
-QUEST_LV_0100_20151001_008334	
-QUEST_LV_0100_20151001_008335	
-QUEST_LV_0100_20151001_008336	
-QUEST_LV_0100_20151001_008337	
-QUEST_LV_0100_20151001_008338	
-QUEST_LV_0100_20151001_008339	
-QUEST_LV_0100_20151001_008340	
-QUEST_LV_0100_20151001_008341	
-QUEST_LV_0100_20151001_008342	
-QUEST_LV_0100_20151001_008343	
-QUEST_LV_0100_20151001_008344	
-QUEST_LV_0100_20151001_008345	
-QUEST_LV_0100_20151001_008346	
-QUEST_LV_0100_20151001_008347	
-QUEST_LV_0100_20151001_008348	
-QUEST_LV_0100_20151001_008349	
-QUEST_LV_0100_20151001_008350	
-QUEST_LV_0100_20151001_008351	
-QUEST_LV_0100_20151001_008352	
-QUEST_LV_0100_20151001_008353	
-QUEST_LV_0100_20151001_008354	
-QUEST_LV_0100_20151001_008355	
-QUEST_LV_0100_20151001_008356	
-QUEST_LV_0100_20151001_008357	
-QUEST_LV_0100_20151001_008358	
-QUEST_LV_0100_20151001_008359	
-QUEST_LV_0100_20151001_008360	
-QUEST_LV_0100_20151001_008361	
-QUEST_LV_0100_20151001_008362	
-QUEST_LV_0100_20151001_008363	
-QUEST_LV_0100_20151001_008364	
-QUEST_LV_0100_20151001_008365	
-QUEST_LV_0100_20151001_008366	
-QUEST_LV_0100_20151001_008367	
-QUEST_LV_0100_20151001_008368	
-QUEST_LV_0100_20151001_008369	
-QUEST_LV_0100_20151001_008370	
-QUEST_LV_0100_20151001_008371	
-QUEST_LV_0100_20151001_008372	
-QUEST_LV_0100_20151001_008373	
-QUEST_LV_0100_20151001_008374	
-QUEST_LV_0100_20151001_008375	
-QUEST_LV_0100_20151001_008376	
-QUEST_LV_0100_20151001_008377	
-QUEST_LV_0100_20151001_008378	
-QUEST_LV_0100_20151001_008379	
-QUEST_LV_0100_20151001_008380	
-QUEST_LV_0100_20151001_008381	
-QUEST_LV_0100_20151001_008382	
-QUEST_LV_0100_20151001_008383	
-QUEST_LV_0100_20151001_008384	
-QUEST_LV_0100_20151001_008385	
-QUEST_LV_0100_20151001_008386	
-QUEST_LV_0100_20151001_008387	
-QUEST_LV_0100_20151001_008388	
-QUEST_LV_0100_20151001_008389	
-QUEST_LV_0100_20151001_008390	
-QUEST_LV_0100_20151001_008391	{memo X}
-QUEST_LV_0100_20151001_008392	{memo X}
-QUEST_LV_0100_20151001_008393	{memo X}
-QUEST_LV_0100_20151001_008394	{memo X}
-QUEST_LV_0100_20151001_008395	
-QUEST_LV_0100_20151001_008396	{memo X}
-QUEST_LV_0100_20151001_008397	{memo X}
-QUEST_LV_0100_20151001_008398	{memo X}
-QUEST_LV_0100_20151001_008399	
-QUEST_LV_0100_20151001_008400	
-QUEST_LV_0100_20151001_008401	
-QUEST_LV_0100_20151001_008402	
-QUEST_LV_0100_20151001_008403	
-QUEST_LV_0100_20151001_008404	
-QUEST_LV_0100_20151001_008405	{memo X}
-QUEST_LV_0100_20151001_008406	{memo X}
-QUEST_LV_0100_20151001_008407	{memo X}
-QUEST_LV_0100_20151001_008408	{memo X}
-QUEST_LV_0100_20151001_008409	
-QUEST_LV_0100_20151001_008410	
-QUEST_LV_0100_20151001_008411	
-QUEST_LV_0100_20151001_008412	{memo X}
-QUEST_LV_0100_20151001_008413	{memo X}
-QUEST_LV_0100_20151001_008414	
-QUEST_LV_0100_20151001_008415	
-QUEST_LV_0100_20151001_008416	
-QUEST_LV_0100_20151001_008417	{memo X}
-QUEST_LV_0100_20151001_008418	{memo X}
-QUEST_LV_0100_20151001_008419	
-QUEST_LV_0100_20151001_008420	
-QUEST_LV_0100_20151001_008421	
-QUEST_LV_0100_20151001_008422	
-QUEST_LV_0100_20151001_008423	
-QUEST_LV_0100_20151001_008424	
-QUEST_LV_0100_20151001_008425	
-QUEST_LV_0100_20151001_008426	
-QUEST_LV_0100_20151001_008427	
-QUEST_LV_0100_20151001_008428	
-QUEST_LV_0100_20151001_008429	
-QUEST_LV_0100_20151001_008430	
-QUEST_LV_0100_20151001_008431	
-QUEST_LV_0100_20151001_008432	
+QUEST_LV_0100_20151001_008183	I'm thinking of converting the Demons using the power of the altar. {nl} The converted Demons will absorb the divine power and slowly start to die. {nl}
+QUEST_LV_0100_20151001_008184	So you found the seal of space. {nl}Honestly, I did not believe it when my friend, Paladin Master, said a Savior would come. {nl}
+QUEST_LV_0100_20151001_008185	That's how bad the situation was. {nl}My family and friends all went to the Goddess... {nl}It seemed like there was no hope naymore in this world. {nl}
+QUEST_LV_0100_20151001_008186	Here, use the Seal of Space on the pillar beside me and go to the sanctuary. {nl}It is prepared only for the Revelator. 
+QUEST_LV_0100_20151001_008187	I was there when the Divine Tree was destroying the capital. {nl}But I was not able to stop it. I was not able to save everyone.{nl}This will remain in my heart like a needle and hurt me forever. 
+QUEST_LV_0100_20151001_008188	But you were different. You have the power to save everyone. {nl}All the followers, the guards, even the wishes that me and the first paladin longed for... {nl} 
+QUEST_LV_0100_20151001_008189	Right. {nl}Did you mention that you need to find Goddess Saule? {nl}
+QUEST_LV_0100_20151001_008190	The colorful stream mentioned in the revelation starts at above the Veja Ravine. {nl}Well then, may the blessings of Goddess be with you.
+QUEST_LV_0100_20151001_008191	When you find the revelation, tell Mater Paladin of the story you've been through so far. {nl}He must be the one most anxious about it. {nl}
+QUEST_LV_0100_20151001_008192	I will gather all the prayers for my fammily and friends and offer it to you. {nl}May the blessings of Goddess be with you...
+QUEST_LV_0100_20151001_008193	But his old body of mine does not follow my will anymore. {nl}Now I can only trust my old friend Algis and you. {nl}
+QUEST_LV_0100_20151001_008194	Go. Tenet Cathedral is in Tenet Garden.{nl}My lifelong wish.. Be sure to stop the revelation from falling into the hands of Gesti.
+QUEST_LV_0100_20151001_008195	Please bring me the Mali seeds in the way to Labure roads. {nl} They would be a good source of magic for the shaman doll. {nl} {nl}
+QUEST_LV_0100_20151001_008196	Won't you help me purify Labure road? {nl} The shaman doll finds the evil force but we have to purify it ourselves.
+QUEST_LV_0100_20151001_008197	We need the rope for ceremony to make the shaman doll. {nl} It's on the waist of the Panto Shaman in the Cottage. {nl} Bring it to me.
+QUEST_LV_0100_20151001_008198	I came back because the elders told me to restore the dolls used for spells.{nl}A doll for spells. Isn't it exciting?
+QUEST_LV_0100_20151001_008199	I can't stand seeing the Panto totems pressed with evil energy. {nl} I'm going to break it through the shaman doll. Want to give it a try?
+QUEST_LV_0100_20151001_008200	I heard the first Paladin promised three things in return for saving our family. {nl}
+QUEST_LV_0100_20151001_008201	Our Shaman dolls are different from Bokor's Shaman dolls. {nl}
+QUEST_LV_0100_20151001_008202	You can summon the shaman doll with this summon scroll. {nl}
+QUEST_LV_0100_20151001_008203	Understanding the root of everything becomes the power of Elementalist. {nl}Wind, Water, Fire, Earth. We pull the strongest powers from the simplest forms. 
+QUEST_LV_0100_20151001_008204	This forest is also growing dark. {nl}Many people should realize that the Medis Diena is the start of a disaster. {nl}
+QUEST_LV_0100_20151001_008205	Too bad that Gesti wasn't killed, but still you did a great job.{nl}It will end soon..
+QUEST_LV_0100_20151001_008206	Without Irene, I would have died.{nl}Of course, I really appreciate for your help.
+QUEST_LV_0100_20151001_008207	It's all my fault.{nl}Smid is dead.. what should I do alone.
+QUEST_LV_0100_20151001_008208	I don't think prayers and ceremonies are the only way to serve the Goddess. {nl}Serving the world through physical training is also an important mission of the cleric. 
+QUEST_LV_0100_20151001_008209	There are two ways to approach the Goddess. {nl}Strong belief for the Goddess and the sound of silver dropping on the offering box. Just that. 
+QUEST_LV_0100_20151001_008210	The magic to control time is the essence of all magics.{nl}It's what Agailla Flurry told me.
+QUEST_LV_0100_20151001_008211	I heard a Revelator defeated the Demon Lord slurring the Royal Mausoleum.{nl}As a person undergoing training, I am ashamed that I can't go out and fight.
+QUEST_LV_0100_20151001_008212	The Bishop is praying in closure. {nl}When you are ready, please go to Aras in the Eastern Woods.
+QUEST_LV_0100_20151001_008213	I'll give you more than what the Knights asked for so please help us find the Goddesses. {nl}{nl}Welcome!{nl}Oh, you're the Revelator. I really wanted to meet you.{nl}
+QUEST_LV_0100_20151001_008214	Klaipeda is full of hope and expectations for the Revelators who dreamed of the Goddess. {nl}I am also one of them. {nl}
+QUEST_LV_0100_20151001_008215	We'll give you more than what the Knights asked for. {nl}Since we have many Revelators, things will get better, right? 
+QUEST_LV_0100_20151001_008216	You mean you actually drove away the Demon Lord from Crystal Mines... {nl}Thank you for reminding me of something that I have forgotten for a while. A hope. 
+QUEST_LV_0100_20151001_008217	The first Paladin and Tenet Chapel fulfilled their duties. {nl}Right.. The time has finally come. Together with the Revelator. 
+QUEST_LV_0100_20151001_008218	I heard the monsters in Kateen Forest is eating up the Owl Statues I've made. {nl}I'm sure it is trying to use the souls for something else. Like using it for nourishments... 
+QUEST_LV_0100_20151001_008219	Did you know? A Revelator defeated the Demon Lord in Crystal Mines. {nl}Do you think that disaster also comes with hope? 
+QUEST_LV_0100_20151001_008220	When I first saw the Revelators, I wondered if they were worthy of that name. {nl}But they saved Crystal Mines and Tenet Chapel. {nl}There is definitely a savior whom the Goddess sent. 
+QUEST_LV_0100_20151001_008221	I heard some Revelator defeated the Demon Lord in Crystal Mines. {nl}That's incredible. Aren't Demon Lords the greatest among the demons? 
+QUEST_LV_0100_20151001_008222	Did you hear about the Revelator who blocked the Demon Lord in Tenet Chapel? {nl}It would have been better if it was killed for good {nl}but it was a Demon Lord that even the Paladin Master wasn't able to defeat. {nl}That is awesome enough. 
+QUEST_LV_0100_20151001_008223	As a Hunter, my instinct says the monsters in this forest is showing unusual movements. {nl}As if pushed by something. 
+QUEST_LV_0100_20151001_008224	I feel ashamed that I wasn't able to join the squad in Tenet Chapel. {nl}But isn't it amazing? The Tenet Chapel was saved from that Demon Lord. 
+QUEST_LV_0100_20151001_008225	Just as I thought. The monsters in this forest were chased by the Vubbes. {nl}And to see that the Revelator actually defeated the Demon Lord that planned all this.{nl}I really wonder who that is. 
+QUEST_LV_0100_20151001_008226	If it was my hometown, if a demon occupied the Mines, everyone would have attacked it and celebrated. {nl}Anyway, I don't know who that Revelator is but this weak kingdom finally found someone useful. 
+QUEST_LV_0100_20151001_008227	A sacred chapel had to go through such bad things. The clerics of this kingdom is planning something unusual. {nl}But it's a good thing to have protected the Tenet Chapel. It means they have the guts, don't you think? {nl}{nl}
+QUEST_LV_0100_20151001_008228	The Vubbes suddenly rushed out of the Mines. {nl}I have no idea what's going on. Do you have anything that comes to mind? 
+QUEST_LV_0100_20151001_008229	We won't know if the revelators really dreamed of the Goddess. It could even be a trick of the Demons. {nl}But didn't someone among them save the Tenet Chapel. {nl}From the Demon Lord even. 
+QUEST_LV_0100_20151001_008230	It's a relief a revelator drove away the Demon Lord from the mines. I was scared another Medis Diena would happen. {nl}But I felt something warm... Was it just my delusion? {nl}It was a pure and good energy. 
+QUEST_LV_0100_20151001_008231	It's such good news that a revelator helped drive away the Demon Lord of Crystal Mines.{nl}But a strange and sacred enery was felt... Could it have been just a delusion? {nl}It is very vague.  
+QUEST_LV_0100_20151001_008232	Do you think Medis Diena and the Demons are related? {nl}I mean the Tenet Chapel. It was as if the demons were waiting for that moment...{nl}Come to think of it, the revelators could have been ones prepared for such situation. 
+QUEST_LV_0100_20151001_008233	I made it through the wild monsters and you made through the Thorn Forest. {nl}I'm sure you're not looking for the Goddess... Then what's the matter? 
+QUEST_LV_0100_20151001_008234	I heard the historians were attacked by the Demon Lord in King's Plateau. {nl}So it means the disaster was forewarned a thousand years ago? {nl}Anyway, it's a relief the Revelator was able to block it. 
+QUEST_LV_0100_20151001_008235	In between this Valley area and Klaipeda is the Thorn Forest that is full of evil energy. {nl}It was just a normal and peaceful forest before but..{nl}You making it through the forest... Does it mean the forest is now purified? 
+QUEST_LV_0100_20151001_008236	There is still so much left unrevealed about the Great King Zachariel.{nl}But since the demons lived longer than us... This must have been what they were preying at. {nl}I don't know who it is but it's a good thing the Revelator stopped it. We might even have had another Medis Diena.
+QUEST_LV_0100_20151001_008237	I heard the source of the evil energy deep in the Thorn Forest recently disappeared. {nl}But it will need a long time for the forest to return to its previous state...
+QUEST_LV_0100_20151001_008238	Did you hear that a Revelator stopped the Demon Lord's plan in Royal Mausoleum? {nl}I heard that Demon Lord was going around destroying the ruins in King's Plateau. Now we finally taught him a lesson. 
+QUEST_LV_0100_20151001_008239	How did you come here? Did you make it through the Thorn Forest? {nl}Hmm. Are you saying you can't tell me about it.
+QUEST_LV_0100_20151001_008240	The Demon Lord that was messing the King's Plateau seems to have been the reason behind all the cases of people missing. {nl}It serves him right that a revelator stopped all his plans from going through. 
+QUEST_LV_0100_20151001_008241	Since Goddess Saule disappeared, areas centering around Kvailas Forest was filled with evil energy and thorns. {nl}But you made it through the Thorn Forest? Can we say that it's a good sign? {nl}
+QUEST_LV_0100_20151001_008242	A Revelator saved the Royal Mausoleum of King Zachariel. {nl}But why would the demons go after the ruins that's over a thousand years old? {nl}There is too much that we don't know about. {nl}
+QUEST_LV_0100_20151001_008243	I heard the monsters keep attacking the ruins and the historians keep disappearing. {nl}But also, nobody remembers. How funny. 
+QUEST_LV_0100_20151001_008244	I heard a Revelator drove out the Demon Lord that was trying to rule over the Royal Mausoleum. {nl}That's funny. Doesn't it mean that it was foreseen since a thousand years ago? 
+QUEST_LV_0100_20151001_008245	If the Demon Lord invaded the Royal Mausoleum, then the symptoms of Jonas in Gate Route also becomes clear. {nl}If King Zachariel erased the memory of the workers in the Mausoleum, then it must be a side effect of the old magic. {nl}What do you think he was planning to do? 
+QUEST_LV_0100_20151001_008246	Now the demons even wear the mask of a human. {nl}I heard some Revelator stopped the Demon Lord in the Royal Mausoleum but I wonder how many demons are now hiding amongst humans. 
+QUEST_LV_0100_20151001_008247	This place holds records of the hidden side of history. {nl}Time is an absolute thing. It just depends on how you look at it. 
+QUEST_LV_0100_20151001_008248	I heard a Revelator stopped the Demon Lord that was eyeing the Royal Mausoleum. {nl}It may be a bit overboard to make a connection between Medis Diena and a king from a thousand years ago... {nl}But I'm sure there is something that we are all forgot.
+QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before the Medis Diena.{nl}Thanks to the Goddess sending us the revelator, we finally make an end to the long battle. 
+QUEST_LV_0100_20151001_008250	The weight of history feels greatly heavy when you stand in this place. {nl}Maybe you can find a clue about Medis Diena. 
+QUEST_LV_0100_20151001_008251	I keep getting the though that Medis Diena might have just been a process.{nl}If not, then why would the demons go after a mausoleum that is over a thousand years old? {nl}It's a good some thing some Revelator stopped it. 
+QUEST_LV_0100_20151001_008252	Everyone know that Helgasercle showed an obsession towards the Mage Tower since centuries ago. {nl}Whatever is in that tower, we can finally see the end of it. {nl}That's a great thing. 
+QUEST_LV_0100_20151001_008253	From Tenet Chapel and now to the Cathedral... But they say it was resolved well by the Revelator so I hope things get better. {nl}Not minding the talks of the world and doing what you must is what's good for the Goddess and the Kingdom. 
+QUEST_LV_0100_20151001_008254	The story that a Revelator saved the Mage Tower is something that even someone like me, who is not interest in the gossips of the world, can hear. {nl}It's a surprise that there was a least one person who was good enough from anybody there. 
+QUEST_LV_0100_20151001_008255	Hergasercle was an incarnation of obsession. {nl}The chain of obsession was broken thanks to the Revelator but its souls is not something that can be saved. 
+QUEST_LV_0100_20151001_008256	I heard a revelator defeated the Demon Lord that dirtied the teachings of save Maven. {nl}Now it is time for us clergies to come forward. {nl}We should put away our regrets about failing to protect the Cathedral and atone our sins. 
+QUEST_LV_0100_20151001_008257	My colleague is dead?{nl}That can't be. Only if I had not tempted him...{nl}
+QUEST_LV_0100_20151001_008258	This map is useless now since my colleague is dead.{nl}Please pray that my colleague would go to the Goddess safely.
+QUEST_LV_0100_20151001_008259	I can't leave with everything behind...
+QUEST_LV_0100_20151001_008260	What do we do? {nl}The Vubbes rushed in and kidnapped the villagers!
+QUEST_LV_0100_20151001_008261	You are the Revelator, right? {nl}The Goddess must have helped. {nl}
+QUEST_LV_0100_20151001_008262	This is all because of the dream of the bishop of Klaipeda. {nl}What is he talking about evidence of salvation in Crystal Mines. I have never seen such thing. {nl}
+QUEST_LV_0100_20151001_008263	I'm not sure if that is the reason but the Vubbes suddenly rushed out of the Crystal Mines. {nl}Those Vubbes took all the villagers they see into the mines. {nl}
+QUEST_LV_0100_20151001_008264	Please... Save the villagers. {nl}I beg of you!
+QUEST_LV_0100_20151001_008265	Let's go to the Crystal Mines. {nl}I will tell you the rest of the story in the Crystal Mine entrance. 
+QUEST_LV_0100_20151001_008266	Hold on! There is something you should know. {nl}We went into the mines to save the kidnapped villagers too.{nl}But the purifiers were broken and the mine was filled with toxic fumes so we failed every time. {nl}
+QUEST_LV_0100_20151001_008267	Ye..Yes..{nl}Find a young man named Vaidotas!{nl}
+QUEST_LV_0100_20151001_008268	That fellow knows well about the purifiers in Crystal Mines. {nl}It hasn't been long since he was taken away by the Vubbes so he must be in the Vubbe Outpost. 
+QUEST_LV_0100_20151001_008269	{memo X}You want to learn my skills?{nl}It's not hard for me to teach you, but would you be able to handle it?
+QUEST_LV_0100_20151001_008270	The Goddess always told us to help those around us.{nl}By helping others near you, you will help your spirit as well.
+QUEST_LV_0100_20151001_008271	Zachariel's ordeal is not easy.{nl}With the skill you have, he should have acknowledged you.
+QUEST_LV_0100_20151001_008272	The kingdom has lost all its hope. {nl}It does not have any will to stand back anymore and is just crying out for the Goddess.{nl}
+QUEST_LV_0100_20151001_008273	It is during this time that the people came forward saying they dreamed of the Goddess. {nl}It is you, the revelators. {nl}
+QUEST_LV_0100_20151001_008274	Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the Goddess told him the evidence of salvation will be found in the Crystal Mines. {nl}
+QUEST_LV_0100_20151001_008275	Knight Aras in the Eastern Woods is in charge of it so go and meet him. 
+QUEST_LV_0100_20151001_008276	Why is the Goddess sending us revelators now, four years after the incident... {nl}A peasant like me may no tbe able to understand the deeper meaning of the Goddess' will.
+QUEST_LV_0100_20151001_008277	But at least, I know that the Revelators are our only hope.{nl}
+QUEST_LV_0100_20151001_008278	Well then, go on to the Eastern Woods. {nl}Don't forget to worship the Statue of Goddess Ausrine in the central plaza before you leave. {nl}
+QUEST_LV_0100_20151001_008279	Also, be sure to drop by the Tools Merchant.{nl}I have left some warp scrolls for the revelators. 
+QUEST_LV_0100_20151001_008280	I can feel Bramble suffering.{nl}He is getting retribution for extracting all vigor from this land.
+QUEST_LV_0100_20151001_008281	I am not afraid of dying.{nl}The Goddess Saule will guide me well.
+QUEST_LV_0100_20151001_008282	The portal that you tried to open is the gate of lies.{nl}That portal leads to where all the knowledge of the world is. 
+QUEST_LV_0100_20151001_008283	I have been fighting Demon Lord Bramble that tried to take over the revelation. {nl}I have fought with it nights and days to hand the revelation to you. {nl}
+QUEST_LV_0100_20151001_008284	But Medis Diena broke the balance of strength. {nl}The Goddesses has lost most of their strength since that day. {nl}
+QUEST_LV_0100_20151001_008285	Bramble took that chance to steal the revelation and seal me in this place. {nl}Because only I know how to interpret the revelation.{nl} 
+QUEST_LV_0100_20151001_008286	But I did not give into Bramble's order to interpret the revelation.{nl}That is why he made a plot to open a portal that leads to where all knowledge of the world is. {nl}
+QUEST_LV_0100_20151001_008287	The residents of this area is the plot to open that portal. {nl}To find a way to get the revelation using your power as the savior... Something brutal was done. {nl}
+QUEST_LV_0100_20151001_008288	I lost most of my strength and couldn't stop that horror from happening. {nl}All I could do was... to despair. {nl}
+QUEST_LV_0100_20151001_008289	But the revelation led you to me. {nl}I am certain that you are the ray of light who will save all of the world. {nl}
+QUEST_LV_0100_20151001_008290	Savior. {nl}Please destroy the magic that is trapping me. {nl}In order to deliver and follow the revelation, I must first be freed. 
+QUEST_LV_0100_20151001_008291	The magic circle of confinement is located in Drugys Courtyard and Vapsva lot. {nl}Please hurry before I lose consciousness.
+QUEST_LV_0100_20151001_008292	{memo X}Thank you for saving me. {nl}You are... The only true savior who will save the world. {nl}The one who Goddess Laima talked about. 
+QUEST_LV_0100_20151001_008293	{memo X}I am Saule, the Goddess of the Sun.{nl}I was the guardian of the revelation.
+QUEST_LV_0100_20151001_008294	But this is not the only barrier confining me here. {nl} We've got to find the inspector, Clymen, hiding in between the gap of dimensions.
+QUEST_LV_0100_20151001_008295	Please bring me the sacrifice tools in the Grand Corridor. {nl} I will try to use the divine power that dwell in the tool.
+QUEST_LV_0100_20151001_008296	I am finally free. {nl}I will prepare to interpret the revelation from this point on. {nl}
+QUEST_LV_0100_20151001_008297	As I have told you before, the revelation is in the hands of Demon Lord Bramble. {nl}I feel sorry that I have to burden you, but your strength is the only thing I can rely on.{nl}
+QUEST_LV_0100_20151001_008298	But Bramble is also not in its usual condition due to the previous battle. {nl}It is recovering by turning the forest into a thorn forest and extracting nourishments. 
+QUEST_LV_0100_20151001_008299	My disciples are waiting for you in Gate Route. {nl}Please take back the revelation from him. 
+QUEST_LV_0100_20151001_008300	I haved carved many owls for a long time to help Goddess Arusine.{nl}At one point in time, they got their lives and determination.{nl}
+QUEST_LV_0100_20151001_008301	Was Medis Diena just the beginning. {nl}A forest far away from the capital such as this one is also starting to soak its way into the evil energy. {nl} 
+QUEST_LV_0100_20151001_008302	I will be able to guide you to the revelation if I use all the strength left in me. {nl}That is why you should release me. 
+QUEST_LV_0100_20151001_008303	But please don't reveal my existence for now. {nl}It is in nature of humans to want to depend on somewhere. {nl}If they find out about the helplessness of the Goddess, the world will be full of moans and confusion. 
+QUEST_LV_0100_20151001_008304	That portal is.. a fantasy... No. A portal going to Goddess Saule. {nl} Anyway, opening the portal is very important.
+QUEST_LV_0100_20151001_008305	If the armors protect you from physical attacks, accessories protect you from magic attacks. {nl} I hope it would be useful for you.{nl}Nice to meet you!{nl}Are you the Revelator who dreamed of the Goddess? {nl}
+QUEST_LV_0100_20151001_008306	Everyone in Klaipeda is talking about that. {nl}I wonder if the revelators really saw the disappeared Goddesses in their dreams... and where is that dream... {nl}
+QUEST_LV_0100_20151001_008307	I am curious to know more about the dream but I'm sure they can't tell me about it.{nl}But it's ok. {nl}I believe that the revelators are people who will find the Goddesses. {nl}
+QUEST_LV_0100_20151001_008308	Please take this accessory. {nl}If the armors protect you from physical attacks, accessories protect you from magic attacks. {nl} 
+QUEST_LV_0100_20151001_008309	I hope you it will be useful for you. {nl}May the blessings of Goddess be with you...
+QUEST_LV_0100_20151001_008310	The poison of Scorpio, it was somewhat strange.{nl}Well. It already happened so what can I do anyway. I won't mind as long as it doesn't threaten my life.
+QUEST_LV_0100_20151001_008311	Oh I'm causing such trouble.. Thank you for hleping me. {nl}You just have to make a magic circle with the firewood I give you and burn the Shaman doll on top of it.
+QUEST_LV_0100_20151001_008312	The crops died when you did what you were told to do? {nl}It's okay. I was told that the bad aura within the crops will go away like that. {nl}
+QUEST_LV_0100_20151001_008313	This is tough. {nl}Many might be killed..
+QUEST_LV_0100_20151001_008314	Huh? You killed it because it tried to eat people? {nl}Ah.. well then, nevermind. I will report it to the Baron myself.
+QUEST_LV_0100_20151001_008315	This is the last one. {nl}The magic circle in Tarvas Entrance will have a lot of monsters interfering. {nl}With the divine power suppressed, the monsters are naturally drawn to that area.
+QUEST_LV_0100_20151001_008316	The baron is doing something to purify this farm. {nl}But recently the crops are dying and people are starting to fall sick. {nl}
+QUEST_LV_0100_20151001_008317	If the magic circles are really a lie, then you should be able to remove the magic circles in Talia trails with Goddess' power. {nl}I mean something like the Goddess Statue. Is there any way to get it?
+QUEST_LV_0100_20151001_008318	If I only had little more time...{nl}My documents... I can't leave them...
+QUEST_LV_0100_20151001_008319	These things are useless to me now...{nl}Okay. Maybe you... My documents at Dykyne Crossroad...
+QUEST_LV_0100_20151001_008320	Gerda
+QUEST_LV_0100_20151001_008321	I am a new member of the Kedolaomer Merchants. {nl}I am setting up Warning and Notice Boards related to the Kedolaomers here and there. {nl}It is very tiring though. 
+QUEST_LV_0100_20151001_008322	{nl}If it is alright with you, can you set up some boards on the lower area over there? {nl}That's where Jurate is trying to excavate Divine objects so we need to put up a warning for pedestrians. {nl}But I need to go somewhere else...
+QUEST_LV_0100_20151001_008323	Thank you. {nl}That would be good enough. 
+QUEST_LV_0100_20151001_008324	Serapinas
+QUEST_LV_0100_20151001_008325	I am Serapinas, one of the new members of the Kedolaomer Merchants. {nl}I am in charge of promoting the merchants. {nl}If you have time, can you help me in one of my promotion agenda? 
+QUEST_LV_0100_20151001_008326	{nl}It's nothing difficult. You just have to go near Orsha or Klaipeda and help the revelators who just began their adventures. {nl}I will give you a scroll. If you use it on them, it will help them and promote the merchants as well. 
+QUEST_LV_0100_20151001_008327	You must use it near the fields of Orsha or Klaipeda. {nl}And it must be someone who just began their adventure. {nl}I will not work on people who have seen the promotion material already. 
+QUEST_LV_0100_20151001_008328	Thank you for stepping up to help.
+QUEST_LV_0100_20151001_008329	Oh, you're back already. {nl}Revelators sure are different. 
+QUEST_LV_0100_20151001_008330	Jurate
+QUEST_LV_0100_20151001_008331	I am Jurate, the leader of Divine object excavation team. {nl}Are you here to help? {nl}We need some. 
+QUEST_LV_0100_20151001_008332	{nl}Let's take time to talk later but first, please help excavate the area I tell you . 
+QUEST_LV_0100_20151001_008333	It would also be nice to take care of the monsters on your way there too. 
+QUEST_LV_0100_20151001_008334	It won't be that dangerous.
+QUEST_LV_0100_20151001_008335	Oh, you brought it. {nl}This is a Divine object known as the Incense of Goddess.
+QUEST_LV_0100_20151001_008336	Did I tell you? {nl}Oh, it was a long day... {nl}We faced Medis Diena right here while we were transporting the Divine objects to Orsha. 
+QUEST_LV_0100_20151001_008337	{nl}The wagon flipped and the divine objects scattered around. {nl}That's why we are going through this excavation to find it. {nl}But people are hesitating to excavate that area because of the monsters... Please help us. 
+QUEST_LV_0100_20151001_008338	I wonder if it was eaten by the monster...
+QUEST_LV_0100_20151001_008339	Looks like the monsters ripped it to shreds but here. {nl}Let me try to have it back.
+QUEST_LV_0100_20151001_008340	{nl}Since it is the record of the merchants, only if I could stick it back together...
+QUEST_LV_0100_20151001_008341	This record is about the materials of the arrow that the merchants supplied to Lydia Schaffen and her arrow maker, the first Fletcher MAster. 
+QUEST_LV_0100_20151001_008342	I think there should be some divine objects up here too though. {nl}I can't tell where exactly. {nl}Can you look for it? I'll give you a detector. 
+QUEST_LV_0100_20151001_008343	Locate the area and then carefully dig that area. {nl}You will probably find the divine object. 
+QUEST_LV_0100_20151001_008344	Carefully use the detector as you go north. 
+QUEST_LV_0100_20151001_008345	Oh, you found it. 
+QUEST_LV_0100_20151001_008346	{nl}Let's see...
+QUEST_LV_0100_20151001_008347	{nl}This Divine object is an ink bottle. {nl}It contains the secret ink that was used for important records and documents. {nl}I assume this ink was used when they needed to hide the record. 
+QUEST_LV_0100_20151001_008348	{nl}Ah, I think that's about all the work we need to do for the day. {nl}Thank you for your help.
+QUEST_LV_0100_20151001_008349	Marzelius
+QUEST_LV_0100_20151001_008350	Hello. {nl}I am the Record leader Marzelius. 
+QUEST_LV_0100_20151001_008351	{nl}If you want to help me... {nl}Please find the records of the merchant that the monsters stole from us. 
+QUEST_LV_0100_20151001_008352	As Leopoldas says, we, the merchants, have been doing a lot of things. {nl}The records hold the history of our works. 
+QUEST_LV_0100_20151001_008353	If we get back the records that the monsters stole from us, then we must rewrite them again so that it will stand the times.
+QUEST_LV_0100_20151001_008354	Thank you for coming forward to help us. {nl}We are in really tight hands. 
+QUEST_LV_0100_20151001_008355	Now we have to rewrite the damaged records... {nl}The ink made from monster fluids are good and lasts long. {nl}I will give you a trap to use so please get me the monster fluid.  
+QUEST_LV_0100_20151001_008356	If you place the trap near the monster, the monster will be lured to it and faint. {nl}You need to extract its fluid while it is still alive. 
+QUEST_LV_0100_20151001_008357	You can get it from all the monsters around the area. 
+QUEST_LV_0100_20151001_008358	This is good enough! {nl}Thank you very much!
+QUEST_LV_0100_20151001_008359	Now it's time to make the sanctuary. {nl}Try to make it here. {nl}I will give you the materials and tools you need. 
+QUEST_LV_0100_20151001_008360	You can make it here. 
+QUEST_LV_0100_20151001_008361	Good work. {nl}I have a feeling that Gierda, in the northern area, also needs your help.
+QUEST_LV_0100_20151001_008362	Gierda
+QUEST_LV_0100_20151001_008363	You're the revelator. {nl}I am Giedra of Rud order. {nl}If you're here to meet Antanas, I'm sure you've already heard about our order so I won't talk so much about it. 
+QUEST_LV_0100_20151001_008364	{nl}I am collecting the materials needed to make the Scriptures of Goddess. {nl}Normal paper turns yellow and decays quickly... So I'm looking for materials that won't get wet nor be discolored easily. {nl}The transparent shell of the monsters are great for it. If you polish it well before writing on it, it will last a long time. {nl}Can you get me those? {nl}
+QUEST_LV_0100_20151001_008365	It's a pretty common material so it will be easily to collect. 
+QUEST_LV_0100_20151001_008366	Bring it to me when you collect them all. 
+QUEST_LV_0100_20151001_008367	You brought them earlier than I expected. {nl}These shells will now be polished and used as pages of the scripture. {nl}Thank you.
+QUEST_LV_0100_20151001_008368	We also need to do some bookbinding. {nl}Making sure the book does not break lose is the most important thing. {nl}The leather string made from monster leather is the best but the problem is that it is too short. {nl}I will give you an anvil. Can you make me some bookbinding strings using the leather strings? 
+QUEST_LV_0100_20151001_008369	Listen carefully. First, get leather string from the monsters, then use this anvil to turn the leather strings into a strings for bookbinding. {nl}You need to connect the short strings and make it into a single string. {nl}It also becomes more durable this way. 
+QUEST_LV_0100_20151001_008370	Return to me when you are done making the string. 
+QUEST_LV_0100_20151001_008371	Awesome! {nl}You can say that you made a book yourself. 
+QUEST_LV_0100_20151001_008372	{nl}Kestas over there also needs your help. Try talking to him. 
+QUEST_LV_0100_20151001_008373	Kestas
+QUEST_LV_0100_20151001_008374	I had the records of my seniors...{nl}But it was all stolen... {nl}I'm done...
+QUEST_LV_0100_20151001_008375	Oh oh oh!{nl}Please help me!{nl}My seniors' records are all gone!
+QUEST_LV_0100_20151001_008376	{nl}That's my job but it's all gone! All of it! {nl}Please find it! {nl}I'm sure the monsters took it!
+QUEST_LV_0100_20151001_008377	What to do... What do I do... {nl}I'm done... All the hardworks put in to make those records...
+QUEST_LV_0100_20151001_008378	{nl}That's it! Wow, you got them all! {nl}Thank you!{nl}How can I thank you enough...
+QUEST_LV_0100_20151001_008379	Aah it's all good now! Now go back to Orsha and complete the records!{nl}Hahaha!
+QUEST_LV_0100_20151001_008380	Ah really... {nl}Actually, these records are made out of the polished shells of the monsters. {nl}You need to write it there to make it last long.
+QUEST_LV_0100_20151001_008381	{nl}Yes, yes, right. That is also why Gierda is trying to make the scripture using the monster shells. {nl}That's why we are always attacked like this. {nl}Because they can smell their fellows...
+QUEST_LV_0100_20151001_008382	{nl}Anyway, now I'll really go to Orsha now. {nl}Thank you very much!
+QUEST_LV_0100_20151001_008383	Chisel?{nl}The tools merchant should have it. {nl}Go on over there.
+QUEST_LV_0100_20151001_008384	It's a long way back with the tool... {nl}Be careful.
+QUEST_LV_0100_20151001_008385	A Chisel? {nl}You will use it to repair the sanctuary? 
+QUEST_LV_0100_20151001_008386	{nl}Well, I just bought some old chisels from other revelators... {nl}If you need, you can take one of it. 
+QUEST_LV_0100_20151001_008387	Did you get the chisel? 
+QUEST_LV_0100_20151001_008388	Oh, you got them all. 
+QUEST_LV_0100_20151001_008389	It's a long way to Gernas Plains... {nl}Go on.
+QUEST_LV_0100_20151001_008390	Albinas
+QUEST_LV_0100_20151001_008391	Thank you for what just happened. {nl}Ah, this sanctuary...
+QUEST_LV_0100_20151001_008392	{nl}I expected it to be polluted but.. I mean who would have thought it would be this bad? {nl}Making a sanctuary like this here is bad enough but those Nestos. {nl}What are they thinking leaving it corrupted like this.
+QUEST_LV_0100_20151001_008393	{nl}Can you help me out for a while? 
+QUEST_LV_0100_20151001_008394	I belong to the Anastos. {nl}The Nestos still pursue unconditional belief even at this point when the Goddesses are all gone. {nl}That's why they are building sanctuaries here and there. 
+QUEST_LV_0100_20151001_008395	{nl}What's the use of sanctuaries when the Goddesses are all gone? {nl}When you know it will just be corrupted like this even if you build it. {nl}On the other hand, the Anastos pursue practicality. 
+QUEST_LV_0100_20151001_008396	{nl}People come first, mopping up the demons come first, and what's the use of faith when the Goddess themselves abandoned us?  
+QUEST_LV_0100_20151001_008397	There is another sanctuary over there. {nl}I will finish burning this sanctuary so please destroy the one over there. {nl}We need to teach those Nestos as lesson. 
+QUEST_LV_0100_20151001_008398	{nl}I'm sure the sanctuary over there is also fuming red enegy. {nl}A sign of corruption. 
+QUEST_LV_0100_20151001_008399	Damijonas
+QUEST_LV_0100_20151001_008400	What the... {nl}Who are you? What are you doing to our sanctuary...
+QUEST_LV_0100_20151001_008401	This is the sacred sanctuary of the Nestos. Did you do this? 
+QUEST_LV_0100_20151001_008402	I have never heard about someone like that. {nl}I may not know every singe person in Anastopas but I at least know those who set up this camp.
+QUEST_LV_0100_20151001_008403	I'm at loss for any word.
+QUEST_LV_0100_20151001_008404	{nl}Albinas? He is one of Anastopas? That can't be. {nl}Bring that person here. I need to check for myself. 
+QUEST_LV_0100_20151001_008405	Are you saying that Albinas guy is missing? {nl}It's getting out of hand. {nl}I'm sure Anastos won't do such a thing. 
+QUEST_LV_0100_20151001_008406	{nl}Anyway, our priority then is to restore this sanctuary. {nl}You did this so you should be responsible for it. {nl}There are rocks over there. 
+QUEST_LV_0100_20151001_008407	{nl}This sanctuary was also made of the rocks here so collect some rocks. {nl}And the Nestos Camp is over there. {nl}You'll find someone named Eduinas . {nl}Ask him to polish the rocks to use as materials for restoring the sanctuary. 
+QUEST_LV_0100_20151001_008408	If he finds out you did this to the sanctuary, he won't polish the rocks easily. {nl}But that's a price you have to pay and you should be responsbile for it. 
+QUEST_LV_0100_20151001_008409	Still not done yet? 
+QUEST_LV_0100_20151001_008410	Eduinas
+QUEST_LV_0100_20151001_008411	Who are you..? {nl}And what are these rocks? 
+QUEST_LV_0100_20151001_008412	What? Destoryed the sanctuary? {nl}The sanctuary that was built with everyone's efforts here? 
+QUEST_LV_0100_20151001_008413	I don't need your apologies. {nl}I'll polish the rocks to use as materials since Damijonas said so but don't ever do that again. {nl}And while I polish these, I don't want to see your face so go away and take care of some monsters nearby.
+QUEST_LV_0100_20151001_008414	You should wait longer. 
+QUEST_LV_0100_20151001_008415	Done. Now, don't ever do that again.
+QUEST_LV_0100_20151001_008416	You brought it. {nl}Now let's begin the restoration. 
+QUEST_LV_0100_20151001_008417	Done. It's a good thing it wasn't totally destroyed. {nl}I apologize for being angry at you a while ago. Seeing the sanctuary destroyed was upsetting. {nl}But it's not total nonsense. {nl}Anastos and Nestos may be in conflict of interests but we do not invade each other's territory. 
+QUEST_LV_0100_20151001_008418	{nl}But you mentioned someone from Anastos that I don't even know as the reason behind destroying the sanctuary so I couldn't hold my anger. {nl}Anyway, at least you restored it...
+QUEST_LV_0100_20151001_008419	{nl}But it strange. I have never heard of that name...{nl}Anastos Camp is in the northern side so why don't you go there and ask. {nl}It really is strange. 
+QUEST_LV_0100_20151001_008420	Gedas
+QUEST_LV_0100_20151001_008421	Don't bother me if you don't have any business. {nl}Ah... I really need that...
+QUEST_LV_0100_20151001_008422	{nl}Hey, can you find it for me? {nl}My research materials. {nl}The monsters took them all from me...
+QUEST_LV_0100_20151001_008423	More than other things, we need to find it first! {nl}My research! My research! {nl}The monsters took it! {nl}Find me that first!
+QUEST_LV_0100_20151001_008424	Are you not done yet? 
+QUEST_LV_0100_20151001_008425	Let me see... {nl}Yes, right! You got them all! {nl}Thank you very much!
+QUEST_LV_0100_20151001_008426	{nl}Oh, did you have something to ask? 
+QUEST_LV_0100_20151001_008427	Albi...nas...?
+QUEST_LV_0100_20151001_008428	{nl}Uh...
+QUEST_LV_0100_20151001_008429	{nl}Nope. I can't think of anyone on Anastos with that name. {nl}Moreover, he hold you go burn and destroy the Nestos sanctuary? {nl}Oh my god...
+QUEST_LV_0100_20151001_008430	{nl}Nonsense. We don't do such a thing. {nl}I think we need to investigate on that matter. {nl}We give danger signal fires when we send out people for investigation {nl}and we ran out of it just now. {nl}Can you find some firepowder that are used to make the danger signal fires? 
+QUEST_LV_0100_20151001_008431	We all servce the Goddess. That is why we're on the pilgrimages. {nl}It's just a small difference in how we see the world. 
+QUEST_LV_0100_20151001_008432	{nl}Nestos people say that we should believe in the Goddesses unconditionally even if they disappeared, {nl}while we, the Anastos, pursue something more practical. 
 QUEST_LV_0100_20151001_008433	
 QUEST_LV_0100_20151001_008434	
 QUEST_LV_0100_20151001_008435	

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -1579,12 +1579,12 @@ QUEST_LV_0100_20150317_001574	There is an owl that knows well about this problem
 QUEST_LV_0100_20150317_001575	Ah, I can't concentrate.{nl}While I am remembering it, can you take care of that Ellogua?{nl}I just can't remember easily.
 QUEST_LV_0100_20150317_001576	We are made of ordinary wood so we are scared of moist and insects.{nl}We are keen to be broken as well.{nl}It would have been better if we were made of iron.
 QUEST_LV_0100_20150317_001577	Thank you!{nl}I can't scratch my head because I am a tree..Hehe..{nl}
-QUEST_LV_0100_20150317_001578	Hm! Yes, I finally remembered it! {nl}Find instabilized owl.{nl}That owl was so close to Sequoia so it must know the method.
+QUEST_LV_0100_20150317_001578	Hm! Yes, I finally remembered it! {nl}Find the Instabilized Owl.{nl}That owl was so close to Sequoia so it must know the method.
 QUEST_LV_0100_20150317_001579	Instabilized Owl Sculpture
 QUEST_LV_0100_20150317_001580	I will tell you as I promised. I mean Sequoia. {nl}
 QUEST_LV_0100_20150317_001581	Sequoia is obsessed with vicious power.{nl}You face vicious power with divine power.{nl}Yes. We should face it!{nl}
 QUEST_LV_0100_20150317_001582	Please gather wood pieces from the broken sculpture.{nl}Ah. the ones with the power in them. Select well.
-QUEST_LV_0100_20150317_001583	My friends became ordinary. {nl}Yes. Ordinary wooden statues. {nl}They must still have some divine power left, for sure. I believe..
+QUEST_LV_0100_20150317_001583	My friends became ordinary. {nl}Yes. Ordinary wooden sculptures. {nl}They must still have some divine power left, for sure. I believe..
 QUEST_LV_0100_20150317_001584	Okay. Good. This will be enough! {nl}We have enough materials. Good. Good.
 QUEST_LV_0100_20150317_001585	Hm? Sequoia? I know it well. Big mouth, big hip..{nl}Look at this. Many of my friends fell down.{nl}Sequoia did this. That's right.{nl}
 QUEST_LV_0100_20150317_001586	But, monsters are keep trying to take them.{nl}What was that? Okay. The Essence of Spirits.{nl}If you get them again, I will tell you. The Essence of Spirits. My poor friends!

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -269,7 +269,7 @@ QUEST_LV_0200_20150317_000268	{memo X}Did you dry the seeds? Good, anyway.
 QUEST_LV_0200_20150317_000269	{memo X}Now, the next test is for you to take this and test if it's usable while I find the formula of magic circle. {nl}An Ice wall will appear if you use this so check how useful that is to the monsters. {nl}We need a safety net in order to test and this will do the job.
 QUEST_LV_0200_20150317_000270	{memo X}The monsters will come attacking when the Ice wall is formed so take care of the rest of the monsters that you missed a while ago.
 QUEST_LV_0200_20150317_000271	{memo X}Stone Frost will not happen anymore for a while. {nl}Don't worry about that.
-QUEST_LV_0200_20150317_000272	{memo X}It's very effective! Now this should be able to block monsters or revelators.
+QUEST_LV_0200_20150317_000272	{memo X}It's very effective! Now this should be able to block monsters or Revelators.
 QUEST_LV_0200_20150317_000273	{memo X}Now we get to the important part. The most important part of the test is to find the Mark of Silk, a strong magic tool that can turn back petrified things. {nl}The stupid Royal Army lost the last Mark in this area 4 years ago so it's probably somewhere around here. {nl}It can also be inside the monster's stomach.
 QUEST_LV_0200_20150317_000274	{memo X}Defeat the monsters and get the shiny stone from them. That will shine by itself so bring that and I will look for it.
 QUEST_LV_0200_20150317_000275	{memo X}The stupid Royal Army probably doesn't know how great that Mark is. {nl}Probably no one knows, except me.
@@ -451,7 +451,7 @@ QUEST_LV_0200_20150317_000450	$The Rearguard Unit always complains the supplies 
 QUEST_LV_0200_20150317_000451	$Oh, you got them. Thank you. {nl}Please go back to the monster's nest and burn the Destroyed Owls.
 QUEST_LV_0200_20150317_000452	$Terrible things are happening. {nl}Can we go back to peaceful days?
 QUEST_LV_0200_20150317_000453	$The Goddess can be so cruel. {nl}Please pray that my colleagues may rest in peace.
-QUEST_LV_0200_20150317_000454	$Pilgrim Lylia
+QUEST_LV_0200_20150317_000454	$Pilgrim Liliya
 QUEST_LV_0200_20150317_000455	{memo X}If I die, please bury me..{nl}Make my body unseen..{nl}If I lose my breath, please bury me..
 QUEST_LV_0200_20150317_000456	{memo X}And if you meet a pilgrim named Julius, please tell him these words.. tell him goodbye..
 QUEST_LV_0200_20150317_000457	Pilgrim's Memo
@@ -470,7 +470,7 @@ QUEST_LV_0200_20150317_000469	Pilgrim Julius
 QUEST_LV_0200_20150317_000470	{memo X}I think there was some food here.. {nl}Did that guy take it? {nl}Ugh..
 QUEST_LV_0200_20150317_000471	{memo X}I'm starving and now I'm having headaches! {nl}I feel my head exploding with just the thought of food but other things keep coming to mind. {nl}What was it.. Something like an orgel..
 QUEST_LV_0200_20150317_000472	{memo X}{nl}Why does it's food keep popping up in my mind when I can't even eat it.
-QUEST_LV_0200_20150317_000473	{memo X}Those dirty fools.. I will revenge.. {nl}Aah Lylia..
+QUEST_LV_0200_20150317_000473	{memo X}Those dirty fools.. I will revenge.. {nl}Aah Liliya..
 QUEST_LV_0200_20150317_000474	{memo X}The necklace.. yes. {nl}Well done.. Please take good care of it. {nl}This is a token of my gratitude.. The orgel was a memento for both of us but the necklace is special..
 QUEST_LV_0200_20150317_000475	{memo X}{nl}The Cathedral was blessed so I'm sure it'll be a good thing for you too.
 QUEST_LV_0200_20150317_000476	{memo X}Aaaaagghh! Aaagh! {nl}I will swallow it all!!!
@@ -483,14 +483,14 @@ QUEST_LV_0200_20150317_000482	{memo X}That is it! give me that! {nl}I'm going to
 QUEST_LV_0200_20150317_000483	{memo X}...? That? What about that? {nl}
 QUEST_LV_0200_20150317_000484	{memo X}Oww! My head! Arrgh! Yuck! What's that? What about that orgel? {nl}
 QUEST_LV_0200_20150317_000485	{memo X}Memory.. Her.. Give me that! It's mine!
-QUEST_LV_0200_20150317_000486	{memo X}So that's what happened.. Thank you. She left this orgel behind. {nl}We promised marriage and we left our way on pilgrimage to the Cathedral to confirm our promise for the future. {nl}But ah.. Lylia.. Lylia..!!{nl}
+QUEST_LV_0200_20150317_000486	{memo X}So that's what happened.. Thank you. She left this orgel behind. {nl}We promised marriage and we left our way on pilgrimage to the Cathedral to confirm our promise for the future. {nl}But ah.. Liliya.. Liliya..!!{nl}
 QUEST_LV_0200_20150317_000487	{memo X}In our happy journey to pilgrimage.. That's where we met then. {nl}Na.. Naktis! Demon Lord!{nl}She took away our necklace and orgel, stared at it for some time, and threw it far away!
 QUEST_LV_0200_20150317_000488	{memo X}{nl}Then she made us fight and hate each other for gluttony and just disappeared. {nl}I need to go.. To meet her, she, how is she..
 QUEST_LV_0200_20150317_000489	{memo X}The orgel rolled out somewhere and the necklace.. Her subordinate swallowed it. {nl}
 QUEST_LV_0200_20150317_000490	{memo X}Then Naktis made us.. Like this.. {nl}
 QUEST_LV_0200_20150317_000491	{memo X}Oh, sorry. {nl}I'm too dizzy and it's difficult to talk. {nl}There are Nikotias in the Starving Demon's Way that are used as medicinal herbs. Won't the dizziness fade away if I eat some of those herbs?
 QUEST_LV_0200_20150317_000492	{memo X}I heard Nikotias grow in the upper area. {nl}But it's not easy to get it so be careful.
-QUEST_LV_0200_20150317_000493	{memo X}Ah, it's that.. Thank you. {nl}It feels better. {nl}Lylia.. Her orgel.. She probably isn't in this world anymore.. Without her, I don't need this necklace either. {nl}
+QUEST_LV_0200_20150317_000493	{memo X}Ah, it's that.. Thank you. {nl}It feels better. {nl}Liliya.. Her orgel.. She probably isn't in this world anymore.. Without her, I don't need this necklace either. {nl}
 QUEST_LV_0200_20150317_000494	{memo X}If you meet that nasty Naktis' monster, please strike a revenge for me. {nl}Please take out the sign of our love from it and let it see the light of the world. {nl}And as a sign of gratitude for the revenge, please keep that necklace. {nl}
 QUEST_LV_0200_20150317_000495	{memo X}It's a necklace that received the blessings of the Cathedral so it will come in handy. {nl}That necklace doesn't mean anything to me anymore..
 QUEST_LV_0200_20150317_000496	Pilgrim Zenius
@@ -986,10 +986,10 @@ QUEST_LV_0200_20150317_000985	By the way, I'm worried about mister Dorjen. {nl}H
 QUEST_LV_0200_20150317_000986	I think he is planning to burn the whole forest.. {nl}He just won't listen to us. Can you stop him?
 QUEST_LV_0200_20150317_000987	Oil barrels are spread out in Mikolas Brewery. You must get rid of those first. {nl}And mister Dorjen.. Please help us.
 QUEST_LV_0200_20150317_000988	Brewer Dorjen
-QUEST_LV_0200_20150317_000989	What would the revelator want from me. {nl}
+QUEST_LV_0200_20150317_000989	What would the Revelator want from me. {nl}
 QUEST_LV_0200_20150317_000990	Huh? Aren't these my cork screws? {nl}Did you ruin my plans? {nl}
-QUEST_LV_0200_20150317_000991	Don't think of stopping me. {nl}I want to blow them off even if it would cost me my brewery. {nl}I don't trust the revelators anymore.
-QUEST_LV_0200_20150317_000992	{memo X}The monsters ruined the beefarm and brewery. {nl}So Jozef went to Klaipeda to look for revelator who could help us. {nl}{NP}I thought the problem would be solved but guess what happened. {nl}They started disappearing one by one. They backed out. Those cowards.
+QUEST_LV_0200_20150317_000991	Don't think of stopping me. {nl}I want to blow them off even if it would cost me my brewery. {nl}I don't trust the Revelators anymore.
+QUEST_LV_0200_20150317_000992	{memo X}The monsters ruined the beefarm and brewery. {nl}So Jozef went to Klaipeda to look for Revelator who could help us. {nl}{NP}I thought the problem would be solved but guess what happened. {nl}They started disappearing one by one. They backed out. Those cowards.
 QUEST_LV_0200_20150317_000993	Calm down? Do I look like I can calm down? {nl}Okay. Maybe I can calm down if you get my masterpiece liquor from the mead warehouse. {nl}That's if you can get it.
 QUEST_LV_0200_20150317_000994	I'm not sure if you can get that. {nl}You must know that if you fail, I will burn down my workshop.
 QUEST_LV_0200_20150317_000995	Oh my, did you really get that? {nl}I thought you would give up because of the monsters.. That's awesome.
@@ -997,7 +997,7 @@ QUEST_LV_0200_20150317_000996	Alright. I lost. I will not burn down my workshop 
 QUEST_LV_0200_20150317_000997	Thank you very much. {nl}I will feel much better if you do that.
 QUEST_LV_0200_20150317_000998	I won't think about burning down the forest again. {nl}I'm sure a person with abilities like you can save our village.
 QUEST_LV_0200_20150317_000999	That is enough. Jozef did send a great talent. {nl}Anyway those monsters ruined my bee farm and brewery. {nl}
-QUEST_LV_0200_20150317_001000	{memo X}I guess I can trust you unlike other revelators. {nl}If it's alright, can you go to Maras in Three Brooks Wood?
+QUEST_LV_0200_20150317_001000	{memo X}I guess I can trust you unlike other Revelators. {nl}If it's alright, can you go to Maras in Three Brooks Wood?
 QUEST_LV_0200_20150317_001001	Kyrina
 QUEST_LV_0200_20150317_001002	I followed because I was worried about Darren but what do I do? {nl}There are too many monsters and I'm worried how I should go back.
 QUEST_LV_0200_20150317_001003	The monsters here all seem like they're possessed by something and it's scary. {nl}Well, our honey really is sweet after all.
@@ -1029,7 +1029,7 @@ QUEST_LV_0200_20150317_001028	{memo X}Was it you who Jozef was looking for? {nl}
 QUEST_LV_0200_20150317_001029	Anyways. I trusted the disciples, but I can't stand anymore.{nl}That's why I want to hire someone who is skillful like you. {nl}I will compensate you enough.
 QUEST_LV_0200_20150317_001030	Anyone would know that it's because of the honey, but I don't know know what the disciples are doing.
 QUEST_LV_0200_20150317_001031	I made a request at Klaipeda, but they are not responding since they have a lack of soldiers.{nl}And it is not easy to hire merceneries in this era.{nl}
-QUEST_LV_0200_20150317_001032	Then the ones that are left are the revelators.{nl}You looking for the Goddess? we have the Goddess in our village too.
+QUEST_LV_0200_20150317_001032	Then the ones that are left are the Revelators.{nl}You looking for the Goddess? we have the Goddess in our village too.
 QUEST_LV_0200_20150317_001033	Look carefully on the unbroken bee boxes.{nl}You could maybe obtain some bee boxes that are in good status.
 QUEST_LV_0200_20150317_001034	Oh, this is quite big.{nl}Well done.
 QUEST_LV_0200_20150317_001035	You go back to Bulbini Farm.{nl}If we could provide a proof that it was due to the honey, the disciples would not only think about the altar.{nl}
@@ -1071,7 +1071,7 @@ QUEST_LV_0200_20150317_001070	I want to explain about the circumstances a bit, b
 QUEST_LV_0200_20150317_001071	I am relieved by your words.{nl}If we don't protect this, the whole Siaulai forest may be destroyed so I am counting on you.{nl}
 QUEST_LV_0200_20150317_001072	I will explain it to you in details after you come back.{nl}Please get rid of the monsters.
 QUEST_LV_0200_20150317_001073	{memo X}I am now a little relieved.{nl}My greeting was a bit late. I am Disciple Raely serving Austeja Goddess.
-QUEST_LV_0200_20150317_001074	You mean the purification before?{nl}Unlike the other revelators who were lured to the vicious energy, I purifed you in the name of the Goddess.{nl}
+QUEST_LV_0200_20150317_001074	You mean the purification before?{nl}Unlike the other Revelators who were lured to the vicious energy, I purifed you in the name of the Goddess.{nl}
 QUEST_LV_0200_20150317_001075	The Goddesses already blessed the villagers, but they don't know about it well.{nl}The Goddesses don't want chaos.
 QUEST_LV_0200_20150317_001076	It is good to hear that you feel responsible for it.{nl}
 QUEST_LV_0200_20150317_001077	We have something to gain from purifying those demons.{nl}Please obtain the branches of bee trees that are endowed with the power of the Goddess near the village.
@@ -1086,7 +1086,7 @@ QUEST_LV_0200_20150317_001085	Palama Cliff is the nearest place for it so please
 QUEST_LV_0200_20150317_001086	This will be enough. {nl}Please prepare to restore the seal. It might become a huge fight.
 QUEST_LV_0200_20150317_001087	The weak seal tower is in the near Stula Road. {nl}It bothers me that the demons were calm until now.
 QUEST_LV_0200_20150317_001088	Please hurry. I can feel that the seal is weak. {nl}May you have the Goddess' blessings..
-QUEST_LV_0200_20150317_001089	Are you the revelator who purified the Seal Tower?
+QUEST_LV_0200_20150317_001089	Are you the Revelator who purified the Seal Tower?
 QUEST_LV_0200_20150317_001090	I have been suppressing the evil force of this place.
 QUEST_LV_0200_20150317_001091	Please restore the Seal Tower in Spring Light Wood.
 QUEST_LV_0200_20150317_001092	After the evil force gushed out, plants mutated and enlarged abnomally. {nl}It seems dangerous so I just watched from afar but it fumed out ominous forces. {nl}I'm worried those mutated plants might harm the village residents.
@@ -1107,31 +1107,31 @@ QUEST_LV_0200_20150317_001106	Are you trying to comfort me? {nl}Then nothing wou
 QUEST_LV_0200_20150317_001107	I know the priest is right but I can still rant about it, right?
 QUEST_LV_0200_20150317_001108	That feels better. {nl}How I wish they'd be gone forever.
 QUEST_LV_0200_20150317_001109	Priest Dajine
-QUEST_LV_0200_20150317_001110	Dear revelator. I assume you've heard from Goddess Austeja. {nl}The other revelators who were dazzled by evil forces will attack the village before restoring the seal. {nl}
+QUEST_LV_0200_20150317_001110	Dear Revelator. I assume you've heard from Goddess Austeja. {nl}The other Revelators who were dazzled by evil forces will attack the village before restoring the seal. {nl}
 QUEST_LV_0200_20150317_001111	But there is a way. {nl}We can purify it if we find the symbol of the Goddess.
-QUEST_LV_0200_20150317_001112	First regain the symbol of the Goddess and then restore the Altar of Austeja. {nl} Purifying revelators are next.
-QUEST_LV_0200_20150317_001113	Whether it's restoring the weakened seal or curing the dazzled revelators, {nl}it will need that symbol.
+QUEST_LV_0200_20150317_001112	First regain the symbol of the Goddess and then restore the Altar of Austeja. {nl} Purifying Revelators are next.
+QUEST_LV_0200_20150317_001113	Whether it's restoring the weakened seal or curing the dazzled Revelators, {nl}it will need that symbol.
 QUEST_LV_0200_20150317_001114	{memo X}The damage is worse than at the seal in the shaking field. {nl}The evil forces are fuming out stronger.
-QUEST_LV_0200_20150317_001115	Fortunately, the Goddess returned the Divine symbol to the villagers before going all in on the seal.. {nl}The innocent revelators did not know about it and got themselves in danger.
-QUEST_LV_0200_20150317_001116	This is it. {nl}This will save the dazzled revelators.
-QUEST_LV_0200_20150317_001117	The dazzled revelators will start to march in soon. {nl}Please purify them before anyone gets hurt.
+QUEST_LV_0200_20150317_001115	Fortunately, the Goddess returned the Divine symbol to the villagers before going all in on the seal.. {nl}The innocent Revelators did not know about it and got themselves in danger.
+QUEST_LV_0200_20150317_001116	This is it. {nl}This will save the dazzled Revelators.
+QUEST_LV_0200_20150317_001117	The dazzled Revelators will start to march in soon. {nl}Please purify them before anyone gets hurt.
 QUEST_LV_0200_20150317_001118	Luckily, the damage is minimal. {nl}Now, if we only get to restore the seal, this will never have to repeat.
 QUEST_LV_0200_20150317_001119	Restore the weakened Seal Tower using the symbol of Goddess Austeja.{nl}It's the Rankis seal and Ranka seal.
 QUEST_LV_0200_20150317_001120	The demons found out about the source of evil force and continued their attacks to destroy the seal. {nl}I'm sure if the seal is strengthened well this time, they will draw out for a while.
 QUEST_LV_0200_20150317_001121	But we don't know what will happen next.{nl} We just believe that Goddess Austeja will take care of this matter if anything happens.
 QUEST_LV_0200_20150317_001122	{memo X}But one thing that worries me is that.. {nl}The symbol was destroyed once so it might not be fully restored again. {nl}Of course everything will depend.. on the Goddess..{nl}
 QUEST_LV_0200_20150317_001123	Merchant Dulke
-QUEST_LV_0200_20150317_001124	Oh no, what do I do? {nl}I lost all the seed money for my shop while running away from the mosnters. {nl}But I'm afraid I might turn lunatic like the other revelators if I go out for it.
+QUEST_LV_0200_20150317_001124	Oh no, what do I do? {nl}I lost all the seed money for my shop while running away from the mosnters. {nl}But I'm afraid I might turn lunatic like the other Revelators if I go out for it.
 QUEST_LV_0200_20150317_001125	At first, I wasn't able to tell if it was human or monster. {nl}It was staring blank in the air so I called him and it disappeared making a strange noise.
 QUEST_LV_0200_20150317_001126	There are many like that. {nl}I think people in our village are normal.. Could the Goddess have protected us with her blessings?
 QUEST_LV_0200_20150317_001127	Please help me. {nl}I started my business with all that I've got and now I'm about to end up with nothing.
-QUEST_LV_0200_20150317_001128	Oh how can I thank you.. These sure are my stuff. {nl}I did think it was weird that you were fine unlike other revelators. You truly are the special one.
+QUEST_LV_0200_20150317_001128	Oh how can I thank you.. These sure are my stuff. {nl}I did think it was weird that you were fine unlike other Revelators. You truly are the special one.
 QUEST_LV_0200_20150317_001129	Villager Emil
 QUEST_LV_0200_20150317_001130	I need to go downtown but the priest says the seal is dangerous and I should stay put. {nl}That seal really is nothing for me but the demons are scary.
 QUEST_LV_0200_20150317_001131	I guess there's nothing I can do in order to live. {nl}Although all the villagers here are just looking up to the Goddess and priest.
-QUEST_LV_0200_20150317_001132	I saw other revelators all gone weird but you seem fine. Did you meet the Goddess or something? {nl}Anyways, that's awesome. I want to be as strong as you are.
+QUEST_LV_0200_20150317_001132	I saw other Revelators all gone weird but you seem fine. Did you meet the Goddess or something? {nl}Anyways, that's awesome. I want to be as strong as you are.
 QUEST_LV_0200_20150317_001133	Pharmacist Tiana
-QUEST_LV_0200_20150317_001134	Priest Dajine asked me for medicine to cure the dazzled revelator in the future. {nl}But I ran out of Spring Light Grass.. and I'm scared of the demons.
+QUEST_LV_0200_20150317_001134	Priest Dajine asked me for medicine to cure the dazzled Revelator in the future. {nl}But I ran out of Spring Light Grass.. and I'm scared of the demons.
 QUEST_LV_0200_20150317_001135	You're a warm person. {nl}Oh, Spring Light Grass is not easy to find. {nl}It shows up only when reacting to this honey jelly.
 QUEST_LV_0200_20150317_001136	You saved me. {nl}I'm sure this will be more than enough for the priest.
 QUEST_LV_0200_20150317_001137	Church Candlestick
@@ -1489,7 +1489,7 @@ QUEST_LV_0200_20150317_001488	I'll get going now
 QUEST_LV_0200_20150317_001489	Hope of the Brewer
 QUEST_LV_0200_20150317_001490	Calm down
 QUEST_LV_0200_20150317_001491	Can't seem to calm down. Let's just go.
-QUEST_LV_0200_20150317_001492	About the other revelator
+QUEST_LV_0200_20150317_001492	About the other Revelator
 QUEST_LV_0200_20150317_001493	{memo X}Checking/LOOK/3/TRACK_BEFORE/None
 QUEST_LV_0200_20150317_001494	{memo X}Notice/Found the mead Dorgen asked you to bring.#5
 QUEST_LV_0200_20150317_001495	Sweet Revenge
@@ -1511,7 +1511,7 @@ QUEST_LV_0200_20150317_001510	{memo X}I'll save it
 QUEST_LV_0200_20150317_001511	{memo X}It's taken care of so leave the place
 QUEST_LV_0200_20150317_001512	{memo X}About Mikolas and Cleopas
 QUEST_LV_0200_20150317_001513	{memo X}Objective of Monsters in Three Brooks (1)
-QUEST_LV_0200_20150317_001514	Reason behind hiring revelators
+QUEST_LV_0200_20150317_001514	Reason behind hiring Revelators
 QUEST_LV_0200_20150317_001515	{memo X}Objective of Monsters in Three Brooks (2)
 QUEST_LV_0200_20150317_001516	I'll check if the monsters are really attracted to the scent of honey
 QUEST_LV_0200_20150317_001517	About the Altar
@@ -1599,9 +1599,9 @@ QUEST_LV_0200_20150317_001598	$Insatiable Hunger (2)
 QUEST_LV_0200_20150317_001599	$Insatiable Hunger (3)
 QUEST_LV_0200_20150317_001600	$Insatiable Hunger (4)
 QUEST_LV_0200_20150317_001601	{memo X}I'll make it next time
-QUEST_LV_0200_20150317_001602	{memo X}Notice /! / Lylia died .. {nl} Please make a grave for her # 3
-QUEST_LV_0200_20150317_001603	{memo X}Making a grave for Lylia/ SITGROPE / 3 / TRACK_BEFORE / None
-QUEST_LV_0200_20150317_001604	{memo X}Notice /You made a grave for Lylia # 5
+QUEST_LV_0200_20150317_001602	{memo X}Notice /! / Liliya died .. {nl} Please make a grave for her # 3
+QUEST_LV_0200_20150317_001603	{memo X}Making a grave for Liliya/ SITGROPE / 3 / TRACK_BEFORE / None
+QUEST_LV_0200_20150317_001604	{memo X}Notice /You made a grave for Liliya # 5
 QUEST_LV_0200_20150317_001605	Endless Gluttony (1)
 QUEST_LV_0200_20150317_001606	{memo X}I'll find something to eat
 QUEST_LV_0200_20150317_001607	Ignore it and go your way
@@ -2552,15 +2552,15 @@ QUEST_LV_0200_20150317_002551	Restore the weak sealed tower at Stula Highway. Th
 QUEST_LV_0200_20150317_002552	Talk with the Austeja goddess
 QUEST_LV_0200_20150317_002553	As you restored the sealed tower which was changed by the demons, Austeja goddess has appeared. Listen to the story of Austeja goddess.
 QUEST_LV_0200_20150317_002554	Listen to the story of Austeja goddess
-QUEST_LV_0200_20150317_002555	Austeja goddess told you that the everything that is occuring at the apiary is the act of the demons that are trying to release the seal that is placed upon the demon lord.
+QUEST_LV_0200_20150317_002555	Austeja goddess told you that the everything that is occuring at the apiary is the act of the demons that are trying to release the seal that is placed upon the Demon Lord.
 QUEST_LV_0200_20150317_002556	The disciple, Raelie is worrying about something. Ask him what to do.
 QUEST_LV_0200_20150317_002557	Check the gigantic transformed plant
 QUEST_LV_0200_20150317_002558	The gigantic grass looks somewhat dangerous. Look carefully on it.
 QUEST_LV_0200_20150317_002559	The gigantic transformed plant was Kurumis. Go meet Disciple Raely.
 QUEST_LV_0200_20150317_002560	Check the weakened sealed tower
 QUEST_LV_0200_20150317_002561	Check the sealed tower that became weak due to the attacks from the demons
-QUEST_LV_0200_20150317_002562	{memo X}Defeat the demon lord Tautrimas
-QUEST_LV_0200_20150317_002563	{memo X}The demon lord, Tautrimas appeared to go after the weakened sealed tower. Defeat the demon lord, Tautrimas.
+QUEST_LV_0200_20150317_002562	{memo X}Defeat the Demon Lord Tautrimas
+QUEST_LV_0200_20150317_002563	{memo X}The Demon Lord, Tautrimas appeared to go after the weakened sealed tower. Defeat the Demon Lord, Tautrimas.
 QUEST_LV_0200_20150317_002564	{memo X}Talk with Greedy Druba
 QUEST_LV_0200_20150317_002565	{memo X}Greedy Druba is looking for someone who can help him out. Talk with greedy Druba.
 QUEST_LV_0200_20150317_002566	Extract oak stems
@@ -2577,16 +2577,16 @@ QUEST_LV_0200_20150317_002576	Defeated the monsters as Rosen requested. Return t
 QUEST_LV_0200_20150317_002577	Talk to Priest Dajine
 QUEST_LV_0200_20150317_002578	Go to Priest Dajine in Spring Light Woods.
 QUEST_LV_0200_20150317_002579	Collect the broken pieces of symbol of Austeja
-QUEST_LV_0200_20150317_002580	You need the symbol of Austeja to turn back the revelators who are endazzled by the evil force. First, collect the pieces of the symbol.
+QUEST_LV_0200_20150317_002580	You need the symbol of Austeja to turn back the Revelators who are endazzled by the evil force. First, collect the pieces of the symbol.
 QUEST_LV_0200_20150317_002581	Retrieve the pieces of symbol of Austeja
 QUEST_LV_0200_20150317_002582	Restore the symbol in Austeja Altar
 QUEST_LV_0200_20150317_002583	Restore the broken peices of symbol of Austeja in Austeja Altar.
 QUEST_LV_0200_20150317_002584	Restored the symbol in Austeja Altar. Give it to Dajine.
-QUEST_LV_0200_20150317_002585	Talk to Austeja follower about purifying the endazzled revelators.
-QUEST_LV_0200_20150317_002586	Purify the endazzled revelators
-QUEST_LV_0200_20150317_002587	Attack the endazzled revelators to subdue them then use the symbol of Austeja to purify.
-QUEST_LV_0200_20150317_002588	Purified all endazzled revelators. Talk to priest Dajine.
-QUEST_LV_0200_20150317_002589	Cured all endazzled revelators. Ask Austeja follower what to do next. {nl}{nl}The endazzled revelators are all purified. Talk to Dajine about the seal.
+QUEST_LV_0200_20150317_002585	Talk to Austeja follower about purifying the endazzled Revelators.
+QUEST_LV_0200_20150317_002586	Purify the endazzled Revelators
+QUEST_LV_0200_20150317_002587	Attack the endazzled Revelators to subdue them then use the symbol of Austeja to purify.
+QUEST_LV_0200_20150317_002588	Purified all endazzled Revelators. Talk to priest Dajine.
+QUEST_LV_0200_20150317_002589	Cured all endazzled Revelators. Ask Austeja follower what to do next. {nl}{nl}The endazzled Revelators are all purified. Talk to Dajine about the seal.
 QUEST_LV_0200_20150317_002590	Restore Rangkis Seal and Rangka Seal
 QUEST_LV_0200_20150317_002591	The Seal Tower for locking up the evil force were all destroyed by the monsters. Symbol of Austeja can add a little bit of power to the Seal. {nl}{nl}The Seal Tower for locking up the evil force were all destroyed by the monsters. Use symbol of Austeja and restore the seal.
 QUEST_LV_0200_20150317_002592	Add power of the Goddess to Rangkis seal tower and Rangka seal tower
@@ -2649,26 +2649,26 @@ QUEST_LV_0200_20150317_002648	$Find traces of the kidnapped Owls
 QUEST_LV_0200_20150317_002649	{memo X}The Weak Owl wants you to find other owls that the monsters took away. Find the traces of owl statue in the monster's hideaway located at each end of the Ishrai Crossroad.
 QUEST_LV_0200_20150317_002650	$Give the Broken Piece of Owl
 QUEST_LV_0200_20150317_002651	{memo X}Found all the Broken Pieces of the Owl. Give it to the Weak Owl.
-QUEST_LV_0200_20150317_002652	{memo X}Talk to Lylia
-QUEST_LV_0200_20150317_002653	{memo X}There is a pilgrim names Lylia in Way of the Big Staving Demons. Seems like she desperately needs something so try talking to her.
+QUEST_LV_0200_20150317_002652	{memo X}Talk to Liliya
+QUEST_LV_0200_20150317_002653	{memo X}There is a pilgrim names Liliya in Way of the Big Staving Demons. Seems like she desperately needs something so try talking to her.
 QUEST_LV_0200_20150317_002654	{memo X}Find food
-QUEST_LV_0200_20150317_002655	{memo X}Lylia keeps saying that she's hungry. Get some meat from the monsters around and give it to her.
-QUEST_LV_0200_20150317_002656	{memo X}Give monster meat to Lylia.
+QUEST_LV_0200_20150317_002655	{memo X}Liliya keeps saying that she's hungry. Get some meat from the monsters around and give it to her.
+QUEST_LV_0200_20150317_002656	{memo X}Give monster meat to Liliya.
 QUEST_LV_0200_20150317_002657	{memo X}Get %s from monsters nearby
-QUEST_LV_0200_20150317_002658	$Lylia still seems hungry. Talk to her again.
+QUEST_LV_0200_20150317_002658	$Liliya still seems hungry. Talk to her again.
 QUEST_LV_0200_20150317_002659	{memo X}Get soft reed stem
-QUEST_LV_0200_20150317_002660	{memo X}Gather soft reed stem for Lylia from the reed sprouts nearby.
-QUEST_LV_0200_20150317_002661	{memo X}Gathered all the soft reed stems. Give it to Lylia.
+QUEST_LV_0200_20150317_002660	{memo X}Gather soft reed stem for Liliya from the reed sprouts nearby.
+QUEST_LV_0200_20150317_002661	{memo X}Gathered all the soft reed stems. Give it to Liliya.
 QUEST_LV_0200_20150317_002662	{memo X}Gather %s from reed sprouts
-QUEST_LV_0200_20150317_002663	{memo X}Is Lylia's hunger satisfied? Talk to her again.
+QUEST_LV_0200_20150317_002663	{memo X}Is Liliya's hunger satisfied? Talk to her again.
 QUEST_LV_0200_20150317_002664	$Defeat Carnivore
-QUEST_LV_0200_20150317_002665	$What happened? The hungry Lylia is gone and a Carnivore suddenly appeared. First, defeat the Carnivore that is attacking you.
-QUEST_LV_0200_20150317_002666	{memo X}Talk to Lylia on the floor
-QUEST_LV_0200_20150317_002667	{memo X}Lylia appeared on the spot where Carnivore was defeated. Try talking to Lylia.
-QUEST_LV_0200_20150317_002668	{memo X}Defeat the Carnivore that seems like what Lylia turned into
-QUEST_LV_0200_20150317_002669	{memo X}Make a grave for Lylia
-QUEST_LV_0200_20150317_002670	{memo X}Seems like Lylia will lose her breathe soon.. Do her last favor.
-QUEST_LV_0200_20150317_002671	{memo X}Make a grave for Lylia
+QUEST_LV_0200_20150317_002665	$What happened? The hungry Liliya is gone and a Carnivore suddenly appeared. First, defeat the Carnivore that is attacking you.
+QUEST_LV_0200_20150317_002666	{memo X}Talk to Liliya on the floor
+QUEST_LV_0200_20150317_002667	{memo X}Liliya appeared on the spot where Carnivore was defeated. Try talking to Liliya.
+QUEST_LV_0200_20150317_002668	{memo X}Defeat the Carnivore that seems like what Liliya turned into
+QUEST_LV_0200_20150317_002669	{memo X}Make a grave for Liliya
+QUEST_LV_0200_20150317_002670	{memo X}Seems like Liliya will lose her breathe soon.. Do her last favor.
+QUEST_LV_0200_20150317_002671	{memo X}Make a grave for Liliya
 QUEST_LV_0200_20150317_002672	$Talk to Pilgrim Julius
 QUEST_LV_0200_20150317_002673	$There are many pilgrims with stories in the Starving Demon's Way. Talk to Julius.
 QUEST_LV_0200_20150317_002674	{memo X}Get monster meat
@@ -2685,8 +2685,8 @@ QUEST_LV_0200_20150317_002684	{memo X}Get the young Nikotia leaves
 QUEST_LV_0200_20150317_002685	{memo X}You need to get young Nikotia leaves so that Julius can get back up and tell his story. You can get the leaves in Emptry Tree Forest.
 QUEST_LV_0200_20150317_002686	{memo X}Gathered all the young Nikotia leaves needed. Give it to Julius.
 QUEST_LV_0200_20150317_002687	{memo X}Food supplies in the Ascetic haven
-QUEST_LV_0200_20150317_002688	{memo X}The rotten meat Julius mentioned can be found past the Ascetic haven, just before the Ray-lit Land. Go there and find the Reaverpeded that swallowed Julius and Lylia's ring.
-QUEST_LV_0200_20150317_002689	$The Reaverpede that swallowed Lylia and Julius' necklace appeared! Defeat it and get back the necklace.
+QUEST_LV_0200_20150317_002688	{memo X}The rotten meat Julius mentioned can be found past the Ascetic haven, just before the Ray-lit Land. Go there and find the Reaverpeded that swallowed Julius and Liliya's ring.
+QUEST_LV_0200_20150317_002689	$The Reaverpede that swallowed Liliya and Julius' necklace appeared! Defeat it and get back the necklace.
 QUEST_LV_0200_20150317_002690	$Defeat the Reaverpede that swallowed the necklace
 QUEST_LV_0200_20150317_002691	Talk to Pilgrim Zenius
 QUEST_LV_0200_20150317_002692	{memo X}There are two pilgrims in the Reed field in Starving Demon's Way. Seems like they have a story to tell so try talking to them.
@@ -3188,8 +3188,8 @@ QUEST_LV_0200_20150323_003187	$Okay.. I think I can eat those Young Leaves.{nl}T
 QUEST_LV_0200_20150323_003188	$My hunger doesn't go away even after eating a lot.{nl}It's actually getting worse, I might as well just die.
 QUEST_LV_0200_20150323_003189	$There must be something to eat around here..{nl}Please.. get me something to eat.{nl}
 QUEST_LV_0200_20150323_003190	$I am so hungry yet something is echoing inside my head..{nl}The sound of a music box..  I can't eat an echo..
-QUEST_LV_0200_20150323_003191	$Ahah, my Lylia..{nl}I probably can never see you again.
-QUEST_LV_0200_20150323_003192	$Please think of that necklace as the gift from Lylia and keep it safely.{nl}It is blessed from the Great Cathedral so it will help you.
+QUEST_LV_0200_20150323_003191	$Ahah, my Liliya..{nl}I probably can never see you again.
+QUEST_LV_0200_20150323_003192	$Please think of that necklace as the gift from Liliya and keep it safely.{nl}It is blessed from the Great Cathedral so it will help you.
 QUEST_LV_0200_20150323_003193	$I am still hungry. Hungry.{nl}I can't take it anymore. I am hungry!
 QUEST_LV_0200_20150323_003194	$I am so.. hungry.{nl}Hey, if you have any leftover food, if you could share it with me..
 QUEST_LV_0200_20150323_003195	$Even if that's all you have, please share it with me.. please..
@@ -3197,13 +3197,13 @@ QUEST_LV_0200_20150323_003196	$Meat..quickly. {nl}I feel like I am dying.
 QUEST_LV_0200_20150323_003197	$Meat.. Meat!{nl}Please give it to me fast. Fast!
 QUEST_LV_0200_20150323_003198	$Wait, that music box.. what was it?{nl}
 QUEST_LV_0200_20150323_003199	$My memories.. she..{nl}Give it to me! That's mine!
-QUEST_LV_0200_20150323_003200	{memo X}Damn. What was I doing?{nl}Ahah. Lylia.. My Lylia!{nl}
+QUEST_LV_0200_20150323_003200	{memo X}Damn. What was I doing?{nl}Ahah. Liliya.. My Liliya!{nl}
 QUEST_LV_0200_20150323_003201	$We left for a pilgrimage to the Great Cathedral to receive the blessings of the Goddesses to celebrate our wedding.{nl}But then, that evil Naktis.. that unforgivable Demon Lord.{nl}
 QUEST_LV_0200_20150323_003202	{memo X}Stole her music box and necklace and gave them to the monsters and cursed her with gluttony.{nl}As if to laugh at Maven's lessons.
 QUEST_LV_0200_20150323_003203	{memo X}Wait. My head is shaking because of the curse. {nl}I still have a lot more to say.. I don't know if I would be able to endure until then.
 QUEST_LV_0200_20150323_003204	$I heard the Asellus at the Hollow Tree Forest have purifying powers.{nl}I should be able to endure with its purification.
-QUEST_LV_0200_20150323_003205	$To completely remove the curse, you should go see the disciples..{nl}I want to stay here and recollect Lylia a little more.
-QUEST_LV_0200_20150323_003206	{memo X}Thanks. Way better.{nl}My Lylia.. my music box.. She must not be in this world.{nl}
+QUEST_LV_0200_20150323_003205	$To completely remove the curse, you should go see the disciples..{nl}I want to stay here and recollect Liliya a little more.
+QUEST_LV_0200_20150323_003206	{memo X}Thanks. Way better.{nl}My Liliya.. my music box.. She must not be in this world.{nl}
 QUEST_LV_0200_20150323_003207	{memo X}If you meet the henchman of Naktis in any case, please get a revenge for her.{nl}The mark of our love which the demon possesses.. Please receive it as a compensation for my gratitude.{nl}
 QUEST_LV_0200_20150323_003208	{memo X}This necklce will be very useful since it is blessed by the Great Cathedral. {nl}That necklace is meaningless to me.
 QUEST_LV_0200_20150323_003209	{memo X}You should not touch it.{nl}It will come soon.. just wait little more.
@@ -3227,7 +3227,7 @@ QUEST_LV_0200_20150323_003226	{memo X}That night.. I hid behind the grass forest
 QUEST_LV_0200_20150323_003227	{memo X}And they were so absorbed with madness even after their death so they could not even return to the goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
 QUEST_LV_0200_20150323_003228	Maybe, everything here was my destiny to become a disciple. Ah goddesses..
 QUEST_LV_0200_20150323_003229	I can't move with my legs like this.{nl}How could this be.. the only one I can trust is you.
-QUEST_LV_0200_20150323_003230	Before I left for my pilgrimage, I overheard the stories of the revelators.{nl}And you are really special among them. Can you listen to me little more?
+QUEST_LV_0200_20150323_003230	Before I left for my pilgrimage, I overheard the stories of the Revelators.{nl}And you are really special among them. Can you listen to me little more?
 QUEST_LV_0200_20150323_003231	{memo X}It was really horrible. Those brothers who used to be keen to each other hurt each other..{nl}And the demons cheated on those brothers who died.{nl}
 QUEST_LV_0200_20150323_003232	Some spirits were thrown to the monsters like toys.{nl}Those spirits need the eternal sleep as well.
 QUEST_LV_0200_20150323_003233	Can you first test this?{nl}I am making a reagent that will extract spirits from monsters, but it's not working so well.{nl}
@@ -3325,7 +3325,7 @@ QUEST_LV_0200_20150323_003324	$I saw the true nature of the curse with my own ey
 QUEST_LV_0200_20150323_003325	Even on Medis Diena, this place was safe.{nl}I used to think a disaster is someone else's story.
 QUEST_LV_0200_20150323_003326	The bees are not the only ones that changed.{nl}The monsters that I saw for the first time in my life were coming over to Siaulai Forest continuously.
 QUEST_LV_0200_20150323_003327	I spent many years to make the honey alcohol, but I have to end now without any siginificant result.{nl}Who should I blame for this..
-QUEST_LV_0200_20150323_003328	{memo X}All other revelators were wrong.{nl}But if it were you.. I don't know.
+QUEST_LV_0200_20150323_003328	{memo X}All other Revelators were wrong.{nl}But if it were you.. I don't know.
 QUEST_LV_0200_20150323_003329	The disciples told us to wait, and the damages that were caused by the monsters were bad.{nl}I could not stand anymore so I stood up myself.
 QUEST_LV_0200_20150323_003330	I will find out why monsters are making mess here.{nl}Then the disciples will not say anything.
 QUEST_LV_0200_20150323_003331	Maybe we touched something that we shoudn't touch.{nl}I think we did..
@@ -3334,7 +3334,7 @@ QUEST_LV_0200_20150323_003333	The villagers told us that they can't trust the di
 QUEST_LV_0200_20150323_003334	Where did Austeja goddess go in this kind of time?
 QUEST_LV_0200_20150323_003335	I know that the disciples try their best, but we should protect our village.{nl}We have a trouble living on due to those monsters so we can't just do nothing.
 QUEST_LV_0200_20150323_003336	The disciples never tell us what's wrong.{nl}We know that they are afraid that we would feel unstable.. But still we want to know.
-QUEST_LV_0200_20150323_003337	I know its not the right thing to tell you, but I will count on you.{nl}I don't know what to tell to the disciples.. I am sorry to the revelator.
+QUEST_LV_0200_20150323_003337	I know its not the right thing to tell you, but I will count on you.{nl}I don't know what to tell to the disciples.. I am sorry to the Revelator.
 QUEST_LV_0200_20150323_003338	So we created the incident.{nl}Because of us.. I am so sorry.{nl}
 QUEST_LV_0200_20150323_003339	Austeja goddess would protect our village..{nl}But, I am more scared of the monsters in front of us.
 QUEST_LV_0200_20150323_003340	I refuse to wait for disciples only.{nl}I refuse to be driven by those monsters anymore.
@@ -3351,7 +3351,7 @@ QUEST_LV_0200_20150323_003350	I am a refugee from the capital city.{nl}I moved h
 QUEST_LV_0200_20150323_003351	Ahah, I am hungry.. I can't endure anymore.{nl}Hey. Is there something to eat?
 QUEST_LV_0200_20150323_003352	I can't do anything since I am starving to death..
 QUEST_LV_0200_20150323_003353	I came here to save my son who is cursed.{nl}If you see a young man who is about to die due to hunger, let me know.
-QUEST_LV_0200_20150323_003354	{memo X}I will return to my hometown with my son.{nl}Yes. The revelator of the Goddesses helped us.
+QUEST_LV_0200_20150323_003354	{memo X}I will return to my hometown with my son.{nl}Yes. The Revelator of the Goddesses helped us.
 QUEST_LV_0200_20150323_003355	{memo X}I want to see my son being healthy again.{nl}It's too painful to wait until my son to throw up the vicious energy.
 QUEST_LV_0200_20150323_003356	What should I do about it to save the spirits?
 QUEST_LV_0200_20150323_003357	These are not Maven's lessons.{nl}They are just Naktis' curse.
@@ -3443,7 +3443,7 @@ QUEST_LV_0200_20150323_003442	{memo X}I am counting on you.{nl}I think feel more
 QUEST_LV_0200_20150323_003443	{memo X}Ah, I am tired..
 QUEST_LV_0200_20150323_003444	{memo X}Yes? The crops died?{nl}Was the spell too strong?{nl}Well, don't think about that too much. If you were able to remove the strage energy, it would be fine.
 QUEST_LV_0200_20150323_003445	{memo X}Wizard Limas
-QUEST_LV_0200_20150323_003446	{memo X}Are you the revelator?{nl}Please do not think about the machine behind me.{nl}Unless you help me with one of my tasks.
+QUEST_LV_0200_20150323_003446	{memo X}Are you the Revelator?{nl}Please do not think about the machine behind me.{nl}Unless you help me with one of my tasks.
 QUEST_LV_0200_20150323_003447	{memo X}This machine is being used for an important task.{nl}It is related to the past that isn't that long ago.{nl}The portal that would bring the eternal life and the power that sustains the eternal life..
 QUEST_LV_0200_20150323_003448	{memo X}You can only minimize the strange energy surrounding this place by enhancing the seal magic field.{nl}To do so, we need those empty bottles.{nl}Good luck.
 QUEST_LV_0200_20150323_003449	{memo X}Is everything going alright?
@@ -3520,7 +3520,7 @@ QUEST_LV_0200_20150323_003519	{memo X}The problem is that the food storage gets 
 QUEST_LV_0200_20150323_003520	{memo X}The food storage should be somewhere.
 QUEST_LV_0200_20150323_003521	{memo X}I can relax for now, but I don't know when they would attack again..
 QUEST_LV_0200_20150323_003522	Albina
-QUEST_LV_0200_20150323_003523	{memo X}Are you the revelator?{nl}I listen to the stories even when I am here in this rural region.{nl}I am planning to restore the Tenents' Farm here.
+QUEST_LV_0200_20150323_003523	{memo X}Are you the Revelator?{nl}I listen to the stories even when I am here in this rural region.{nl}I am planning to restore the Tenents' Farm here.
 QUEST_LV_0200_20150323_003524	{memo X}{nl}It is crucial to avoid the eyes of the baron.{nl}It is my mission to eliminate the vicious marks that were put in various places.
 QUEST_LV_0200_20150323_003525	{memo X}I've been doing this job for a long time..{nl}And we have only 3 left.
 QUEST_LV_0200_20150323_003526	{memo X}Over the fence, there is an altar that the villagers used to do ritual ceremonies.{nl}But due to the strong monster that the baron left here, we can't do ritual ceremonies anymore.
@@ -3605,7 +3605,7 @@ QUEST_LV_0200_20150323_003604	Pilgrim Orville
 QUEST_LV_0200_20150323_003605	Please help me.{nl}I ran away to this place by avoding the monsters, but I can't see my friends who came with me.
 QUEST_LV_0200_20150323_003606	{memo X}Please find my friend.{nl}I lived so hard until now, so I can't just die here.
 QUEST_LV_0200_20150323_003607	Disciple Roana
-QUEST_LV_0200_20150323_003608	{memo X}Thanks for helping us.{nl}The goddess help the ones who try their best, and I think it was you, the revelator.
+QUEST_LV_0200_20150323_003608	{memo X}Thanks for helping us.{nl}The goddess help the ones who try their best, and I think it was you, the Revelator.
 QUEST_LV_0200_20150323_003609	It is getting stronger.
 QUEST_LV_0200_20150323_003610	{memo X}So the true nature of the curse was Chapparitions.{nl}I was busy with the curse of Naktis so I think its so fortunate.{nl}
 QUEST_LV_0200_20150323_003611	Ah, can you send this report to Aden if you get a chance to go back to the main church?{nl}
@@ -3616,12 +3616,12 @@ QUEST_LV_0200_20150323_003615	{memo X}Blut's
 QUEST_LV_0200_20150323_003616	{memo X}They tried to break the loosened barriers and run away outside.{nl}Get some help from Hauberks if you can.
 QUEST_LV_0200_20150323_003617	{memo X}Well done. I feel that the barriers in this region are more enhanced now.
 QUEST_LV_0200_20150323_003618	{memo X}You have big ambition..{nl}I can feel the strong spirit in you,.
-QUEST_LV_0200_20150323_003619	{memo X}I am the demon lord, Hauberk. I will tell you the story that you may be interested in..{nl}About Vakarine, the goddess of night star.. I will tell you where she is.{nl}You want to find Vakarine?
+QUEST_LV_0200_20150323_003619	{memo X}I am the Demon Lord, Hauberk. I will tell you the story that you may be interested in..{nl}About Vakarine, the goddess of night star.. I will tell you where she is.{nl}You want to find Vakarine?
 QUEST_LV_0200_20150323_003620	{memo X}So you want to save the goddesses? You made a clever decision.
 QUEST_LV_0200_20150323_003621	{memo X}Unlike the other guys, I can't possess your body.{nl}So please carry my pieces of the seal now and enter inside.{nl}I will guide you from there.
 QUEST_LV_0200_20150323_003622	{memo X}Bluts are facing against Kupole Giderone at Nujicalti Hall.{nl}Giderone would try his best to resist, but I can't keep them anymore with our power only.
 QUEST_LV_0200_20150323_003623	{memo X}The only way to weaken Blut is to get the secreting glands that Blut shared with his subordinates and weaken his influence.{nl}There are Blut's guys near Byeaulleo Hideout. Get the secreting glands of Bluts from them.
-QUEST_LV_0200_20150323_003624	{memo X}The goddess is facing against the demon lord somewhere in the prison.{nl}She desperately needs help from you and Hauberk.
+QUEST_LV_0200_20150323_003624	{memo X}The goddess is facing against the Demon Lord somewhere in the prison.{nl}She desperately needs help from you and Hauberk.
 QUEST_LV_0200_20150323_003625	{memo X}Good. I will eliminate this from this world.{nl}Blut would feel like as if he lost it's feelers.{nl}It will be a big help to Gidrone.
 QUEST_LV_0200_20150323_003626	{memo X}The battle with Blut will be hard for us.{nl}Hauberk should help us. We should grant the substance to Hauberk again.
 QUEST_LV_0200_20150323_003627	{memo X}{nl}Blut sealed his power at his altar for his escape.{nl}If Hauberk could absorb that, it will be a great help to us.{nl}Go to the concentrated area. Control the altar there.
@@ -3652,7 +3652,7 @@ QUEST_LV_0200_20150323_003651	{memo X}When the power of the goddesses get weak, 
 QUEST_LV_0200_20150323_003652	{memo X}They were thinking of making the demon prison into their demon world from the first place.{nl}If this place falls into the hands of him, even Ausrine won't be able to do anything.{nl}You just told me an important information. Thank you.
 QUEST_LV_0200_20150323_003653	{memo X}There's * monster at the 4th isolated area. Hauberk used to trust him the most, but as Hauberk was sealed, he went to Nuaele's side.{nl}If you could defeat him, then its like you are eliminating one of strongest weapons of Nuaele.
 QUEST_LV_0200_20150323_003654	{memo X}Hauberk would welcome this. We don't need that kind of subordinates anymore.
-QUEST_LV_0200_20150323_003655	{memo X}When Hauberk was sealed by Helgasercle, the demons thought that no one like Hauberk would appear again.{nl}But, Nuaele is acting like Hauberk and he became the most threatening demon lord.
+QUEST_LV_0200_20150323_003655	{memo X}When Hauberk was sealed by Helgasercle, the demons thought that no one like Hauberk would appear again.{nl}But, Nuaele is acting like Hauberk and he became the most threatening Demon Lord.
 QUEST_LV_0200_20150323_003656	{memo X}What did Hauberk tell you? It's good for all of us.
 QUEST_LV_0200_20150323_003657	{memo X}After Nuaele disappeared, among the demons that were being controlled by Nuaele, there are some demons that want to expand their influences.{nl}Please destroy the demon monster at the 1st isolated area.
 QUEST_LV_0200_20150323_003658	{memo X}Hauberk and Nuaele will become symbolic figures to the demons.
@@ -3663,7 +3663,7 @@ QUEST_LV_0200_20150323_003662	{memo X}I will pass these necklaces to Vakarine wh
 QUEST_LV_0200_20150323_003663	{memo X}Nuaele is planning something.{nl}Please go see Aldona. He will take you to Nuaele's area.
 QUEST_LV_0200_20150323_003664	{memo X}We don't have enough time to catch him and ask what he is planning!
 QUEST_LV_0200_20150323_003665	{memo X}I can feel that Nuaele has disappeared.{nl}Please go to the 3rd district.{nl}Vakarine is waiting for your help.
-QUEST_LV_0200_20150323_003666	{memo X}Because of you, Gidrone Aldona was able to help me.{nl}Thank you revelator and Hauberk.
+QUEST_LV_0200_20150323_003666	{memo X}Because of you, Gidrone Aldona was able to help me.{nl}Thank you Revelator and Hauberk.
 QUEST_LV_0200_20150323_003667	{memo X}{nl}I will restore my Dionys to its previous status now.{nl}Go meet Gidrone. Please help her to complete my key.
 QUEST_LV_0200_20150323_003668	{memo X}The goddesses are trying to calm down the violent Dionys and trying to help her to come back to her previous status.{nl}To do so, we should accumulate the power of the goddesses that are scattered across this region.{nl}We can collect that power using the key of night star. But we will definitely need your help.
 QUEST_LV_0200_20150323_003669	{memo X}Due to the space that was created near the Orualma, the great hall, the place where the key should be recharged, it's pretty hard to do the ritual normally. {nl}Deactivate the space at the scar of tranformation.
@@ -3677,7 +3677,7 @@ QUEST_LV_0200_20150323_003676	{memo X}Please unleash Rwalda, Casa and Rada seals
 QUEST_LV_0200_20150323_003677	{memo X}The goddesses prepared for the everything that could occur.{nl}The problem is time. If we arrive late, then even Vakarine won't be able to do anything.
 QUEST_LV_0200_20150323_003678	{memo X}As the seal unleashes, the lights of the goddesses are coming to the magic suppressor.{nl}Now, everything is ready. We also have enough time.
 QUEST_LV_0200_20150323_003679	{memo X}I will persuade Dionys first, but it won't be effective.{nl}Dionys has the chains that Gitine had created.{nl}That's why she is breaking everything she sees.
-QUEST_LV_0200_20150323_003680	{memo X}If we fail, Dinois will escape from this place.{nl}It will be the same thing as unleashing tens of demon lords to this world.{nl}Tell me when you are ready.
+QUEST_LV_0200_20150323_003680	{memo X}If we fail, Dinois will escape from this place.{nl}It will be the same thing as unleashing tens of Demon Lords to this world.{nl}Tell me when you are ready.
 QUEST_LV_0200_20150323_003681	{memo X}We just ran into a problem. The reason why the goddesses helped Hauberk to regain his energy was because Hauberk is the key who can quiet down this mess.{nl}The goddesses tried to close the space that was opened from the demon world using the chains and the spirits of Hauberk.
 QUEST_LV_0200_20150323_003682	{memo X}I am sorry to deceive you. But, I can't tell you the truth as long as Hauberk is with you.{nl}Hauberk ran away to the 4th district. Please tell this to the goddess as quickly as possible.
 QUEST_LV_0200_20150323_003683	{memo X}Okay.. so that's why.{nl}Do not lose your hope savior, it's not too late as long as you are alive.{nl}Hauberk ran away to the 4th district which is like a mae in this prison.
@@ -3720,7 +3720,7 @@ QUEST_LV_0200_20150323_003719	Something that was not in the plan occured.
 QUEST_LV_0200_20150323_003720	{memo X}There were so many sacrifices. Everything that was caused by the metastasis space is collapsing this place.
 QUEST_LV_0200_20150323_003721	{memo X}We've done it. Please go to the goddess in the 5th district.{nl}We will send the sealed Hauberk to the goddess when we need it.
 QUEST_LV_0200_20150323_003722	{memo X}After catching Hauberk, his subordinates ran away to various places in the prison.{nl}If we relase them, we don't know what they will do later so we should find them and get rid of them.{nl}Could you defeat Hauberk's demons that ran away to Aklaga isolated place?
-QUEST_LV_0200_20150323_003723	{memo X}The influence that started to spread fom the capital city of the humans would disturb the control of Vakarine more and more.{nl}In order to prepare for that, we should get rid of the subordinates who used to follow the demon lord.
+QUEST_LV_0200_20150323_003723	{memo X}The influence that started to spread fom the capital city of the humans would disturb the control of Vakarine more and more.{nl}In order to prepare for that, we should get rid of the subordinates who used to follow the Demon Lord.
 QUEST_LV_0200_20150323_003724	{memo X}Thanks. I will stay here and chase after the rest of them.
 QUEST_LV_0200_20150323_003725	{memo X}Right before you succeeded on sealing Hauberk, some of the subordinates of Hauberk ran away to Ishidebi hideout by disobeying the order of Hauberk.{nl}The conspiracy that Nuaele planned occured because we failed to catch him before he ran away.
 QUEST_LV_0200_20150323_003726	{memo X}{nl}That should never occur again. Please get rid of the betrayers near Ishidebi hideout.
@@ -3737,16 +3737,16 @@ QUEST_LV_0200_20150323_003736	{memo X}{nl}I will give you the rune of the night 
 QUEST_LV_0200_20150323_003737	{memo X}I should have listened to Laima's warnings from the beginning.
 QUEST_LV_0200_20150323_003738	{memo X}I've collected enough Runes of the night star.{nl}I will use this to pull the spirits of demons.{nl}Receive the rune of the night star.
 QUEST_LV_0200_20150323_003739	{memo X}Use the rune of the night star to the demons and neutralize those demons.{nl}The demons that became neutralized would come to me.{nl}I will combine them with the spirits of Hauberk here.
-QUEST_LV_0200_20150323_003740	{memo X}The Goddesses and the demons can't control each other's spirits easily, but it is possible through the revelator like you.
-QUEST_LV_0200_20150323_003741	{memo X}Thank you revelator..{nl}The demons you've sent, the Kupoles are combining the with the spirit of Hauberk.
+QUEST_LV_0200_20150323_003740	{memo X}The Goddesses and the demons can't control each other's spirits easily, but it is possible through the Revelator like you.
+QUEST_LV_0200_20150323_003741	{memo X}Thank you Revelator..{nl}The demons you've sent, the Kupoles are combining the with the spirit of Hauberk.
 QUEST_LV_0200_20150323_003742	{memo X}The demons are also gathered at Ishishula which is little bit far from here.{nl}Use the rune of the night star there and neutralize them.{nl}My Kupoles would go there and receive them..
-QUEST_LV_0200_20150323_003743	{memo X}Since you helped me, the influence of me and the Kupoles is recovering in the prison.{nl}We can go anywhere and we can appear from anywhere.{nl}And I am always looking at you. Be confident revelator..
+QUEST_LV_0200_20150323_003743	{memo X}Since you helped me, the influence of me and the Kupoles is recovering in the prison.{nl}We can go anywhere and we can appear from anywhere.{nl}And I am always looking at you. Be confident Revelator..
 QUEST_LV_0200_20150323_003744	{memo X}Due to your help, the Kupoles are combining with the spirits of Hauberk.{nl}We almost filled them..
 QUEST_LV_0200_20150323_003745	{memo X}There's a way to get more power of the demon spirits.{nl}Retrieve the symbols of the condemned criminals that we placed on them so that they can't use their power.{nl}Go to Etmesta isolated area and suppress the guys there. If you use the rune of the night star, you would be able to receive the symbol.
 QUEST_LV_0200_20150323_003746	{memo X}Me and the Kupoles could go anywhere in the prison, but I could not observe all of them besides.{nl}I engraved the symbol of the condemned criminal who committed most deadly sins so that they can't use their power.
 QUEST_LV_0200_20150323_003747	{memo X}With these symbols, we would be able to increase the size of Hauberk's spirits even more.
 QUEST_LV_0200_20150323_003748	{memo X}We collected enough power of the demon spirits to block the metastasis space.{nl}As me and my Kupoles block the metastasis space, you should protect us.
-QUEST_LV_0200_20150323_003749	{memo X}The root of the disaster that came to this place doesn't exist here anymore. You should receive the credit for this, revelator.{nl}Now we will call Hauberk. And we will eliminate the metastasis space here.
+QUEST_LV_0200_20150323_003749	{memo X}The root of the disaster that came to this place doesn't exist here anymore. You should receive the credit for this, Revelator.{nl}Now we will call Hauberk. And we will eliminate the metastasis space here.
 QUEST_LV_0200_20150323_003750	{memo X}{nl}I am going to be here. If you need my help, come any time..
 QUEST_LV_0200_20150323_003751	{memo X}The demons hid into various places in the 5th district before I was able to fill the metastasis space when I arrived here..{nl}And many of them are concentrated near Banaga Monitor District, so please defeat them.
 QUEST_LV_0200_20150323_003752	{memo X}The number of Kupoles is increasing a lot..
@@ -3756,10 +3756,10 @@ QUEST_LV_0200_20150323_003755	{memo X}When Dionys gets recovered, you would be a
 QUEST_LV_0200_20150323_003756	{memo X}Thanks. When Dionys comes back, it will be okay even if I leave this place for a while.
 QUEST_LV_0200_20150323_003757	{memo X}The small metastasis space is widening at the areas where we can't reach.{nl}The Kupoles all went to different districts so I have no way to block the metastasis space.{nl}Can you do it?
 QUEST_LV_0200_20150323_003758	{memo X}I have big debts to you, Gidrone and Aldona.
-QUEST_LV_0200_20150323_003759	{memo X}Thank you revelator.
+QUEST_LV_0200_20150323_003759	{memo X}Thank you Revelator.
 QUEST_LV_0200_20150323_003760	{memo X}As Aldona ordered me, I've been wating for you.
 QUEST_LV_0200_20150323_003761	{memo X}Do you think the circumstances would be better if we were to receive Laima's warning little sooner from Vakarine?
-QUEST_LV_0200_20150323_003762	{memo X}You ended the lengthy battle..{nl}Aldona and Gidrone, I will send the revelator so you guys should wait.
+QUEST_LV_0200_20150323_003762	{memo X}You ended the lengthy battle..{nl}Aldona and Gidrone, I will send the Revelator so you guys should wait.
 QUEST_LV_0200_20150323_003763	Please leave me alone..
 QUEST_LV_0200_20150323_003764	The demons's tricks are becoming more vicious.{nl}That demon is waiting for the next victim by hiding its vicious energy.{nl}
 QUEST_LV_0200_20150323_003765	It seems that Naktis found out why we came to the Great Cathedral.{nl}If that's not it, there's no reason that those demons are going after the reports that should be passed to Adel.
@@ -3839,7 +3839,7 @@ QUEST_LV_0200_20150323_003838	Soldier Alan
 QUEST_LV_0200_20150323_003839	Don't come! Monsters are coming!{nl}Damn, how will I be able to stand against this alone..
 QUEST_LV_0200_20150323_003840	{memo X}It's so fortunate that you are here.{nl}How come I can't hear anything from the soldiers who went to defeat Gorgon.
 QUEST_LV_0200_20150323_003841	Was Alan okay?{nl}It is so fortunate that you were here, otherwise the whole district would have been swept away.
-QUEST_LV_0200_20150323_003842	So you are the revelator that I've heard rumors of. Thank you so much.{nl}I don't know why those monsters turned out like that.
+QUEST_LV_0200_20150323_003842	So you are the Revelator that I've heard rumors of. Thank you so much.{nl}I don't know why those monsters turned out like that.
 QUEST_LV_0200_20150323_003843	Louise
 QUEST_LV_0200_20150323_003844	${memo X}I received the farm land from Gitis, but it's such a mess.{nl}Especially Ridimed. But, what can I do with my hands that only touched hoes before.
 QUEST_LV_0200_20150323_003845	I didn't know what to do, but it was so fortunate for me to have met the Goddesses.{nl}I am counting on you. It's already too late to manage the crops.
@@ -3878,7 +3878,7 @@ QUEST_LV_0200_20150323_003877	The person who is leading the mission at Dvasia Pe
 QUEST_LV_0200_20150323_003878	Thanks for your words.{nl}But it would be better to support Julian's squad at Dvasia Peak instead of this place.{nl}
 QUEST_LV_0200_20150323_003879	{memo X}I heard that the hardness and the elasticity of the wood sticks of Firent at Nepritas Cliffs is good.{nl}You can get the rope that was made from tieing those sticks from Red Pantos with spears. Please get me those first.
 QUEST_LV_0200_20150323_003880	At first, they were gathered to Uskis Arable Land and Spring Light Wood.{nl}But, not after a long time, they came to this place.{nl}They must be going after the honey.
-QUEST_LV_0200_20150323_003881	I think I can trust you more than any other revelators.{nl}If it's okay for you, could you look for Maras at Vilna Forest up there?
+QUEST_LV_0200_20150323_003881	I think I can trust you more than any other Revelators.{nl}If it's okay for you, could you look for Maras at Vilna Forest up there?
 QUEST_LV_0200_20150323_003882	If something suspicious appears again near the wood observatory tower, please hand it over to Ramar.{nl}I.. really don't know.
 QUEST_LV_0200_20150323_003883	You've gathered them a lot.{nl}I think this will be enough.
 QUEST_LV_0200_20150323_003884	Damage is bigger than the one that was caused no the seal on the Uskis Arable Land.{nl}The vicious energy is flowing more stronger.{nl}
@@ -3962,8 +3962,8 @@ QUEST_LV_0200_20150323_003961	There are dangerous demons that lure the disciples
 QUEST_LV_0200_20150323_003962	The location is Yujima Antenave.{nl}Please calm our disciples so they can concentrate on their mission.
 QUEST_LV_0200_20150323_003963	I will submit the report as soon as I return to the congregation.{nl}I should soothe the disciples who are in despair prior to that. Thanks.{nl}
 QUEST_LV_0200_20150323_003964	So the five keys are all collected.{nl}Go to Pasara Altar. The secrets would lead you to the hidden room.
-QUEST_LV_0200_20150323_003965	Are you the revelator of the Goddesses or the one who belongs to the mighty power of the darkness?{nl}The vicious darkness can not cross here.{nl}
-QUEST_LV_0200_20150323_003966	You've proven yourself that you are the revelator of the Goddesses.{nl}You may enter the room where the revelation is located.
+QUEST_LV_0200_20150323_003965	Are you the Revelator of the Goddesses or the one who belongs to the mighty power of the darkness?{nl}The vicious darkness can not cross here.{nl}
+QUEST_LV_0200_20150323_003966	You've proven yourself that you are the Revelator of the Goddesses.{nl}You may enter the room where the revelation is located.
 QUEST_LV_0200_20150323_003967	It's so brutal. {nl}Our Great Cathedral, to those demons..
 QUEST_LV_0200_20150323_003968	Druid Elley
 QUEST_LV_0200_20150323_003969	{memo X}Hello. This is the garden of Ginaga.{nl}This place is the hometown and the land of Druid Master, Gina Green.{nl}The master welcomes all people who visit this land.
@@ -3982,13 +3982,13 @@ QUEST_LV_0200_20150323_003981	{memo X}I will see the responses of this sample li
 QUEST_LV_0200_20150323_003982	Oh my god, please look at this. The ritual was successful.{nl}The master would purify everything at once with these trees.
 QUEST_LV_0200_20150323_003983	{memo X}Until the master comes back, I am going to do some base work for the large scale purification.{nl}Can you collect the five bottles of Tanus fluids from the Kvie farm?
 QUEST_LV_0200_20150323_003984	Thanks for helping me.{nl}Anyways, the girl who left the trees.. what is her identity?
-QUEST_LV_0200_20150323_003985	These trees are so mysterious.{nl}It's like the revelator brought the clues of purification.
+QUEST_LV_0200_20150323_003985	These trees are so mysterious.{nl}It's like the Revelator brought the clues of purification.
 QUEST_LV_0200_20150323_003986	You've done enough.{nl}I should tell the Druid Master that you've been a great help.{nl}
 QUEST_LV_0200_20150323_003987	Ah, I have one more thing to request to you lastly.
 QUEST_LV_0200_20150323_003988	This is the box that we discovered with the trees.{nl}If you get a chance to go to Shaton farm, please hand it over to Martineck.
 QUEST_LV_0200_20150323_003989	He likes to interfere with others' lives so he may have involved in some kind of matter.{nl}Maybe, we should ask the other people about the whereabout of him.
 QUEST_LV_0200_20150323_003990	The Farm Supervisor Dorun
-QUEST_LV_0200_20150323_003991	This is the private land of Shaton. {nl}Even a revelator should not interfere here.
+QUEST_LV_0200_20150323_003991	This is the private land of Shaton. {nl}Even a Revelator should not interfere here.
 QUEST_LV_0200_20150323_003992	{memo X}Farmer Max
 QUEST_LV_0200_20150323_003993	{memo X}Wheat farming is possible here unlike Shaton Farm.{nl}We were able to harvest the last farming... but...{nl}I am worried about the next farming.
 QUEST_LV_0200_20150323_003994	Farmer Daahsi
@@ -4007,7 +4007,7 @@ QUEST_LV_0200_20150323_004006	{memo X}Matilda, the young lady of the farm
 QUEST_LV_0200_20150323_004007	{memo X}This is my hometown that I returned after a long time and it has changed a lot.
 QUEST_LV_0200_20150323_004008	Farmer Miren
 QUEST_LV_0200_20150323_004009	I want Druids to drive the monsters out, but they are only looking at the tree.{nl}I am so mad. Who is that girl anyways. {nl}
-QUEST_LV_0200_20150323_004010	{memo X}Hey. You, revelator. Please help me instead of just looking at me.{nl}I want you to drive out the monsters that are on my fields.
+QUEST_LV_0200_20150323_004010	{memo X}Hey. You, Revelator. Please help me instead of just looking at me.{nl}I want you to drive out the monsters that are on my fields.
 QUEST_LV_0200_20150323_004011	The girl that the druids are talking about.{nl}I don't know about the trees, but I think they will bring the disaster.{nl}
 QUEST_LV_0200_20150323_004012	I can't do the farming due to the vicious energy and also those monsters..{nl}I've been farming here for a long time, but since that girl came here and left, we have so many troubles.{nl}
 QUEST_LV_0200_20150323_004013	I know that I've lived here for my whole life, but those young men should not lie.{nl}Are you telling me the trees or the girl would be a help? That's nonsense.
@@ -4070,7 +4070,7 @@ QUEST_LV_0200_20150323_004069	It's so fortunate to see you are okay. {nl}Let's s
 QUEST_LV_0200_20150323_004070	Okay then let's get started. {nl}It is a simple ritual so it should end soon.
 QUEST_LV_0200_20150323_004071	So you came.{nl}I guess I didn't think too deeply.
 QUEST_LV_0200_20150323_004072	The soldier at the farm, Gedson
-QUEST_LV_0200_20150323_004073	{memo X}Even if you are the revelator, this is a private land. {nl}Go out if you don't have any business here!{nl}
+QUEST_LV_0200_20150323_004073	{memo X}Even if you are the Revelator, this is a private land. {nl}Go out if you don't have any business here!{nl}
 QUEST_LV_0200_20150323_004074	If that's so, come back after defeating Cist up there.{nl}After seeing how you behave, I will think about whether I would just let it go or not.
 QUEST_LV_0200_20150323_004075	I can't do this anymore.{nl}This place is polluted with the vicious energy and they are not even paying me a lot.
 QUEST_LV_0200_20150323_004076	Good. I like it a lot.{nl}But, I don't meat to let it go yet. {nl}
@@ -4107,7 +4107,7 @@ QUEST_LV_0200_20150323_004106	I can't do this anymore.{nl}If I could find that s
 QUEST_LV_0200_20150323_004107	Thanks for finding it for me.{nl}I understand that he lost his son, but still..{nl}I heard that they are recruiting tennat farmers near Klaipeda suburban area so maybe we should go there.
 QUEST_LV_0200_20150323_004108	{memo X}I hope Shaton thinks about the people who are starving a little more.
 QUEST_LV_0200_20150323_004109	I heard that Shaton is stubborn, but I didn't know he was stubborn this much.{nl}If we don't persuade him somewho, the vicious energy would spread across the kingdom.{nl}
-QUEST_LV_0200_20150323_004110	The revelator may listen to me.{nl}You should persuade him for sure.
+QUEST_LV_0200_20150323_004110	The Revelator may listen to me.{nl}You should persuade him for sure.
 QUEST_LV_0200_20150323_004111	Gorde Shaton
 QUEST_LV_0200_20150323_004112	Are you with that Druid?{nl}Are you saying that you are going to plant that useless tree pieces on my son's farm? That's absurd.
 QUEST_LV_0200_20150323_004113	If we fail to persuade Shaton..{nl}Maybe we could meet his daughter.
@@ -4132,7 +4132,7 @@ QUEST_LV_0200_20150323_004131	I don't wanna talk about it anymore.{nl}Get out fr
 QUEST_LV_0200_20150323_004132	Did you think you can persuade me with that?{nl}You guys don't know the feeling of a father who lost his son.{nl}
 QUEST_LV_0200_20150323_004133	That's not enough. {nl}Actually, I have a good object.
 QUEST_LV_0200_20150323_004134	{memo X}Hmm... If you have something to do in my farm, I won't block you.{nl}But, you should not disturb my subordinates or my farmers! Do you understand?
-QUEST_LV_0200_20150323_004135	{memo X}I paid a lot for this from the black market in Fedimian. {nl}It will be much more helpful than the revelator like you or those shameless druids.{nl}
+QUEST_LV_0200_20150323_004135	{memo X}I paid a lot for this from the black market in Fedimian. {nl}It will be much more helpful than the Revelator like you or those shameless druids.{nl}
 QUEST_LV_0200_20150323_004136	Soon, a strong monster will be born that will only listen to my orders.{nl}I will get rid of those monsters in my son's farm.
 QUEST_LV_0200_20150323_004137	{memo X}Our colleagues came to the garden of Green Family to support us.{nl}With their help, we were able to set the protective barriers on the trees.{nl}I came here in a hurry since I had an ominous feeling. It was indeed dangerous.{nl}If it weren't you, it would have been really dangerous. Thank you.
 QUEST_LV_0200_20150323_004138	What am I doing.. {nl}I feel like my son is scolding me.{nl}
@@ -4196,7 +4196,7 @@ QUEST_LV_0200_20150323_004195	Ask him what kind of food he wants
 QUEST_LV_0200_20150323_004196	Ask him if there's anything he particularly wants
 QUEST_LV_0200_20150323_004197	You better leave without being involved in the matter
 QUEST_LV_0200_20150323_004198	Keep listen to him
-QUEST_LV_0200_20150323_004199	{memo X}Notice/!/Lylia passed away..{nl}Please make the grave for her#5
+QUEST_LV_0200_20150323_004199	{memo X}Notice/!/Liliya passed away..{nl}Please make the grave for her#5
 QUEST_LV_0200_20150323_004200	I will get the meats of the monsters if that's fine with him.
 QUEST_LV_0200_20150323_004201	Give him the music box
 QUEST_LV_0200_20150323_004202	Ask him if there's anything you could help
@@ -4607,7 +4607,7 @@ QUEST_LV_0200_20150323_004606	The hidden seeds
 QUEST_LV_0200_20150323_004607	I will find the seeds for him
 QUEST_LV_0200_20150323_004608	The stubborn owner of the farm
 QUEST_LV_0200_20150323_004609	I will try persuading him
-QUEST_LV_0200_20150323_004610	Tell him that even a revelator can't do it
+QUEST_LV_0200_20150323_004610	Tell him that even a Revelator can't do it
 QUEST_LV_0200_20150323_004611	The key to the persuasion
 QUEST_LV_0200_20150323_004612	I don't want to get involved
 QUEST_LV_0200_20150323_004613	About Gorde Shaton
@@ -4673,24 +4673,24 @@ QUEST_LV_0200_20150323_004672	Defeat the monsters at the Forest of Prayer
 QUEST_LV_0200_20150323_004673	The knight commander, Uska told you that many monsters have appeared from the deep in the forest, but he couldn't do anything since he didn't have enough soldiers. Defeat 100 monsters at the Forest of Prayer on behalf of the knitage.
 QUEST_LV_0200_20150323_004674	You've completed defeating all the monsters at the Forest of Prayer. Return to Uska and help him relieve his worry.
 QUEST_LV_0200_20150323_004675	Defeat the monsters at the Forest of Prayer
-QUEST_LV_0200_20150323_004676	$Talk to Pilgrim Lylia
-QUEST_LV_0200_20150323_004677	$You can see Lylia at the Starving Demon's Way. She desperately wants something so get closer to her and talk to her.
+QUEST_LV_0200_20150323_004676	$Talk to Pilgrim Liliya
+QUEST_LV_0200_20150323_004677	$You can see Liliya at the Starving Demon's Way. She desperately wants something so get closer to her and talk to her.
 QUEST_LV_0200_20150323_004678	$Collect monster meat
-QUEST_LV_0200_20150323_004679	{memo X}Pilgrim Lylia told you that she is very hungry, so get her any food you can find. Get some edible meats from the monsters.
-QUEST_LV_0200_20150323_004680	$Hand them over to Pilgrim Lylia
+QUEST_LV_0200_20150323_004679	{memo X}Pilgrim Liliya told you that she is very hungry, so get her any food you can find. Get some edible meats from the monsters.
+QUEST_LV_0200_20150323_004680	$Hand them over to Pilgrim Liliya
 QUEST_LV_0200_20150323_004681	$Got enough to eat for three consecutive days without any worries . Bring her the lumps of meat.
 QUEST_LV_0200_20150323_004682	{memo X}Obtain %s from the monsters
 QUEST_LV_0200_20150323_004683	$Get some Young Leaves
-QUEST_LV_0200_20150323_004684	$Pilgrim Lylia is saying she wants more even after eating a lot. Get some Young Leaves for hungry Lylia.
-QUEST_LV_0200_20150323_004685	$You've collected a lot of Young Leaves. Hand them over to Pilgrim Lylia.
+QUEST_LV_0200_20150323_004684	$Pilgrim Liliya is saying she wants more even after eating a lot. Get some Young Leaves for hungry Liliya.
+QUEST_LV_0200_20150323_004685	$You've collected a lot of Young Leaves. Hand them over to Pilgrim Liliya.
 QUEST_LV_0200_20150323_004686	{memo X}Extract %s from the wild herbs
-QUEST_LV_0200_20150323_004687	$Did Pilgrim Lylia's hunger go away? Talk to her again
-QUEST_LV_0200_20150323_004688	$Talk to the fallen Pilgrim Lylia
-QUEST_LV_0200_20150323_004689	$Pilgrim Lylia appeared again from the place where the Carnivore was defeated. Talk to Lylia again.
-QUEST_LV_0200_20150323_004690	$Defeat Lylia who turned into a Carnivore
-QUEST_LV_0200_20150323_004691	$Make a grave for Pilgrim Lylia
-QUEST_LV_0200_20150323_004692	$Lylia is dying... Please listen to her last words
-QUEST_LV_0200_20150323_004693	$Lylia passed away. Please make a grave for Lylia.
+QUEST_LV_0200_20150323_004687	$Did Pilgrim Liliya's hunger go away? Talk to her again
+QUEST_LV_0200_20150323_004688	$Talk to the fallen Pilgrim Liliya
+QUEST_LV_0200_20150323_004689	$Pilgrim Liliya appeared again from the place where the Carnivore was defeated. Talk to Liliya again.
+QUEST_LV_0200_20150323_004690	$Defeat Liliya who turned into a Carnivore
+QUEST_LV_0200_20150323_004691	$Make a grave for Pilgrim Liliya
+QUEST_LV_0200_20150323_004692	$Liliya is dying... Please listen to her last words
+QUEST_LV_0200_20150323_004693	$Liliya passed away. Please make a grave for Liliya.
 QUEST_LV_0200_20150323_004694	{memo X}The pilgrim, Julius, can't move due to his severe hunger. Obtain some meat from the monsters.
 QUEST_LV_0200_20150323_004695	{memo X}You've obtained enough meat from the monsters. Bring them to the pilgrim, Julius.
 QUEST_LV_0200_20150323_004696	Obtain %s from the monsters
@@ -4701,7 +4701,7 @@ QUEST_LV_0200_20150323_004700	$Obtain Asellu Leaf Buds
 QUEST_LV_0200_20150323_004701	$Pilgrim Julius is still suffering from the influence of the curse. Get some Asellu Leaf Buds from the Hollow Tree Forest so he can recover.
 QUEST_LV_0200_20150323_004702	$You've obtained some Asellu Leaf Buds. Take them to Pilgrim Julius.
 QUEST_LV_0200_20150323_004703	Look through the lump of rotten meat at the resting area of the ascetics.
-QUEST_LV_0200_20150323_004704	$Julius and Lylia met Naktis around this location. Could Lylia's necklace be around here?
+QUEST_LV_0200_20150323_004704	$Julius and Liliya met Naktis around this location. Could Liliya's necklace be around here?
 QUEST_LV_0200_20150323_004705	$Pilgrim Zenius is protecting food at the Starving Demon's Way. He seems to have a story to tell so go talk to him.
 QUEST_LV_0200_20150323_004706	$A man stole a lump of food under Pilgrim Zenius' watch. Talk to Zenius about it.
 QUEST_LV_0200_20150323_004707	$Pilgrim Zenius said that man is his son, and he wants the curse removed from his son. First, defeat the monsters nearby.
@@ -5303,8 +5303,8 @@ QUEST_LV_0200_20150323_005302	Gares told you that the device which suppresses th
 QUEST_LV_0200_20150323_005303	You've retrieved the device. Report to Gares.
 QUEST_LV_0200_20150323_005304	Talk to Asta
 QUEST_LV_0200_20150323_005305	Go meet Asta at Aqueduct restricted area.
-QUEST_LV_0200_20150323_005306	Talk to the demon lord, Hauberk
-QUEST_LV_0200_20150323_005307	The demon lord, Hauberk whose spirit was inside Asta appeared. Hauberk told you that he knows where the Goddess, Vakarine is. Ask him the location of the Goddess, Vakarine.
+QUEST_LV_0200_20150323_005306	Talk to the Demon Lord, Hauberk
+QUEST_LV_0200_20150323_005307	The Demon Lord, Hauberk whose spirit was inside Asta appeared. Hauberk told you that he knows where the Goddess, Vakarine is. Ask him the location of the Goddess, Vakarine.
 QUEST_LV_0200_20150323_005308	You've found that the Goddess, Vakarine is in trouble. Hauberk told you that if you could take him to the demons' prison that is across the portal, he will cooperate with you so that you could meet Vakarine. Listen for more details from Hauberk.
 QUEST_LV_0200_20150323_005309	Listen to the plan of Hauberk
 QUEST_LV_0200_20150323_005310	Enter the 1st district of the demons' prison
@@ -5356,7 +5356,7 @@ QUEST_LV_0200_20150323_005355	Defeat Dionys
 QUEST_LV_0200_20150323_005356	Talk to Kupole Daiva
 QUEST_LV_0200_20150323_005357	{memo X}Go meet Kupole Daiva at the 4th district in the demons' prison
 QUEST_LV_0200_20150323_005358	Chase after Hauberk
-QUEST_LV_0200_20150323_005359	{memo X}Kupole Daiva told you to resist the demon lord, Hauberk that is breaking the barrier at Nevirau Collapsed Area.
+QUEST_LV_0200_20150323_005359	{memo X}Kupole Daiva told you to resist the Demon Lord, Hauberk that is breaking the barrier at Nevirau Collapsed Area.
 QUEST_LV_0200_20150323_005360	{memo X}Talk to Kupole Daiva
 QUEST_LV_0200_20150323_005361	Defeat the subordinates of Hauberk
 QUEST_LV_0200_20150323_005362	Collect the pieces of the spirit of Hauberk
@@ -5541,7 +5541,7 @@ QUEST_LV_0200_20150323_005540	{memo X}You've found the pockets of the seeds that
 QUEST_LV_0200_20150323_005541	Search for %s at the farm square
 QUEST_LV_0200_20150323_005542	It seems that Druid Martineque failed to persuade Gorde Shaton. Talk to him again what happened.
 QUEST_LV_0200_20150323_005543	Talk to Gorde Shaton
-QUEST_LV_0200_20150323_005544	Druid Martineque told you that he may listen to the words of the revelator. Persuade Gorde Shaton directly.
+QUEST_LV_0200_20150323_005544	Druid Martineque told you that he may listen to the words of the Revelator. Persuade Gorde Shaton directly.
 QUEST_LV_0200_20150323_005545	Talk to Vanessa Shaton
 QUEST_LV_0200_20150323_005546	{memo X}Druid Martineque told you that if you fail to persuade Gorde Shaton, meet his daughter. Meet Vanessa Shaton and persuade her.
 QUEST_LV_0200_20150323_005547	Look for the traces of Shaton's son at the underground tunnel
@@ -5589,12 +5589,12 @@ QUEST_LV_0200_20150323_005588	You've found the private soldier of the farm, Upha
 QUEST_LV_0200_20150323_005589	Guide Upham to a safe place
 QUEST_LV_0200_20150323_005590	Upham was seperated from the colleagues due to the attacks from the monsters. Please take Upham to the gathering place at the farm where Broknews is at.
 QUEST_LV_0200_20150323_005591	You've took Upham to Broknews. Talk with Broknews.
-QUEST_LV_0200_20150401_005592	How would we know about the mind of the baron.{nl}He told us to behave well when the revelator comes so we are just doing the work he told us to do.{nl}
+QUEST_LV_0200_20150401_005592	How would we know about the mind of the baron.{nl}He told us to behave well when the Revelator comes so we are just doing the work he told us to do.{nl}
 QUEST_LV_0200_20150401_005593	Well, if you see the baron yourself, you may find out something.{nl}He is working on something big at Mirukiti farm, so why don't you go meet him?
 QUEST_LV_0200_20150401_005594	$I have to tie the sacks of the grains, but I don't have enough rope.{nl}I am sure that the monsters nearby took them. Please get some tight rope for me.
 QUEST_LV_0200_20150401_005595	Ah, ignore what the workers near here say.{nl}They are whining.
 QUEST_LV_0200_20150401_005596	Good. {nl}Now the task here is completed.
-QUEST_LV_0200_20150401_005597	Hey, Are you the revelator?{nl}Then I welcome you. The baron told me to treat you well.{nl}
+QUEST_LV_0200_20150401_005597	Hey, Are you the Revelator?{nl}Then I welcome you. The baron told me to treat you well.{nl}
 QUEST_LV_0200_20150401_005598	There is a small task you can do.{nl}We don't have enough workforce here. Ah, I am not talking about farming.{nl}
 QUEST_LV_0200_20150401_005599	Something seems to be moving in the sacks.
 QUEST_LV_0200_20150401_005600	$I request that you finish the rest.{nl}There are some abandoned sacks on Tvora Road. I want you to complete them.
@@ -5676,7 +5676,7 @@ QUEST_LV_0200_20150401_005677	{memo X}The food storage is at Vinoga Brewery.
 QUEST_LV_0200_20150401_005678	I am counting on you for the storage
 QUEST_LV_0200_20150401_005679	{memo X}I am working for that day.
 QUEST_LV_0200_20150401_005680	{memo X}You've defeated all the monsters that were attacking the storage!{nl}Thanks.{nl}As we were about to attack, the storage keeper hid well since you helped.{nl}I should tell him to protect the storage well.
-QUEST_LV_0200_20150401_005681	{memo X}Are you the revelator?{nl}I often hear your stories even when I am in this kind of rural area.{nl}I am removing the magic fields that are stuck in the tenants' farm.
+QUEST_LV_0200_20150401_005681	{memo X}Are you the Revelator?{nl}I often hear your stories even when I am in this kind of rural area.{nl}I am removing the magic fields that are stuck in the tenants' farm.
 QUEST_LV_0200_20150401_005682	{memo X}{nl}We are doing this kind of tasks to help Horaceus.{nl}Of course, I am doing the tasks for me as well.
 QUEST_LV_0200_20150401_005683	{memo X}I've doing this job til now..{nl}Now, we have about 3 left.
 QUEST_LV_0200_20150401_005684	{memo X}The seal magic field that was discovered in the fallow ground.. We should eliminate them.{nl}I can't break them since they have protective barrier.{nl}I will give you the stone of the blessing so try to break it by throwing this.{nl}
@@ -5704,26 +5704,26 @@ QUEST_LV_0200_20150401_005706	{memo X}We are keep going to do the task to find o
 QUEST_LV_0200_20150401_005707	{memo X}Revelator.{nl}We are now ready.{nl}Now, we are going to do our work.
 QUEST_LV_0200_20150401_005708	Then, I will go into your small pocket.{nl}Don't forget. Trust no one.
 QUEST_LV_0200_20150401_005709	{memo X}The Goddess wants you to eliminate all demons in the prison.{nl}The demons became unforgivable creatures after Medis Diena.
-QUEST_LV_0200_20150401_005710	{memo X}But, since the demons are coming through the space of the metastasis, it's not going to be easy.{nl}You should resist the demons that are trying to free the demon lord, Blut.
+QUEST_LV_0200_20150401_005710	{memo X}But, since the demons are coming through the space of the metastasis, it's not going to be easy.{nl}You should resist the demons that are trying to free the Demon Lord, Blut.
 QUEST_LV_0200_20150401_005711	{memo X}This place is not the world of humans or the demons' world, but it is another isolated place.{nl}We've locked the demons in this prison that are not helpful in this world.{nl}
 QUEST_LV_0200_20150401_005712	It was like that before Medis Diena, but the circumstances have changed a lot.{nl}We now have reasons to destroy the demons. They caused Medis Diena.{nl}
 QUEST_LV_0200_20150401_005713	{memo X}But, it's not easy since the space of metastasis is keep enlarging.{nl}The demons are keep coming through the space of the metastasis.
 QUEST_LV_0200_20150401_005714	{memo X}Lots of demons are gathering at Rituala to paricipate the ritual to free Bluts.{nl}Please first defeat them.
-QUEST_LV_0200_20150401_005715	{memo X}The subordinates of the demon lord, Blut are trying to escape from here by breaking the power of the barrier.{nl}}Hauberk's help will be useful this time.
-QUEST_LV_0200_20150401_005716	Well done. You've blocked the most emergent thing.{nl}Now it the time to block the power of the demon lord, Blut.
-QUEST_LV_0200_20150401_005717	Finally I met the one whom my spirit was looking for.{nl}I am the demon lord, Hauberk. I have a suggetion to you.{nl}
+QUEST_LV_0200_20150401_005715	{memo X}The subordinates of the Demon Lord, Blut are trying to escape from here by breaking the power of the barrier.{nl}}Hauberk's help will be useful this time.
+QUEST_LV_0200_20150401_005716	Well done. You've blocked the most emergent thing.{nl}Now it the time to block the power of the Demon Lord, Blut.
+QUEST_LV_0200_20150401_005717	Finally I met the one whom my spirit was looking for.{nl}I am the Demon Lord, Hauberk. I have a suggetion to you.{nl}
 QUEST_LV_0200_20150401_005718	Please help me to get a part of my spirit.{nl}The place where the Goddess of the night star, Vakarine exists.. It will be an interesting suggestion to you.
 QUEST_LV_0200_20150401_005719	Okay. The deal is established.{nl}Don't worry. I won't hurt you.
 QUEST_LV_0200_20150401_005720	Strange.{nl}Unlike other humans, I can't possess your body.{nl}
 QUEST_LV_0200_20150401_005721	We have no other choice. Take my seal piece and go in there.{nl}I will guide you from there.
 QUEST_LV_0200_20150401_005722	{memo X}Now, Gidrone is holding Blut.{nl}But, I don't know how much we can endure by ourselves.{nl}
-QUEST_LV_0200_20150401_005723	{memo X}We should somehow reduce the influence of the demon lord, Blut.{nl}Please take the secreting gland of Blut away from Blut's allies at Byeaulleo Hideout.
+QUEST_LV_0200_20150401_005723	{memo X}We should somehow reduce the influence of the Demon Lord, Blut.{nl}Please take the secreting gland of Blut away from Blut's allies at Byeaulleo Hideout.
 QUEST_LV_0200_20150401_005724	He is the head of the demons that are locked in this district.{nl}They are trying to control this prison somehow and looking for chances to escape from here.{nl}
 QUEST_LV_0200_20150401_005725	{memo X}Actually, Blut told the others proudly that Hauberk turned out like that because of him.{nl}There were followers to the demons that were increasing their influence and Hauberk was leading all that.{nl}
 QUEST_LV_0200_20150401_005726	{memo X}Blut thought that Hauberk was being presumptuous so he told about it to Giltine.{nl}That's why he got ripped off by Helgasercle.
 QUEST_LV_0200_20150401_005727	Vakarine and the other Kupols are also having hard time.{nl}Let's finish our task here fast and go to a different district to help.
 QUEST_LV_0200_20150401_005728	It will be a great help to Gidrone.{nl}I will eliminate this. Blut would feel like that he lost his feelers.
-QUEST_LV_0200_20150401_005729	To defeat the demon lord, Blut completely, our power is not enough.{nl}I didn't want to do this, but let's try getting some help from Hauberk.{nl}
+QUEST_LV_0200_20150401_005729	To defeat the Demon Lord, Blut completely, our power is not enough.{nl}I didn't want to do this, but let's try getting some help from Hauberk.{nl}
 QUEST_LV_0200_20150401_005730	There's something which Blut accumulated the power in at the altar in the concentrated control district.{nl}Only demons could control it, but we have Hauberk.
 QUEST_LV_0200_20150401_005731	When Hauberk absorbs that power, please go help Gidrone right away.{nl}To Nujicalti Hall. Hurry. We don't have enough time.
 QUEST_LV_0200_20150401_005732	We are the attendants who are serving the Goddesses.{nl}Our work differs depending on which Goddess we serve.
@@ -5740,7 +5740,7 @@ QUEST_LV_0200_20150401_005742	{memo X}I want to calm their spirits by finding th
 QUEST_LV_0200_20150401_005743	{memo X}Humans should not come here.
 QUEST_LV_0200_20150401_005744	Thanks. {nl}I hope there are no more sacrifices like this..
 QUEST_LV_0200_20150401_005745	Kupol Medeina
-QUEST_LV_0200_20150401_005746	{memo X}We are in a trouble.{nl}The barrier of the Goddess is breaking due to the mighty power of the demon lord, Nuaele.{nl}
+QUEST_LV_0200_20150401_005746	{memo X}We are in a trouble.{nl}The barrier of the Goddess is breaking due to the mighty power of the Demon Lord, Nuaele.{nl}
 QUEST_LV_0200_20150401_005747	{memo X}Aldona went to face against Nuaele since he wants to resist some more.{nl}If you could reduce the mighty power of Nualele a bit.. It will help Aldona a lot!
 QUEST_LV_0200_20150401_005748	The barrier of the Goddess is like a great wall surrounding this prison.{nl}It will block the demons coming into the prison or escaping from here.{nl}
 QUEST_LV_0200_20150401_005749	The space of the metastasis started to be created on the barrier due to Medis Diena.{nl}Vakarine is having hard time since she should maintain the barrier and face the demons at the same time.
@@ -5749,11 +5749,11 @@ QUEST_LV_0200_20150401_005751	{memo X}Goddesses.{nl}Please protect Aldona..
 QUEST_LV_0200_20150401_005752	{memo X}Well done.{nl}Since you've defeated many demons and their power will be reduce a lot.
 QUEST_LV_0200_20150401_005753	{memo X}Nuaele is luring his subordinates and spreading his influence with the pieces of the seal of Hauberk.{nl}Hauberk should feel something.{nl}
 QUEST_LV_0200_20150401_005754	{memo X}There are more methods to increase the power of Hauberk using that.{nl}Hauberk would also want that.
-QUEST_LV_0200_20150401_005755	Nuaele was in fact not that strong demon lord.{nl}But, after obtaining the seal piece of Hauberk, he spreaded his influence at a astonishingly fast pace.{nl}
+QUEST_LV_0200_20150401_005755	Nuaele was in fact not that strong Demon Lord.{nl}But, after obtaining the seal piece of Hauberk, he spreaded his influence at a astonishingly fast pace.{nl}
 QUEST_LV_0200_20150401_005756	{memo X}After losing his master, Hauberk's subordinates started to follow him who has the piece of the seal.{nl}They are like betrayers to Hauberk.
 QUEST_LV_0200_20150401_005757	{memo X}Hauberk is retriving his manes that he gave to his subordinates as a symbol of their faithfulness.{nl}Now, go to the 2nd isolated area. They must be gathered there.
 QUEST_LV_0200_20150401_005758	{memo X}The subordinates of Hauberk are still following Nuaele as if he is Hauberk.{nl}But, if Hauberk retrieves his manes, they will know who is their true master.{nl}
-QUEST_LV_0200_20150401_005759	{memo X}Now, the demon lord, Nuaele would know it.{nl}In order to escapse from this prison, he should not only rely on his subordinates.{nl}But, its too late now.
+QUEST_LV_0200_20150401_005759	{memo X}Now, the Demon Lord, Nuaele would know it.{nl}In order to escapse from this prison, he should not only rely on his subordinates.{nl}But, its too late now.
 QUEST_LV_0200_20150401_005760	{memo X}By the way, Nuaele's behavior is somewhat strange.{nl}In fact, with the power that he accumulated secretly for a long time, he may just break the barrier and go out.{nl}
 QUEST_LV_0200_20150401_005761	{memo X}But, for us, we are waiting for someone that we don't know. {nl}I guess we should interrogate the subordinates of Nuaele.
 QUEST_LV_0200_20150401_005762	{memo X}I will give you the marbles that I received from the Goddess.{nl}We, Kupols can't do it, but since Hauberk is a demon, he would be able to read our mind.
@@ -5761,13 +5761,13 @@ QUEST_LV_0200_20150401_005763	When the power of the Goddesses get weak, the migh
 QUEST_LV_0200_20150401_005764	{memo X}He was thinking about changing the prison into his demonic world from the first place.{nl}If this place falls under the hands of him, even Ausrine can't do anything.
 QUEST_LV_0200_20150401_005765	Since we've found the objective of Nuaele, let's get moving fast.{nl}
 QUEST_LV_0200_20150401_005766	{memo X}How about we first attack * monster at the 4th isolated area?{nl}If we could defeat it, it's like we are defeating one of the strongest weapons of Nuaele.
-QUEST_LV_0200_20150401_005767	Hauberk was once the strong demon lord who led the biggest herd.{nl}After he was sealed, I thought no one as strong as him would appear again.{nl}
-QUEST_LV_0200_20150401_005768	But, Nuaele is imitating as if he is Hauberk with the piece of the seal.{nl}He became the strongest demon lord at least in this place.
+QUEST_LV_0200_20150401_005767	Hauberk was once the strong Demon Lord who led the biggest herd.{nl}After he was sealed, I thought no one as strong as him would appear again.{nl}
+QUEST_LV_0200_20150401_005768	But, Nuaele is imitating as if he is Hauberk with the piece of the seal.{nl}He became the strongest Demon Lord at least in this place.
 QUEST_LV_0200_20150401_005769	You will see the end of someone who tried to use other's power instead of using his power.
 QUEST_LV_0200_20150401_005770	{memo X}He was in fact the subordinate of Hauberk. Hauberk won't need him anymore.{nl}After Hauberk was sealed, he ran to Nuaele and handed over the seal piece to him.
 QUEST_LV_0200_20150401_005771	{memo X}Nuaele is disappeared, but his ramnents are gathering at the 1st isolated area.{nl}They are going to continue his mission. Get rid of those demons.
 QUEST_LV_0200_20150401_005772	You gotta be careful more.{nl}Hauberk and Nuaele became the symbolic figures to them.
-QUEST_LV_0200_20150401_005773	Many demons came here via the space of the metastasis to support the demon lord.{nl}It will be the same in other places as well. It became quiet as a result.
+QUEST_LV_0200_20150401_005773	Many demons came here via the space of the metastasis to support the Demon Lord.{nl}It will be the same in other places as well. It became quiet as a result.
 QUEST_LV_0200_20150401_005775	{memo X}If it continues like this, the demons will stand up again.{nl}Help us so that the demons that are locked in the prison do not look down on us.
 QUEST_LV_0200_20150401_005776	{memo X}The demons look down on us.{nl}It will take a long time before the rules here get established here.
 QUEST_LV_0200_20150401_005777	{memo X}I will pass these necklaces to the sisters myself.{nl}May the Goddesses protect you.
@@ -5776,7 +5776,7 @@ QUEST_LV_0200_20150401_005779	{memo X}Go meet Aldona. {nl}He would take you to t
 QUEST_LV_0200_20150401_005780	Without Aldona's help, you will never enter the area of Nuaele.{nl}You should be guided by Aldona.
 QUEST_LV_0200_20150401_005781	{memo X}Nuaele's behavior was something that can't be accepted.{nl}If he stayed quietly, he would have been forgiven.{nl}
 QUEST_LV_0200_20150401_005782	{memo X}Let's go to 3rd district.{nl}Vakarine is waiting for your help.
-QUEST_LV_0200_20150401_005783	{memo X}Hauberk and the savior.{nl}With help from you, I can now punish the demon lord, Baltrus.{nl}But the threat of the space of the metastasis still exists.{nl}
+QUEST_LV_0200_20150401_005783	{memo X}Hauberk and the savior.{nl}With help from you, I can now punish the Demon Lord, Baltrus.{nl}But the threat of the space of the metastasis still exists.{nl}
 QUEST_LV_0200_20150401_005784	{memo X}My poor Dionys..{nl}I will remove the strong power that is controlling her and close the space of the metastasis.{nl}
 QUEST_LV_0200_20150401_005785	{memo X}Complete the key of night star by helping Gidrone.{nl}With that key, you will be able to remove the power from Dionys.
 QUEST_LV_0200_20150401_005786	{memo X}The strong power that we tried to protect from Baltrus is controlling the ego of Dionys.{nl}Fortunately, that power can be detached and be put in the key of the night star.{nl}
@@ -5793,7 +5793,7 @@ QUEST_LV_0200_20150401_005796	{memo X}Vakarine saved some power to prepare for t
 QUEST_LV_0200_20150401_005797	{memo X}The problem is the time.{nl}If you are late, Vakarine can't do anything.
 QUEST_LV_0200_20150401_005798	{memo X}The power of the Goddesses is accumulating at the magical suppressor.{nl}We are now all ready. And we have enough time.
 QUEST_LV_0200_20150401_005799	{memo X}We will now remove the power from Dionys.{nl}If we fail, Dionys may escape from here with the power.{nl}
-QUEST_LV_0200_20150401_005800	{memo X}It's going to bring the same result like unleashing tens of demon lords.{nl}You should approach it carefully. Tell me when you are ready.
+QUEST_LV_0200_20150401_005800	{memo X}It's going to bring the same result like unleashing tens of Demon Lords.{nl}You should approach it carefully. Tell me when you are ready.
 QUEST_LV_0200_20150401_005801	{memo X}The direction where Hauberk ran away is the 4th district where Daiva is protecting.{nl}First, go back to the Goddess. I will take care of Dionys.
 QUEST_LV_0200_20150401_005802	{memo X}Savior. You are now ready to know the truth.{nl}The reason why I am just leaving Hauberk like that is because he too is the key to close the space of the metastasis.{nl}
 QUEST_LV_0200_20150401_005803	{memo X}The power that he took away from Dionys is called the chain of revivification.{nl}He was planning to close the space of the metastasis using that chain and the spirit of Hauberk.{nl}
@@ -5881,7 +5881,7 @@ QUEST_LV_0200_20150401_005884	{memo X}Thank you, Revelator. {nl}If all powers ar
 QUEST_LV_0200_20150401_005885	{memo X}It's done. {nl}I hope it works.. Can you give this meat to the pilgrim down below? {nl}{nl}You must feed him until he's satisfied. {nl}It's all the meat that you got. 15 pieces, right?
 QUEST_LV_0200_20150401_005886	{memo X}Do I still look like a stone in your pouch.. {nl}You think this Hauberk will fall just like that!
 QUEST_LV_0200_20150401_005887	{memo X}You were all in this together from the start.. {nl}I was foolish.{nl}But do you think you can take on my powers now!
-QUEST_LV_0200_20150401_005888	About why the revelators are treated well
+QUEST_LV_0200_20150401_005888	About why the Revelators are treated well
 QUEST_LV_0200_20150401_005889	I can do that much
 QUEST_LV_0200_20150401_005890	Reject dirty works
 QUEST_LV_0200_20150401_005891	About the lacking manpower
@@ -6227,7 +6227,7 @@ QUEST_LV_0200_20150406_006230	Thank you very much. {nl}We need to be full to fig
 QUEST_LV_0200_20150406_006231	{memo X}Lastly.. The problem is that the monsters frequently prey on the food storage house. {nl}There is a fella guarding that place but it's constanly exposed to danger.
 QUEST_LV_0200_20150406_006232	The Food Storage is in Vinoga Brewery Site. {nl}Do you think it's already late?
 QUEST_LV_0200_20150406_006233	The warehouse keeper told me to thank you for him. {nl}Oh, if you see my colleagues asking for help, please help them.
-QUEST_LV_0200_20150406_006234	Are you the revelator? {nl}I do hear the news even out here.
+QUEST_LV_0200_20150406_006234	Are you the Revelator? {nl}I do hear the news even out here.
 QUEST_LV_0200_20150406_006235	I'm helping Horacius remove the magic circles of the baron. {nl}If it's alright, can you help me?
 QUEST_LV_0200_20150406_006236	The baron said the strange aura is dangerous and told us not to go near it. {nl}But I don't think so.
 QUEST_LV_0200_20150406_006237	It was similar to the aura I felt from the giant Statue of Goddess Zemyna in Fedimian. {nl}It's like I wonder if it is actually purifying the land instead.
@@ -6309,7 +6309,7 @@ QUEST_LV_0200_20150406_006312	{memo X}That's why I lured the demons with the dem
 QUEST_LV_0200_20150406_006313	{memo X}We should find out whether that is just a symbol or endowned with some kind of power.{nl}First, I want you to collect the toe nails of Lizardmen from the abondoned grape fields.
 QUEST_LV_0200_20150406_006314	{memo X}Lizard men are the monsters that appeared a lot after Medis Diena.{nl}If some kind of power is in this tree, it will definitely react to the toe nails.
 QUEST_LV_0200_20150406_006315	{memo X}Revelator, this is astonishing!{nl}After I put the power of the tree into the toe nails of the monster that you brought, it corroded right away.
-QUEST_LV_0200_20150406_006316	I will also see how this sample would react.{nl}I hope it works out fine.. You also see it revelator!
+QUEST_LV_0200_20150406_006316	I will also see how this sample would react.{nl}I hope it works out fine.. You also see it Revelator!
 QUEST_LV_0200_20150406_006317	Until the master comes, I will prepare for the massive scale purification.{nl}Could you collect five bottles of the fluids of orange Tamas at Kvie Farm?
 QUEST_LV_0200_20150406_006318	The bigger problem we have right now is the monsters instead of the reduced harvests.
 QUEST_LV_0200_20150406_006319	{memo X}Hey you. Revelator. Don't just look at me. Help me.{nl}Please kick out Lizard men on my fields.
@@ -7013,7 +7013,7 @@ QUEST_LV_0200_20150511_007016	{memo X}Hauberk just passed by this way. {nl}I'm s
 QUEST_LV_0200_20150511_007017	Hauberk is also a sinner. {nl}You don't need to sympathize with him.
 QUEST_LV_0200_20150511_007018	Just as I thought. The Monster Suppressor was the problem. {nl}It was to stop the monsters from multiplying but it almost messed up the crops too.
 QUEST_LV_0200_20150511_007019	The bees are a problem but the monsters that came in from the other forest is a bigger problem. {nl}I'm sure they are preying on the honey. {nl}
-QUEST_LV_0200_20150511_007020	Are you the one Joseph was looking for? {nl}Well, it doesn't matter even if you're not. {nl}If you don't help us, then you're no different from the other revelators who ran away. {nl}
+QUEST_LV_0200_20150511_007020	Are you the one Joseph was looking for? {nl}Well, it doesn't matter even if you're not. {nl}If you don't help us, then you're no different from the other Revelators who ran away. {nl}
 QUEST_LV_0200_20150511_007021	There must be fine documents still left in the deeper area of the Cathedral.. {nl}I feel bad about not being able to see it.
 QUEST_LV_0200_20150511_007022	I'm making drugs to cure the pilgrims under curse. {nl}I'm almost done but it's really difficult to get thristles.{nl}
 QUEST_LV_0200_20150511_007023	Whether you have business here or not, you better leave this place if you don't have permission.
@@ -7023,7 +7023,7 @@ QUEST_LV_0200_20150511_007026	It will be better for you to explain it rather tha
 QUEST_LV_0200_20150511_007027	You were the one ransacking the nest so it's your responsibility. {nl}But I also have a reputation so I will reward you for it.
 QUEST_LV_0200_20150511_007028	Better return quickly
 QUEST_LV_0200_20150511_007029	Better meet the priest
-QUEST_LV_0200_20150511_007030	Treating the revelators comes first
+QUEST_LV_0200_20150511_007030	Treating the Revelators comes first
 QUEST_LV_0200_20150511_007031	Better stand back as it's dangerous
 QUEST_LV_0200_20150511_007032	Better give up as it's dangerous
 QUEST_LV_0200_20150511_007033	{memo X}Notice/The magic circle strengthened when you removed the 4 crystals!!#5
@@ -7055,7 +7055,7 @@ QUEST_LV_0200_20150714_007058	Hopefully this can be resolved without causing a c
 QUEST_LV_0200_20150714_007059	For the most part, do try and appease the monk's demands.{nl}We'll assist you wherever we can.
 QUEST_LV_0200_20150714_007060	I'm glad to hear that Natasha is doing well.{nl} I wish you the best at Raoki Swamps.
 QUEST_LV_0200_20150714_007061	Good. So finally the time to retrieve the monastery.{nl}We will be using our power in a such a long time.
-QUEST_LV_0200_20150714_007062	We've reached this far with your help, revelator.{nl}Now we just to have to hope that Evoniphon gets taken care of well. Let's go.
+QUEST_LV_0200_20150714_007062	We've reached this far with your help, Revelator.{nl}Now we just to have to hope that Evoniphon gets taken care of well. Let's go.
 QUEST_LV_0200_20150714_007063	Senior Monk Potos
 QUEST_LV_0200_20150714_007064	What brought you here?{nl}Things are not the way they used to be, but we will try our best to help you.
 QUEST_LV_0200_20150714_007065	I am sorry if you've come here to visit the monastery.{nl}We are like this since the monsters rushed in.
@@ -7129,14 +7129,14 @@ QUEST_LV_0200_20150714_007132	I kinda expected that he would be alright since he
 QUEST_LV_0200_20150714_007133	Please wait beside Mintz for a while.{nl}I should explain everything so it may take little time.
 QUEST_LV_0200_20150714_007134	I've heard about Evoniphon's letter from Guus.{nl}Please wait little more since everything fits the situation.
 QUEST_LV_0200_20150714_007135	We've retrieved the monastery and the Hunters fulfilled what they wanted...{nl}These are all blessings of the goddesses.
-QUEST_LV_0200_20150714_007136	Without your help, I am sure that it would've not gone so easy.{nl}I've heard the stories of many revelators before, but you are the only one I saw in person.
+QUEST_LV_0200_20150714_007136	Without your help, I am sure that it would've not gone so easy.{nl}I've heard the stories of many Revelators before, but you are the only one I saw in person.
 QUEST_LV_0200_20150714_007137	Monk Moheim
 QUEST_LV_0200_20150714_007138	It's so good that we've retrieved the monastery...{nl}But it's a mess.
 QUEST_LV_0200_20150714_007139	Should we get rid of the monsters first or clean this place first...{nl}That's the problem we are facing at the moment.
 QUEST_LV_0200_20150714_007140	Now is the best chance to get Evoniphon.{nl}We are surrounding the monastery so I guess even he would not be able to sneak out.
 QUEST_LV_0200_20150714_007141	You saw Evoniphon?{nl}He is not here. We better go down a bit more.
 QUEST_LV_0200_20150714_007142	Please pray so that we could get Evoniphon.{nl}I wish you the good luck.
-QUEST_LV_0200_20150714_007143	Don't worry revelator. Just go on your way. The people here are just fainted temporarily.{nl}I hope to see you next time for something better instead of Evoniphon.
+QUEST_LV_0200_20150714_007143	Don't worry Revelator. Just go on your way. The people here are just fainted temporarily.{nl}I hope to see you next time for something better instead of Evoniphon.
 QUEST_LV_0200_20150714_007144	I lost many colleagues from Stone Frosts here.{nl}I don't understand why I am here to support a newbie Chronomancer here.
 QUEST_LV_0200_20150714_007145	On top of that, we don't know when those violent monsters would attack here.{nl}I don't care what you do, I just hope those monsters get taken care of.
 QUEST_LV_0200_20150714_007146	We are still sad that we lost our colleagues.{nl}It is very unfortunate that we should take care of that woman in this time.
@@ -7178,11 +7178,11 @@ QUEST_LV_0200_20150714_007181	Not bad.{nl}I guess the rumors don't always get ex
 QUEST_LV_0200_20150714_007182	We are activating the detectors here because of irregular pertrified frosts that are blowing,{nl}but, there are no soldiers who could check that due to a recent battle.{nl}
 QUEST_LV_0200_20150714_007183	So if you could do that for us,{nl}that will be the way to be loyal to the kingdom and continue the determination.
 QUEST_LV_0200_20150714_007184	There are monsters who try to go after the soldiers who maintain the device.{nl}Be careful.
-QUEST_LV_0200_20150714_007185	The stone frosts are to be blown from the two places.{nl}I heard you are a quite famous revelator. Aren't you?{nl}
+QUEST_LV_0200_20150714_007185	The stone frosts are to be blown from the two places.{nl}I heard you are a quite famous Revelator. Aren't you?{nl}
 QUEST_LV_0200_20150714_007186	From some time ago, more soliders are being attacked by Sparnashorn near the detectors.{nl}If you are the one from the rumor, you would be able to face against that monster.{nl}
 QUEST_LV_0200_20150714_007187	Those soldiers are the ones who survived from the Stone Frosts and Sparnashorn.{nl}They can't fight against Sparnashorn since they are blind due to fear. They also have no chance of defeating Sparnashorn.
 QUEST_LV_0200_20150714_007188	The Stone Frosts are delayed a bit.{nl}Whatever we do, there is no way to block the punishements that were brought by Ruklys.
-QUEST_LV_0200_20150714_007189	Now the only thing that is remaining is Sparnashorn... Defeat it quickly and get outta from there.{nl}Even a greateste revelator would not withstand the Stone Frosts.
+QUEST_LV_0200_20150714_007189	Now the only thing that is remaining is Sparnashorn... Defeat it quickly and get outta from there.{nl}Even a greateste Revelator would not withstand the Stone Frosts.
 QUEST_LV_0200_20150714_007190	Retreating is also a tactic, but we can't always do it.{nl}We should finish it when we have an volunteer who is loyal and competent like you.
 QUEST_LV_0200_20150714_007191	Hearing that it was defeated is the most hopeful story I've heard in years. {nl}Now I better let the troops rest first and tell them the good news.
 QUEST_LV_0200_20150714_007192	Although I don't know you, I am glad to see you.{nl}It's good to be acquainted with someone here. Everyone should help each other out.{nl}
@@ -7452,13 +7452,13 @@ QUEST_LV_0200_20150714_007455	It is illegal to take the artifiacts, records or r
 QUEST_LV_0200_20150714_007456	Once you get attacked by the Stone Frosts, everything will be over.{nl}We've lost many of our colleagues due to the Stone Frosts.
 QUEST_LV_0200_20150714_007457	Many famous scholars or magicians that belonged to the kingdom weren't able to lift the curse of the petrification...{nl}I don't understand how a Kaliss Knight would lift the curse.
 QUEST_LV_0200_20150714_007458	The relationship between the kingdom soldiers and Kaliss Knitage is somewhat irregular.{nl}Please refrain from doing something forbidden even if you received a request from Kaliss Knightage.
-QUEST_LV_0200_20150714_007459	The rules of the kingdom army comes first here.{nl}Even if you are the revelator from the rumors.;
+QUEST_LV_0200_20150714_007459	The rules of the kingdom army comes first here.{nl}Even if you are the Revelator from the rumors.;
 QUEST_LV_0200_20150714_007460	Even if you've received a request from the Kaliss Knightage, the orders of the kingdom army comes first.{nl}Our words are the laws here.
 QUEST_LV_0200_20150714_007461	I am irritated by the kingdom soldiers, but then those Dico thieves appeared.{nl}How come there are so many people in this small space.
 QUEST_LV_0200_20150714_007462	I can't endure anymore. Please save me from these restraints.{nl}I will be released when you defeat the watchers nearby.
 QUEST_LV_0200_20150714_007463	$My name is Agailla Flurry. {nl}I have realized something from the epitaphs left in the land and I would like to make a confession.
 QUEST_LV_0200_20150714_007464	How foolish it is to be overconfident and be swayed by shallow feelings. {nl}You, who lives through such times, must have realized something like I did.{nl}
-QUEST_LV_0200_20150714_007465	All other revelators were wrong.{nl}But if it were you.. I don't know.
+QUEST_LV_0200_20150714_007465	All other Revelators were wrong.{nl}But if it were you.. I don't know.
 QUEST_LV_0200_20150714_007466	I will return to my hometown with my son.{nl}Yes. For sure.
 QUEST_LV_0200_20150714_007467	I can't close my eyes before we defeat that monster.
 QUEST_LV_0200_20150714_007468	I never expected to see someone in this spooky place. I guess you are very competent.{nl}I am continuing the research of my master here. I guess I can be called a scholar.{nl}
@@ -7483,10 +7483,10 @@ QUEST_LV_0200_20150714_007486	Maybe, it turned out better than we thought.{nl}I 
 QUEST_LV_0200_20150714_007487	The master researched about the goddesses throughout his entire life.{nl}And then he discovered something important, but he said if it goes into the hands of the demons, it will be dangerous.{nl}
 QUEST_LV_0200_20150714_007488	As you saw, Raius is trying to find the remains of the research of the master due to his greed.{nl}But, they should never be exposed to the world.
 QUEST_LV_0200_20150714_007489	Ahah. Revelator. Maybe...{nl}The master said someone who is reliable should dispose of his research before he died.{nl}
-QUEST_LV_0200_20150714_007490	And the remains of the research are at the place where normal people like me or Raius can not reach.{nl}If you are really the revelator, I want you to dispose of them.
+QUEST_LV_0200_20150714_007490	And the remains of the research are at the place where normal people like me or Raius can not reach.{nl}If you are really the Revelator, I want you to dispose of them.
 QUEST_LV_0200_20150714_007491	In order to find the remains of the research, we need the eyes of the truth.{nl}But, not too long ago, they were destroyed due to monsters.
 QUEST_LV_0200_20150714_007492	With the guide stone of the wisdom you have, you would be able to find the monster that has the eyes of the truth.
-QUEST_LV_0200_20150714_007493	Even if you are not the revelator, I am counting on you.{nl}I know the guide stone of the wisdom can't be obtained that easily.
+QUEST_LV_0200_20150714_007493	Even if you are not the Revelator, I am counting on you.{nl}I know the guide stone of the wisdom can't be obtained that easily.
 QUEST_LV_0200_20150714_007494	Good. With this, we've restored the eyes of the truth completely.
 QUEST_LV_0200_20150714_007495	Okay. With these eyes of the truth, we will find the crystal of the spirit.{nl}It is little complicated, but please think that is it is that important.{nl}
 QUEST_LV_0200_20150714_007496	Shadowgaoler in the Room of Lamentation has the Crystal of the Spirit, but you can't attack it with an usual method.{nl}It has an astral body so it is invisible.{nl}However, with the eyes of the truth, you would be able to see it.
@@ -7634,10 +7634,10 @@ QUEST_LV_0200_20150714_007637	So, I will give you a bait box.{nl}They go crazy o
 QUEST_LV_0200_20150714_007638	When you find the sticky resin, please mix it with this coagulant before using it.{nl}Stones will be easily attached.
 QUEST_LV_0200_20150714_007639	{memo X}
 QUEST_LV_0200_20150714_007640	Ah. It definitely reacted this time.{nl}I would have spent a long time without your help. Thank you so much.
-QUEST_LV_0200_20150714_007641	Thanks for helping us.{nl}The goddess help the ones who try their best, and I think it was you, the revelator.
+QUEST_LV_0200_20150714_007641	Thanks for helping us.{nl}The goddess help the ones who try their best, and I think it was you, the Revelator.
 QUEST_LV_0200_20150714_007642	Lots of demons are gathering at Rituala to paricipate the ritual to free Bluts.{nl}Please first defeat them.
 QUEST_LV_0200_20150714_007643	Valtruss is defeated but its servants are still left in Orualma Grand Hall. {nl}I want you to let those demons pay for their sins.
-QUEST_LV_0200_20150714_007644	Even if you are the revelator, you better not fool around. {nl}The pollution is not something for you to mind.
+QUEST_LV_0200_20150714_007644	Even if you are the Revelator, you better not fool around. {nl}The pollution is not something for you to mind.
 QUEST_LV_0200_20150714_007645	I wish you luck in the name of the Goddess.
 QUEST_LV_0200_20150714_007646	I am solely to blame for it.{nl}With the Key of the Night Star, three seals should be unleashed so I could recover my power to find Dionys.
 QUEST_LV_0200_20150714_007647	The space of the metastasis... We can't close it without Dionys.{nl}Please find Dionys until I recover my power...
@@ -7649,7 +7649,7 @@ QUEST_LV_0200_20150714_007652	Death of death... what does that mean.{nl}Do you h
 QUEST_LV_0200_20150714_007653	Amanda
 QUEST_LV_0200_20150714_007654	{memo X}Let's see
 QUEST_LV_0200_20150714_007655	{memo X}
-QUEST_LV_0200_20150714_007656	The monsters ruined the beefarm and the brewery.{nl}So Jozef went to Klaipeda to look for revelators who could help us. {nl}
+QUEST_LV_0200_20150714_007656	The monsters ruined the beefarm and the brewery.{nl}So Jozef went to Klaipeda to look for Revelators who could help us. {nl}
 QUEST_LV_0200_20150714_007657	I thought the problem would be solved but guess what happened.{nl}They started disappearing one by one. They backed out. Those cowards.
 QUEST_LV_0200_20150714_007658	If you think you are ready, I will show you the true nature of the curse.{nl}If you can't eliminate it at once, it will make a bigger trouble.
 QUEST_LV_0200_20150714_007659	But, there is still a way.{nl}If you could help me.
@@ -7658,7 +7658,7 @@ QUEST_LV_0200_20150714_007661	It's done. {nl}I hope it works.. Can you give this
 QUEST_LV_0200_20150714_007662	You must feed him until he's satisfied.{nl}It's all the meat that you got. 15 pieces, right?
 QUEST_LV_0200_20150714_007663	Are the peaceful days going to return like the old times?
 QUEST_LV_0200_20150714_007664	I want to bury Dalus under the Ramivi Cliffs where he can see his hometown.{nl}But there are so many monsters there. Please get rid of them.
-QUEST_LV_0200_20150714_007665	Aren't you the revelator?{nl}
+QUEST_LV_0200_20150714_007665	Aren't you the Revelator?{nl}
 QUEST_LV_0200_20150714_007666	Ah, so fortunate. Then, you must have traveled various places in the kingdom.{nl}I am sorry, but do you know anything about the mysterious girl?{nl}
 QUEST_LV_0200_20150714_007667	The girl left these trees before the day of divine tree.{nl}My master asked me to find about the trees, but I knew nothing about them... I want to get help from you.
 QUEST_LV_0200_20150714_007668	This farm's owner is Gina Green.{nl}They kindly lend this farm to us who lost the land since the day of Divine Tree.
@@ -7666,13 +7666,13 @@ QUEST_LV_0200_20150714_007669	Hey you. Revelator. Don't just look at me. Help me
 QUEST_LV_0200_20150714_007670	You must know that there isn't enough food in the kingdom.{nl}If you are okay, can you help me with my investigation?
 QUEST_LV_0200_20150714_007671	That's really appreciated.[nl}Firstly, collect the lumps of hair from Rambear Archers. I have something to check.
 QUEST_LV_0200_20150714_007672	If that's the case, please eliminate all short trees.{nl}Ah, don't forget to bring the evidences as well. I need something to report.
-QUEST_LV_0200_20150714_007673	Even if you are the revelator, this is a private land. {nl}Go out if you don't have any business here!{nl}
+QUEST_LV_0200_20150714_007673	Even if you are the Revelator, this is a private land. {nl}Go out if you don't have any business here!{nl}
 QUEST_LV_0200_20150714_007674	Damn!{nl}Monsters came after smelling the polluted grape vines dried to their deathes.{nl}What should we do?
 QUEST_LV_0200_20150714_007675	If you go near the bushes, the hidden monsters may suddenly appear.{nl}I am counting on you.
 QUEST_LV_0200_20150714_007676	More monsters will appear when you shake the bushes.
-QUEST_LV_0200_20150714_007677	I paid a lot for this from the black market in Fedimian.{nl}It will be much more helpful than the revelator like you or those shameless druids.{nl}
+QUEST_LV_0200_20150714_007677	I paid a lot for this from the black market in Fedimian.{nl}It will be much more helpful than the Revelator like you or those shameless druids.{nl}
 QUEST_LV_0200_20150714_007678	This is sturdy. You've been suffered by the trap of Evoniphon.{nl}But, what have brought you here?{nl}
-QUEST_LV_0200_20150714_007679	You were the revelator? It's so nice to meet you.{nl}Thanks for saving me... I have another request for you.
+QUEST_LV_0200_20150714_007679	You were the Revelator? It's so nice to meet you.{nl}Thanks for saving me... I have another request for you.
 QUEST_LV_0200_20150714_007680	We are doing an important mission at the moment.
 QUEST_LV_0200_20150714_007681	It's little complicated. We are chasing after Evoniphon who is the suspect of the murder case at the Tower of the Stars.{nl}But, this guys is being protected by the religious rules at the monastery near here.{nl}
 QUEST_LV_0200_20150714_007682	So please help us to get Evoniphon.{nl}We should somehow first persuade the monks...
@@ -8552,7 +8552,7 @@ QUEST_LV_0200_20150714_008555	Hunter Commander, Mintz went to the central part o
 QUEST_LV_0200_20150714_008556	Hunter Commander, Mintz wants you to cooperate with him for saving you. Listen for more details.
 QUEST_LV_0200_20150714_008557	Talk with the senior monk, Potos
 QUEST_LV_0200_20150714_008558	Hunter Commander, Mintz wants the monks to cooperate with Hunters, but it's not working alright. Persuade the senior monk Potos on behalf of him.
-QUEST_LV_0200_20150714_008559	The senior monk, Potos has some request to the revelator. Talk with him.
+QUEST_LV_0200_20150714_008559	The senior monk, Potos has some request to the Revelator. Talk with him.
 QUEST_LV_0200_20150714_008560	Cure the addicted monk after talking to Hunter Commander, Mintz
 QUEST_LV_0200_20150714_008561	Find a way to cure the addictied monks from the comnander, Mintz, and cure them.
 QUEST_LV_0200_20150714_008562	The antidote of Mintz is effective to the addicted monks. Return to Potos and let him know.
@@ -8885,7 +8885,7 @@ QUEST_LV_0200_20150729_008888	The Seal Stone will just scatter away when release
 QUEST_LV_0200_20150729_008889	Defeat the Flask Mage and get the Crystal of Restriction
 QUEST_LV_0200_20150729_008890	{memo Why is there a memo x, if this is used in the game?} {memo X}The spirit of the Sealed Stone wants to be freed from the seal. Gather the Crystal of Restriction from the Flask Mage and break them.
 QUEST_LV_0200_20150729_008891	{memo X}The Weak Owl wants you to find other owls that the monsters took away. Find the traces of owl statue in the monster's hideaway locate at the end of Ishrai Crossroads.
-QUEST_LV_0200_20150729_008892	$Pilgrim Lylia told you that she is very hungry and asked you to get her some food. Get some edible meat from Kepo.
+QUEST_LV_0200_20150729_008892	$Pilgrim Liliya told you that she is very hungry and asked you to get her some food. Get some edible meat from Kepo.
 QUEST_LV_0200_20150729_008893	Get the meat of Kepari
 QUEST_LV_0200_20150729_008894	Pilgrim Julius can't move due to severe hunger. Get some Kepari meat for him to eat.
 QUEST_LV_0200_20150729_008895	Got enough Kepari meat. Give it to Pilgrim Julius.
@@ -8931,8 +8931,8 @@ QUEST_LV_0200_20150908_008934	Thank you for freeing me.
 QUEST_LV_0200_20150908_008935	Now I'm really released.
 QUEST_LV_0200_20150908_008936	Go upstairs and find Goddess Gabija!
 QUEST_LV_0200_20150908_008937	$The Mushwort that destroyed the Owl Sculpture appeared!
-QUEST_LV_0200_20150908_008938	Lylia passed away. {nl}Make a grave for her.
-QUEST_LV_0200_20150908_008939	Made a grave for Lylia
+QUEST_LV_0200_20150908_008938	Liliya passed away. {nl}Make a grave for her.
+QUEST_LV_0200_20150908_008939	Made a grave for Liliya
 QUEST_LV_0200_20150908_008940	Searching through the rottem meat
 QUEST_LV_0200_20150908_008941	Found food waste from the food pile! {nl}Throw it to the monsters using V key and defeat it!
 QUEST_LV_0200_20150908_008942	Successfully destroyed Tree Root Crystal! {nl}The curse laid around will disappear!
@@ -9078,10 +9078,10 @@ QUEST_LV_0200_20150918_009081	However, do me a favor and I'll give you some equi
 QUEST_LV_0200_20150918_009082	We don't ask for a lot. {nl} You can see this in the signs the pilgrims make along Starving Demon's Way.
 QUEST_LV_0200_20150918_009083	If not, then we don't have a choice. {nl} If we can, we will mutually profit.
 QUEST_LV_0200_20150918_009084	You've come to want something, huh? {nl} An interesting life really depends on reckless challenges, huh?
-QUEST_LV_0200_20150918_009085	{memo X}$Well, well. What have I been doing? {nl} Oh, my Lylia...{nl}
+QUEST_LV_0200_20150918_009085	{memo X}$Well, well. What have I been doing? {nl} Oh, my Liliya...{nl}
 QUEST_LV_0200_20150918_009086	$Her music box and necklace were snatched by Naktis' subordinates, and infused with Naktis' curse. It's as if they are trying to mock Maven's teachings.
 QUEST_LV_0200_20150918_009087	$Hold on a sec, my head's ringing again from that curse. {nl} There's still so much to say... I don't know if I will be able to handle it right now.
-QUEST_LV_0200_20150918_009088	$Thank you very much. It's really gotten better. {nl} The music box.. My Lylia.. She may no longer be in this world. {nl}
+QUEST_LV_0200_20150918_009088	$Thank you very much. It's really gotten better. {nl} The music box.. My Liliya.. She may no longer be in this world. {nl}
 QUEST_LV_0200_20150918_009089	$If you run into any Naktis' possessions, please be sure to carefully inspect them for her sake. {nl} The symbol of our love that the demon swallowed... Please accept it as our gratitude for helping us claim revenge.
 QUEST_LV_0200_20150918_009090	$That symbol is a necklace blessed by the Cathedral, so it must be very useful. {nl} To me, that necklace no longer holds any meaning.
 QUEST_LV_0200_20150918_009091	$Thanks for your words.{nl}I would really appreciate it if you could defeat the monsters here that are disturbing me.
@@ -9111,14 +9111,14 @@ QUEST_LV_0200_20150918_009114	Worrying Owl at Ishrai Crossroads
 QUEST_LV_0200_20150918_009115	$Grita said in order to activate the Tower's Barrier Device again, it would need a great amount of energy. Set the gem Grita gave you on the ground and recharge the gem with the monsters' life force.
 QUEST_LV_0200_20150918_009116	$The Weak Owl Sculpture told you to find his Owl colleagues.{nl}Look for them at the monster hideout towards the right side of Ishrai Crossroads. 
 QUEST_LV_0200_20150918_009117	$The Destroyed Owl Sculpture was completely destroyed. Tell the Weak Owl Sculpture what happened.
-QUEST_LV_0200_20150918_009118	The pilgrim, Julious suddenly turned into a Draferiun after seeing the music box. Calm down the Draferiun that is attacking and reduce HP under 50% and persuade him.
+QUEST_LV_0200_20150918_009118	Pilgrim Julius suddenly turned into a Draperion after seeing the music box. Calm down the Draperion that is attacking and reduce its HP below 50% to persuade him.
 QUEST_LV_0200_20150918_009119	Destroy the protecting stone of the tree root crystal of the curse
 QUEST_LV_0200_20150918_009120	Talk with the restrained spirit
-QUEST_LV_0200_20150918_009121	Check Veinika altar
-QUEST_LV_0200_20150918_009122	Check Veinika altar
-QUEST_LV_0200_20150918_009123	Defeat the monsters at Ramivie Cliffs
-QUEST_LV_0200_20150918_009124	Ramivie Cliffs seem safe. Talk to the pilgrim Orville.
-QUEST_LV_0200_20150918_009125	The pilgrim Orville went to Ramivie Cliffs to bury his friend. Follow him to Ramivie Cliffs.
+QUEST_LV_0200_20150918_009121	Check the Veinika Altar
+QUEST_LV_0200_20150918_009122	Check the Veinika Altar
+QUEST_LV_0200_20150918_009123	Defeat the monsters at Ramybe Cliff
+QUEST_LV_0200_20150918_009124	Ramybe Cliff seems to be safe. Talk to Pilgrim Orville.
+QUEST_LV_0200_20150918_009125	The pilgrim Orville went to Ramybe Cliff to bury his friend. Follow him to Ramybe Cliff.
 QUEST_LV_0200_20150918_009126	The tenant Vice hid the seeds that he secretly grew, but he can't go get them due to the monsters. Please bring the seed pocket from the farm square.
 QUEST_LV_0200_20151001_009127	If I am going to fall down tomorrow, I don't care if I risk my life today.
 QUEST_LV_0200_20151001_009128	I am sure that they brought them to Drasa Worship Ruins, but since we can't leave this place, we are going to die due to hunger.{nl}I am sorry, but can you retrieve the stolen supplies for us?
@@ -9127,7 +9127,7 @@ QUEST_LV_0200_20151001_009130	Would dead people come back if the curse is cured 
 QUEST_LV_0200_20151001_009131	I understand their loyalty for the kingdom, but when I see them make people do impossible things that lead to deaths...{nl}I don't know who is the monster anymore.
 QUEST_LV_0200_20151001_009132	If you could help me...{nl}Maybe we could save them even if they are cursed with the petrification. Although they may lose their arms.
 QUEST_LV_0200_20151001_009133	Did you defeat it? Great job!{nl}Now I don't have to fear this place being torn down until another monster shows up.
-QUEST_LV_0200_20151001_009134	Have you met Wilhelmina at Kovos Hall before?{nl}She is in charge of Kaliss knightage, but she is full of hatred towards the kingdom soldiers.{nl}
+QUEST_LV_0200_20151001_009134	Have you met Wilhelmina at Kovos Hall before?{nl}She is in charge of the Kaliss Knightage, but she is full of hatred towards the kingdom soldiers.{nl}
 QUEST_LV_0200_20151001_009135	We are in a good relationship with her since we work well together.{nl}We were able to plan this since she helped us well.{nl}
 QUEST_LV_0200_20151001_009136	Can you hand over the records to Wilhelmina that you've brought?{nl}We told them that we would help penetrate into Gargoyle so don't forget to receive something before you come here. 
 QUEST_LV_0200_20151001_009137	Finally, the records which weren't in hands of the kingdom soldiers are here.{nl}
@@ -9157,15 +9157,15 @@ QUEST_LV_0200_20151001_009160	Very nice indeed.{nl}You have no problem understan
 QUEST_LV_0200_20151001_009161	The Thaumaturge Master told me to give it to you.{nl}If you hadn't done it, I would have kept it for myself.. Such a pity.
 QUEST_LV_0200_20151001_009162	I don't really mind the rumours but do people believe that spell can retain your youth? {nl}Well, maybe it can but.. {nl}Ah, I don't want to talk about it anymore.
 QUEST_LV_0200_20151001_009163	For the people who go on the way of the pilgrim with hope, this curse is so much pain for them.{nl}We don't even know the true nature of the curse so I am so mad.
-QUEST_LV_0200_20151001_009164	I was so mad that I am not a revelator before.{nl}But, after listening that some revelator saved Mage Tower, my thought changed.{nl}
+QUEST_LV_0200_20151001_009164	I was so mad that I am not a Revelator before.{nl}But, after listening that some Revelator saved Mage Tower, my thought changed.{nl}
 QUEST_LV_0200_20151001_009165	When they complete their duties and I complete my duties, I think the goddess may com back.
-QUEST_LV_0200_20151001_009166	I didn't expect that the true nature of the curse that is fallen down on this forest is going after the great cathedral.{nl}Fortunatlely, we were able to block the curse due to one revelator, but I feel ashamed.
+QUEST_LV_0200_20151001_009166	I didn't expect that the true nature of the curse that is fallen down on this forest is going after the great cathedral.{nl}Fortunately, we were able to block the curse due to one Revelator, but I feel ashamed.
 QUEST_LV_0200_20151001_009167	The curse here is serious, but there are other places where the influences of the curse are more severe. {nl}The city of Ruklys... I heard everything turns into stones due to the curse of the petrification.
-QUEST_LV_0200_20151001_009168	I think it was my fault that I went out of Mage Tower to save the people after the day of divine tree.{nl}Maybe, I could save the tower and not the revelator.
-QUEST_LV_0200_20151001_009169	I heard the story about the revaltor who blocked the demon lord who casted the curse in this region.{nl}I guess... there won't be any more people who would suffer from the curse.
+QUEST_LV_0200_20151001_009168	I think it was my fault that I went out of Mage Tower to save the people after the day of divine tree.{nl}Maybe, I could save the tower and not the Revelator.
+QUEST_LV_0200_20151001_009169	I heard the story about the revaltor who blocked the Demon Lord who casted the curse in this region.{nl}I guess... there won't be any more people who would suffer from the curse.
 QUEST_LV_0200_20151001_009170	I've been to many places before in my life, but this place is really horrible.{nl}Even if I want to rescue the ones who are cursed, the only thing I can do is to help them fall asleep comfortably.
-QUEST_LV_0200_20151001_009171	I heard a revelator defeated the demon lord who were attacking the Mage Tower.{nl}That's the most happy news I've heard lately.{nl}Other news I've heard were horrible.
-QUEST_LV_0200_20151001_009172	Is it true that some revelator defeated the demon lord who casted the curse in this region?{nl}If that's true, it is so fortunate since we don't have to see these horrible things again.
+QUEST_LV_0200_20151001_009171	I heard a Revelator defeated the Demon Lord who were attacking the Mage Tower.{nl}That's the most happy news I've heard lately.{nl}Other news I've heard were horrible.
+QUEST_LV_0200_20151001_009172	Is it true that some Revelator defeated the Demon Lord who casted the curse in this region?{nl}If that's true, it is so fortunate since we don't have to see these horrible things again.
 QUEST_LV_0200_20151001_009173	Damn. What was I doing?{nl}Ahah. My Liliya...{nl}
 QUEST_LV_0200_20151001_009174	Do not bother the placed food piles.{nl} They should have shuffled over here by now... just keep watching.
 QUEST_LV_0200_20151001_009175	While my brothers were on the their way to the training, they all died due to the tricks from the demons.{nl}I feel sorry for my brothers who can't return to the godddesses.{nl}
@@ -9210,13 +9210,13 @@ QUEST_LV_0200_20151001_009213	The demons didn't have special objects.{nl}What...
 QUEST_LV_0200_20151001_009214	Revelator. {nl}After the day of divine tree, Vakarine have become weak so we have to protect her.
 QUEST_LV_0200_20151001_009215	This is not the world of humans nor the world of demons, but another space of Vakarine...{nl}We've locked the demons inside this prison who are evil to this world.{nl}
 QUEST_LV_0200_20151001_009216	But, after the day of divine tree, Vakarine doesn't have any power left to maintain this space.{nl}As you can see, the space is gradually collapsing and the space of the metastasis has gotten widen.{nl}
-QUEST_LV_0200_20151001_009217	The demon lords who are locked in this prison are trying to escape here.{nl}The demons who came here through the metastasis are joining as well.{nl}
+QUEST_LV_0200_20151001_009217	The Demon Lords who are locked in this prison are trying to escape here.{nl}The demons who came here through the metastasis are joining as well.{nl}
 QUEST_LV_0200_20151001_009218	Vakarine desperately needs your help.{nl}Please help defeating the demons at the prison.
-QUEST_LV_0200_20151001_009219	Please first block the demons that are trying to release the demon lord, Blut that is locked here.
-QUEST_LV_0200_20151001_009220	The subordinates of Blut are trying to escape here. {nl}Haubuck's help will be useful this time.
+QUEST_LV_0200_20151001_009219	Please first block the demons that are trying to release the Demon Lord, Blut that is locked here.
+QUEST_LV_0200_20151001_009220	The subordinates of Blut are trying to escape here. {nl}Hauberk's help will be useful this time.
 QUEST_LV_0200_20151001_009221	Right now, Blut is holding Kupole Giderone. {nl}But, since the power of Vakarine has weakend after the day of divine tree, we are not like before.{nl}
 QUEST_LV_0200_20151001_009222	Fortunately, Blut hasn't been completely freed...{nl}But, we don't know how much longer we would endure ourselves.{nl}
-QUEST_LV_0200_20151001_009223	We have to somehow weaken the power of the demon lord, Blut.{nl}I am sure his allies set the camp near Byeaulleo Hideout.{nl}Please get the symbol of Blut that they have.
+QUEST_LV_0200_20151001_009223	We have to somehow weaken the power of the Demon Lord, Blut.{nl}I am sure his allies set the camp near Byeaulleo Hideout.{nl}Please get the symbol of Blut that they have.
 QUEST_LV_0200_20151001_009224	Our original duty was to supervise and manage the prison originally.{nl}But... now, we are trying out best to block the demons. {nl}No matter what it takes.
 QUEST_LV_0200_20151001_009225	So you are the one who Vakarine talked about.{nl}Well done. Everything will be done with the wishes of the goddesses.
 QUEST_LV_0200_20151001_009226	We've locked Blut across this wall.{nl}
@@ -9224,34 +9224,34 @@ QUEST_LV_0200_20151001_009227	There' no way that Blut knows the proson more than
 QUEST_LV_0200_20151001_009228	But, if we don't defeat Blut quickly, this wall would collpase soon.{nl}Let's defeat it at once. Are you ready?{nl}
 QUEST_LV_0200_20151001_009229	We were able to defeat Blut because of you.{nl}You brought us the hope to us.{nl}
 QUEST_LV_0200_20151001_009230	As you know, the powrer of Vakarine is... really weak at the moment.{nl}If we had not defeated Blut here, we wouldn't have protected Vakarine.{nl}
-QUEST_LV_0200_20151001_009231	Okay. Go to the 2nd district of the prison.{nl}To defeat the next demon lord, I am sure Kupol Arune has prepared something.
+QUEST_LV_0200_20151001_009231	Okay. Go to the 2nd district of the prison.{nl}To defeat the next Demon Lord, I am sure Kupol Arune has prepared something.
 QUEST_LV_0200_20151001_009232	The demons that lost Blut are causing a rampage. {nl}If they escape to the outside world, then it will be a great disaster.
 QUEST_LV_0200_20151001_009233	The space is gradually collapsing.{nl}I don't know what would happen even if we defeated the demons...
 QUEST_LV_0200_20151001_009234	Good work. {nl}It's a relief that those demons did not notice the barrier weakening.
 QUEST_LV_0200_20151001_009235	Human exploration teams came in from the outside world in the past. {nl}Unfortunately, they died before we could do anything. {nl}
 QUEST_LV_0200_20151001_009236	Humans should not come here.
-QUEST_LV_0200_20151001_009237	You are the revelator who Vakarine talked about. {nl}It is so fortunate that you are not late.{nl}
-QUEST_LV_0200_20151001_009238	The power of the demon lord, Nuaele is weakening the prison more fast.{nl}But, there's no way to blcok Nuaele with just us Kupols.{nl}
-QUEST_LV_0200_20151001_009239	And Kupol Aldona told us that they can't just wait for the revelator...{nl}Without the time for persuasion, she followed after Nuaele.
+QUEST_LV_0200_20151001_009237	You are the Revelator who Vakarine talked about. {nl}It is so fortunate that you are not late.{nl}
+QUEST_LV_0200_20151001_009238	The power of the Demon Lord, Nuaele is weakening the prison more fast.{nl}But, there's no way to blcok Nuaele with just us Kupols.{nl}
+QUEST_LV_0200_20151001_009239	And Kupol Aldona told us that they can't just wait for the Revelator...{nl}Without the time for persuasion, she followed after Nuaele.
 QUEST_LV_0200_20151001_009240	Please block the demons that are coming over through the space of the metastasis.{nl}If you could block them before they join Nuaele, it will be great help to the safety of Aldona.
 QUEST_LV_0200_20151001_009241	Goddess.{nl}I hope nothing occurs to Aldona...
 QUEST_LV_0200_20151001_009242	Since her force was cut down, Nuaele's power will be weakened.{nl}Before anything happens to Aldona, I will tell you what to do next.
-QUEST_LV_0200_20151001_009243	Nuaele is hard to face against by us.{nl}But, Nuaele wasn't that strong demon lord.{nl}
-QUEST_LV_0200_20151001_009244	Nuaele got strong after obtaining the pieces of the seal of Haubuck. {nl}The subordinates that lost their master started to follow her since she had the pieces of the seal.{nl}
-QUEST_LV_0200_20151001_009245	Since then, Nuales started use her mighty power,{nl}To Haubuck, she was like a traitor.{nl}
-QUEST_LV_0200_20151001_009246	By using that, there is a way to increase the power of Haubuck.{nl}It wouldn't be a bad suggestion to Haubuck.
-QUEST_LV_0200_20151001_009247	Please go to the 2nd isolated district. {nl}I am sure the subordinates of Haubuck are gathered there.
-QUEST_LV_0200_20151001_009248	I am sure the demon lord, Nuaele knows well about it now.{nl}The power of the others can't be her.
+QUEST_LV_0200_20151001_009243	Nuaele is hard to face against by us.{nl}But, Nuaele wasn't that strong Demon Lord.{nl}
+QUEST_LV_0200_20151001_009244	Nuaele got strong after obtaining the pieces of the seal of Hauberk. {nl}The subordinates that lost their master started to follow her since she had the pieces of the seal.{nl}
+QUEST_LV_0200_20151001_009245	Since then, Nuales started use her mighty power,{nl}To Hauberk, she was like a traitor.{nl}
+QUEST_LV_0200_20151001_009246	By using that, there is a way to increase the power of Hauberk.{nl}It wouldn't be a bad suggestion to Hauberk.
+QUEST_LV_0200_20151001_009247	Please go to the 2nd isolated district. {nl}I am sure the subordinates of Hauberk are gathered there.
+QUEST_LV_0200_20151001_009248	I am sure the Demon Lord, Nuaele knows well about it now.{nl}The power of the others can't be her.
 QUEST_LV_0200_20151001_009249	But... there's something that keeps attracting my attention.{nl}In fact, if we only have the power collected by Nuaele, we may try escaping immediately.{nl}
 QUEST_LV_0200_20151001_009250	But, it seems that Nuaele is waiting for something.{nl}We should find out what they are planning.{nl}{nl}
-QUEST_LV_0200_20151001_009251	Please interrogate the subordinates of Nuaele.{nl}Since Haubuck is also a demon, it will be easy to read it's minds.{nl}Also if that's a spirit, it will be more easy.
+QUEST_LV_0200_20151001_009251	Please interrogate the subordinates of Nuaele.{nl}Since Hauberk is also a demon, it will be easy to read it's minds.{nl}Also if that's a spirit, it will be more easy.
 QUEST_LV_0200_20151001_009252	She planned to make this prison her world from the start. {nl}If her plans succeeded, even if Goddess Vakarine powers were restored, it would not have been enough.
 QUEST_LV_0200_20151001_009253	Go meet Aldona. {nl}He would take you to the area of Nuaele.
 QUEST_LV_0200_20151001_009254	Vakarine is waiting for you at the 3rd district.{nl}But, I feel somewhat uneasy since she is so stubborn.
 QUEST_LV_0200_20151001_009255	In the past, she told us that she can't just do nothing even if her power was weakened.{nl}We barely managed to persuade her.{nl} 
 QUEST_LV_0200_20151001_009256	To prevent something happening to Vakarine, please move to 3rd district as quickly as possible.{nl}
-QUEST_LV_0200_20151001_009257	The space of the metastasis and the demon lords... they were expected.{nl}I could feel my power was getting weak after the day of divine tree and I had to find another way.{nl}
-QUEST_LV_0200_20151001_009258	I've given Dionis the power that should not be stolen by the demon lord.{nl}But, that power was so strong so it started to dominate Dionis...{nl}
+QUEST_LV_0200_20151001_009257	The space of the metastasis and the Demon Lords... they were expected.{nl}I could feel my power was getting weak after the day of divine tree and I had to find another way.{nl}
+QUEST_LV_0200_20151001_009258	I've given Dionis the power that should not be stolen by the Demon Lord.{nl}But, that power was so strong so it started to dominate Dionis...{nl}
 QUEST_LV_0200_20151001_009259	I can't tell you about the power in details at the moment.{nl}But, please just know that the power that is controlling Dionis is the only way to close the space of the metastasis.{nl}
 QUEST_LV_0200_20151001_009260	Please complete the Evening Star Key with Kupole Giderone.{nl}With the Evening Star Key, Dionis would withdraw that power.
 QUEST_LV_0200_20151001_009261	Savior!{nl}I was waiting for you. {nl}
@@ -9267,42 +9267,42 @@ QUEST_LV_0200_20151001_009270	You are not late!{nl}Let's release the power of th
 QUEST_LV_0200_20151001_009271	When you unleash the seal, the power that is indwelled in the key will be collected to the magic suppressor.{nl}I want you to unleash Rwalda, Casa, and Rada seals. 
 QUEST_LV_0200_20151001_009272	Dionis is not someone we can face against.{nl}Even Vakarine in her old days would not be able to do anything.
 QUEST_LV_0200_20151001_009273	The power of the evening star key is accumulating in the magical suppressor.{nl}We are all ready and we have enough time.
-QUEST_LV_0200_20151001_009274	We are going to detach the power from Dionis from now on.{nl}If we fail, it would bring the same result as if tens of demon lords are on the loose.{nl}
+QUEST_LV_0200_20151001_009274	We are going to detach the power from Dionis from now on.{nl}If we fail, it would bring the same result as if tens of Demon Lords are on the loose.{nl}
 QUEST_LV_0200_20151001_009275	We need to approach it with caution. {nl}Let me know when you are ready.
-QUEST_LV_0200_20151001_009276	Haubuck ran towards 4th prison which is protected by Daiva. {nl}First, you should return to the Vakarine. I will look after Dionis.
+QUEST_LV_0200_20151001_009276	Hauberk ran towards 4th prison which is protected by Daiva. {nl}First, you should return to the Vakarine. I will look after Dionis.
 QUEST_LV_0200_20151001_009277	Savior. {nl}You are now ready to know the truth.{nl}The power which I gave to Dionis is called the chain of the returning.{nl}
-QUEST_LV_0200_20151001_009278	The chain of the returning is the wonder which connects every boundaries or return...{nl}Haubuck wants to use the chain of the returning to connect his spirits.{nl}
-QUEST_LV_0200_20151001_009279	But, Haubuck too is the key to close the space of the metastasis.{nl}The reason why I left him like that was to store the power so that the key functions well.{nl} 
-QUEST_LV_0200_20151001_009280	Haubuck hasn't collected his spirit in full yet so it wouldn't be hard to face against.{nl}Catch him again and close the space of the metastasis with the chain of the returning.{nl}
+QUEST_LV_0200_20151001_009278	The chain of the returning is the wonder which connects every boundaries or return...{nl}Hauberk wants to use the chain of the returning to connect his spirits.{nl}
+QUEST_LV_0200_20151001_009279	But, Hauberk too is the key to close the space of the metastasis.{nl}The reason why I left him like that was to store the power so that the key functions well.{nl} 
+QUEST_LV_0200_20151001_009280	Hauberk hasn't collected his spirit in full yet so it wouldn't be hard to face against.{nl}Catch him again and close the space of the metastasis with the chain of the returning.{nl}
 QUEST_LV_0200_20151001_009281	The 4th district which he ran away to is like a maze. {nl}Kupole Daiva and you would be able to follow him.
-QUEST_LV_0200_20151001_009282	How come Vakarine left Haubuck to go crazy like that..{nl}I guess she must have a reason for that.
+QUEST_LV_0200_20151001_009282	How come Vakarine left Hauberk to go crazy like that..{nl}I guess she must have a reason for that.
 QUEST_LV_0200_20151001_009283	The Grand Hall is where the Goddess recovers her powers. {nl}That is why it should always be safe from the demons. Thank you very much.
 QUEST_LV_0200_20151001_009284	Please collect the pieces of the symbol of the star that are scattered near Rada seal.{nl}It will help the Goddess to recover her power.
 QUEST_LV_0200_20151001_009285	Thanks. {nl}If Vakarine recover, Dionis would also recover.
-QUEST_LV_0200_20151001_009286	So you've come, savior.{nl}Fortunately, it seems that Haubuck doesn't want to go out through the space of the metastasis.{nl}Which means it is not complete yet enough to go out through the sapce.{nl}
+QUEST_LV_0200_20151001_009286	So you've come, savior.{nl}Fortunately, it seems that Hauberk doesn't want to go out through the space of the metastasis.{nl}Which means it is not complete yet enough to go out through the sapce.{nl}
 QUEST_LV_0200_20151001_009287	I think...{nl}In order to go out without going through the prison or the space of the metastasis..{nl}You should look for the space which has been weakened due to the collapse.{nl}
 QUEST_LV_0200_20151001_009288	Nevirau collapsed sphere is most weak so he probably went there.{nl}Please follow him, I will prepare for the next strategy.
-QUEST_LV_0200_20151001_009289	Even if Haubuck does something, this is inside the prison.{nl}Haubuck could never run away.
-QUEST_LV_0200_20151001_009290	With this illuminating sphere of the night star, we could easily find Haubuck.{nl}If Haubuck gives up and tries to run away, I will do my best to block it. {nl}
-QUEST_LV_0200_20151001_009291	We won't be able to block Haubuck completely, but...{nl}We would be able to earn some time before the savior comes here.
-QUEST_LV_0200_20151001_009292	If Haubuck gives up and tries to run away, I will do my best to block it. {nl}
-QUEST_LV_0200_20151001_009293	We won't be able to block Haubuck completely, but...{nl}We would be able to earn some time before the savior comes here.
+QUEST_LV_0200_20151001_009289	Even if Hauberk does something, this is inside the prison.{nl}Hauberk could never run away.
+QUEST_LV_0200_20151001_009290	With this illuminating sphere of the night star, we could easily find Hauberk.{nl}If Hauberk gives up and tries to run away, I will do my best to block it. {nl}
+QUEST_LV_0200_20151001_009291	We won't be able to block Hauberk completely, but...{nl}We would be able to earn some time before the savior comes here.
+QUEST_LV_0200_20151001_009292	If Hauberk gives up and tries to run away, I will do my best to block it. {nl}
+QUEST_LV_0200_20151001_009293	We won't be able to block Hauberk completely, but...{nl}We would be able to earn some time before the savior comes here.
 QUEST_LV_0200_20151001_009294	Fortunately, it is not coming to my side and moves as I think.{nl}We can surely catch it if we only have the power of the savior.
-QUEST_LV_0200_20151001_009295	Success!{nl}Haubuck won't waste its time on defeating Sigita.{nl}We really hope so.
-QUEST_LV_0200_20151001_009296	There is only one way from here.{nl}It will be a great chance to catch Haubuck.{nl}
-QUEST_LV_0200_20151001_009297	Push Haubuck into Galutin poisonous room.{nl}Don't worry since Sigita is blocking Haubuck's exit at the opposite side.{nl}
-QUEST_LV_0200_20151001_009298	Well done.{nl}Haubuck didn't know what to do as it saw me and ran away to Galutin poisonous room.{nl}
-QUEST_LV_0200_20151001_009299	Haubuck nowadays would be able to defeat me easily...{nl}but, I guess it thought I would be caught by the revelator right away.{nl}
-QUEST_LV_0200_20151001_009300	But, the way up from here is a dead end.{nl}Tell me if you are ready to catch Haubuck.
-QUEST_LV_0200_20151001_009301	Thank you.{nl}We will collect the sealed Haubuck's power and take it to Vakarine.{nl}
+QUEST_LV_0200_20151001_009295	Success!{nl}Hauberk won't waste its time on defeating Sigita.{nl}We really hope so.
+QUEST_LV_0200_20151001_009296	There is only one way from here.{nl}It will be a great chance to catch Hauberk.{nl}
+QUEST_LV_0200_20151001_009297	Push Hauberk into Galutin poisonous room.{nl}Don't worry since Sigita is blocking Hauberk's exit at the opposite side.{nl}
+QUEST_LV_0200_20151001_009298	Well done.{nl}Hauberk didn't know what to do as it saw me and ran away to Galutin poisonous room.{nl}
+QUEST_LV_0200_20151001_009299	Hauberk nowadays would be able to defeat me easily...{nl}but, I guess it thought I would be caught by the Revelator right away.{nl}
+QUEST_LV_0200_20151001_009300	But, the way up from here is a dead end.{nl}Tell me if you are ready to catch Hauberk.
+QUEST_LV_0200_20151001_009301	Thank you.{nl}We will collect the sealed Hauberk's power and take it to Vakarine.{nl}
 QUEST_LV_0200_20151001_009302	Vakarine is getting ready to close the space of the metastasis with other Kupoles.{nl}She is waiting for you desperately so please hurry to the 5th district in the prison.
 QUEST_LV_0200_20151001_009303	We don't know whether the Goddess is okay or not, but we need to show them a sample.{nl}Can you collect the Demon's Tooth in Heuradeti Instersection?
 QUEST_LV_0200_20151001_009304	Thank you. {nl}Please keep it a secret from Vakarine.
-QUEST_LV_0200_20151001_009305	Savior.{nl}We really appreciate for you for blocking Haubuck.{nl}Because of you, we were able to close the space of the metastasis and retrieve the spirit of Haubuck and the chain of the returning.{nl}
-QUEST_LV_0200_20151001_009306	Please do not feel sympathy towards Haubuck.{nl}It is sad that his destiny is torn apart, but it too is a demon to be eliminated.{nl}
+QUEST_LV_0200_20151001_009305	Savior.{nl}We really appreciate for you for blocking Hauberk.{nl}Because of you, we were able to close the space of the metastasis and retrieve the spirit of Hauberk and the chain of the returning.{nl}
+QUEST_LV_0200_20151001_009306	Please do not feel sympathy towards Hauberk.{nl}It is sad that his destiny is torn apart, but it too is a demon to be eliminated.{nl}
 QUEST_LV_0200_20151001_009307	Good. Now is the last stage... We should close the space of the metastasis.{nl}With your help, we were able to block the catastrophe of the prison.{nl}
 QUEST_LV_0200_20151001_009308	Please be prepared since we will start the ritual to seal the space of the metastasis.
-QUEST_LV_0200_20151001_009309	We will add the power of demons to the sealed spirit of Haubuck.{nl}
+QUEST_LV_0200_20151001_009309	We will add the power of demons to the sealed spirit of Hauberk.{nl}
 QUEST_LV_0200_20151001_009310	I will give you the Evening Star Rune, but it is the object which used my power...{nl}Which means it is not complete yet.{nl}
 QUEST_LV_0200_20151001_009311	Defeat the demons at Ausura worship hall and collect the traces of the metastasis.{nl}With this, I would be able to complement my lacking power and  complete Evening Star Rune.
 QUEST_LV_0200_20151001_009312	I was able to complete the Evening Star Rune because of you.{nl}Receive it. You should collect the spirits of the demons with Evening Star Rune.{nl}{nl}
@@ -9313,7 +9313,7 @@ QUEST_LV_0200_20151001_009316	Vakarine should recover soon...{nl}She was tired a
 QUEST_LV_0200_20151001_009317	This prison was created by Ausrine Goddess.{nl}Vakarine comes here periodically and manages this place.
 QUEST_LV_0200_20151001_009318	Oh..my poor Dionis..I'm so sorry for giving you this big burden.
 QUEST_LV_0200_20151001_009319	We weren't able to monitor all the demons in the prision.{nl}That's why we engraved the symbol of the seal on them so their power can't be unleashed.
-QUEST_LV_0200_20151001_009320	The spirit of Haubuck has become strong to handle the space of the metastasis because of your efforts.{nl}The chain of the returning is also ready.{nl}
+QUEST_LV_0200_20151001_009320	The spirit of Hauberk has become strong to handle the space of the metastasis because of your efforts.{nl}The chain of the returning is also ready.{nl}
 QUEST_LV_0200_20151001_009321	We will close the space of the metastasis now.
 QUEST_LV_0200_20151001_009322	We will try our best to seal the space of the metastasis with Kupoles.{nl}Only one chance... if we fail this time, we may not have another chance.{nl}
 QUEST_LV_0200_20151001_009323	To tell you again, it is the last chance for the counter attack for the demons.{nl}Until the space of the metastasis completely seals off, please block their attacks.{nl}{nl}

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -201,7 +201,7 @@ QUEST_LV_0200_20150317_000200	$I am looking for a few artifacts on Lydia Schaffe
 QUEST_LV_0200_20150317_000201	The Kingdom Soldier Retia
 QUEST_LV_0200_20150317_000202	{memo X}Because of the Stone Frosts that were created due to Ruklys' rebellion a few hundreds years ago, the land turned into a wasteland.
 QUEST_LV_0200_20150317_000203	{memo X}We will allow you to enter since Kaliss Knightage requested us to do so, but please stay where our gaze remains.
-QUEST_LV_0200_20150317_000204	{memo X}After the Medis Diena 4 years ago, Benas was appointed as the chief commander for the forces here.{nl}He ordered to take good care of the road leading to the Fortress of the Earth.
+QUEST_LV_0200_20150317_000204	{memo X}After Medis Diena 4 years ago, Benas was appointed as the chief commander for the forces here.{nl}He ordered to take good care of the road leading to the Fortress of the Earth.
 QUEST_LV_0200_20150317_000205	{memo X}If you are not in a hurry, please defeat the monsters in area A.{nl}That will be the first step for you to contribute to the Goddess and the Kingdom..{nl}Of course, I will promise you enough rewards.
 QUEST_LV_0200_20150317_000206	{memo X}Rebel Commander Ruklys, and the citizens here engaged in an evil conduct{nl}despite the selections from the great merchant, Premier Eminent. The result is this place.
 QUEST_LV_0200_20150317_000207	{memo X}That's not bad. Maybe the guards can use it.
@@ -6239,7 +6239,7 @@ QUEST_LV_0200_20150406_006241	It's a monster called Kirmeleech. {nl}Don't forget
 QUEST_LV_0200_20150406_006242	It's been a while since we've offered prayers because of Kirmeleech. {nl}What if the Goddess is angry?
 QUEST_LV_0200_20150406_006243	Good job. {nl}Now we can pray again to Goddess Zemyna.
 QUEST_LV_0200_20150406_006244	The magic circle in Fallow Land has protective barriers so it's difficult to destroy it right away. {nl}I will give you magic stone of blessings. Try thowing this to destroy it.
-QUEST_LV_0200_20150406_006245	I used to take priest lessons before the Medis Diena. {nl}I'm here now because I like farming more.
+QUEST_LV_0200_20150406_006245	I used to take priest lessons before Medis Diena. {nl}I'm here now because I like farming more.
 QUEST_LV_0200_20150406_006246	{memo X}You will get hurt if you go near the magic circle rashly. {nl}Be sure to destroy the magic circle using magic stone of blessings.
 QUEST_LV_0200_20150406_006247	You did it! {nl}Now this farm is looking back like it should.
 QUEST_LV_0200_20150406_006248	{memo X}This is the last one. {nl}The magic circle in Tarvas Entrance will have a lot of monsters interfering. {nl}With the divine power suppressed, the monsters are naturally drawn to that area.
@@ -7162,7 +7162,7 @@ QUEST_LV_0200_20150714_007164	Maybe... we could restore the time of the portal t
 QUEST_LV_0200_20150714_007165	What we are planning right now could lead us to the gallows.{nl}Please keep it secret.
 QUEST_LV_0200_20150714_007166	{memo X}When we were in the era of Premier Eminent, we were supported by the superior troops, lots of supplies and etc.{nl}But, 600 years have passed after Premier Eminent died.{nl}
 QUEST_LV_0200_20150714_007167	
-QUEST_LV_0200_20150714_007168	I heard the Dico Thieves were well known thieves.{nl}I heard that they were seperated on the Medis Diena... Anyways... what they are doing is like what bandits are doing.{nl}
+QUEST_LV_0200_20150714_007168	I heard the Dico Thieves were well known thieves.{nl}I heard that they were seperated on Medis Diena... Anyways... what they are doing is like what bandits are doing.{nl}
 QUEST_LV_0200_20150714_007169	I also know that there are thieves called Amanda Thieves. They were quiet.{nl}I want to know if they really exist or not since I never saw them before.{nl}
 QUEST_LV_0200_20150714_007170	Both of them are criminals that we should catch when we receive more reinforcements.{nl}Especially, Dico Thieves.
 QUEST_LV_0200_20150714_007171	We are observing what the researchers of Kaliss Knitage are doing and while pretending to be their guards.{nl}Sabina was one of them.{nl}
@@ -7200,7 +7200,7 @@ QUEST_LV_0200_20150714_007202	I took a sneak peek, but it seems they haven't ret
 QUEST_LV_0200_20150714_007203	Seems like Diko thieves are planning to do their business bigger than I thought. {nl}That's an enormous amount. Do you think they also have connections with the kingdom army?
 QUEST_LV_0200_20150714_007204	The terrible scene you can see in this city are the results of the rebellion that was carried out by Ruklys and the citizens 600 years ago.{nl}The Stone Frosts that started to blow after suppressing the rebellion turn everything into stones.{nl}
 QUEST_LV_0200_20150714_007205	The kingdom would've been destroyed already if Premier Eminent wasn't present.{nl}If he was still alive... We may have got over these hard times sooner.
-QUEST_LV_0200_20150714_007206	That's the scary wind that turns everything into stones.{nl}After the Medis Diena, the occurence of the wind changed irregularly.{nl}
+QUEST_LV_0200_20150714_007206	That's the scary wind that turns everything into stones.{nl}After Medis Diena, the occurence of the wind changed irregularly.{nl}
 QUEST_LV_0200_20150714_007207	Once you encounter the curse of the Stone Frosts, you can't restore it.{nl}The sin of the traitor, Ruklys is that heavy.{nl}
 QUEST_LV_0200_20150714_007208	Kaliss Knightage is trying to find a remedy...{nl}The curse continued for 600 years. I don't think there's a remedy.
 QUEST_LV_0200_20150714_007209	Sparnashorn appears with the wind of Stone Frosts.{nl}To avoid the exhausted soldiers not get involved with it, we should avoid them fighting against Sparnashorn.{nl}
@@ -7439,7 +7439,7 @@ QUEST_LV_0200_20150714_007441	I just hope the monsters stay calm.{nl}Maybe I am 
 QUEST_LV_0200_20150714_007442	The blessings of the Goddesses has not reached at this city.{nl}Only the monsters and the criminals are full in this city.
 QUEST_LV_0200_20150714_007443	Please report to us when you see monsters.{nl}Especially, when they are grouped together or make a mess.
 QUEST_LV_0200_20150714_007444	I've written down what to do at the memo.{nl}First, find the demonic stone fusion device at Ritinis Underground Grave.
-QUEST_LV_0200_20150714_007445	Long time ago, I had serviced as a guard in the military like those guys.{nl}I was a junior officer who wanted become a strategist. At least before the Medis Diena.
+QUEST_LV_0200_20150714_007445	Long time ago, I had serviced as a guard in the military like those guys.{nl}I was a junior officer who wanted become a strategist. At least before Medis Diena.
 QUEST_LV_0200_20150714_007446	If you find someone suspicious besides kingdom soldiers and Kaliss Knightage, please report to us.{nl}Especially, those grave thieves.
 QUEST_LV_0200_20150714_007447	Please do not touch anything. Just stay calm.
 QUEST_LV_0200_20150714_007448	If you find the old records that are negative to the kingdom, immediatly destroy them or report to us.
@@ -7615,7 +7615,7 @@ QUEST_LV_0200_20150714_007617	If his records are real, it will make many people 
 QUEST_LV_0200_20150714_007618	I am chasing after the gold plate that is engraved with the records of Demetrius.{nl}I am keep getting interrupted by the monsters, but we have some results though.
 QUEST_LV_0200_20150714_007619	Ahah...
 QUEST_LV_0200_20150714_007620	I am looking for the disappeared spirits.{nl}The spirits that are out of their normal journey.{nl}
-QUEST_LV_0200_20150714_007621	After the Medis Diena, scary things are happening.{nl}The reason why the spirits lose their ways are related to it.
+QUEST_LV_0200_20150714_007621	After Medis Diena, scary things are happening.{nl}The reason why the spirits lose their ways are related to it.
 QUEST_LV_0200_20150714_007622	The spirits don't say anything to me.{nl}Have you heard any stories of them?
 QUEST_LV_0200_20150714_007623	The only thing I could do was to depress for hundreds of years.{nl}I want to just disappear if I can.
 QUEST_LV_0200_20150714_007624	What can I do after losing the master and the body.{nl}Besides just watching the demons...
@@ -7661,7 +7661,7 @@ QUEST_LV_0200_20150714_007663	Are the peaceful days going to return like the old
 QUEST_LV_0200_20150714_007664	I want to bury Dalus under the Ramivi Cliffs where he can see his hometown.{nl}But there are so many monsters there. Please get rid of them.
 QUEST_LV_0200_20150714_007665	Aren't you the Revelator?{nl}
 QUEST_LV_0200_20150714_007666	Ah, so fortunate. Then, you must have traveled various places in the kingdom.{nl}I am sorry, but do you know anything about the mysterious girl?{nl}
-QUEST_LV_0200_20150714_007667	The girl left these trees before the Medis Diena.{nl}My master asked me to find about the trees, but I knew nothing about them... I want to get help from you.
+QUEST_LV_0200_20150714_007667	The girl left these trees before Medis Diena.{nl}My master asked me to find about the trees, but I knew nothing about them... I want to get help from you.
 QUEST_LV_0200_20150714_007668	This farm's owner is Gina Green.{nl}They kindly lend this farm to us who lost the land since the day of Divine Tree.
 QUEST_LV_0200_20150714_007669	Hey you. Revelator. Don't just look at me. Help me.{nl}Please kick out Lizard men on my fields.
 QUEST_LV_0200_20150714_007670	You must know that there isn't enough food in the kingdom.{nl}If you are okay, can you help me with my investigation?
@@ -7681,7 +7681,7 @@ QUEST_LV_0200_20150714_007683	I am so sorry. {nl}Please first persuade Potos at 
 QUEST_LV_0200_20150714_007684	But, the monks shake their heads in denial when we mention Evoniphon...
 QUEST_LV_0200_20150714_007685	Do you know the Tower of the Stars?{nl}Starting with Lydia Schaffen, the greatest archers are all from that place.{nl}
 QUEST_LV_0200_20150714_007686	The head of the tower was murdered by Evoniphon.{nl}I've chased him upto here, but I can't do anything further due to those god damn religious rules.{nl}
-QUEST_LV_0200_20150714_007687	They protect the ones who are falsely charged.{nl}I thought that law was ineffective after the Medis Diena... I want to resolve it by avoiding a conflict with them.
+QUEST_LV_0200_20150714_007687	They protect the ones who are falsely charged.{nl}I thought that law was ineffective after Medis Diena... I want to resolve it by avoiding a conflict with them.
 QUEST_LV_0200_20150714_007688	Hello. Traveller.{nl}What has brought you here?
 QUEST_LV_0200_20150714_007689	If you are going to ask about Hunters, I am sorry, but I can't tell you anything.{nl}
 QUEST_LV_0200_20150714_007690	The monastery is full of monsters and we should first cure the monks who've been hit by the paralysis needles.{nl}Now is not the time to get involved in a complicated matter.
@@ -9162,7 +9162,7 @@ QUEST_LV_0200_20151001_009164	I was so mad that I am not a Revelator before.{nl}
 QUEST_LV_0200_20151001_009165	I think the Goddess may come back when they complete their duties and I complete mine.
 QUEST_LV_0200_20151001_009166	I didn't expect that the true nature of the curse that is fallen down on this forest is going after the great cathedral.{nl}Fortunately, we were able to block the curse due to one Revelator, but I feel ashamed.
 QUEST_LV_0200_20151001_009167	The curse here is serious, but there are other places where the influences of the curse are more severe. {nl}The city of Ruklys... I heard everything turns into stones due to the curse of the petrification.
-QUEST_LV_0200_20151001_009168	I think it was my fault that I went out of Mage Tower to save the people after the Medis Diena.{nl}Maybe, I could save the tower and not the Revelator.
+QUEST_LV_0200_20151001_009168	I think it was my fault that I went out of Mage Tower to save the people after Medis Diena.{nl}Maybe, I could save the tower and not the Revelator.
 QUEST_LV_0200_20151001_009169	I heard the story about the revaltor who blocked the Demon Lord who casted the curse in this region.{nl}I guess... there won't be any more people who would suffer from the curse.
 QUEST_LV_0200_20151001_009170	I've been to many places before in my life, but this place is really horrible.{nl}Even if I want to rescue the ones who are cursed, the only thing I can do is to help them fall asleep comfortably.
 QUEST_LV_0200_20151001_009171	I heard a Revelator defeated the Demon Lord who were attacking the Mage Tower.{nl}That's the most happy news I've heard lately.{nl}Other news I've heard were horrible.
@@ -9208,14 +9208,14 @@ QUEST_LV_0200_20151001_009210	This must be more than a few hundreds years old.{n
 QUEST_LV_0200_20151001_009211	By the way, why did you come here?{nl}Since you don't say anything about it, this must be important right?{nl}
 QUEST_LV_0200_20151001_009212	Anyway, let's enter more deep inside.{nl}You should tell me later. Okay?
 QUEST_LV_0200_20151001_009213	The demons didn't have special objects.{nl}What... you don't have them?
-QUEST_LV_0200_20151001_009214	Revelator. {nl}After the Medis Diena, Vakarine have become weak so we have to protect her.
+QUEST_LV_0200_20151001_009214	Revelator. {nl}After Medis Diena, Vakarine have become weak so we have to protect her.
 QUEST_LV_0200_20151001_009215	This is not the world of humans nor the world of demons, but another space of Vakarine...{nl}We've locked the demons inside this prison who are evil to this world.{nl}
-QUEST_LV_0200_20151001_009216	But, after the Medis Diena, Vakarine doesn't have any power left to maintain this space.{nl}As you can see, the space is gradually collapsing and the space of the metastasis has gotten widen.{nl}
+QUEST_LV_0200_20151001_009216	But, after Medis Diena, Vakarine doesn't have any power left to maintain this space.{nl}As you can see, the space is gradually collapsing and the space of the metastasis has gotten widen.{nl}
 QUEST_LV_0200_20151001_009217	The Demon Lords who are locked in this prison are trying to escape here.{nl}The demons who came here through the metastasis are joining as well.{nl}
 QUEST_LV_0200_20151001_009218	Vakarine desperately needs your help.{nl}Please help defeating the demons at the prison.
 QUEST_LV_0200_20151001_009219	Please first block the demons that are trying to release the Demon Lord, Blut that is locked here.
 QUEST_LV_0200_20151001_009220	The subordinates of Blut are trying to escape here. {nl}Hauberk's help will be useful this time.
-QUEST_LV_0200_20151001_009221	Right now, Blut is holding Kupole Giderone. {nl}But, since the power of Vakarine has weakend after the Medis Diena, we are not like before.{nl}
+QUEST_LV_0200_20151001_009221	Right now, Blut is holding Kupole Giderone. {nl}But, since the power of Vakarine has weakend after Medis Diena, we are not like before.{nl}
 QUEST_LV_0200_20151001_009222	Fortunately, Blut hasn't been completely freed...{nl}But, we don't know how much longer we would endure ourselves.{nl}
 QUEST_LV_0200_20151001_009223	We have to somehow weaken the power of the Demon Lord, Blut.{nl}I am sure his allies set the camp near Byeaulleo Hideout.{nl}Please get the symbol of Blut that they have.
 QUEST_LV_0200_20151001_009224	Our original duty was to supervise and manage the prison originally.{nl}But... now, we are trying out best to block the demons. {nl}No matter what it takes.
@@ -9251,7 +9251,7 @@ QUEST_LV_0200_20151001_009253	Meet Aldona. {nl}He would take you to the area of 
 QUEST_LV_0200_20151001_009254	Vakarine is waiting for you at the 3rd district.{nl}But, I feel somewhat uneasy since she is so stubborn.
 QUEST_LV_0200_20151001_009255	In the past, she told us that she can't just do nothing even if her power was weakened.{nl}We barely managed to persuade her.{nl} 
 QUEST_LV_0200_20151001_009256	To prevent something happening to Vakarine, please move to 3rd district as quickly as possible.{nl}
-QUEST_LV_0200_20151001_009257	The space of the metastasis and the Demon Lords... they were expected.{nl}I could feel my power was getting weak after the Medis Diena and I had to find another way.{nl}
+QUEST_LV_0200_20151001_009257	The space of the metastasis and the Demon Lords... they were expected.{nl}I could feel my power was getting weak after Medis Diena and I had to find another way.{nl}
 QUEST_LV_0200_20151001_009258	I've given Dionys the power that should not be stolen by the Demon Lord.{nl}But, that power was so strong so it started to dominate Dionys...{nl}
 QUEST_LV_0200_20151001_009259	I can't tell you about the power in details at the moment.{nl}But, please just know that the power that is controlling Dionys is the only way to close the space of the metastasis.{nl}
 QUEST_LV_0200_20151001_009260	Please complete the Evening Star Key with Kupole Giderone.{nl}With the Evening Star Key, Dionys would withdraw that power.
@@ -9390,14 +9390,14 @@ QUEST_LV_0200_20151001_009392	The disciples are only concentrating on the altars
 QUEST_LV_0200_20151001_009393	You will pay for your intent of obtaining the revelation.{nl}Of course, you should obtain the fourth key of Maven as well.
 QUEST_LV_0200_20151001_009394	We should find out whether that is just a symbol or endowed with some kind of power.{nl}First, I want you to collect the leathers of Lizardmen from the abondoned at the Grape Fields.
 QUEST_LV_0200_20151001_009395	Recently, we saw a similar looking girl at the crystal mine. {nl}But, strangely, she wasn't able to say anything.
-QUEST_LV_0200_20151001_009396	Lizardmen are the monsters that appeared a lot since the Medis Diena.{nl}If some kind of power is in this tree, it will definitely react to the leathers.
+QUEST_LV_0200_20151001_009396	Lizardmen are the monsters that appeared a lot since Medis Diena.{nl}If some kind of power is in this tree, it will definitely react to the leathers.
 QUEST_LV_0200_20151001_009397	Revelator, this is astonishing!{nl}After I put the power of the tree into the leathers of the monster that you brought, it corroded right away.
 QUEST_LV_0200_20151001_009398	Please help us.{nl}We have to grow things like this, they will all die within a short period of time due to the poison.
 QUEST_LV_0200_20151001_009399	You are not...a messenger.{nl}This place is a military district, but we desperately need help these days.{nl}
 QUEST_LV_0200_20151001_009400	It seems that you are quite competent.{nl}Can you help us a bit?
 QUEST_LV_0200_20151001_009401	Thanks.{nl}There's one thing you need to know about this place.{nl}
 QUEST_LV_0200_20151001_009402	This place is the strategic location which was built when Ruklys caused the chaos.{nl}Eminent who was the prime minister at that time came up with it to block their marching route. {nl}
-QUEST_LV_0200_20151001_009403	They are maintained to block monsters or demons nowadays.{nl}But, since the Medis Diena, we are not receiving any supplies or orders from the kingdom.{nl}
+QUEST_LV_0200_20151001_009403	They are maintained to block monsters or demons nowadays.{nl}But, since Medis Diena, we are not receiving any supplies or orders from the kingdom.{nl}
 QUEST_LV_0200_20151001_009404	How could he just abondon his duty as a person who belongs to the kingdom?{nl}Anyways, our duty is to protect the magic circle here when some incident occurs here.{nl}
 QUEST_LV_0200_20151001_009405	Actually, we were having hard time since we didn't have any forces to look for the subordinate who went missing after going there to repair it.{nl}His name is Hicks. Please look for him.
 QUEST_LV_0200_20151001_009406	Are you the one sent by the commanding officer?{nl}I'll be alright now!

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -451,7 +451,7 @@ QUEST_LV_0200_20150317_000450	$The Rearguard Unit always complains the supplies 
 QUEST_LV_0200_20150317_000451	$Oh, you got them. Thank you. {nl}Please go back to the monster's nest and burn the Destroyed Owls.
 QUEST_LV_0200_20150317_000452	$Terrible things are happening. {nl}Can we go back to peaceful days?
 QUEST_LV_0200_20150317_000453	$The Goddess can be so cruel. {nl}Please pray that my colleagues may rest in peace.
-QUEST_LV_0200_20150317_000454	$Pilgrim Liliya
+QUEST_LV_0200_20150317_000454	$Pilgrim Lilija
 QUEST_LV_0200_20150317_000455	{memo X}If I die, please bury me..{nl}Make my body unseen..{nl}If I lose my breath, please bury me..
 QUEST_LV_0200_20150317_000456	{memo X}And if you meet a pilgrim named Julius, please tell him these words.. tell him goodbye..
 QUEST_LV_0200_20150317_000457	Pilgrim's Memo
@@ -470,7 +470,7 @@ QUEST_LV_0200_20150317_000469	Pilgrim Julius
 QUEST_LV_0200_20150317_000470	{memo X}I think there was some food here.. {nl}Did that guy take it? {nl}Ugh..
 QUEST_LV_0200_20150317_000471	{memo X}I'm starving and now I'm having headaches! {nl}I feel my head exploding with just the thought of food but other things keep coming to mind. {nl}What was it.. Something like an orgel..
 QUEST_LV_0200_20150317_000472	{memo X}{nl}Why does it's food keep popping up in my mind when I can't even eat it.
-QUEST_LV_0200_20150317_000473	{memo X}Those dirty fools.. I will revenge.. {nl}Aah Liliya..
+QUEST_LV_0200_20150317_000473	{memo X}Those dirty fools.. I will revenge.. {nl}Aah Lilija..
 QUEST_LV_0200_20150317_000474	{memo X}The necklace.. yes. {nl}Well done.. Please take good care of it. {nl}This is a token of my gratitude.. The orgel was a memento for both of us but the necklace is special..
 QUEST_LV_0200_20150317_000475	{memo X}{nl}The Cathedral was blessed so I'm sure it'll be a good thing for you too.
 QUEST_LV_0200_20150317_000476	{memo X}Aaaaagghh! Aaagh! {nl}I will swallow it all!!!
@@ -483,14 +483,14 @@ QUEST_LV_0200_20150317_000482	{memo X}That is it! give me that! {nl}I'm going to
 QUEST_LV_0200_20150317_000483	{memo X}...? That? What about that? {nl}
 QUEST_LV_0200_20150317_000484	{memo X}Oww! My head! Arrgh! Yuck! What's that? What about that orgel? {nl}
 QUEST_LV_0200_20150317_000485	{memo X}Memory.. Her.. Give me that! It's mine!
-QUEST_LV_0200_20150317_000486	{memo X}So that's what happened.. Thank you. She left this orgel behind. {nl}We promised marriage and we left our way on pilgrimage to the Cathedral to confirm our promise for the future. {nl}But ah.. Liliya.. Liliya..!!{nl}
+QUEST_LV_0200_20150317_000486	{memo X}So that's what happened.. Thank you. She left this orgel behind. {nl}We promised marriage and we left our way on pilgrimage to the Cathedral to confirm our promise for the future. {nl}But ah.. Lilija.. Lilija..!!{nl}
 QUEST_LV_0200_20150317_000487	{memo X}In our happy journey to pilgrimage.. That's where we met then. {nl}Na.. Naktis! Demon Lord!{nl}She took away our necklace and orgel, stared at it for some time, and threw it far away!
 QUEST_LV_0200_20150317_000488	{memo X}{nl}Then she made us fight and hate each other for gluttony and just disappeared. {nl}I need to go.. To meet her, she, how is she..
 QUEST_LV_0200_20150317_000489	{memo X}The orgel rolled out somewhere and the necklace.. Her subordinate swallowed it. {nl}
 QUEST_LV_0200_20150317_000490	{memo X}Then Naktis made us.. Like this.. {nl}
 QUEST_LV_0200_20150317_000491	{memo X}Oh, sorry. {nl}I'm too dizzy and it's difficult to talk. {nl}There are Nikotias in the Starving Demon's Way that are used as medicinal herbs. Won't the dizziness fade away if I eat some of those herbs?
 QUEST_LV_0200_20150317_000492	{memo X}I heard Nikotias grow in the upper area. {nl}But it's not easy to get it so be careful.
-QUEST_LV_0200_20150317_000493	{memo X}Ah, it's that.. Thank you. {nl}It feels better. {nl}Liliya.. Her orgel.. She probably isn't in this world anymore.. Without her, I don't need this necklace either. {nl}
+QUEST_LV_0200_20150317_000493	{memo X}Ah, it's that.. Thank you. {nl}It feels better. {nl}Lilija.. Her orgel.. She probably isn't in this world anymore.. Without her, I don't need this necklace either. {nl}
 QUEST_LV_0200_20150317_000494	{memo X}If you meet that nasty Naktis' monster, please strike a revenge for me. {nl}Please take out the sign of our love from it and let it see the light of the world. {nl}And as a sign of gratitude for the revenge, please keep that necklace. {nl}
 QUEST_LV_0200_20150317_000495	{memo X}It's a necklace that received the blessings of the Cathedral so it will come in handy. {nl}That necklace doesn't mean anything to me anymore..
 QUEST_LV_0200_20150317_000496	Pilgrim Zenius
@@ -1599,9 +1599,9 @@ QUEST_LV_0200_20150317_001598	$Insatiable Hunger (2)
 QUEST_LV_0200_20150317_001599	$Insatiable Hunger (3)
 QUEST_LV_0200_20150317_001600	$Insatiable Hunger (4)
 QUEST_LV_0200_20150317_001601	{memo X}I'll make it next time
-QUEST_LV_0200_20150317_001602	{memo X}Notice /! / Liliya died .. {nl} Please make a grave for her # 3
-QUEST_LV_0200_20150317_001603	{memo X}Making a grave for Liliya/ SITGROPE / 3 / TRACK_BEFORE / None
-QUEST_LV_0200_20150317_001604	{memo X}Notice /You made a grave for Liliya # 5
+QUEST_LV_0200_20150317_001602	{memo X}Notice /! / Lilija died .. {nl} Please make a grave for her # 3
+QUEST_LV_0200_20150317_001603	{memo X}Making a grave for Lilija/ SITGROPE / 3 / TRACK_BEFORE / None
+QUEST_LV_0200_20150317_001604	{memo X}Notice /You made a grave for Lilija # 5
 QUEST_LV_0200_20150317_001605	Endless Gluttony (1)
 QUEST_LV_0200_20150317_001606	{memo X}I'll find something to eat
 QUEST_LV_0200_20150317_001607	Ignore it and go your way
@@ -2649,26 +2649,26 @@ QUEST_LV_0200_20150317_002648	$Find traces of the kidnapped Owls
 QUEST_LV_0200_20150317_002649	{memo X}The Weak Owl wants you to find other owls that the monsters took away. Find the traces of owl statue in the monster's hideaway located at each end of the Ishrai Crossroad.
 QUEST_LV_0200_20150317_002650	$Give the Broken Piece of Owl
 QUEST_LV_0200_20150317_002651	{memo X}Found all the Broken Pieces of the Owl. Give it to the Weak Owl.
-QUEST_LV_0200_20150317_002652	{memo X}Talk to Liliya
-QUEST_LV_0200_20150317_002653	{memo X}There is a pilgrim names Liliya in Way of the Big Staving Demons. Seems like she desperately needs something so try talking to her.
+QUEST_LV_0200_20150317_002652	{memo X}Talk to Lilija
+QUEST_LV_0200_20150317_002653	{memo X}There is a pilgrim names Lilija in Way of the Big Staving Demons. Seems like she desperately needs something so try talking to her.
 QUEST_LV_0200_20150317_002654	{memo X}Find food
-QUEST_LV_0200_20150317_002655	{memo X}Liliya keeps saying that she's hungry. Get some meat from the monsters around and give it to her.
-QUEST_LV_0200_20150317_002656	{memo X}Give monster meat to Liliya.
+QUEST_LV_0200_20150317_002655	{memo X}Lilija keeps saying that she's hungry. Get some meat from the monsters around and give it to her.
+QUEST_LV_0200_20150317_002656	{memo X}Give monster meat to Lilija.
 QUEST_LV_0200_20150317_002657	{memo X}Get %s from monsters nearby
-QUEST_LV_0200_20150317_002658	$Liliya still seems hungry. Talk to her again.
+QUEST_LV_0200_20150317_002658	$Lilija still seems hungry. Talk to her again.
 QUEST_LV_0200_20150317_002659	{memo X}Get soft reed stem
-QUEST_LV_0200_20150317_002660	{memo X}Gather soft reed stem for Liliya from the reed sprouts nearby.
-QUEST_LV_0200_20150317_002661	{memo X}Gathered all the soft reed stems. Give it to Liliya.
+QUEST_LV_0200_20150317_002660	{memo X}Gather soft reed stem for Lilija from the reed sprouts nearby.
+QUEST_LV_0200_20150317_002661	{memo X}Gathered all the soft reed stems. Give it to Lilija.
 QUEST_LV_0200_20150317_002662	{memo X}Gather %s from reed sprouts
-QUEST_LV_0200_20150317_002663	{memo X}Is Liliya's hunger satisfied? Talk to her again.
+QUEST_LV_0200_20150317_002663	{memo X}Is Lilija's hunger satisfied? Talk to her again.
 QUEST_LV_0200_20150317_002664	$Defeat Carnivore
-QUEST_LV_0200_20150317_002665	$What happened? The hungry Liliya is gone and a Carnivore suddenly appeared. First, defeat the Carnivore that is attacking you.
-QUEST_LV_0200_20150317_002666	{memo X}Talk to Liliya on the floor
-QUEST_LV_0200_20150317_002667	{memo X}Liliya appeared on the spot where Carnivore was defeated. Try talking to Liliya.
-QUEST_LV_0200_20150317_002668	{memo X}Defeat the Carnivore that seems like what Liliya turned into
-QUEST_LV_0200_20150317_002669	{memo X}Make a grave for Liliya
-QUEST_LV_0200_20150317_002670	{memo X}Seems like Liliya will lose her breathe soon.. Do her last favor.
-QUEST_LV_0200_20150317_002671	{memo X}Make a grave for Liliya
+QUEST_LV_0200_20150317_002665	$What happened? The hungry Lilija is gone and a Carnivore suddenly appeared. First, defeat the Carnivore that is attacking you.
+QUEST_LV_0200_20150317_002666	{memo X}Talk to Lilija on the floor
+QUEST_LV_0200_20150317_002667	{memo X}Lilija appeared on the spot where Carnivore was defeated. Try talking to Lilija.
+QUEST_LV_0200_20150317_002668	{memo X}Defeat the Carnivore that seems like what Lilija turned into
+QUEST_LV_0200_20150317_002669	{memo X}Make a grave for Lilija
+QUEST_LV_0200_20150317_002670	{memo X}Seems like Lilija will lose her breathe soon.. Do her last favor.
+QUEST_LV_0200_20150317_002671	{memo X}Make a grave for Lilija
 QUEST_LV_0200_20150317_002672	$Talk to Pilgrim Julius
 QUEST_LV_0200_20150317_002673	$There are many pilgrims with stories in the Starving Demon's Way. Talk to Julius.
 QUEST_LV_0200_20150317_002674	{memo X}Get monster meat
@@ -2685,8 +2685,8 @@ QUEST_LV_0200_20150317_002684	{memo X}Get the young Nikotia leaves
 QUEST_LV_0200_20150317_002685	{memo X}You need to get young Nikotia leaves so that Julius can get back up and tell his story. You can get the leaves in Emptry Tree Forest.
 QUEST_LV_0200_20150317_002686	{memo X}Gathered all the young Nikotia leaves needed. Give it to Julius.
 QUEST_LV_0200_20150317_002687	{memo X}Food supplies in the Ascetic haven
-QUEST_LV_0200_20150317_002688	{memo X}The rotten meat Julius mentioned can be found past the Ascetic haven, just before the Ray-lit Land. Go there and find the Reaverpeded that swallowed Julius and Liliya's ring.
-QUEST_LV_0200_20150317_002689	$The Reaverpede that swallowed Liliya and Julius' necklace appeared! Defeat it and get back the necklace.
+QUEST_LV_0200_20150317_002688	{memo X}The rotten meat Julius mentioned can be found past the Ascetic haven, just before the Ray-lit Land. Go there and find the Reaverpeded that swallowed Julius and Lilija's ring.
+QUEST_LV_0200_20150317_002689	$The Reaverpede that swallowed Lilija and Julius' necklace appeared! Defeat it and get back the necklace.
 QUEST_LV_0200_20150317_002690	$Defeat the Reaverpede that swallowed the necklace
 QUEST_LV_0200_20150317_002691	Talk to Pilgrim Zenius
 QUEST_LV_0200_20150317_002692	{memo X}There are two pilgrims in the Reed field in Starving Demon's Way. Seems like they have a story to tell so try talking to them.
@@ -3188,8 +3188,8 @@ QUEST_LV_0200_20150323_003187	$Okay.. I think I can eat those Young Leaves.{nl}T
 QUEST_LV_0200_20150323_003188	$My hunger doesn't go away even after eating a lot.{nl}It's actually getting worse, I might as well just die.
 QUEST_LV_0200_20150323_003189	$There must be something to eat around here..{nl}Please.. get me something to eat.{nl}
 QUEST_LV_0200_20150323_003190	$I am so hungry yet something is echoing inside my head..{nl}The sound of a music box..  I can't eat an echo..
-QUEST_LV_0200_20150323_003191	$Ahah, my Liliya..{nl}I probably can never see you again.
-QUEST_LV_0200_20150323_003192	$Please think of that necklace as the gift from Liliya and keep it safely.{nl}It is blessed from the Great Cathedral so it will help you.
+QUEST_LV_0200_20150323_003191	$Ahah, my Lilija..{nl}I probably can never see you again.
+QUEST_LV_0200_20150323_003192	$Please think of that necklace as the gift from Lilija and keep it safely.{nl}It is blessed from the Great Cathedral so it will help you.
 QUEST_LV_0200_20150323_003193	$I am still hungry. Hungry.{nl}I can't take it anymore. I am hungry!
 QUEST_LV_0200_20150323_003194	$I am so.. hungry.{nl}Hey, if you have any leftover food, if you could share it with me..
 QUEST_LV_0200_20150323_003195	$Even if that's all you have, please share it with me.. please..
@@ -3197,13 +3197,13 @@ QUEST_LV_0200_20150323_003196	$Meat..quickly. {nl}I feel like I am dying.
 QUEST_LV_0200_20150323_003197	$Meat.. Meat!{nl}Please give it to me fast. Fast!
 QUEST_LV_0200_20150323_003198	$Wait, that music box.. what was it?{nl}
 QUEST_LV_0200_20150323_003199	$My memories.. she..{nl}Give it to me! That's mine!
-QUEST_LV_0200_20150323_003200	{memo X}Damn. What was I doing?{nl}Ahah. Liliya.. My Liliya!{nl}
+QUEST_LV_0200_20150323_003200	{memo X}Damn. What was I doing?{nl}Ahah. Lilija.. My Lilija!{nl}
 QUEST_LV_0200_20150323_003201	$We left for a pilgrimage to the Great Cathedral to receive the blessings of the Goddesses to celebrate our wedding.{nl}But then, that evil Naktis.. that unforgivable Demon Lord.{nl}
 QUEST_LV_0200_20150323_003202	{memo X}Stole her music box and necklace and gave them to the monsters and cursed her with gluttony.{nl}As if to laugh at Maven's lessons.
 QUEST_LV_0200_20150323_003203	{memo X}Wait. My head is shaking because of the curse. {nl}I still have a lot more to say.. I don't know if I would be able to endure until then.
 QUEST_LV_0200_20150323_003204	$I heard the Asellus at the Hollow Tree Forest have purifying powers.{nl}I should be able to endure with its purification.
-QUEST_LV_0200_20150323_003205	$To completely remove the curse, you should go see the disciples..{nl}I want to stay here and recollect Liliya a little more.
-QUEST_LV_0200_20150323_003206	{memo X}Thanks. Way better.{nl}My Liliya.. my music box.. She must not be in this world.{nl}
+QUEST_LV_0200_20150323_003205	$To completely remove the curse, you should go see the disciples..{nl}I want to stay here and recollect Lilija a little more.
+QUEST_LV_0200_20150323_003206	{memo X}Thanks. Way better.{nl}My Lilija.. my music box.. She must not be in this world.{nl}
 QUEST_LV_0200_20150323_003207	{memo X}If you meet the henchman of Naktis in any case, please get a revenge for her.{nl}The mark of our love which the demon possesses.. Please receive it as a compensation for my gratitude.{nl}
 QUEST_LV_0200_20150323_003208	{memo X}This necklce will be very useful since it is blessed by the Great Cathedral. {nl}That necklace is meaningless to me.
 QUEST_LV_0200_20150323_003209	{memo X}You should not touch it.{nl}It will come soon.. just wait little more.
@@ -4196,7 +4196,7 @@ QUEST_LV_0200_20150323_004195	Ask him what kind of food he wants
 QUEST_LV_0200_20150323_004196	Ask him if there's anything he particularly wants
 QUEST_LV_0200_20150323_004197	You better leave without being involved in the matter
 QUEST_LV_0200_20150323_004198	Keep listen to him
-QUEST_LV_0200_20150323_004199	{memo X}Notice/!/Liliya passed away..{nl}Please make the grave for her#5
+QUEST_LV_0200_20150323_004199	{memo X}Notice/!/Lilija passed away..{nl}Please make the grave for her#5
 QUEST_LV_0200_20150323_004200	I will get the meats of the monsters if that's fine with him.
 QUEST_LV_0200_20150323_004201	Give him the music box
 QUEST_LV_0200_20150323_004202	Ask him if there's anything you could help
@@ -4673,24 +4673,24 @@ QUEST_LV_0200_20150323_004672	Defeat the monsters at the Forest of Prayer
 QUEST_LV_0200_20150323_004673	The knight commander, Uska told you that many monsters have appeared from the deep in the forest, but he couldn't do anything since he didn't have enough soldiers. Defeat 100 monsters at the Forest of Prayer on behalf of the knitage.
 QUEST_LV_0200_20150323_004674	You've completed defeating all the monsters at the Forest of Prayer. Return to Uska and help him relieve his worry.
 QUEST_LV_0200_20150323_004675	Defeat the monsters at the Forest of Prayer
-QUEST_LV_0200_20150323_004676	$Talk to Pilgrim Liliya
-QUEST_LV_0200_20150323_004677	$You can see Liliya at the Starving Demon's Way. She desperately wants something so get closer to her and talk to her.
+QUEST_LV_0200_20150323_004676	$Talk to Pilgrim Lilija
+QUEST_LV_0200_20150323_004677	$You can see Lilija at the Starving Demon's Way. She desperately wants something so get closer to her and talk to her.
 QUEST_LV_0200_20150323_004678	$Collect monster meat
-QUEST_LV_0200_20150323_004679	{memo X}Pilgrim Liliya told you that she is very hungry, so get her any food you can find. Get some edible meats from the monsters.
-QUEST_LV_0200_20150323_004680	$Hand them over to Pilgrim Liliya
+QUEST_LV_0200_20150323_004679	{memo X}Pilgrim Lilija told you that she is very hungry, so get her any food you can find. Get some edible meats from the monsters.
+QUEST_LV_0200_20150323_004680	$Hand them over to Pilgrim Lilija
 QUEST_LV_0200_20150323_004681	$Got enough to eat for three consecutive days without any worries . Bring her the lumps of meat.
 QUEST_LV_0200_20150323_004682	{memo X}Obtain %s from the monsters
 QUEST_LV_0200_20150323_004683	$Get some Young Leaves
-QUEST_LV_0200_20150323_004684	$Pilgrim Liliya is saying she wants more even after eating a lot. Get some Young Leaves for hungry Liliya.
-QUEST_LV_0200_20150323_004685	$You've collected a lot of Young Leaves. Hand them over to Pilgrim Liliya.
+QUEST_LV_0200_20150323_004684	$Pilgrim Lilija is saying she wants more even after eating a lot. Get some Young Leaves for hungry Lilija.
+QUEST_LV_0200_20150323_004685	$You've collected a lot of Young Leaves. Hand them over to Pilgrim Lilija.
 QUEST_LV_0200_20150323_004686	{memo X}Extract %s from the wild herbs
-QUEST_LV_0200_20150323_004687	$Did Pilgrim Liliya's hunger go away? Talk to her again
-QUEST_LV_0200_20150323_004688	$Talk to the fallen Pilgrim Liliya
-QUEST_LV_0200_20150323_004689	$Pilgrim Liliya appeared again from the place where the Carnivore was defeated. Talk to Liliya again.
-QUEST_LV_0200_20150323_004690	$Defeat Liliya who turned into a Carnivore
-QUEST_LV_0200_20150323_004691	$Make a grave for Pilgrim Liliya
-QUEST_LV_0200_20150323_004692	$Liliya is dying... Please listen to her last words
-QUEST_LV_0200_20150323_004693	$Liliya passed away. Please make a grave for Liliya.
+QUEST_LV_0200_20150323_004687	$Did Pilgrim Lilija's hunger go away? Talk to her again
+QUEST_LV_0200_20150323_004688	$Talk to the fallen Pilgrim Lilija
+QUEST_LV_0200_20150323_004689	$Pilgrim Lilija appeared again from the place where the Carnivore was defeated. Talk to Lilija again.
+QUEST_LV_0200_20150323_004690	$Defeat Lilija who turned into a Carnivore
+QUEST_LV_0200_20150323_004691	$Make a grave for Pilgrim Lilija
+QUEST_LV_0200_20150323_004692	$Lilija is dying... Please listen to her last words
+QUEST_LV_0200_20150323_004693	$Lilija passed away. Please make a grave for Lilija.
 QUEST_LV_0200_20150323_004694	{memo X}The pilgrim, Julius, can't move due to his severe hunger. Obtain some meat from the monsters.
 QUEST_LV_0200_20150323_004695	{memo X}You've obtained enough meat from the monsters. Bring them to the pilgrim, Julius.
 QUEST_LV_0200_20150323_004696	Obtain %s from the monsters
@@ -4701,7 +4701,7 @@ QUEST_LV_0200_20150323_004700	$Obtain Asellu Leaf Buds
 QUEST_LV_0200_20150323_004701	$Pilgrim Julius is still suffering from the influence of the curse. Get some Asellu Leaf Buds from the Hollow Tree Forest so he can recover.
 QUEST_LV_0200_20150323_004702	$You've obtained some Asellu Leaf Buds. Take them to Pilgrim Julius.
 QUEST_LV_0200_20150323_004703	Look through the lump of rotten meat at the resting area of the ascetics.
-QUEST_LV_0200_20150323_004704	$Julius and Liliya met Naktis around this location. Could Liliya's necklace be around here?
+QUEST_LV_0200_20150323_004704	$Julius and Lilija met Naktis around this location. Could Lilija's necklace be around here?
 QUEST_LV_0200_20150323_004705	$Pilgrim Zenius is protecting food at the Starving Demon's Way. He seems to have a story to tell so go talk to him.
 QUEST_LV_0200_20150323_004706	$A man stole a lump of food under Pilgrim Zenius' watch. Talk to Zenius about it.
 QUEST_LV_0200_20150323_004707	$Pilgrim Zenius said that man is his son, and he wants the curse removed from his son. First, defeat the monsters nearby.
@@ -7235,7 +7235,7 @@ QUEST_LV_0200_20150714_007238	Don't mind what's written on the records. {nl}It's
 QUEST_LV_0200_20150714_007239	I have to escort, clean up, and guard. I wonder how they are expecting me to do everything alone. {nl}It's a good thing you came to help.
 QUEST_LV_0200_20150714_007240	It is an old story,{nl}but many kingdom soldiers came to this place to do a preliminary check to support for the research of Kalis Knightage.{nl}
 QUEST_LV_0200_20150714_007241	But, unlike their expectations, the Stone Frosts were waiting for them.{nl}They died there... I want to get their keepstakes, but it's hard...
-QUEST_LV_0200_20150714_007242	The authorities do not take it well that tens of soldiers were sacrificed for support activities. {nl}That's why the Kingdom army and Kalis knights have become distant.
+QUEST_LV_0200_20150714_007242	The authorities do not take it well that tens of soldiers were sacrificed for support activities. {nl}That's why the kingdom army and Kalis knights have become distant.
 QUEST_LV_0200_20150714_007243	Good thing I was off duty that day.. I don't even want to think about it.{nl}I will deliver this to the families of the deceased.
 QUEST_LV_0200_20150714_007244	Gofden...{nl}The symbol of Schilt... Ah sorry I talked alone in front of you.{nl}When you are carrying this, you will not receive the curse of the Stone Frosts. Don't you think it's amazing?{nl}
 QUEST_LV_0200_20150714_007245	People say you go around to save the world according to the will of Goddess?{nl}Then you could save also save this city!
@@ -8885,7 +8885,7 @@ QUEST_LV_0200_20150729_008888	The Seal Stone will just scatter away when release
 QUEST_LV_0200_20150729_008889	Defeat the Flask Mage and get the Crystal of Restriction
 QUEST_LV_0200_20150729_008890	{memo Why is there a memo x, if this is used in the game?} {memo X}The spirit of the Sealed Stone wants to be freed from the seal. Gather the Crystal of Restriction from the Flask Mage and break them.
 QUEST_LV_0200_20150729_008891	{memo X}The Weak Owl wants you to find other owls that the monsters took away. Find the traces of owl statue in the monster's hideaway locate at the end of Ishrai Crossroads.
-QUEST_LV_0200_20150729_008892	$Pilgrim Liliya told you that she is very hungry and asked you to get her some food. Get some edible meat from Kepo.
+QUEST_LV_0200_20150729_008892	$Pilgrim Lilija told you that she is very hungry and asked you to get her some food. Get some edible meat from Kepo.
 QUEST_LV_0200_20150729_008893	Get the meat of Kepari
 QUEST_LV_0200_20150729_008894	Pilgrim Julius can't move due to severe hunger. Get some Kepari meat for him to eat.
 QUEST_LV_0200_20150729_008895	Got enough Kepari meat. Give it to Pilgrim Julius.
@@ -8931,8 +8931,8 @@ QUEST_LV_0200_20150908_008934	Thank you for freeing me.
 QUEST_LV_0200_20150908_008935	Now I'm really released.
 QUEST_LV_0200_20150908_008936	Go upstairs and find Goddess Gabija!
 QUEST_LV_0200_20150908_008937	$The Mushwort that destroyed the Owl Sculpture appeared!
-QUEST_LV_0200_20150908_008938	Liliya passed away. {nl}Make a grave for her.
-QUEST_LV_0200_20150908_008939	Made a grave for Liliya
+QUEST_LV_0200_20150908_008938	Lilija passed away. {nl}Make a grave for her.
+QUEST_LV_0200_20150908_008939	Made a grave for Lilija
 QUEST_LV_0200_20150908_008940	Searching through the rottem meat
 QUEST_LV_0200_20150908_008941	Found food waste from the food pile! {nl}Throw it to the monsters using V key and defeat it!
 QUEST_LV_0200_20150908_008942	Successfully destroyed Tree Root Crystal! {nl}The curse laid around will disappear!
@@ -9078,10 +9078,10 @@ QUEST_LV_0200_20150918_009081	However, do me a favor and I'll give you some equi
 QUEST_LV_0200_20150918_009082	We don't ask for a lot. {nl} You can see this in the signs the pilgrims make along Starving Demon's Way.
 QUEST_LV_0200_20150918_009083	If not, then we don't have a choice. {nl} If we can, we will mutually profit.
 QUEST_LV_0200_20150918_009084	You've come to want something, huh? {nl} An interesting life really depends on reckless challenges, huh?
-QUEST_LV_0200_20150918_009085	{memo X}$Well, well. What have I been doing? {nl} Oh, my Liliya...{nl}
+QUEST_LV_0200_20150918_009085	{memo X}$Well, well. What have I been doing? {nl} Oh, my Lilija...{nl}
 QUEST_LV_0200_20150918_009086	$Her music box and necklace were snatched by Naktis' subordinates, and infused with Naktis' curse. It's as if they are trying to mock Maven's teachings.
 QUEST_LV_0200_20150918_009087	$Hold on a sec, my head's ringing again from that curse. {nl} There's still so much to say... I don't know if I will be able to handle it right now.
-QUEST_LV_0200_20150918_009088	$Thank you very much. It's really gotten better. {nl} The music box.. My Liliya.. She may no longer be in this world. {nl}
+QUEST_LV_0200_20150918_009088	$Thank you very much. It's really gotten better. {nl} The music box.. My Lilija.. She may no longer be in this world. {nl}
 QUEST_LV_0200_20150918_009089	$If you run into any Naktis' possessions, please be sure to carefully inspect them for her sake. {nl} The symbol of our love that the demon swallowed... Please accept it as our gratitude for helping us claim revenge.
 QUEST_LV_0200_20150918_009090	$That symbol is a necklace blessed by the Cathedral, so it must be very useful. {nl} To me, that necklace no longer holds any meaning.
 QUEST_LV_0200_20150918_009091	$Thanks for your words.{nl}I would really appreciate it if you could defeat the monsters here that are disturbing me.
@@ -9166,7 +9166,7 @@ QUEST_LV_0200_20151001_009169	I heard the story about the revaltor who blocked t
 QUEST_LV_0200_20151001_009170	I've been to many places before in my life, but this place is really horrible.{nl}Even if I want to rescue the ones who are cursed, the only thing I can do is to help them fall asleep comfortably.
 QUEST_LV_0200_20151001_009171	I heard a Revelator defeated the Demon Lord who were attacking the Mage Tower.{nl}That's the most happy news I've heard lately.{nl}Other news I've heard were horrible.
 QUEST_LV_0200_20151001_009172	Is it true that some Revelator defeated the Demon Lord who casted the curse in this region?{nl}If that's true, it is so fortunate since we don't have to see these horrible things again.
-QUEST_LV_0200_20151001_009173	Damn. What was I doing?{nl}Ahah. My Liliya...{nl}
+QUEST_LV_0200_20151001_009173	Damn. What was I doing?{nl}Ahah. My Lilija...{nl}
 QUEST_LV_0200_20151001_009174	Do not bother the placed food piles.{nl} They should have shuffled over here by now... just keep watching.
 QUEST_LV_0200_20151001_009175	While my brothers were on the their way to the training, they all died due to the tricks from the demons.{nl}I feel sorry for my brothers who can't return to the godddesses.{nl}
 QUEST_LV_0200_20151001_009176	And they were so obsessed with madness even after their death so they could not even return to the goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -22,13 +22,13 @@ QUEST_LV_0200_20150317_000021	$Ever since that huge tree suddenly arose, this fo
 QUEST_LV_0200_20150317_000022	$Devoted Owl Sculpture
 QUEST_LV_0200_20150317_000023	$Someone called Mokuhyoto was held captive. {nl} I have a feeling he's going to disappear...
 QUEST_LV_0200_20150317_000024	$The sacred force created by the Goddess hasn't completely dissipated. {nl}Will it be able to suppress this devastation? {nl}
-QUEST_LV_0200_20150317_000025	$The Commander gave me power.{nl}I won't be scared.
-QUEST_LV_0200_20150317_000026	$I'm not going to be afraid anymore.[nl}I will never be eaten by monsters.
+QUEST_LV_0200_20150317_000025	$The chief gave me power.{nl}I won't be scared.
+QUEST_LV_0200_20150317_000026	$I'm not going to be afraid anymore. I will never be eaten by monsters.
 QUEST_LV_0200_20150317_000027	$Painful Owl Sculpture
 QUEST_LV_0200_20150317_000028	$I'm suffering every day.{nl}Perhaps, I will also be eaten by monsters.
 QUEST_LV_0200_20150317_000029	$This forest is increasingly covered with demons.{nl}Where is the Goddess?
-QUEST_LV_0200_20150317_000030	$I was chosen by the Commander... {nl} I'll do my best to defeat the monsters.
-QUEST_LV_0200_20150317_000031	$The Commander was also struggling like this..{nl}Never would I be eaten until the Goddess comes back.
+QUEST_LV_0200_20150317_000030	$I was chosen by the chief... {nl} I'll do my best to defeat the monsters.
+QUEST_LV_0200_20150317_000031	$The chief was also struggling like this..{nl}Never would I be eaten until the Goddess comes back.
 QUEST_LV_0200_20150317_000032	Subordinate Owl 3
 QUEST_LV_0200_20150317_000033	We are always here at this place, but where is our Goddess who is always worried about us?
 QUEST_LV_0200_20150317_000034	Do we exist only for the Human's soul?
@@ -140,8 +140,8 @@ QUEST_LV_0200_20150317_000139	$Earnest Owl Chief Sculpture
 QUEST_LV_0200_20150317_000140	$Thank you so much. {nl}The other owls must have gained confidence because of you.
 QUEST_LV_0200_20150317_000141	$Weak Owl Sculpture
 QUEST_LV_0200_20150317_000142	$It really was too late..{nl}The Goddess really can be harsh sometimes..
-QUEST_LV_0200_20150317_000143	$I have a last request. {nl}Can you burn the Owls so they could rest in peace?
-QUEST_LV_0200_20150317_000144	$Do you think my colleagues can reach Goddess Ausrine safely?
+QUEST_LV_0200_20150317_000143	$I have one last request. {nl}Can you burn the Owls so they could rest in peace?
+QUEST_LV_0200_20150317_000144	$Do you think my allies can reach Goddess Ausrine safely?
 QUEST_LV_0200_20150317_000145	$Thank you so much. {nl}First bring me the Oil from Oil Boxes on the way to Neuoder Field.
 QUEST_LV_0200_20150317_000146	$If you are okay with it, I'd like to get some more help from you.{nl}I've sent a messenger, but due to the last attack, I am now worried about him.{nl}
 QUEST_LV_0200_20150317_000147	$That messenger should be safe... but I still worry for him.
@@ -392,7 +392,7 @@ QUEST_LV_0200_20150317_000391	$If we retreat, Klaipeda will be totally isolated.
 QUEST_LV_0200_20150317_000392	$Troops in the frontlines don't know what hardships we go through. {nl}They think that they're the only ones who have their lives on the line.
 QUEST_LV_0200_20150317_000393	$It would be nice if the Goddess send us her blessings at times like this.. {nl}Honestly, we're exhausted.
 QUEST_LV_0200_20150317_000394	$Do you think there will be an end to this war? {nl}Frankly, I'm scared.
-QUEST_LV_0200_20150317_000395	$The Rearguard Units are doing their best but the supply situation remains horrible.
+QUEST_LV_0200_20150317_000395	$The Rearguard Units are doing their best, but the supply situation remains horrible.
 QUEST_LV_0200_20150317_000396	$Is Helgasercle attacking again? {nl}If that's the case, this battle will be a very long one..
 QUEST_LV_0200_20150317_000397	Are there still a lot of monsters in the tower?
 QUEST_LV_0200_20150317_000398	Even if they outnumber us, we can't let them ruin the tower!
@@ -409,12 +409,12 @@ QUEST_LV_0200_20150317_000408	{memo X}Nevermind if you can't. {nl}But if you can
 QUEST_LV_0200_20150317_000409	{memo X}Oh, you got it... {nl}Well, aren't reckless challenges the fun in life?
 QUEST_LV_0200_20150317_000410	The monsters are eating my colleagues. {nl}I still have the divine power received from the Goddess but it won't last long.
 QUEST_LV_0200_20150317_000411	Officer Danus
-QUEST_LV_0200_20150317_000412	If we don't get back this forest, many cities will be isolated. {nl}But the situation isn't on our side.
+QUEST_LV_0200_20150317_000412	Many cities will become isolated if we don't get back this forest.. {nl}But the situation isn't on our side.
 QUEST_LV_0200_20150317_000413	This forest doesn't even have Owl Sculptures. {nl}Makes you feel like you really don't want to come back.
 QUEST_LV_0200_20150317_000414	$Soldier Roy
 QUEST_LV_0200_20150317_000415	$I heard the Rearguard Unit was surrounded. How did you make it through? {nl}
-QUEST_LV_0200_20150317_000416	$Commander Johan
-QUEST_LV_0200_20150317_000417	I'm a commander who sent his men first. What words can I say? {nl}I feel miserable.
+QUEST_LV_0200_20150317_000416	$Squad Commander Johan
+QUEST_LV_0200_20150317_000417	I am a squad commander who sent his men first. What words can I say? {nl}I feel miserable.
 QUEST_LV_0200_20150317_000418	This battle was a shameful one as a commander. {nl}I don't know what would have happened if it wasn't for you..
 QUEST_LV_0200_20150317_000419	Danus' Scout
 QUEST_LV_0200_20150317_000420	It's too scary to patrol the area full of monsters. {nl}But I can't keep relying on other people either..
@@ -451,7 +451,7 @@ QUEST_LV_0200_20150317_000450	$The Rearguard Unit always complains the supplies 
 QUEST_LV_0200_20150317_000451	$Oh, you got them. Thank you. {nl}Please go back to the monster's nest and burn the Destroyed Owls.
 QUEST_LV_0200_20150317_000452	$Terrible things are happening. {nl}Can we go back to peaceful days?
 QUEST_LV_0200_20150317_000453	$The Goddess can be so cruel. {nl}Please pray that my colleagues may rest in peace.
-QUEST_LV_0200_20150317_000454	$Pilgrim Lilija
+QUEST_LV_0200_20150317_000454	$Pilgrim Liliya
 QUEST_LV_0200_20150317_000455	{memo X}If I die, please bury me..{nl}Make my body unseen..{nl}If I lose my breath, please bury me..
 QUEST_LV_0200_20150317_000456	{memo X}And if you meet a pilgrim named Julius, please tell him these words.. tell him goodbye..
 QUEST_LV_0200_20150317_000457	Pilgrim's Memo
@@ -470,7 +470,7 @@ QUEST_LV_0200_20150317_000469	Pilgrim Julius
 QUEST_LV_0200_20150317_000470	{memo X}I think there was some food here.. {nl}Did that guy take it? {nl}Ugh..
 QUEST_LV_0200_20150317_000471	{memo X}I'm starving and now I'm having headaches! {nl}I feel my head exploding with just the thought of food but other things keep coming to mind. {nl}What was it.. Something like an orgel..
 QUEST_LV_0200_20150317_000472	{memo X}{nl}Why does it's food keep popping up in my mind when I can't even eat it.
-QUEST_LV_0200_20150317_000473	{memo X}Those dirty fools.. I will revenge.. {nl}Aah Lilija..
+QUEST_LV_0200_20150317_000473	{memo X}Those dirty fools.. I will revenge.. {nl}Aah Liliya..
 QUEST_LV_0200_20150317_000474	{memo X}The necklace.. yes. {nl}Well done.. Please take good care of it. {nl}This is a token of my gratitude.. The orgel was a memento for both of us but the necklace is special..
 QUEST_LV_0200_20150317_000475	{memo X}{nl}The Cathedral was blessed so I'm sure it'll be a good thing for you too.
 QUEST_LV_0200_20150317_000476	{memo X}Aaaaagghh! Aaagh! {nl}I will swallow it all!!!
@@ -483,14 +483,14 @@ QUEST_LV_0200_20150317_000482	{memo X}That is it! give me that! {nl}I'm going to
 QUEST_LV_0200_20150317_000483	{memo X}...? That? What about that? {nl}
 QUEST_LV_0200_20150317_000484	{memo X}Oww! My head! Arrgh! Yuck! What's that? What about that orgel? {nl}
 QUEST_LV_0200_20150317_000485	{memo X}Memory.. Her.. Give me that! It's mine!
-QUEST_LV_0200_20150317_000486	{memo X}So that's what happened.. Thank you. She left this orgel behind. {nl}We promised marriage and we left our way on pilgrimage to the Cathedral to confirm our promise for the future. {nl}But ah.. Lilija.. Lilija..!!{nl}
+QUEST_LV_0200_20150317_000486	{memo X}So that's what happened.. Thank you. She left this orgel behind. {nl}We promised marriage and we left our way on pilgrimage to the Cathedral to confirm our promise for the future. {nl}But ah.. Liliya.. Liliya..!!{nl}
 QUEST_LV_0200_20150317_000487	{memo X}In our happy journey to pilgrimage.. That's where we met then. {nl}Na.. Naktis! Demon Lord!{nl}She took away our necklace and orgel, stared at it for some time, and threw it far away!
 QUEST_LV_0200_20150317_000488	{memo X}{nl}Then she made us fight and hate each other for gluttony and just disappeared. {nl}I need to go.. To meet her, she, how is she..
 QUEST_LV_0200_20150317_000489	{memo X}The orgel rolled out somewhere and the necklace.. Her subordinate swallowed it. {nl}
 QUEST_LV_0200_20150317_000490	{memo X}Then Naktis made us.. Like this.. {nl}
 QUEST_LV_0200_20150317_000491	{memo X}Oh, sorry. {nl}I'm too dizzy and it's difficult to talk. {nl}There are Nikotias in the Starving Demon's Way that are used as medicinal herbs. Won't the dizziness fade away if I eat some of those herbs?
 QUEST_LV_0200_20150317_000492	{memo X}I heard Nikotias grow in the upper area. {nl}But it's not easy to get it so be careful.
-QUEST_LV_0200_20150317_000493	{memo X}Ah, it's that.. Thank you. {nl}It feels better. {nl}Lilija.. Her orgel.. She probably isn't in this world anymore.. Without her, I don't need this necklace either. {nl}
+QUEST_LV_0200_20150317_000493	{memo X}Ah, it's that.. Thank you. {nl}It feels better. {nl}Liliya.. Her orgel.. She probably isn't in this world anymore.. Without her, I don't need this necklace either. {nl}
 QUEST_LV_0200_20150317_000494	{memo X}If you meet that nasty Naktis' monster, please strike a revenge for me. {nl}Please take out the sign of our love from it and let it see the light of the world. {nl}And as a sign of gratitude for the revenge, please keep that necklace. {nl}
 QUEST_LV_0200_20150317_000495	{memo X}It's a necklace that received the blessings of the Cathedral so it will come in handy. {nl}That necklace doesn't mean anything to me anymore..
 QUEST_LV_0200_20150317_000496	Pilgrim Zenius
@@ -683,7 +683,7 @@ QUEST_LV_0200_20150317_000682	$This is a fragment of my friend's wing. {nl}It wa
 QUEST_LV_0200_20150317_000683	$Please. Deliver this Wing Fragment to the other owls. {nl}It still has the power of the Goddess left in it so it will encourage them. {nl}
 QUEST_LV_0200_20150317_000684	$This is a fragment of Owl Chief's wing.. {nl}Thank you. We will continue to work hard!
 QUEST_LV_0200_20150317_000685	$The other owls are in Kongfiska Hill and Clover Highland. {nl}I believe that this strength will help at least a bit.
-QUEST_LV_0200_20150317_000686	$Isn't that a fragment of the Chiefs' wing? {nl}
+QUEST_LV_0200_20150317_000686	$Isn't that a fragment of the chief's wing? {nl}
 QUEST_LV_0200_20150317_000687	$Be careful. The monsters are flocking in!
 QUEST_LV_0200_20150317_000688	$Patrol Scout
 QUEST_LV_0200_20150317_000689	$If you see an unlit bonfire, please light it again. {nl}This place is quite dark even during the day.
@@ -815,16 +815,16 @@ QUEST_LV_0200_20150317_000814	$Have you seen a soldier named Roy? {nl}
 QUEST_LV_0200_20150317_000815	$You mean you returned him to the Rearguard? {nl}That's bad. We're short on men. You are partly responsible for that now, so you better cooperate.
 QUEST_LV_0200_20150317_000816	$Blood will be shed soon. {nl}I pity you for going in Roy's stead.
 QUEST_LV_0200_20150317_000817	$So, just as I've heard. {nl}
-QUEST_LV_0200_20150317_000818	$The next mission is to find my missing scouts. {nl}They were sent to Razysis Hills but have not returned for hours.
-QUEST_LV_0200_20150317_000819	$The scout unit was attacked, myself included. {nl}I hope I can at least find the report to send to Sir Philipas..
+QUEST_LV_0200_20150317_000818	$The next mission is to find my missing scouts. {nl}They were sent to Razygis Hill but have not returned for hours.
+QUEST_LV_0200_20150317_000819	$The scout unit was attacked, myself included. {nl}I hope I can at least find the report to send to sir Philipas..
 QUEST_LV_0200_20150317_000820	{memo X}Our squad is all dead because of my incompetence. {nl}I'm the only one alive but I don't think I have much time left either.
-QUEST_LV_0200_20150317_000821	$This report is completely soaked in blood and can't be read. {nl}I can't stand that my men's efforts were all for nothing.
-QUEST_LV_0200_20150317_000822	$There is one last favor I would like to ask you. {nl}The remains of my men are in the hills. Please take care of them.
+QUEST_LV_0200_20150317_000821	$This report is completely soaked in blood and unreadable. {nl}I can't stand that my men's efforts were all for nothing.
+QUEST_LV_0200_20150317_000822	$There is one last favor I would like to ask you. {nl}The remains of my men are up in the hills. Please take care of them.
 QUEST_LV_0200_20150317_000823	$I feel sorry for them being abandoned amongst the monsters.
 QUEST_LV_0200_20150317_000824	$Thank you.{nl}My men can now rest in peace. {nl}
-QUEST_LV_0200_20150317_000825	$Oh, I've found some readable parts from my men's reports. {nl}Please tell Sir Philipas that the monsters will attack the regular troops soon.
-QUEST_LV_0200_20150317_000826	$..is that so. I guess it's too late for the scouts. {nl}I swear to treat them with respect. {nl}
-QUEST_LV_0200_20150317_000827	$According to Johan's report, we better strike them from behind. {nl}I'll meet you in Izdaginakas Highway.
+QUEST_LV_0200_20150317_000825	$Oh, I've found some readable parts from my men's reports. {nl}Please tell sir Philipas that the monsters will attack the regular troops soon.
+QUEST_LV_0200_20150317_000826	$..Is that so? I guess it's too late for the scouts. {nl}I swear to treat them with respect. {nl}
+QUEST_LV_0200_20150317_000827	$According to Johan's report, we better strike them from behind. {nl}I will meet you in Izdaginakas Highway.
 QUEST_LV_0200_20150317_000828	$Revenge is best served cold. {nl}Even for Johan and his men.
 QUEST_LV_0200_20150317_000829	$You're here. {nl}Are you ready? {nl}
 QUEST_LV_0200_20150317_000830	$The battle has begun. Troops have entered Izdaginakas Highway already. {nl}It will be a big help if you fight with them.
@@ -833,10 +833,10 @@ QUEST_LV_0200_20150317_000832	{memo X}It looks like you've done more than Roy's 
 QUEST_LV_0200_20150317_000833	$I hope the blessings of the Goddess be with you on your journey.
 QUEST_LV_0200_20150317_000834	{memo X}I can't close my eyes before we defeat that monster.
 QUEST_LV_0200_20150317_000835	When will this pitiful feeling end. {nl}When I look at the souls, I don't think it will end.
-QUEST_LV_0200_20150317_000836	I can't help that the supplies or backup is delayed. {nl}But tellin us to just wait is too much.
+QUEST_LV_0200_20150317_000836	I can't help that the supplies or backup is delayed. {nl}But telling us to just wait is too much.
 QUEST_LV_0200_20150317_000837	I'm afraid where the monsters will jump out from. {nl}I plan to run away if an unknown monster shows up.
 QUEST_LV_0200_20150317_000838	We're making up for the lacking supplies. {nl}If the supplies don't arrive, we have to cover for it on site.
-QUEST_LV_0200_20150317_000839	Somehow, at least Sir Philipas' troops..
+QUEST_LV_0200_20150317_000839	Somehow, at least sir Philipas' troops..
 QUEST_LV_0200_20150317_000840	There was another way that we used before. {nl}But this happened when the gigantic tree suddenly emerged. {nl}
 QUEST_LV_0200_20150317_000841	We're clearing up the route to make it easy for the supplies but.. {nl}As if the monsters causing us isolation is not enough, now there is no news of supplies and the soldiers are becoming weary.
 QUEST_LV_0200_20150317_000842	$I'll be grateful if you can do that. {nl}If you relieve us from their attacks, it might even boost the troop's morale.
@@ -846,7 +846,7 @@ QUEST_LV_0200_20150317_000845	$There are more and more wandering souls. {nl}So a
 QUEST_LV_0200_20150317_000846	$First, you have to find the hiding Throneweaver. {nl}Please gather Ridimed Leaves. The Throneweaver loves it. {nl}{nl}
 QUEST_LV_0200_20150317_000847	{memo X}Good. {nl}First, defeat the Big Blue Grivas up the hills and put a damper on them.
 QUEST_LV_0200_20150317_000848	I feel regretful. I can't close my eyes like this.
-QUEST_LV_0200_20150317_000849	$I have a request. Please save my colleagues. {nl}They will be eaten if we don't save them quickly.
+QUEST_LV_0200_20150317_000849	$I have a request. Please save my allies. {nl}They will be eaten if we don't save them quickly.
 QUEST_LV_0200_20150317_000850	{memo X}There is a monster's nest at the end of this road. {nl}My colleagues may still be alive there.
 QUEST_LV_0200_20150317_000851	{memo X}Thank you. {nl}My colleagues were taken to the nest at the end of the road.
 QUEST_LV_0200_20150317_000852	$I can't feel the owl that guides the souls at Ishrai Crossroads. {nl}I'm worried that it may have been attacked by the monsters.
@@ -1337,16 +1337,16 @@ QUEST_LV_0200_20150317_001336	Where are the Supply Troops (2)
 QUEST_LV_0200_20150317_001337	I'll help retrieve the supplies
 QUEST_LV_0200_20150317_001338	I'll wait until all the supplies are retrieved
 QUEST_LV_0200_20150317_001339	Where are the Supply Troops (3)
-QUEST_LV_0200_20150317_001340	Mission over mission
+QUEST_LV_0200_20150317_001340	Mission over Mission
 QUEST_LV_0200_20150317_001341	I'll help collect the hooks
 QUEST_LV_0200_20150317_001342	Let's wait until everything is collected
 QUEST_LV_0200_20150317_001343	Leadership of Philipas
 QUEST_LV_0200_20150317_001344	I will cooperate
 QUEST_LV_0200_20150317_001345	That is unfair
-QUEST_LV_0200_20150317_001346	Troop left alone
+QUEST_LV_0200_20150317_001346	Troop Left Alone
 QUEST_LV_0200_20150317_001347	Find the report
 QUEST_LV_0200_20150317_001348	{memo X}Better return quickly
-QUEST_LV_0200_20150317_001349	Spend the last together
+QUEST_LV_0200_20150317_001349	Spend the Last Together
 QUEST_LV_0200_20150317_001350	I will collect the keepstakes
 QUEST_LV_0200_20150317_001351	{memo X}Disaster of Great Root Plain (1)
 QUEST_LV_0200_20150317_001352	Let's follow to the Izdagingkas Road
@@ -1599,9 +1599,9 @@ QUEST_LV_0200_20150317_001598	$Insatiable Hunger (2)
 QUEST_LV_0200_20150317_001599	$Insatiable Hunger (3)
 QUEST_LV_0200_20150317_001600	$Insatiable Hunger (4)
 QUEST_LV_0200_20150317_001601	{memo X}I'll make it next time
-QUEST_LV_0200_20150317_001602	{memo X}Notice /! / Lilija died .. {nl} Please make a grave for her # 3
-QUEST_LV_0200_20150317_001603	{memo X}Making a grave for Lilija/ SITGROPE / 3 / TRACK_BEFORE / None
-QUEST_LV_0200_20150317_001604	{memo X}Notice /You made a grave for Lilija # 5
+QUEST_LV_0200_20150317_001602	{memo X}Notice /! / Liliya died .. {nl} Please make a grave for her # 3
+QUEST_LV_0200_20150317_001603	{memo X}Making a grave for Liliya/ SITGROPE / 3 / TRACK_BEFORE / None
+QUEST_LV_0200_20150317_001604	{memo X}Notice /You made a grave for Liliya # 5
 QUEST_LV_0200_20150317_001605	Endless Gluttony (1)
 QUEST_LV_0200_20150317_001606	{memo X}I'll find something to eat
 QUEST_LV_0200_20150317_001607	Ignore it and go your way
@@ -2160,7 +2160,7 @@ QUEST_LV_0200_20150317_002159	$The Supply Officer told you that since the soldie
 QUEST_LV_0200_20150317_002160	$Talk to Soldier Roy
 QUEST_LV_0200_20150317_002161	$It seems that you found Soldier Roy. Talk to Soldier Roy.
 QUEST_LV_0200_20150317_002162	$Obtain a Puragi's Hook
-QUEST_LV_0200_20150317_002163	$Soldier Roy told you that he can't go back before he completes his mission. Collect a Puragi's Hook to help Soldier Roy.
+QUEST_LV_0200_20150317_002163	$Soldier Roy told you that he can't go back before he completes his mission. Collect a Puragi's Hook to help him.
 QUEST_LV_0200_20150317_002164	$Hand it over to Soldier Roy
 QUEST_LV_0200_20150317_002165	$You've got a Puragi's Hook. Hand it over to Soldier Roy.
 QUEST_LV_0200_20150317_002166	$Talk to Senior Officer Philipas
@@ -2169,25 +2169,25 @@ QUEST_LV_0200_20150317_002168	$Defeat a Big Blue Griba at the hills
 QUEST_LV_0200_20150317_002169	$Senior Officer Philipas is blaming you for Soldier Roy being at the Rearguard. First defeat a Big Blue Griba at the hills.
 QUEST_LV_0200_20150317_002170	$Report to Philipas
 QUEST_LV_0200_20150317_002171	$You've defeated a Big Blue Griba on the hills. Report to Senior Officer Philipas
-QUEST_LV_0200_20150317_002172	$Look for the Squad Commander Johan
+QUEST_LV_0200_20150317_002172	$Look for Squad Commander Johan
 QUEST_LV_0200_20150317_002173	$Senior Officer Philipas is telling you that he direly needs the report of his scouts, but the scouts are not coming back. Look for the scouts who left for Razygis Hills.
 QUEST_LV_0200_20150317_002174	$Look for the report from the monsters nearby
 QUEST_LV_0200_20150317_002175	$Squad Commander Johan told you that all his colleagues are dead and he is the only one that managed to survive. Defeat the monsters nearby and look for the report.
 QUEST_LV_0200_20150317_002176	$Hand it over to Squad Commander Johan
 QUEST_LV_0200_20150317_002177	$You found the reports that are not readable since they are soaked with blood. Hand them over to Squad Commander Johan
 QUEST_LV_0200_20150317_002178	$Talk to Squad Commander Johan
-QUEST_LV_0200_20150317_002179	$Johan thought deeply about something after receiving the reports that are soaked with blood. Talk to Johan again.
-QUEST_LV_0200_20150317_002180	$Collect the remains of the soldiers
-QUEST_LV_0200_20150317_002181	$Squad Commander Johann is sad to discover that the corpses of his comrades are left with the monsters. Recover the remains of the soldiers for Johan.
-QUEST_LV_0200_20150317_002182	$Hand them over to Johan
-QUEST_LV_0200_20150317_002183	$You've finished retrieving all the remains. Hand them over to Johan.
-QUEST_LV_0200_20150317_002184	$Please report Johan's message, and the story of his colleagues to the Senior Officer Philipas.
+QUEST_LV_0200_20150317_002179	$Johan thought deeply about something after receiving the reports that are soaked with blood. Talk to him again.
+QUEST_LV_0200_20150317_002180	$Collect the remains of a soldier
+QUEST_LV_0200_20150317_002181	$Squad Commander Johan is sad to discover that the corpses of his comrades are left with the monsters. Recover the remains of the soldiers for him.
+QUEST_LV_0200_20150317_002182	$Hand them over to Squad Commander Johan
+QUEST_LV_0200_20150317_002183	$You've finished retrieving all the remains. Hand them over to Squad Commander Johan.
+QUEST_LV_0200_20150317_002184	$Please report Squad Commander Johan's message, and the story of his colleagues to the Senior Officer Philipas.
 QUEST_LV_0200_20150317_002185	$Follow the Senior Officer Philipas
 QUEST_LV_0200_20150317_002186	$Senior Officer Philipas is trembling with fury and decided to head to battle. Follow Philipas to Izdaginakas Highway.
 QUEST_LV_0200_20150317_002187	$Senior Officer Philipas' Mission
 QUEST_LV_0200_20150317_002188	$All the soldiers are participating in the battle. Talk with Senior Officer Philipas
 QUEST_LV_0200_20150317_002189	$The soldiers are already fighting against Mushwort. Defeat the Mushwort.
-QUEST_LV_0200_20150317_002190	$Report to Philipas
+QUEST_LV_0200_20150317_002190	$Report to Senior Officer Philipas
 QUEST_LV_0200_20150317_002191	$You've defeated the Mushwort. Talk to Philipas.
 QUEST_LV_0200_20150317_002192	$Found a herd of small Gribas
 QUEST_LV_0200_20150317_002193	$There is a small herd of Gribas near the Rearguard Unit Camp. Let's go and see them carefully.
@@ -2641,7 +2641,7 @@ QUEST_LV_0200_20150317_002640	$Defeat Corrupted
 QUEST_LV_0200_20150317_002641	$Talk to the Owl Chief Sculpture
 QUEST_LV_0200_20150317_002642	$The Earnest Owl Chief Sculpture seems gloomy. Talk to it again.
 QUEST_LV_0200_20150317_002643	$Check the Weak Owl Sculpture in Ishrai Crossroads
-QUEST_LV_0200_20150317_002644	$The Owl Chief says it's worried about the Owl in Ishrai Crossroads. Look for the Weak Owl and if it is out of place or fallen down, help it back up.
+QUEST_LV_0200_20150317_002644	$The Owl Chief says it's worried about the owl in Ishrai Crossroads. Look for the Weak Owl and if it is out of place or fallen down, help it back up.
 QUEST_LV_0200_20150317_002645	$Talk to the Weak Owl Sculpture
 QUEST_LV_0200_20150317_002646	$Stood back the Weak Owl Sculpture lying on the floor. Talk to it.
 QUEST_LV_0200_20150317_002647	$The Weak Owl Sculpture seems like it is about to cry. Talk to it.
@@ -2649,26 +2649,26 @@ QUEST_LV_0200_20150317_002648	$Find traces of the kidnapped Owls
 QUEST_LV_0200_20150317_002649	{memo X}The Weak Owl wants you to find other owls that the monsters took away. Find the traces of owl statue in the monster's hideaway located at each end of the Ishrai Crossroad.
 QUEST_LV_0200_20150317_002650	$Give the Broken Piece of Owl
 QUEST_LV_0200_20150317_002651	{memo X}Found all the Broken Pieces of the Owl. Give it to the Weak Owl.
-QUEST_LV_0200_20150317_002652	{memo X}Talk to Lilija
-QUEST_LV_0200_20150317_002653	{memo X}There is a pilgrim names Lilija in Way of the Big Staving Demons. Seems like she desperately needs something so try talking to her.
+QUEST_LV_0200_20150317_002652	{memo X}Talk to Liliya
+QUEST_LV_0200_20150317_002653	{memo X}There is a pilgrim names Liliya in Way of the Big Staving Demons. Seems like she desperately needs something so try talking to her.
 QUEST_LV_0200_20150317_002654	{memo X}Find food
-QUEST_LV_0200_20150317_002655	{memo X}Lilija keeps saying that she's hungry. Get some meat from the monsters around and give it to her.
-QUEST_LV_0200_20150317_002656	{memo X}Give monster meat to Lilija.
+QUEST_LV_0200_20150317_002655	{memo X}Liliya keeps saying that she's hungry. Get some meat from the monsters around and give it to her.
+QUEST_LV_0200_20150317_002656	{memo X}Give monster meat to Liliya.
 QUEST_LV_0200_20150317_002657	{memo X}Get %s from monsters nearby
-QUEST_LV_0200_20150317_002658	$Lilija still seems hungry. Talk to her again.
+QUEST_LV_0200_20150317_002658	$Liliya still seems hungry. Talk to her again.
 QUEST_LV_0200_20150317_002659	{memo X}Get soft reed stem
-QUEST_LV_0200_20150317_002660	{memo X}Gather soft reed stem for Lilija from the reed sprouts nearby.
-QUEST_LV_0200_20150317_002661	{memo X}Gathered all the soft reed stems. Give it to Lilija.
+QUEST_LV_0200_20150317_002660	{memo X}Gather soft reed stem for Liliya from the reed sprouts nearby.
+QUEST_LV_0200_20150317_002661	{memo X}Gathered all the soft reed stems. Give it to Liliya.
 QUEST_LV_0200_20150317_002662	{memo X}Gather %s from reed sprouts
-QUEST_LV_0200_20150317_002663	{memo X}Is Lilija's hunger satisfied? Talk to her again.
+QUEST_LV_0200_20150317_002663	{memo X}Is Liliya's hunger satisfied? Talk to her again.
 QUEST_LV_0200_20150317_002664	$Defeat Carnivore
-QUEST_LV_0200_20150317_002665	$What happened? The hungry Lilija is gone and a Carnivore suddenly appeared. First, defeat the Carnivore that is attacking you.
-QUEST_LV_0200_20150317_002666	{memo X}Talk to Lilija on the floor
-QUEST_LV_0200_20150317_002667	{memo X}Lilija appeared on the spot where Carnivore was defeated. Try talking to Lilija.
-QUEST_LV_0200_20150317_002668	{memo X}Defeat the Carnivore that seems like what Lilija turned into
-QUEST_LV_0200_20150317_002669	{memo X}Make a grave for Lilija
-QUEST_LV_0200_20150317_002670	{memo X}Seems like Lilija will lose her breathe soon.. Do her last favor.
-QUEST_LV_0200_20150317_002671	{memo X}Make a grave for Lilija
+QUEST_LV_0200_20150317_002665	$What happened? The hungry Liliya is gone and a Carnivore suddenly appeared. First, defeat the Carnivore that is attacking you.
+QUEST_LV_0200_20150317_002666	{memo X}Talk to Liliya on the floor
+QUEST_LV_0200_20150317_002667	{memo X}Liliya appeared on the spot where Carnivore was defeated. Try talking to Liliya.
+QUEST_LV_0200_20150317_002668	{memo X}Defeat the Carnivore that seems like what Liliya turned into
+QUEST_LV_0200_20150317_002669	{memo X}Make a grave for Liliya
+QUEST_LV_0200_20150317_002670	{memo X}Seems like Liliya will lose her breathe soon.. Do her last favor.
+QUEST_LV_0200_20150317_002671	{memo X}Make a grave for Liliya
 QUEST_LV_0200_20150317_002672	$Talk to Pilgrim Julius
 QUEST_LV_0200_20150317_002673	$There are many pilgrims with stories in the Starving Demon's Way. Talk to Julius.
 QUEST_LV_0200_20150317_002674	{memo X}Get monster meat
@@ -2685,8 +2685,8 @@ QUEST_LV_0200_20150317_002684	{memo X}Get the young Nikotia leaves
 QUEST_LV_0200_20150317_002685	{memo X}You need to get young Nikotia leaves so that Julius can get back up and tell his story. You can get the leaves in Emptry Tree Forest.
 QUEST_LV_0200_20150317_002686	{memo X}Gathered all the young Nikotia leaves needed. Give it to Julius.
 QUEST_LV_0200_20150317_002687	{memo X}Food supplies in the Ascetic haven
-QUEST_LV_0200_20150317_002688	{memo X}The rotten meat Julius mentioned can be found past the Ascetic haven, just before the Ray-lit Land. Go there and find the Reaverpeded that swallowed Julius and Lilija's ring.
-QUEST_LV_0200_20150317_002689	$The Reaverpede that swallowed Lilija and Julius' necklace appeared! Defeat it and get back the necklace.
+QUEST_LV_0200_20150317_002688	{memo X}The rotten meat Julius mentioned can be found past the Ascetic haven, just before the Ray-lit Land. Go there and find the Reaverpeded that swallowed Julius and Liliya's ring.
+QUEST_LV_0200_20150317_002689	$The Reaverpede that swallowed Liliya and Julius' necklace appeared! Defeat it and get back the necklace.
 QUEST_LV_0200_20150317_002690	$Defeat the Reaverpede that swallowed the necklace
 QUEST_LV_0200_20150317_002691	Talk to Pilgrim Zenius
 QUEST_LV_0200_20150317_002692	{memo X}There are two pilgrims in the Reed field in Starving Demon's Way. Seems like they have a story to tell so try talking to them.
@@ -2979,9 +2979,9 @@ QUEST_LV_0200_20150317_002978	It seems that monsters came here because there's s
 QUEST_LV_0200_20150317_002979	Defeat the monsters that are blocking the road.
 QUEST_LV_0200_20150317_002980	The monsters that are protecting the boxes
 QUEST_LV_0200_20150317_002981	{memo X}There are strange looking treasure boxes at the single story area. Take a close look at it.
-QUEST_LV_0200_20150317_002982	Defeat the monsters that gathered around the boxes
-QUEST_LV_0200_20150317_002983	As you touched the boxes, the monsters suddenly rushed in! You don't know why they are rushing in, but defeat them first!
-QUEST_LV_0200_20150317_002984	Defeat the monsters that are around the treasure boxes
+QUEST_LV_0200_20150317_002982	Defeat the monsters that gathered around the treasure chest
+QUEST_LV_0200_20150317_002983	As you touched the treasure chest, the monsters suddenly rushed in! You don't know why they are rushing in, but defeat them first!
+QUEST_LV_0200_20150317_002984	Defeat the monsters that are around the treasure chest
 QUEST_LV_0200_20150317_002985	$Inspect the Destroyed Owl Sculpture
 QUEST_LV_0200_20150317_002986	$There are broken Owl Sculptures at the end of Ishrai Crossroads. When you take a close look at them, you may be able to find out why.
 QUEST_LV_0200_20150317_002987	$Monsters appeared right after you found the traces of the Owl Sculptures! Defeat them first.
@@ -3188,8 +3188,8 @@ QUEST_LV_0200_20150323_003187	$Okay.. I think I can eat those Young Leaves.{nl}T
 QUEST_LV_0200_20150323_003188	$My hunger doesn't go away even after eating a lot.{nl}It's actually getting worse, I might as well just die.
 QUEST_LV_0200_20150323_003189	$There must be something to eat around here..{nl}Please.. get me something to eat.{nl}
 QUEST_LV_0200_20150323_003190	$I am so hungry yet something is echoing inside my head..{nl}The sound of a music box..  I can't eat an echo..
-QUEST_LV_0200_20150323_003191	$Ahah, my Lilija..{nl}I probably can never see you again.
-QUEST_LV_0200_20150323_003192	$Please think of that necklace as the gift from Lilija and keep it safely.{nl}It is blessed from the Great Cathedral so it will help you.
+QUEST_LV_0200_20150323_003191	$Ahah, my Liliya..{nl}I probably can never see you again.
+QUEST_LV_0200_20150323_003192	$Please think of that necklace as the gift from Liliya and keep it safely.{nl}It is blessed from the Great Cathedral so it will help you.
 QUEST_LV_0200_20150323_003193	$I am still hungry. Hungry.{nl}I can't take it anymore. I am hungry!
 QUEST_LV_0200_20150323_003194	$I am so.. hungry.{nl}Hey, if you have any leftover food, if you could share it with me..
 QUEST_LV_0200_20150323_003195	$Even if that's all you have, please share it with me.. please..
@@ -3197,13 +3197,13 @@ QUEST_LV_0200_20150323_003196	$Meat..quickly. {nl}I feel like I am dying.
 QUEST_LV_0200_20150323_003197	$Meat.. Meat!{nl}Please give it to me fast. Fast!
 QUEST_LV_0200_20150323_003198	$Wait, that music box.. what was it?{nl}
 QUEST_LV_0200_20150323_003199	$My memories.. she..{nl}Give it to me! That's mine!
-QUEST_LV_0200_20150323_003200	{memo X}Damn. What was I doing?{nl}Ahah. Lilija.. My Lilija!{nl}
+QUEST_LV_0200_20150323_003200	{memo X}Damn. What was I doing?{nl}Ahah. Liliya.. My Liliya!{nl}
 QUEST_LV_0200_20150323_003201	$We left for a pilgrimage to the Great Cathedral to receive the blessings of the Goddesses to celebrate our wedding.{nl}But then, that evil Naktis.. that unforgivable Demon Lord.{nl}
 QUEST_LV_0200_20150323_003202	{memo X}Stole her music box and necklace and gave them to the monsters and cursed her with gluttony.{nl}As if to laugh at Maven's lessons.
 QUEST_LV_0200_20150323_003203	{memo X}Wait. My head is shaking because of the curse. {nl}I still have a lot more to say.. I don't know if I would be able to endure until then.
 QUEST_LV_0200_20150323_003204	$I heard the Asellus at the Hollow Tree Forest have purifying powers.{nl}I should be able to endure with its purification.
-QUEST_LV_0200_20150323_003205	$To completely remove the curse, you should go see the disciples..{nl}I want to stay here and recollect Lilija a little more.
-QUEST_LV_0200_20150323_003206	{memo X}Thanks. Way better.{nl}My Lilija.. my music box.. She must not be in this world.{nl}
+QUEST_LV_0200_20150323_003205	$To completely remove the curse, you should go see the disciples..{nl}I want to stay here and recollect Liliya a little more.
+QUEST_LV_0200_20150323_003206	{memo X}Thanks. Way better.{nl}My Liliya.. my music box.. She must not be in this world.{nl}
 QUEST_LV_0200_20150323_003207	{memo X}If you meet the henchman of Naktis in any case, please get a revenge for her.{nl}The mark of our love which the demon possesses.. Please receive it as a compensation for my gratitude.{nl}
 QUEST_LV_0200_20150323_003208	{memo X}This necklce will be very useful since it is blessed by the Great Cathedral. {nl}That necklace is meaningless to me.
 QUEST_LV_0200_20150323_003209	{memo X}You should not touch it.{nl}It will come soon.. just wait little more.
@@ -3664,37 +3664,37 @@ QUEST_LV_0200_20150323_003663	{memo X}Nuaele is planning something.{nl}Please go
 QUEST_LV_0200_20150323_003664	{memo X}We don't have enough time to catch him and ask what he is planning!
 QUEST_LV_0200_20150323_003665	{memo X}I can feel that Nuaele has disappeared.{nl}Please go to the 3rd district.{nl}Vakarine is waiting for your help.
 QUEST_LV_0200_20150323_003666	{memo X}Because of you, Gidrone Aldona was able to help me.{nl}Thank you Revelator and Hauberk.
-QUEST_LV_0200_20150323_003667	{memo X}{nl}I will restore my Dionys to its previous status now.{nl}Meet Gidrone. Please help her to complete my key.
-QUEST_LV_0200_20150323_003668	{memo X}The Goddesses are trying to calm down the violent Dionys and trying to help her to come back to her previous status.{nl}To do so, we should accumulate the power of the Goddesses that are scattered across this region.{nl}We can collect that power using the key of night star. But we will definitely need your help.
+QUEST_LV_0200_20150323_003667	{memo X}{nl}I will restore my Dionis to its previous status now.{nl}Meet Gidrone. Please help her to complete my key.
+QUEST_LV_0200_20150323_003668	{memo X}The Goddesses are trying to calm down the violent Dionis and trying to help her to come back to her previous status.{nl}To do so, we should accumulate the power of the Goddesses that are scattered across this region.{nl}We can collect that power using the key of night star. But we will definitely need your help.
 QUEST_LV_0200_20150323_003669	{memo X}Due to the space that was created near the Orualma, the great hall, the place where the key should be recharged, it's pretty hard to do the ritual normally. {nl}Deactivate the space at the scar of tranformation.
-QUEST_LV_0200_20150323_003670	{memo X}Dionys was the family of the Goddesses and her companion.{nl}The Goddesses are very sad after sacrificing Dionys to seal her up with the chains.
-QUEST_LV_0200_20150323_003671	{memo X}We can start the ritual again. When the key of the night star gets completed, we would be able to restore Dionys who became violent to her normal status.
+QUEST_LV_0200_20150323_003670	{memo X}Dionis was the family of the Goddesses and her companion.{nl}The Goddesses are very sad after sacrificing Dionis to seal her up with the chains.
+QUEST_LV_0200_20150323_003671	{memo X}We can start the ritual again. When the key of the night star gets completed, we would be able to restore Dionis who became violent to her normal status.
 QUEST_LV_0200_20150323_003672	{memo X}Let's go to Orualma, the great hall. As I am recharging this key, you should protect me.
 QUEST_LV_0200_20150323_003673	{memo X}{nl}Are you ready?
-QUEST_LV_0200_20150323_003674	{memo X}Please bring this key to Aldona.{nl}On behalf of tired Goddesses, Aldona is preventing the escape of Dionys.{nl}Please hurry.
-QUEST_LV_0200_20150323_003675	{memo X}We can't stand anymore. Dionys can't be faced by the Kupoles.{nl}You and Hauberk should help. And one more thing..{nl}You should unleash the power of the seal that the Goddesses have prepared for the worst moment.
-QUEST_LV_0200_20150323_003676	{memo X}Please unleash Rwalda, Casa and Rada seals that are near the magic suppressor using the key of night star that you received from Gidrone.{nl}You will have easier time facing against Dionys.
+QUEST_LV_0200_20150323_003674	{memo X}Please bring this key to Aldona.{nl}On behalf of tired Goddesses, Aldona is preventing the escape of Dionis.{nl}Please hurry.
+QUEST_LV_0200_20150323_003675	{memo X}We can't stand anymore. Dionis can't be faced by the Kupoles.{nl}You and Hauberk should help. And one more thing..{nl}You should unleash the power of the seal that the Goddesses have prepared for the worst moment.
+QUEST_LV_0200_20150323_003676	{memo X}Please unleash Rwalda, Casa and Rada seals that are near the magic suppressor using the key of night star that you received from Gidrone.{nl}You will have easier time facing against Dionis.
 QUEST_LV_0200_20150323_003677	{memo X}The Goddesses prepared for the everything that could occur.{nl}The problem is time. If we arrive late, then even Vakarine won't be able to do anything.
 QUEST_LV_0200_20150323_003678	{memo X}As the seal unleashes, the lights of the Goddesses are coming to the magic suppressor.{nl}Now, everything is ready. We also have enough time.
-QUEST_LV_0200_20150323_003679	{memo X}I will persuade Dionys first, but it won't be effective.{nl}Dionys has the chains that Gitine had created.{nl}That's why she is breaking everything she sees.
+QUEST_LV_0200_20150323_003679	{memo X}I will persuade Dionis first, but it won't be effective.{nl}Dionis has the chains that Gitine had created.{nl}That's why she is breaking everything she sees.
 QUEST_LV_0200_20150323_003680	{memo X}If we fail, Dinois will escape from this place.{nl}It will be the same thing as unleashing tens of Demon Lords to this world.{nl}Tell me when you are ready.
 QUEST_LV_0200_20150323_003681	{memo X}We just ran into a problem. The reason why the Goddesses helped Hauberk to regain his energy was because Hauberk is the key who can quiet down this mess.{nl}The Goddesses tried to close the space that was opened from the demon world using the chains and the spirits of Hauberk.
 QUEST_LV_0200_20150323_003682	{memo X}I am sorry to deceive you. But, I can't tell you the truth as long as Hauberk is with you.{nl}Hauberk ran away to the 4th district. Please tell this to the Goddess as quickly as possible.
 QUEST_LV_0200_20150323_003683	{memo X}Okay.. so that's why.{nl}Do not lose your hope savior, it's not too late as long as you are alive.{nl}Hauberk ran away to the 4th district which is like a mae in this prison.
-QUEST_LV_0200_20150323_003684	{memo X}Look for Daiva there. She will guide you to Hauberk.{nl}I will observe Dionys from here.{nl}If you or Kupoles seal Hauberk, we will meet again at the 5th district.
+QUEST_LV_0200_20150323_003684	{memo X}Look for Daiva there. She will guide you to Hauberk.{nl}I will observe Dionis from here.{nl}If you or Kupoles seal Hauberk, we will meet again at the 5th district.
 QUEST_LV_0200_20150323_003685	{memo X}The dimensional door that was opened from the demon world. The metastasis space can't be closed even by the Goddesses.{nl}We should control the metastasis space using Hauberk and eliminate with the chains.{nl}But in that process, Hauberk was completely eliminated. Before he ran away like that, I had to lock him up..{nl}{nl}I am so sorry to see the Goddesses again.{nl}
 QUEST_LV_0200_20150323_003686	{memo X}As Baltrus disappeared, the demons were confused who used to receive orders from him.{nl}That caused the demons more violent whose behaviours were already unpredictable.{nl}Can you defeat those who are coming to Orualma, the great hall?
 QUEST_LV_0200_20150323_003687	{memo X}Even if the Goddesses are not here, the Kupoles won't be violent.{nl}We are the symbol of rules and disciplines.
 QUEST_LV_0200_20150323_003688	{memo X}The great hall is one of the places which the Goddesses could easily regain their energies.{nl}So it should be safe from the demons all the time.{nl}Thanks for taking care of that.
-QUEST_LV_0200_20150323_003689	{memo X}The demons that ran away after being attacked by Dionys are hiding near the Rwalda seal.{nl}The fragments of Dionys that are stuck on them
+QUEST_LV_0200_20150323_003689	{memo X}The demons that ran away after being attacked by Dionis are hiding near the Rwalda seal.{nl}The fragments of Dionis that are stuck on them
 QUEST_LV_0200_20150323_003690	{memo X}The toe nails of the spirits
-QUEST_LV_0200_20150323_003691	{memo X}Retrieve them.{nl}It will help the Goddesses to restore Dionys.
-QUEST_LV_0200_20150323_003692	{memo X}Dionys is not normal. {nl}The Goddesses rescued her when she was being persecuted by the demons and became the Dionys nowadays.{nl}She temporarily lost her conciousness due to the chains, but you should not suspect her belief.
+QUEST_LV_0200_20150323_003691	{memo X}Retrieve them.{nl}It will help the Goddesses to restore Dionis.
+QUEST_LV_0200_20150323_003692	{memo X}Dionis is not normal. {nl}The Goddesses rescued her when she was being persecuted by the demons and became the Dionis nowadays.{nl}She temporarily lost her conciousness due to the chains, but you should not suspect her belief.
 QUEST_LV_0200_20150323_003693	{memo X}Thanks. I will pass these toe nails to the Goddesses.
-QUEST_LV_0200_20150323_003694	{memo X}Dionys was trying to destroy Rada seal before she was locked up inside the magic suppressor.{nl}Luckily, we were able to lock it before..{nl}At then, it released its power to various places.
-QUEST_LV_0200_20150323_003695	{memo X}Please collect the symbols of the stars that Dionys scattered near Rama seal.{nl}It will be a big help to the Goddesses who want to restore Dionys to it's previous status.
-QUEST_LV_0200_20150323_003696	{memo X}The damages that were caused by Dionys were so great. {nl}Hundreds of demon prisoners were dead and the violent Baltrus ran away before the Kupoles locked up Dionys.{nl}There were more than tens of Kupoles that were dead by the toe nails of Dionys at then.
-QUEST_LV_0200_20150323_003697	{memo X}Thank you. I will try my best to restore Dionys.
+QUEST_LV_0200_20150323_003694	{memo X}Dionis was trying to destroy Rada seal before she was locked up inside the magic suppressor.{nl}Luckily, we were able to lock it before..{nl}At then, it released its power to various places.
+QUEST_LV_0200_20150323_003695	{memo X}Please collect the symbols of the stars that Dionis scattered near Rama seal.{nl}It will be a big help to the Goddesses who want to restore Dionis to it's previous status.
+QUEST_LV_0200_20150323_003696	{memo X}The damages that were caused by Dionis were so great. {nl}Hundreds of demon prisoners were dead and the violent Baltrus ran away before the Kupoles locked up Dionis.{nl}There were more than tens of Kupoles that were dead by the toe nails of Dionis at then.
+QUEST_LV_0200_20150323_003697	{memo X}Thank you. I will try my best to restore Dionis.
 QUEST_LV_0200_20150323_003698	{memo X}I've been wating for you. Hauberk is near here.{nl}He is trying to escape from Nevirau by attacking the barriers of the Goddesses.{nl}I hope you resist him.
 QUEST_LV_0200_20150323_003699	{memo X}Now is the only chance to restore everything back to its previous status.{nl}Please catch him.
 QUEST_LV_0200_20150323_003700	{memo X}You should chase him til the end to catch him.{nl}And even a slightest energy should be left in him so that he could share it with his subordinates.{nl}The Goddesses want Hauberk in perfect shape.
@@ -3751,9 +3751,9 @@ QUEST_LV_0200_20150323_003750	{memo X}{nl}I am going to be here. If you need my 
 QUEST_LV_0200_20150323_003751	{memo X}The demons hid into various places in the 5th district before I was able to fill the metastasis space when I arrived here..{nl}And many of them are concentrated near Banaga Monitor District, so please defeat them.
 QUEST_LV_0200_20150323_003752	{memo X}The number of Kupoles is increasing a lot..
 QUEST_LV_0200_20150323_003753	{memo X}If I disappear from this place a bit, this space would go wide again.{nl}I hope you find Laima fast..
-QUEST_LV_0200_20150323_003754	{memo X}Dionys is recovering fast due to you. Someday, she would protect us again near me..{nl}But she is suffering from the slow recovery while I am protecting this place.{nl}Can you defeat the demons that are at the Pasaru isolated place get me the empty spirits.
-QUEST_LV_0200_20150323_003755	{memo X}When Dionys gets recovered, you would be able to stabilize this prison without me.
-QUEST_LV_0200_20150323_003756	{memo X}Thanks. When Dionys comes back, it will be okay even if I leave this place for a while.
+QUEST_LV_0200_20150323_003754	{memo X}Dionis is recovering fast due to you. Someday, she would protect us again near me..{nl}But she is suffering from the slow recovery while I am protecting this place.{nl}Can you defeat the demons that are at the Pasaru isolated place get me the empty spirits.
+QUEST_LV_0200_20150323_003755	{memo X}When Dionis gets recovered, you would be able to stabilize this prison without me.
+QUEST_LV_0200_20150323_003756	{memo X}Thanks. When Dionis comes back, it will be okay even if I leave this place for a while.
 QUEST_LV_0200_20150323_003757	{memo X}The small metastasis space is widening at the areas where we can't reach.{nl}The Kupoles all went to different districts so I have no way to block the metastasis space.{nl}Can you do it?
 QUEST_LV_0200_20150323_003758	{memo X}I have big debts to you, Gidrone and Aldona.
 QUEST_LV_0200_20150323_003759	{memo X}Thank you Revelator.
@@ -4196,7 +4196,7 @@ QUEST_LV_0200_20150323_004195	Ask him what kind of food he wants
 QUEST_LV_0200_20150323_004196	Ask him if there's anything he particularly wants
 QUEST_LV_0200_20150323_004197	You better leave without being involved in the matter
 QUEST_LV_0200_20150323_004198	Keep listen to him
-QUEST_LV_0200_20150323_004199	{memo X}Notice/!/Lilija passed away..{nl}Please make the grave for her#5
+QUEST_LV_0200_20150323_004199	{memo X}Notice/!/Liliya passed away..{nl}Please make the grave for her#5
 QUEST_LV_0200_20150323_004200	I will get the meats of the monsters if that's fine with him.
 QUEST_LV_0200_20150323_004201	Give him the music box
 QUEST_LV_0200_20150323_004202	Ask him if there's anything you could help
@@ -4542,7 +4542,7 @@ QUEST_LV_0200_20150323_004541	I will take care of it later
 QUEST_LV_0200_20150323_004542	The hidden betrayer
 QUEST_LV_0200_20150323_004543	The demons at the crossroad
 QUEST_LV_0200_20150323_004544	A dead end
-QUEST_LV_0200_20150323_004545	The food of Dionys
+QUEST_LV_0200_20150323_004545	The food of Dionis
 QUEST_LV_0200_20150323_004546	Eliminate the small space
 QUEST_LV_0200_20150323_004547	The mysterious tree
 QUEST_LV_0200_20150323_004548	Reject since you still have some tasks to complete
@@ -4673,24 +4673,24 @@ QUEST_LV_0200_20150323_004672	Defeat the monsters at the Forest of Prayer
 QUEST_LV_0200_20150323_004673	The knight commander, Uska told you that many monsters have appeared from the deep in the forest, but he couldn't do anything since he didn't have enough soldiers. Defeat 100 monsters at the Forest of Prayer on behalf of the knitage.
 QUEST_LV_0200_20150323_004674	You've completed defeating all the monsters at the Forest of Prayer. Return to Uska and help him relieve his worry.
 QUEST_LV_0200_20150323_004675	Defeat the monsters at the Forest of Prayer
-QUEST_LV_0200_20150323_004676	$Talk to Pilgrim Lilija
-QUEST_LV_0200_20150323_004677	$You can see Lilija at the Starving Demon's Way. She desperately wants something so get closer to her and talk to her.
+QUEST_LV_0200_20150323_004676	$Talk to Pilgrim Liliya
+QUEST_LV_0200_20150323_004677	$You can see Liliya at the Starving Demon's Way. She desperately wants something so get closer to her and talk to her.
 QUEST_LV_0200_20150323_004678	$Collect monster meat
-QUEST_LV_0200_20150323_004679	{memo X}Pilgrim Lilija told you that she is very hungry, so get her any food you can find. Get some edible meats from the monsters.
-QUEST_LV_0200_20150323_004680	$Hand them over to Pilgrim Lilija
+QUEST_LV_0200_20150323_004679	{memo X}Pilgrim Liliya told you that she is very hungry, so get her any food you can find. Get some edible meats from the monsters.
+QUEST_LV_0200_20150323_004680	$Hand them over to Pilgrim Liliya
 QUEST_LV_0200_20150323_004681	$Got enough to eat for three consecutive days without any worries . Bring her the lumps of meat.
 QUEST_LV_0200_20150323_004682	{memo X}Obtain %s from the monsters
 QUEST_LV_0200_20150323_004683	$Get some Young Leaves
-QUEST_LV_0200_20150323_004684	$Pilgrim Lilija is saying she wants more even after eating a lot. Get some Young Leaves for hungry Lilija.
-QUEST_LV_0200_20150323_004685	$You've collected a lot of Young Leaves. Hand them over to Pilgrim Lilija.
+QUEST_LV_0200_20150323_004684	$Pilgrim Liliya is saying she wants more even after eating a lot. Get some Young Leaves for hungry Liliya.
+QUEST_LV_0200_20150323_004685	$You've collected a lot of Young Leaves. Hand them over to Pilgrim Liliya.
 QUEST_LV_0200_20150323_004686	{memo X}Extract %s from the wild herbs
-QUEST_LV_0200_20150323_004687	$Did Pilgrim Lilija's hunger go away? Talk to her again
-QUEST_LV_0200_20150323_004688	$Talk to the fallen Pilgrim Lilija
-QUEST_LV_0200_20150323_004689	$Pilgrim Lilija appeared again from the place where the Carnivore was defeated. Talk to Lilija again.
-QUEST_LV_0200_20150323_004690	$Defeat Lilija who turned into a Carnivore
-QUEST_LV_0200_20150323_004691	$Make a grave for Pilgrim Lilija
-QUEST_LV_0200_20150323_004692	$Lilija is dying... Please listen to her last words
-QUEST_LV_0200_20150323_004693	$Lilija passed away. Please make a grave for Lilija.
+QUEST_LV_0200_20150323_004687	$Did Pilgrim Liliya's hunger go away? Talk to her again
+QUEST_LV_0200_20150323_004688	$Talk to the fallen Pilgrim Liliya
+QUEST_LV_0200_20150323_004689	$Pilgrim Liliya appeared again from the place where the Carnivore was defeated. Talk to Liliya again.
+QUEST_LV_0200_20150323_004690	$Defeat Liliya who turned into a Carnivore
+QUEST_LV_0200_20150323_004691	$Make a grave for Pilgrim Liliya
+QUEST_LV_0200_20150323_004692	$Liliya is dying... Please listen to her last words
+QUEST_LV_0200_20150323_004693	$Liliya passed away. Please make a grave for Liliya.
 QUEST_LV_0200_20150323_004694	{memo X}The pilgrim, Julius, can't move due to his severe hunger. Obtain some meat from the monsters.
 QUEST_LV_0200_20150323_004695	{memo X}You've obtained enough meat from the monsters. Bring them to the pilgrim, Julius.
 QUEST_LV_0200_20150323_004696	Obtain %s from the monsters
@@ -4701,7 +4701,7 @@ QUEST_LV_0200_20150323_004700	$Obtain Asellu Leaf Buds
 QUEST_LV_0200_20150323_004701	$Pilgrim Julius is still suffering from the influence of the curse. Get some Asellu Leaf Buds from the Hollow Tree Forest so he can recover.
 QUEST_LV_0200_20150323_004702	$You've obtained some Asellu Leaf Buds. Take them to Pilgrim Julius.
 QUEST_LV_0200_20150323_004703	Look through the lump of rotten meat at the resting area of the ascetics.
-QUEST_LV_0200_20150323_004704	$Julius and Lilija met Naktis around this location. Could Lilija's necklace be around here?
+QUEST_LV_0200_20150323_004704	$Julius and Liliya met Naktis around this location. Could Liliya's necklace be around here?
 QUEST_LV_0200_20150323_004705	$Pilgrim Zenius is protecting food at the Starving Demon's Way. He seems to have a story to tell so go talk to him.
 QUEST_LV_0200_20150323_004706	$A man stole a lump of food under Pilgrim Zenius' watch. Talk to Zenius about it.
 QUEST_LV_0200_20150323_004707	$Pilgrim Zenius said that man is his son, and he wants the curse removed from his son. First, defeat the monsters nearby.
@@ -5352,7 +5352,7 @@ QUEST_LV_0200_20150323_005351	{memo X}Protect Kupole Gidrone while he is transfo
 QUEST_LV_0200_20150323_005352	Talk to Kupole Aldona
 QUEST_LV_0200_20150323_005353	{memo X}Install the night star key
 QUEST_LV_0200_20150323_005354	{memo X}Use the night star key to unleash the seals of Rwalda, Casa, and Rada.
-QUEST_LV_0200_20150323_005355	Defeat Dionys
+QUEST_LV_0200_20150323_005355	Defeat Dionis
 QUEST_LV_0200_20150323_005356	Talk to Kupole Daiva
 QUEST_LV_0200_20150323_005357	{memo X}Meet Kupole Daiva at the 4th district in the demons' prison
 QUEST_LV_0200_20150323_005358	Chase after Hauberk
@@ -5410,7 +5410,7 @@ QUEST_LV_0200_20150323_005409	{memo X}Cupol Sigita asked you to defeat the demon
 QUEST_LV_0200_20150323_005410	{memo X}Obtain %s by defeating the demons
 QUEST_LV_0200_20150323_005411	{memo X}The Goddess, Vakarine told you that the demons that came out from the space of the metastasis ran away and headed to Banaga Monitoring District. Let's defeat them.
 QUEST_LV_0200_20150323_005412	Collect the empty spirits
-QUEST_LV_0200_20150323_005413	{memo X}The Goddess, Vakarine asked you to collect the empty spirits from the monsters that are gathered at the isolated district of Pasaru in order to recover Dionys.
+QUEST_LV_0200_20150323_005413	{memo X}The Goddess, Vakarine asked you to collect the empty spirits from the monsters that are gathered at the isolated district of Pasaru in order to recover Dionis.
 QUEST_LV_0200_20150323_005414	Obtain the empty spirit
 QUEST_LV_0200_20150323_005415	{memo X}The Goddess, Vakarine asked you to eliminate the small space of the metastasis that was created due to the disaster at the Gabara isolated district.
 QUEST_LV_0200_20150323_005416	Talk with Druid Elley
@@ -5777,26 +5777,26 @@ QUEST_LV_0200_20150401_005780	Without Aldona's help, you will never enter the ar
 QUEST_LV_0200_20150401_005781	{memo X}Nuaele's behavior was something that can't be accepted.{nl}If he stayed quietly, he would have been forgiven.{nl}
 QUEST_LV_0200_20150401_005782	{memo X}Let's go to 3rd district.{nl}Vakarine is waiting for your help.
 QUEST_LV_0200_20150401_005783	{memo X}Hauberk and the savior.{nl}With help from you, I can now punish the Demon Lord, Baltrus.{nl}But the threat of the space of the metastasis still exists.{nl}
-QUEST_LV_0200_20150401_005784	{memo X}My poor Dionys..{nl}I will remove the strong power that is controlling her and close the space of the metastasis.{nl}
-QUEST_LV_0200_20150401_005785	{memo X}Complete the key of night star by helping Gidrone.{nl}With that key, you will be able to remove the power from Dionys.
-QUEST_LV_0200_20150401_005786	{memo X}The strong power that we tried to protect from Baltrus is controlling the ego of Dionys.{nl}Fortunately, that power can be detached and be put in the key of the night star.{nl}
+QUEST_LV_0200_20150401_005784	{memo X}My poor Dionis..{nl}I will remove the strong power that is controlling her and close the space of the metastasis.{nl}
+QUEST_LV_0200_20150401_005785	{memo X}Complete the key of night star by helping Gidrone.{nl}With that key, you will be able to remove the power from Dionis.
+QUEST_LV_0200_20150401_005786	{memo X}The strong power that we tried to protect from Baltrus is controlling the ego of Dionis.{nl}Fortunately, that power can be detached and be put in the key of the night star.{nl}
 QUEST_LV_0200_20150401_005787	{memo X}Plese close the space of the metastasis that are on the scar of the metastasis first.{nl}Because of the waves coming out from the space, I can't hardly focus on the ritual.
-QUEST_LV_0200_20150401_005788	We don't know exactly what is the strong power that is controlling Dionys.{nl}We just know that it could close the space of the metastasis and it should not be stolen.{nl}
+QUEST_LV_0200_20150401_005788	We don't know exactly what is the strong power that is controlling Dionis.{nl}We just know that it could close the space of the metastasis and it should not be stolen.{nl}
 QUEST_LV_0200_20150401_005789	While the Goddess was maintaining the barrier of the prison, she also had to fight against Baltrus at the same time.{nl}If the Goddess gets defeated, that power can't be protected..{nl}
-QUEST_LV_0200_20150401_005790	{memo X}The Goddess had to make a hard decision.{nl}Until the prison gets stabilized, she will seal the power to Dionys who is like family to her.
-QUEST_LV_0200_20150401_005791	{memo X}Dionys is the guardian who Vakarine most takes care.{nl}She reluctantly sealed the strong power to Dionys and fell into the deep sadness..
+QUEST_LV_0200_20150401_005790	{memo X}The Goddess had to make a hard decision.{nl}Until the prison gets stabilized, she will seal the power to Dionis who is like family to her.
+QUEST_LV_0200_20150401_005791	{memo X}Dionis is the guardian who Vakarine most takes care.{nl}She reluctantly sealed the strong power to Dionis and fell into the deep sadness..
 QUEST_LV_0200_20150401_005792	We can start the ritual now.{nl}When the key of the night star gets completed, we could probably retrieve the ego.
 QUEST_LV_0200_20150401_005793	{memo X}We could go to Orualma grand corridor to put the power of the Goddess into the key of the night star.{nl}As I am charging the key, please protect me from the demons.
-QUEST_LV_0200_20150401_005794	{memo X}It's all completed. Please hand over this key to Aldona.{nl}Aldona is blocking the attacks of Dionys so please hurry up.
-QUEST_LV_0200_20150401_005795	{memo X}Soon.. We would collapse.{nl}Dionys is too strong to face against by us, Kupols.{nl}
+QUEST_LV_0200_20150401_005794	{memo X}It's all completed. Please hand over this key to Aldona.{nl}Aldona is blocking the attacks of Dionis so please hurry up.
+QUEST_LV_0200_20150401_005795	{memo X}Soon.. We would collapse.{nl}Dionis is too strong to face against by us, Kupols.{nl}
 QUEST_LV_0200_20150401_005796	{memo X}Vakarine saved some power to prepare for the worst outcome.{nl}With the key of the night star, please unleash the seals of Rewalda, Casa and Rada seals.
 QUEST_LV_0200_20150401_005797	{memo X}The problem is the time.{nl}If you are late, Vakarine can't do anything.
 QUEST_LV_0200_20150401_005798	{memo X}The power of the Goddesses is accumulating at the magical suppressor.{nl}We are now all ready. And we have enough time.
-QUEST_LV_0200_20150401_005799	{memo X}We will now remove the power from Dionys.{nl}If we fail, Dionys may escape from here with the power.{nl}
+QUEST_LV_0200_20150401_005799	{memo X}We will now remove the power from Dionis.{nl}If we fail, Dionis may escape from here with the power.{nl}
 QUEST_LV_0200_20150401_005800	{memo X}It's going to bring the same result like unleashing tens of Demon Lords.{nl}You should approach it carefully. Tell me when you are ready.
-QUEST_LV_0200_20150401_005801	{memo X}The direction where Hauberk ran away is the 4th district where Daiva is protecting.{nl}First, go back to the Goddess. I will take care of Dionys.
+QUEST_LV_0200_20150401_005801	{memo X}The direction where Hauberk ran away is the 4th district where Daiva is protecting.{nl}First, go back to the Goddess. I will take care of Dionis.
 QUEST_LV_0200_20150401_005802	{memo X}Savior. You are now ready to know the truth.{nl}The reason why I am just leaving Hauberk like that is because he too is the key to close the space of the metastasis.{nl}
-QUEST_LV_0200_20150401_005803	{memo X}The power that he took away from Dionys is called the chain of revivification.{nl}He was planning to close the space of the metastasis using that chain and the spirit of Hauberk.{nl}
+QUEST_LV_0200_20150401_005803	{memo X}The power that he took away from Dionis is called the chain of revivification.{nl}He was planning to close the space of the metastasis using that chain and the spirit of Hauberk.{nl}
 QUEST_LV_0200_20150401_005804	{memo X}But since you are here, it's not too late.{nl}The 4th district, the place where he ran away to is like a maze. Daiva will be able to chase after him.
 QUEST_LV_0200_20150401_005805	{memo X}How come Vakarine left Hauberk to go crazy like that..{nl}I guess she must have a reason for that.
 QUEST_LV_0200_20150401_005806	{memo X}Even if we defeat Baltrus, that doesn't mean we have peace in this prison.{nl}The demons who lost their leader is going crazy here.{nl}
@@ -5804,16 +5804,16 @@ QUEST_LV_0200_20150401_005807	{memo X}His subordinates are keep gathering at the
 QUEST_LV_0200_20150401_005808	We, Kupols are different.{nl}Even if the Goddesses are not around, we don't get violent.{nl}
 QUEST_LV_0200_20150401_005809	We are the symbol of the rules and the principles.
 QUEST_LV_0200_20150401_005810	{memo X}The Goddesses rest at the grand corridor and recover her power.{nl}That's why it has to be safe all the time from the demons. Thank you so much.
-QUEST_LV_0200_20150401_005811	{memo X}Dionys is weak.{nl}If you could find his toenails, he will recover his energy.{nl}
-QUEST_LV_0200_20150401_005812	{memo X}There are many demons who ran away after getting attacked by Dionys near Rewalda seal.{nl}You may find the toe nails of Dionys from them.
-QUEST_LV_0200_20150401_005813	{memo X}Dionys was originally the normal creature from the human world.{nl}Vakarine accepted him who was playing with the demons violently.{nl}
+QUEST_LV_0200_20150401_005811	{memo X}Dionis is weak.{nl}If you could find his toenails, he will recover his energy.{nl}
+QUEST_LV_0200_20150401_005812	{memo X}There are many demons who ran away after getting attacked by Dionis near Rewalda seal.{nl}You may find the toe nails of Dionis from them.
+QUEST_LV_0200_20150401_005813	{memo X}Dionis was originally the normal creature from the human world.{nl}Vakarine accepted him who was playing with the demons violently.{nl}
 QUEST_LV_0200_20150401_005814	{memo X}Now he is the most faithful guardian of Vakarine.{nl}He lost his conciousness due to that power, but he must be suffering a lot himself.
-QUEST_LV_0200_20150401_005815	{memo X}Vakarine will recover fast when Dionys recovers.{nl}There are many things for Dionys to do other than that.
-QUEST_LV_0200_20150401_005816	{memo X}Thanks. {nl}This will greatly help Dionys who is very weak at the moment.
-QUEST_LV_0200_20150401_005817	When Dionys lost his ego, Rada seal may have broken down.{nl}Fortunately, he regained his conciousness before that, but he could not save the symbol of the star.{nl}
+QUEST_LV_0200_20150401_005815	{memo X}Vakarine will recover fast when Dionis recovers.{nl}There are many things for Dionis to do other than that.
+QUEST_LV_0200_20150401_005816	{memo X}Thanks. {nl}This will greatly help Dionis who is very weak at the moment.
+QUEST_LV_0200_20150401_005817	When Dionis lost his ego, Rada seal may have broken down.{nl}Fortunately, he regained his conciousness before that, but he could not save the symbol of the star.{nl}
 QUEST_LV_0200_20150401_005818	{memo X}Please collect the pieces of the symbol of the star that are scattered near Rada seal.{nl}It will help the Goddess to recover her power.
-QUEST_LV_0200_20150401_005819	The power of Dionys is astonishing.{nl}Even violent Baltrus was busy running away instead of touching him.
-QUEST_LV_0200_20150401_005820	{memo X}Thanks. {nl}If the Goddesses recover, Dionys would also recover.
+QUEST_LV_0200_20150401_005819	The power of Dionis is astonishing.{nl}Even violent Baltrus was busy running away instead of touching him.
+QUEST_LV_0200_20150401_005820	{memo X}Thanks. {nl}If the Goddesses recover, Dionis would also recover.
 QUEST_LV_0200_20150401_005821	{memo X}Hauberk just passed here.{nl}I am sure that he is trying to break the barrier of the Goddess who hasn't been fully recovered and escape by breaking the barrier.{nl}
 QUEST_LV_0200_20150401_005822	{memo X}The barrier at the Nevirau collapsed area is most weak so he must have went there.{nl}Hurry and follow him. I will block the route.
 QUEST_LV_0200_20150401_005823	Now, Hauberk is risking everything he's got.{nl}Now is the only chance that he can restore everything about him.
@@ -5871,9 +5871,9 @@ QUEST_LV_0200_20150401_005874	{memo X}With the gap closed, the demons that lost 
 QUEST_LV_0200_20150401_005875	{memo X}The demons should never stay in groups, not for the future. {nl}Please break the power of demons that are gathered in Vanaga Surveillance Area.
 QUEST_LV_0200_20150401_005876	{memo X}The demons are using the aura of disaster to strengthen its powers. {nl}We may have blocked immediate disaster but peace still seems to be far away.
 QUEST_LV_0200_20150401_005877	{memo X}If I don't pay attention just for a while, the gap will open again. {nl}I hope you find Laima as soon as you can.
-QUEST_LV_0200_20150401_005878	{memo X}We were able to find Dionys with your help but he's slow recovery is causing him too much pain. {nl}Can you get the empty souls from the demons in Pasaga Isolation Area?
-QUEST_LV_0200_20150401_005879	{memo X}If Dionys recovers, the prison can be stabilized even if I'm not here.
-QUEST_LV_0200_20150401_005880	{memo X}Thank you. {nl}If Dionys recovers, it will all be thanks to you. {nl}{nl}
+QUEST_LV_0200_20150401_005878	{memo X}We were able to find Dionis with your help but he's slow recovery is causing him too much pain. {nl}Can you get the empty souls from the demons in Pasaga Isolation Area?
+QUEST_LV_0200_20150401_005879	{memo X}If Dionis recovers, the prison can be stabilized even if I'm not here.
+QUEST_LV_0200_20150401_005880	{memo X}Thank you. {nl}If Dionis recovers, it will all be thanks to you. {nl}{nl}
 QUEST_LV_0200_20150401_005881	{memo X}Small gaps are forming in places where my power is not reached. {nl}Even the Kupoles are focused in stabilizing process so there is no one to close the gap in Gavara Isolation Area. {nl}
 QUEST_LV_0200_20150401_005882	{memo X}Can you take the role for us?
 QUEST_LV_0200_20150401_005883	{memo X}I bear debt to Zydrone and Aldona, and even you.
@@ -5951,7 +5951,7 @@ QUEST_LV_0200_20150401_005954	I will look for keepsakes
 QUEST_LV_0200_20150401_005955	{memo X}I will get back the necklace
 QUEST_LV_0200_20150401_005956	{memo X}I will defeat the rampaging demons
 QUEST_LV_0200_20150401_005957	I will retrieve the claws
-QUEST_LV_0200_20150401_005958	About Dionys
+QUEST_LV_0200_20150401_005958	About Dionis
 QUEST_LV_0200_20150401_005959	I will collect the Mark of Star
 QUEST_LV_0200_20150401_005960	I don't have for that
 QUEST_LV_0200_20150401_005961	I might be scolded by the Goddess
@@ -6055,7 +6055,7 @@ QUEST_LV_0200_20150401_006058	{memo X}Ready to defeat Nuaele. Talk to Kupole Med
 QUEST_LV_0200_20150401_006059	{memo X}Defeat Demon Lord Nuaele
 QUEST_LV_0200_20150401_006060	Meet Kupole Aldona and head to Nuaele's territory to defeat Nuaele.
 QUEST_LV_0200_20150401_006061	Defeated Nuaele. Talk to Kupole Medeina.
-QUEST_LV_0200_20150401_006062	Vakarine says that you need to complete the evening star key to ge rid of the power covering Dionys. Go to Kupole Zydrone to complete the key.
+QUEST_LV_0200_20150401_006062	Vakarine says that you need to complete the evening star key to ge rid of the power covering Dionis. Go to Kupole Zydrone to complete the key.
 QUEST_LV_0200_20150401_006063	Remove small contamination gap
 QUEST_LV_0200_20150401_006064	Kupole Jidrone asked you to remove the small contamination gap that interferes with charging the evening star key.
 QUEST_LV_0200_20150401_006065	Removed all the small cracks. Tell Kupole Zydrone about it.
@@ -6063,15 +6063,15 @@ QUEST_LV_0200_20150401_006066	Ready to charge the evening start key. Talk to Kup
 QUEST_LV_0200_20150401_006067	Protect Kupole Zydrone
 QUEST_LV_0200_20150401_006068	{memo X}Kupole Zydrone asked you to protect him while he puts in the power of Goddess in the evening star key.
 QUEST_LV_0200_20150401_006069	Protected Kupole Zydrone safely until the evening star key was charged. Talk to Zydrone.
-QUEST_LV_0200_20150401_006070	Kupole Zydrone asked you to deliver the evening start key to Kupole Aldona who is blocking Dionys.
+QUEST_LV_0200_20150401_006070	Kupole Zydrone asked you to deliver the evening start key to Kupole Aldona who is blocking Dionis.
 QUEST_LV_0200_20150401_006071	Release the Seal
 QUEST_LV_0200_20150401_006072	Use the evening star key to release the seal of Rwalda, Casa, and Rada to free the power of Goddess.
 QUEST_LV_0200_20150401_006073	{memo X}Released all seals and freed the power of Goddess. Return to Kupole Aldona and talk to her.
-QUEST_LV_0200_20150401_006074	Ready to remove the strong power from Dionys. Talk to Kupole Aldona.
-QUEST_LV_0200_20150401_006075	Subdue Dionys for Kupole Aldona to remove the power from Dionys.
-QUEST_LV_0200_20150401_006076	Hauberk took the strong power sealed in Dionys and ran away. Talk to Aldona.
-QUEST_LV_0200_20150401_006077	Hauberk took the strong power sealed in Dionys and ran away. Ask Aldona what to do.
-QUEST_LV_0200_20150401_006078	Tell Goddess Vakarine that Hauberk took the power in Dionys and ask what you should do.
+QUEST_LV_0200_20150401_006074	Ready to remove the strong power from Dionis. Talk to Kupole Aldona.
+QUEST_LV_0200_20150401_006075	Subdue Dionis for Kupole Aldona to remove the power from Dionis.
+QUEST_LV_0200_20150401_006076	Hauberk took the strong power sealed in Dionis and ran away. Talk to Aldona.
+QUEST_LV_0200_20150401_006077	Hauberk took the strong power sealed in Dionis and ran away. Ask Aldona what to do.
+QUEST_LV_0200_20150401_006078	Tell Goddess Vakarine that Hauberk took the power in Dionis and ask what you should do.
 QUEST_LV_0200_20150401_006079	You need to find Hauberk who ran away with the chain of return. Go to Kupole Daiva in Velnias Prison Area 4.
 QUEST_LV_0200_20150401_006080	Pursue Demon Lord Hauberk
 QUEST_LV_0200_20150401_006081	{memo X}Daiva says Hauberk must be after the weakened barrier of Goddess. Defeat Hauberk who is destroying the barrier of Goddess in Nevirau collapsed area.
@@ -6123,14 +6123,14 @@ QUEST_LV_0200_20150401_006126	Seems like Kupole Zydrone needs your hlep. Talk to
 QUEST_LV_0200_20150401_006127	{memo X}Defeat the demon gone wild
 QUEST_LV_0200_20150401_006128	{memo X}Kupole Zydrone says that the demons that came out of Valtruss' influence became wild and strange. Defeat the demons in Orualma.
 QUEST_LV_0200_20150401_006129	{memo X}Defeated the wild demons. Report to Kupole Zydrone.
-QUEST_LV_0200_20150401_006130	Kupole Aldona feels pity to see Dionys in pain. Talk to Kupole Aldona.
-QUEST_LV_0200_20150401_006131	Collect Dionys' Claw
-QUEST_LV_0200_20150401_006132	Kupole Aldonas says Dionys might get back its strength if you bring back its claw. Find and defeat the demon near Rwalda Seal that was attacked by Dionys and get Dionys' claw.
+QUEST_LV_0200_20150401_006130	Kupole Aldona feels pity to see Dionis in pain. Talk to Kupole Aldona.
+QUEST_LV_0200_20150401_006131	Collect Dionis' Claw
+QUEST_LV_0200_20150401_006132	Kupole Aldonas says Dionis might get back its strength if you bring back its claw. Find and defeat the demon near Rwalda Seal that was attacked by Dionis and get Dionis' claw.
 QUEST_LV_0200_20150401_006133	Give it to Kupole Aldona
-QUEST_LV_0200_20150401_006134	Retrieve all Dionys' claws. Give it to Kupole Aldona.
+QUEST_LV_0200_20150401_006134	Retrieve all Dionis' claws. Give it to Kupole Aldona.
 QUEST_LV_0200_20150401_006135	Kupole Aldona needs your help. Talk to Kupole Aldona.
 QUEST_LV_0200_20150401_006136	Collect the destroyed Mark of Star
-QUEST_LV_0200_20150401_006137	Kupole Aldona says Dionys was stopped but the Mark of Star was destroyed. Collect the scattered Mark of Star near Rada Seal.
+QUEST_LV_0200_20150401_006137	Kupole Aldona says Dionis was stopped but the Mark of Star was destroyed. Collect the scattered Mark of Star near Rada Seal.
 QUEST_LV_0200_20150401_006138	Collected all Mark of Star. Give it to Kupole Aldona.
 QUEST_LV_0200_20150401_006139	Successfully caught Hauberk but his demons are still left. Talk to Kupole Daiva.
 QUEST_LV_0200_20150401_006140	Defeating Demons
@@ -6147,7 +6147,7 @@ QUEST_LV_0200_20150401_006150	{memo X}Gathered all demon's teeth. Give it to Kup
 QUEST_LV_0200_20150401_006151	{memo X}Goddess Vakarine spent all her strength in closing the gap and has a favor to ask you. Talk to Goddess Vakarine.
 QUEST_LV_0200_20150401_006152	{memo X}Goddess Vakarine says the demons should not be gathered around for the future. Defeat the demons gathered nearby Vanaga Surveillance area.
 QUEST_LV_0200_20150401_006153	{memo X}Defeated the demons nearby Vanaga Surveillance area. Talk to Goddess Vakarine.
-QUEST_LV_0200_20150401_006154	{memo X}Goddess Vakarine seems concerned for Dionys in pain. Talk to Goddess Vakarine.
+QUEST_LV_0200_20150401_006154	{memo X}Goddess Vakarine seems concerned for Dionis in pain. Talk to Goddess Vakarine.
 QUEST_LV_0200_20150401_006155	{memo X}Colleted empty souls. Give it to Goddess Vakarine.
 QUEST_LV_0200_20150401_006156	{memo X}Seems like there are gaps forming around. Talk to Goddess Vakarine.
 QUEST_LV_0200_20150401_006157	Remove the small transfer gap
@@ -6529,8 +6529,8 @@ QUEST_LV_0200_20150406_006532	You've collected the teeth of the demons. Take the
 QUEST_LV_0200_20150406_006533	Kupol Sigita seems to have a request to you who is exhausted after using all her power blocking the crossover space. Talk to Kupol Sigita.
 QUEST_LV_0200_20150406_006534	Kupol Sigita told you that the demons shouldn't be gathered together for the future. Defeat the demons that are gathered at the Banaga Monitor District.
 QUEST_LV_0200_20150406_006535	You've defeated all demons near Banaga Monitor District. Talk to Kupol Sigita.
-QUEST_LV_0200_20150406_006536	Kupol Sigita is worried about Dionys, who is suffering. Talk to Kupol Sigita.
-QUEST_LV_0200_20150406_006537	To recover Dionys, Kupol Sigita asked you to collect the empty spirits from the demons that are gathered at Pasaru isolated area.
+QUEST_LV_0200_20150406_006536	Kupol Sigita is worried about Dionis, who is suffering. Talk to Kupol Sigita.
+QUEST_LV_0200_20150406_006537	To recover Dionis, Kupol Sigita asked you to collect the empty spirits from the demons that are gathered at Pasaru isolated area.
 QUEST_LV_0200_20150406_006538	You've collected all of the empty spirits. Hand them over to Kupol Sigita.
 QUEST_LV_0200_20150406_006539	It seems that the small crossover spaces keep expanding from various places. Talk to Kupol Sigita again.
 QUEST_LV_0200_20150406_006540	{memo X}Kupol Sigita asked you to eliminate the small crossover spaces that are remaining as a result of the disaster at Gabara Isolated Area.
@@ -6644,25 +6644,25 @@ QUEST_LV_0200_20150414_006647	{memo X}It's the demons in 4th Isolation Area. {nl
 QUEST_LV_0200_20150414_006648	Thank you. I will destroy this fragment myself. {nl}May the blessings of the Goddess be with you.
 QUEST_LV_0200_20150414_006649	Nuaele is performing the demon summon ritual in her territory. {nl}But she is basically cut off so it'll be easy to defeat her. {nl}
 QUEST_LV_0200_20150414_006650	{memo X}Vakarine is waiting for your help in 3rd Area. {nl}Go quickly.
-QUEST_LV_0200_20150414_006651	{memo X}Please help Zydrone complete the Evening Star Key. {nl}You can get the power of Dionys with that key.
-QUEST_LV_0200_20150414_006652	{memo X}The power to protect from Valtruss is what is controlling the ego of Dionys. {nl}Fortunately, that power can be removed if the power of the Goddess is put in the Evening Star Key.
+QUEST_LV_0200_20150414_006651	{memo X}Please help Zydrone complete the Evening Star Key. {nl}You can get the power of Dionis with that key.
+QUEST_LV_0200_20150414_006652	{memo X}The power to protect from Valtruss is what is controlling the ego of Dionis. {nl}Fortunately, that power can be removed if the power of the Goddess is put in the Evening Star Key.
 QUEST_LV_0200_20150414_006653	First, close the small gaps in the scars of crossover. {nl}It is difficult to perform the ritual because of the waves coming out from there.
 QUEST_LV_0200_20150414_006654	{memo X}Now go to Orualma Grand Hall. {nl}Protect me from the demons while I put the Goddess' power in the Evening Star Key.
-QUEST_LV_0200_20150414_006655	{memo X}Here. Give this key to Aldona. {nl}He must be blocking Dionys now. Please hurry.
+QUEST_LV_0200_20150414_006655	{memo X}Here. Give this key to Aldona. {nl}He must be blocking Dionis now. Please hurry.
 QUEST_LV_0200_20150414_006656	{memo X}Hurry, the strength of Goddess Vakarine.. {nl}Use the Evening Star Key to release the Rwalda, Kasa, and Rada seals.
-QUEST_LV_0200_20150414_006657	{memo X}We, Kupoles, cannot block Dionys. {nl}Not even Vakarine can do anything if we are late.
-QUEST_LV_0200_20150414_006658	{memo X}We will begin to separate the power of Dionys. {nl}If we fail.. The result will be as if tens of Demon Lords are on the loose. {nl}
+QUEST_LV_0200_20150414_006657	{memo X}We, Kupoles, cannot block Dionis. {nl}Not even Vakarine can do anything if we are late.
+QUEST_LV_0200_20150414_006658	{memo X}We will begin to separate the power of Dionis. {nl}If we fail.. The result will be as if tens of Demon Lords are on the loose. {nl}
 QUEST_LV_0200_20150414_006659	{memo X}We need to approach it with caution. Let me know when you are ready.
-QUEST_LV_0200_20150414_006660	{memo X}Hauberk ran away to the direction of Prison 4th Area, guarded by Daiva. {nl}Please return to the Goddess first. I will take care of Dionys.
+QUEST_LV_0200_20150414_006660	{memo X}Hauberk ran away to the direction of Prison 4th Area, guarded by Daiva. {nl}Please return to the Goddess first. I will take care of Dionis.
 QUEST_LV_0200_20150414_006661	{memo X}You are still here, so it isn't late yet. {nl}The 4th Area he ran to is like a maze. Daiva can easily chase him.
 QUEST_LV_0200_20150414_006662	{memo X}Valtruss is defeated but its servants are still left in Orualma Grand Hall. {nl}I want you to let those demons pay for their sins.
 QUEST_LV_0200_20150414_006663	{memo X}The Grand Hall is where the Goddess recovers her powers. {nl}That is why it should always be safe from the demons. Thank you very much.
-QUEST_LV_0200_20150414_006664	Dionys is not recovering well. {nl}I think getting claws that have his powers might help him recover.
-QUEST_LV_0200_20150414_006665	Dionys was an ordinary creation of the human world. {nl}The Goddess took and cared for him when the demons were cruelly playing with him. {nl}
+QUEST_LV_0200_20150414_006664	Dionis is not recovering well. {nl}I think getting claws that have his powers might help him recover.
+QUEST_LV_0200_20150414_006665	Dionis was an ordinary creation of the human world. {nl}The Goddess took and cared for him when the demons were cruelly playing with him. {nl}
 QUEST_LV_0200_20150414_006666	Now, he is the most loyal guardian of Vakarine. {nl}Even if he lost his senses for the powers, he must be the one in pain.
-QUEST_LV_0200_20150414_006667	There are many demons that ran away from Dionys's attacks near the Rwalda Seal. {nl}We just hope that Dionys's claws are still stuck in them.
-QUEST_LV_0200_20150414_006668	Dionys should get back his strength for Vakarine to recover. {nl}And there are even more things that Dionys should do.
-QUEST_LV_0200_20150414_006669	Thank you. {nl}This will be of big help to the weakened Dionys.
+QUEST_LV_0200_20150414_006667	There are many demons that ran away from Dionis's attacks near the Rwalda Seal. {nl}We just hope that Dionis's claws are still stuck in them.
+QUEST_LV_0200_20150414_006668	Dionis should get back his strength for Vakarine to recover. {nl}And there are even more things that Dionis should do.
+QUEST_LV_0200_20150414_006669	Thank you. {nl}This will be of big help to the weakened Dionis.
 QUEST_LV_0200_20150414_006670	{memo X}The barrier in Nevirau Ruins is the weakest so they must be headed there. {nl}Follow it quickly.
 QUEST_LV_0200_20150414_006671	The girl who left the sapling, who could it have been?
 QUEST_LV_0200_20150414_006672	I can't leave if I think about the kindness of Gina Greene. {nl}But the land is contaminated so I'm worried if I should leave nevertheless.
@@ -6722,13 +6722,13 @@ QUEST_LV_0200_20150414_006725	{memo X}It's not allowed for humans to enter. {nl}
 QUEST_LV_0200_20150414_006726	I'm waiting for you with the Aldona's order.{nl}But, please hang on as I'm still not ready.
 QUEST_LV_0200_20150414_006727	Though the Master Demon disappeared, peace is not meant to come to this place.{nl}Only by defeating all of the demons will true peace come.
 QUEST_LV_0200_20150414_006728	This demon prion is not related with any world..{nl}The human world should befall a new disaster, if these areas fall to the demons.
-QUEST_LV_0200_20150414_006729	Dionys..He is one of the persons who know Vakarine.{nl}So, He can endure the pain himself.{nl}
+QUEST_LV_0200_20150414_006729	Dionis..He is one of the persons who know Vakarine.{nl}So, He can endure the pain himself.{nl}
 QUEST_LV_0200_20150414_006730	{memo X}The Goddess's barrier should be complete if Vakarine recovers quickly.{nl}Until then, the contaminated gap appears continuously.
 QUEST_LV_0200_20150414_006731	{memo X}This prison has been made by Goddess Ausrine.{nl}Vakarine regularly visited to check here.
-QUEST_LV_0200_20150414_006732	Actually, Kyupol couldn't take care of Dionys.{nl}Quickly, please complete the General Key.
+QUEST_LV_0200_20150414_006732	Actually, Kyupol couldn't take care of Dionis.{nl}Quickly, please complete the General Key.
 QUEST_LV_0200_20150414_006733	Is the General key still not ready?
-QUEST_LV_0200_20150414_006734	{memo X}Oh..my poor Dionys..I'm so sorry for giving you this big burden.
-QUEST_LV_0200_20150414_006735	Revelator. You can't close the contaminated gap if you return Dionys.
+QUEST_LV_0200_20150414_006734	{memo X}Oh..my poor Dionis..I'm so sorry for giving you this big burden.
+QUEST_LV_0200_20150414_006735	Revelator. You can't close the contaminated gap if you return Dionis.
 QUEST_LV_0200_20150414_006736	Hoberg..I'm expecting it already.
 QUEST_LV_0200_20150414_006737	I could not say the truth because you were close with Hoberg.{nl}Please forgive me.
 QUEST_LV_0200_20150414_006738	{memo X}Hoberg is also siner.{nl}You don't need to be sympathetic.
@@ -6740,9 +6740,9 @@ QUEST_LV_0200_20150414_006743	Since the contaminated gap is closed, the demons a
 QUEST_LV_0200_20150414_006744	For the future, demons never gather in the same place.{nl}Defeat the demons in Banaga Isolation District.
 QUEST_LV_0200_20150414_006745	Demons are trying to expand their power using the disaster spirit.{nl}Even after overcoming the current disaster, the peace is still far away.
 QUEST_LV_0200_20150414_006746	The gap will open again if we, the Kyupols, don't keep our eyes on it.{nl}I hope that we can find the Goddess Laima as soon as possible..
-QUEST_LV_0200_20150414_006747	There is a saying that Dionys is suffering pain due to the slow recovery.{nl}Can you collect the empty souls of demon in Pasaga Isolation District.
-QUEST_LV_0200_20150414_006748	{memo X}If Dionys recovers completely, the Goddess can reduce the burden.
-QUEST_LV_0200_20150414_006749	{memo X}Thank you.{nl}If Dionys recovers completely, It's because of you.
+QUEST_LV_0200_20150414_006747	There is a saying that Dionis is suffering pain due to the slow recovery.{nl}Can you collect the empty souls of demon in Pasaga Isolation District.
+QUEST_LV_0200_20150414_006748	{memo X}If Dionis recovers completely, the Goddess can reduce the burden.
+QUEST_LV_0200_20150414_006749	{memo X}Thank you.{nl}If Dionis recovers completely, It's because of you.
 QUEST_LV_0200_20150414_006750	The small contaminated gap has again been carving away from us.{nl}But we don't know why because now we're focusing on the stabilization.
 QUEST_LV_0200_20150414_006751	{memo X}Can you deal with the contaminated gap in Gabara Isolation District?
 QUEST_LV_0200_20150414_006752	We really owe you one.
@@ -6810,7 +6810,7 @@ QUEST_LV_0200_20150414_006813	I will be fine
 QUEST_LV_0200_20150414_006814	I will retrieve the fragments
 QUEST_LV_0200_20150414_006815	I will meet the Vakarine first
 QUEST_LV_0200_20150414_006816	I will defeat the demons
-QUEST_LV_0200_20150414_006817	Dionys Claw
+QUEST_LV_0200_20150414_006817	Dionis Claw
 QUEST_LV_0200_20150414_006818	It said to be it's not enough to cheer up.
 QUEST_LV_0200_20150414_006819	Contaminated Gap(7)
 QUEST_LV_0200_20150414_006820	{memo X}Obtain %s from Kowaks
@@ -6930,10 +6930,10 @@ QUEST_LV_0200_20150428_006933	{memo X}Hauberk is getting back the Marks he gave 
 QUEST_LV_0200_20150428_006934	How about striking the Harugals in 4th Isolation area? {nl}Getting rid of them would mean getting rid of one of Nuaelle's most powerful weapons.
 QUEST_LV_0200_20150428_006935	Nuaelle may be gone but its remnants are gathering in the 1st Isolation Area. {nl}It intends to continue its will. Please get rid of the demons by their roots.
 QUEST_LV_0200_20150428_006936	It's the demons of 4th Isolations Area.{nl}Please let last time be a lesson so that this won't happen again. {nl}
-QUEST_LV_0200_20150428_006937	The Goddess had to make a painful decision. {nl}Dionys was like family but she decided to seal the power in him until the Prison stabilizes.
-QUEST_LV_0200_20150428_006938	{memo X}Hauberk ran towards 4th Velnias Prison which is protected by Daiva. {nl}First, you should return to the Goddess. I will look after Dionys.
+QUEST_LV_0200_20150428_006937	The Goddess had to make a painful decision. {nl}Dionis was like family but she decided to seal the power in him until the Prison stabilizes.
+QUEST_LV_0200_20150428_006938	{memo X}Hauberk ran towards 4th Velnias Prison which is protected by Daiva. {nl}First, you should return to the Goddess. I will look after Dionis.
 QUEST_LV_0200_20150428_006939	We got Hauberk but his servants are the problem. {nl}We don't know what they will do.
-QUEST_LV_0200_20150428_006940	{memo X}Thank you. {nl}If Dionys recovers well, it will be all thanks to you.
+QUEST_LV_0200_20150428_006940	{memo X}Thank you. {nl}If Dionis recovers well, it will be all thanks to you.
 QUEST_LV_0200_20150428_006941	Curse of Gluttony prevents you from digesting food when you eat it. {nl}That's why it makes you hungry all the time. {nl}
 QUEST_LV_0200_20150428_006942	We just need to exterminate all the monsters that interfere with the making of the Gateway Route of the Great King.
 QUEST_LV_0200_20150428_006943	I heard that the hardness and the elasticity of the wood sticks of Firent at Nefritas Cliffs is good.{nl}You can get the rope to tie those sticks from Red Pantos Archers. Please get me those first.
@@ -7045,9 +7045,9 @@ QUEST_LV_0200_20150714_007048	It's dangerous here, get back to the town.{nl} Wha
 QUEST_LV_0200_20150714_007049	$Ah, so you're the Revelator? {nl} I have a problem, but with you here it might not be so bad. {nl} Mind if I borrow some of your time?
 QUEST_LV_0200_20150714_007050	You are aware that we're the unit sent out to take care of the Gaigalas?{nl} Recruit! Take this report to Commander Williams.
 QUEST_LV_0200_20150714_007051	If we get rid of the Gaigalas we can smooth things out with them.{nl}Please make your way to the worried owl.
-QUEST_LV_0200_20150714_007052	Hunter Reconnaisance leader Mintz  
+QUEST_LV_0200_20150714_007052	Hunter Tracking Leader Mintz
 QUEST_LV_0200_20150714_007053	What a pain in the ass.{nl} How to convince those monks...
-QUEST_LV_0200_20150714_007054	Hey you, have you ever seen the one called "Ebony Pony"?
+QUEST_LV_0200_20150714_007054	Hey you, have you ever seen the one called Evoniphon?
 QUEST_LV_0200_20150714_007055	I hope this that was the end of it.{nl}It seems that we Hunters have a bad reputation around these parts.
 QUEST_LV_0200_20150714_007056	Are things going smoothly?{nl}I'm hoping to hear good things in the near future.
 QUEST_LV_0200_20150714_007057	Please help our Natasha.{nl}Shes a good girl, if a bit inexperienced...
@@ -7084,7 +7084,7 @@ QUEST_LV_0200_20150714_007087	How would the commander Mints react if he was in t
 QUEST_LV_0200_20150714_007088	Help whatever you could on what they are trying to do.{nl}We, Hunters would help as well.
 QUEST_LV_0200_20150714_007089	I should've suggested to help retreving the monastery from the first place.{nl}I wasn't patient.
 QUEST_LV_0200_20150714_007090	I will take care for him so don't worry too much, but go to Laukyme Swampy place.
-QUEST_LV_0200_20150714_007091	You can go to Laukyme Swampy place by going up Glade Hillroad again.{nl}Please report to Mintz commander on your way back.
+QUEST_LV_0200_20150714_007091	You can go to Laukyme Swampy place by going up Glade Hillroad again.{nl}Please report to Hunter Tracking Leader Mintz on your way back.
 QUEST_LV_0200_20150714_007092	Hunter Bastille
 QUEST_LV_0200_20150714_007093	Are you going to Tyla Monastery?{nl}The monsters are already worshipping there.
 QUEST_LV_0200_20150714_007094	Careless, careless.{nl}I was so careless...
@@ -7639,8 +7639,8 @@ QUEST_LV_0200_20150714_007642	Lots of demons are gathering at Rituala to paricip
 QUEST_LV_0200_20150714_007643	Valtruss is defeated but its servants are still left in Orualma Grand Hall. {nl}I want you to let those demons pay for their sins.
 QUEST_LV_0200_20150714_007644	Even if you are the Revelator, you better not fool around. {nl}The pollution is not something for you to mind.
 QUEST_LV_0200_20150714_007645	I wish you luck in the name of the Goddess.
-QUEST_LV_0200_20150714_007646	I am solely to blame for it.{nl}With the Key of the Night Star, three seals should be unleashed so I could recover my power to find Dionys.
-QUEST_LV_0200_20150714_007647	The space of the metastasis... We can't close it without Dionys.{nl}Please find Dionys until I recover my power...
+QUEST_LV_0200_20150714_007646	I am solely to blame for it.{nl}With the Key of the Night Star, three seals should be unleashed so I could recover my power to find Dionis.
+QUEST_LV_0200_20150714_007647	The space of the metastasis... We can't close it without Dionis.{nl}Please find Dionis until I recover my power...
 QUEST_LV_0200_20150714_007648	My mission is to retrieve the sacred artifacts, but I can't stand and watch this anymore.{nl}Can you defeat the monsters that are roaming around the Great Cathedral?
 QUEST_LV_0200_20150714_007649	If this Great Cathedral gets purified, all credits would go to you.{nl}But, we still have a long way to go.
 QUEST_LV_0200_20150714_007650	I believe that my research would be helpful in tough times like nowadays.{nl}Of course, we should first find the forecasts that would be helpful.
@@ -7758,7 +7758,7 @@ QUEST_LV_0200_20150714_007761	I was worried that we may have to move to another 
 QUEST_LV_0200_20150714_007762	I am going to absorb poison with this.{nl}I am going to keep looking at him so please care of Marco who is uneasy.
 QUEST_LV_0200_20150714_007763	You won't understand how embarassed and painful I am.{nl}My brother almost died due to the poisonn and I received help from the hunters that I kicked out...{nl}
 QUEST_LV_0200_20150714_007764	Good. You would have to persuade Guus at Laukyme Swampy Place.{nl}Please tell Marco that I've decided to go with Hunters.
-QUEST_LV_0200_20150714_007765	It's is so fortunate that it turned out alright.{nl}Please meet Mintz commander on your way to Laukyme Swampy Place and tell him that everything went alright.
+QUEST_LV_0200_20150714_007765	It's is so fortunate that it turned out alright.{nl}Please meet Captain Mintz on your way to Laukyme Swampy Place and tell him that everything went alright.
 QUEST_LV_0200_20150714_007766	Senior monk, Guus is leading the brothers at Laukyme Swampy Place.{nl}If Evoniphon did all of these, the Goddesses would also understand my rage.
 QUEST_LV_0200_20150714_007767	It's so nice seeing you.{nl}So how did the task at Viltis Forest go?
 QUEST_LV_0200_20150714_007768	Go first.{nl}I will follow you to Laukyme Swampy Place if he gets alright.
@@ -8547,22 +8547,22 @@ QUEST_LV_0200_20150714_008550	You've collected the lump of hairs of Rambear. Tak
 QUEST_LV_0200_20150714_008551	Investigate the bushes and defeat orange Tama
 QUEST_LV_0200_20150714_008552	A tenant Charlotte said that many monsters are gathered by the smell of grape seeds withering. Defeat orange Tama that appears from the bushes by investingating the bushes.
 QUEST_LV_0200_20150714_008553	You've defeated many monsters. Return to Tenant Charlotte.
-QUEST_LV_0200_20150714_008554	Talk with Hunter Commander, Mintz
-QUEST_LV_0200_20150714_008555	Hunter Commander, Mintz went to the central part of the hills. Talk with him who is at the camp which is at the inner garden of Diliti.
-QUEST_LV_0200_20150714_008556	Hunter Commander, Mintz wants you to cooperate with him for saving you. Listen for more details.
+QUEST_LV_0200_20150714_008554	Talk with Hunter Tracking Captain Mintz
+QUEST_LV_0200_20150714_008555	Hunter Tracking Captain Mintz went to the central part of the hills. Talk with him who is at the camp which is at the inner garden of Diliti.
+QUEST_LV_0200_20150714_008556	Hunter Tracking Captain Mintz wants you to cooperate with him for saving you. Listen for more details.
 QUEST_LV_0200_20150714_008557	Talk with the senior monk, Potos
-QUEST_LV_0200_20150714_008558	Hunter Commander, Mintz wants the monks to cooperate with Hunters, but it's not working alright. Persuade the senior monk Potos on behalf of him.
+QUEST_LV_0200_20150714_008558	Hunter Tracking Captain Mintz wants the monks to cooperate with Hunters, but it's not working alright. Persuade the senior monk Potos on behalf of him.
 QUEST_LV_0200_20150714_008559	The senior monk, Potos has some request to the Revelator. Talk with him.
-QUEST_LV_0200_20150714_008560	Cure the addicted monk after talking to Hunter Commander, Mintz
-QUEST_LV_0200_20150714_008561	Find a way to cure the addictied monks from the comnander, Mintz, and cure them.
+QUEST_LV_0200_20150714_008560	Cure the addicted monk after talking to Hunter Tracking Captain Mintz
+QUEST_LV_0200_20150714_008561	Find a way to cure the addictied monks from the Mintz, and cure them.
 QUEST_LV_0200_20150714_008562	The antidote of Mintz is effective to the addicted monks. Return to Potos and let him know.
 QUEST_LV_0200_20150714_008563	You would need an evidence to convince Potos. Ask Mintz if there's any adequate method.
-QUEST_LV_0200_20150714_008564	Talk with Hunter, Reina
-QUEST_LV_0200_20150714_008565	Mintz said Hunter Reina would be able to find an adequate evidence. Go look for Hunter Reina at Rikdimo Gate Route.
+QUEST_LV_0200_20150714_008564	Talk with Hunter Reina
+QUEST_LV_0200_20150714_008565	Mintz said that Hunter Reina would be able to find an adequate evidence. Go look for Hunter Reina at Rikdimo Gate Route.
 QUEST_LV_0200_20150714_008566	Hunter Reina looks ill. Talk to her first.
 QUEST_LV_0200_20150714_008567	Search for the traps using Jareth
 QUEST_LV_0200_20150714_008568	Hunter Reina lent you her companion, Jareth since she can't move. Use Jareth to look for Evoniphon's trap.
-QUEST_LV_0200_20150714_008569	$You found Evoniphon's trap. Return to Reina with Jareth.
+QUEST_LV_0200_20150714_008569	$You found Evoniphon's trap. Return to Hunter Reina with Jareth.
 QUEST_LV_0200_20150714_008570	You've found a trap which can be an evidence. Hand it over to Mintz.
 QUEST_LV_0200_20150714_008571	Show Evoniphon's trap to Potos. If Potos has good eyes, he may able to find an evidence of Evoniphon.
 QUEST_LV_0200_20150714_008572	Talk with Hunter Natasha
@@ -8612,7 +8612,7 @@ QUEST_LV_0200_20150714_008615	Natasha told you that we could make an antidote if
 QUEST_LV_0200_20150714_008616	You've collected enough leaves of Urudwa. Hand them over to Natasha.
 QUEST_LV_0200_20150714_008617	You were able to save the life of young monk. The senior monk, Marco has something to say so talk to him.
 QUEST_LV_0200_20150714_008618	You've obtained the promise from Marco that you would cooperate. Tell Natasha about it.
-QUEST_LV_0200_20150714_008619	It seems that you would have to persuade the senior monk, Guus at Laukyme Swampy Place. First, report to Mintz, the hunter commander at Glade Hillroad.
+QUEST_LV_0200_20150714_008619	It seems that you would have to persuade the senior monk, Guus at Laukyme Swampy Place. First, report to Hunter Tracking Captain Mintz, the hunter commander at Glade Hillroad.
 QUEST_LV_0200_20150714_008620	It seems that Minz is very satisfied with the progress. Now, go meet Natasha at Laukyme Swampy Place to persuade Guus.
 QUEST_LV_0200_20150714_008621	Talk with Hunter Bastille
 QUEST_LV_0200_20150714_008622	It seems that Hunter Bastille is not well. Ask him what happened.
@@ -8704,12 +8704,12 @@ QUEST_LV_0200_20150714_008707	To call out the father superior, Guus is trying to
 QUEST_LV_0200_20150714_008708	Talk with the father superior
 QUEST_LV_0200_20150714_008709	The father superior moved out from the room. Tell him what has happened so far.
 QUEST_LV_0200_20150714_008710	The father superior moved out from the room. Ask him to withdraw the decision to protect Evoniphon.
-QUEST_LV_0200_20150714_008711	The father superior won't decide quickly. While he discusses with senior monks, go meet the commander, Mintz.
+QUEST_LV_0200_20150714_008711	The father superior won't decide quickly. While he discusses with senior monks, go meet Hunter Tracking Captain Mintz.
 QUEST_LV_0200_20150714_008712	After listening from the senior monks, the father superior finally discovered the true nature of Evoniphon. Talk to him.
 QUEST_LV_0200_20150714_008713	It seems that the decision about what to do with Evoniphon has been confirmed. Talk to the father superior.
 QUEST_LV_0200_20150714_008714	Search for the assassin, Evoniphon.
 QUEST_LV_0200_20150714_008715	The father superior requested you to kick out Evoniphon from the monastery. Look for Evoniphon first in the monastery.
-QUEST_LV_0200_20150714_008716	Unfortunately, Evoniphon ran away and Mintz is injured. Talk with Mintz.
+QUEST_LV_0200_20150714_008716	Unfortunately, Evoniphon ran away and Hunter Tracking Captain Mintz is injured. Talk to him.
 QUEST_LV_0200_20150714_008717	The senior monk, Potos thinks that the strange lumps that are scattered across the monastery are luring monsters. Talk to him.
 QUEST_LV_0200_20150714_008718	Eliminate the stinky lump
 QUEST_LV_0200_20150714_008719	Potos requested you to eliminate the lump that is spreading the odor that is luring the monsters. Use the liquid medicine to eliminate them so they can't get near anymore.
@@ -8885,11 +8885,11 @@ QUEST_LV_0200_20150729_008888	The Seal Stone will just scatter away when release
 QUEST_LV_0200_20150729_008889	Defeat the Flask Mage and get the Crystal of Restriction
 QUEST_LV_0200_20150729_008890	{memo Why is there a memo x, if this is used in the game?} {memo X}The spirit of the Sealed Stone wants to be freed from the seal. Gather the Crystal of Restriction from the Flask Mage and break them.
 QUEST_LV_0200_20150729_008891	{memo X}The Weak Owl wants you to find other owls that the monsters took away. Find the traces of owl statue in the monster's hideaway locate at the end of Ishrai Crossroads.
-QUEST_LV_0200_20150729_008892	$Pilgrim Lilija told you that she is very hungry and asked you to get her some food. Get some edible meat from Kepo.
+QUEST_LV_0200_20150729_008892	$Pilgrim Liliya told you that she is very hungry and asked you to get her some food. Get some edible meat from Kepo.
 QUEST_LV_0200_20150729_008893	Get the meat of Kepari
 QUEST_LV_0200_20150729_008894	Pilgrim Julius can't move due to severe hunger. Get some Kepari meat for him to eat.
 QUEST_LV_0200_20150729_008895	Got enough Kepari meat. Give it to Pilgrim Julius.
-QUEST_LV_0200_20150729_008896	Returned to the Weak Owl
+QUEST_LV_0200_20150729_008896	Return to the Weak Owl
 QUEST_LV_0200_20150729_008897	Obtained oil from the box. Return to the Weak Owl.
 QUEST_LV_0200_20150729_008898	You need a brush to remove the soil on the tombstone. Use the paralysis needle on the Wendigo Hunter and collect Stiff Feather.
 QUEST_LV_0200_20150729_008899	Collect %s of Wendigo Hunter
@@ -8931,8 +8931,8 @@ QUEST_LV_0200_20150908_008934	Thank you for freeing me.
 QUEST_LV_0200_20150908_008935	Now I'm really released.
 QUEST_LV_0200_20150908_008936	Go upstairs and find Goddess Gabija!
 QUEST_LV_0200_20150908_008937	$The Mushwort that destroyed the Owl Sculpture appeared!
-QUEST_LV_0200_20150908_008938	Lilija passed away. {nl}Make a grave for her.
-QUEST_LV_0200_20150908_008939	Made a grave for Lilija
+QUEST_LV_0200_20150908_008938	Liliya passed away. {nl}Make a grave for her.
+QUEST_LV_0200_20150908_008939	Made a grave for Liliya
 QUEST_LV_0200_20150908_008940	Searching through the rottem meat
 QUEST_LV_0200_20150908_008941	Found food waste from the food pile! {nl}Throw it to the monsters using V key and defeat it!
 QUEST_LV_0200_20150908_008942	Successfully destroyed Tree Root Crystal! {nl}The curse laid around will disappear!
@@ -9078,24 +9078,24 @@ QUEST_LV_0200_20150918_009081	However, do me a favor and I'll give you some equi
 QUEST_LV_0200_20150918_009082	We don't ask for a lot. {nl} You can see this in the signs the pilgrims make along Starving Demon's Way.
 QUEST_LV_0200_20150918_009083	If not, then we don't have a choice. {nl} If we can, we will mutually profit.
 QUEST_LV_0200_20150918_009084	You've come to want something, huh? {nl} An interesting life really depends on reckless challenges, huh?
-QUEST_LV_0200_20150918_009085	{memo X}$Well, well. What have I been doing? {nl} Oh, my Lilija...{nl}
+QUEST_LV_0200_20150918_009085	{memo X}$Well, well. What have I been doing? {nl} Oh, my Liliya...{nl}
 QUEST_LV_0200_20150918_009086	$Her music box and necklace were snatched by Naktis' subordinates, and infused with Naktis' curse. It's as if they are trying to mock Maven's teachings.
 QUEST_LV_0200_20150918_009087	$Hold on a sec, my head's ringing again from that curse. {nl} There's still so much to say... I don't know if I will be able to handle it right now.
-QUEST_LV_0200_20150918_009088	$Thank you very much. It's really gotten better. {nl} The music box.. My Lilija.. She may no longer be in this world. {nl}
+QUEST_LV_0200_20150918_009088	$Thank you very much. It's really gotten better. {nl} The music box.. My Liliya.. She may no longer be in this world. {nl}
 QUEST_LV_0200_20150918_009089	$If you run into any Naktis' possessions, please be sure to carefully inspect them for her sake. {nl} The symbol of our love that the demon swallowed... Please accept it as our gratitude for helping us claim revenge.
 QUEST_LV_0200_20150918_009090	$That symbol is a necklace blessed by the Cathedral, so it must be very useful. {nl} To me, that necklace no longer holds any meaning.
 QUEST_LV_0200_20150918_009091	$Thanks for your words.{nl}I would really appreciate it if you could defeat the monsters here that are disturbing me.
 QUEST_LV_0200_20150918_009092	Please test it on the monsters that are reflected with the light of the spirits.
 QUEST_LV_0200_20150918_009093	If you use this medicine this time, the spirits that are in the stomach of the monsters will shine.{nl}When you defeat those monsters, the spirits that were tied will be freed.{nl}
 QUEST_LV_0200_20150918_009094	Have you found the rest to the restrained spirits?{nl}As I expected... the owner of this craft manual is you.{nl}
-QUEST_LV_0200_20150918_009095	$Thank you.{nl}Our colleagues were taken to the nest at the right side of the Ishrai Crossroads.
+QUEST_LV_0200_20150918_009095	$Thank you.{nl}Our allies were taken to the nest at the right side of the Ishrai Crossroads.
 QUEST_LV_0200_20150918_009096	$You should walk around as much as you can.{nl} Flame Vapor only appears for a moment.
 QUEST_LV_0200_20150918_009097	I've heard the story that they saw the spirits with resentment.{nl}Maybe, they are the spirits that could not reach Ausrine Goddess... It's horrible.
 QUEST_LV_0200_20150918_009098	So you are now one competent Rodelero.{nl}But, how about Collimencia... The one at the manor of Green Family.
 QUEST_LV_0200_20150918_009099	When there are some things lacking, it means there is some room to improve.{nl}Don't worry. I can fill that in.
 QUEST_LV_0200_20150918_009100	You would feel some weight of it.{nl}But, you should realize your deficiencies in order to become better Rodelero.{nl}
 QUEST_LV_0200_20150918_009101	What you've done is really amazing.{nl}I am looking forward to see your growth as a Sadhu Master.
-QUEST_LV_0200_20150918_009102	{memo X}Dionys is too strong for us to face against.{nl}Even Vakarine won't be able to do anything if we go late.
+QUEST_LV_0200_20150918_009102	{memo X}Dionis is too strong for us to face against.{nl}Even Vakarine won't be able to do anything if we go late.
 QUEST_LV_0200_20150918_009103	$Suddenly, a squad of Red Fishermen appeared!
 QUEST_LV_0200_20150918_009104	$The Mushwort that ate the Owl Sculpture has appeared!
 QUEST_LV_0200_20150918_009105	After absorbing the stamina, Tree Root Crystals threw the cores!{nl}Find the scattered cores and destroy them!
@@ -9111,7 +9111,7 @@ QUEST_LV_0200_20150918_009114	Worrying Owl at Ishrai Crossroads
 QUEST_LV_0200_20150918_009115	$Grita said in order to activate the Tower's Barrier Device again, it would need a great amount of energy. Set the gem Grita gave you on the ground and recharge the gem with the monsters' life force.
 QUEST_LV_0200_20150918_009116	$The Weak Owl Sculpture told you to find his Owl colleagues.{nl}Look for them at the monster hideout towards the right side of Ishrai Crossroads. 
 QUEST_LV_0200_20150918_009117	$The Destroyed Owl Sculpture was completely destroyed. Tell the Weak Owl Sculpture what happened.
-QUEST_LV_0200_20150918_009118	Pilgrim Julius suddenly turned into a Draperion after seeing the music box. Calm down the Draperion that is attacking and reduce its HP below 50% to persuade him.
+QUEST_LV_0200_20150918_009118	Pilgrim Julius suddenly turned into a Drapeliun after seeing the music box. Calm down the Drapeliun that is attacking and reduce its HP below 50% to persuade him.
 QUEST_LV_0200_20150918_009119	Destroy the protecting stone of the tree root crystal of the curse
 QUEST_LV_0200_20150918_009120	Talk with the restrained spirit
 QUEST_LV_0200_20150918_009121	Check the Veinika Altar
@@ -9166,7 +9166,7 @@ QUEST_LV_0200_20151001_009169	I heard the story about the revaltor who blocked t
 QUEST_LV_0200_20151001_009170	I've been to many places before in my life, but this place is really horrible.{nl}Even if I want to rescue the ones who are cursed, the only thing I can do is to help them fall asleep comfortably.
 QUEST_LV_0200_20151001_009171	I heard a Revelator defeated the Demon Lord who were attacking the Mage Tower.{nl}That's the most happy news I've heard lately.{nl}Other news I've heard were horrible.
 QUEST_LV_0200_20151001_009172	Is it true that some Revelator defeated the Demon Lord who casted the curse in this region?{nl}If that's true, it is so fortunate since we don't have to see these horrible things again.
-QUEST_LV_0200_20151001_009173	Damn. What was I doing?{nl}Ahah. My Lilija...{nl}
+QUEST_LV_0200_20151001_009173	Damn. What was I doing?{nl}Ahhh. My Liliya...{nl}
 QUEST_LV_0200_20151001_009174	Do not bother the placed food piles.{nl} They should have shuffled over here by now... just keep watching.
 QUEST_LV_0200_20151001_009175	While my brothers were on the their way to the training, they all died due to the tricks from the demons.{nl}I feel sorry for my brothers who can't return to the Godddesses.{nl}
 QUEST_LV_0200_20151001_009176	And they were so obsessed with madness even after their death so they could not even return to the Goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
@@ -9278,7 +9278,7 @@ QUEST_LV_0200_20151001_009281	The 4th district which he ran away to is like a ma
 QUEST_LV_0200_20151001_009282	How come Vakarine left Hauberk to go crazy like that..{nl}I guess she must have a reason for that.
 QUEST_LV_0200_20151001_009283	The Grand Hall is where the Goddess recovers her powers. {nl}That is why it should always be safe from the demons. Thank you very much.
 QUEST_LV_0200_20151001_009284	Please collect the pieces of the symbol of the star that are scattered near Rada seal.{nl}It will help the Goddess to recover her power.
-QUEST_LV_0200_20151001_009285	Thanks. {nl}If Vakarine recover, Dionis would also recover.
+QUEST_LV_0200_20151001_009285	Thanks. {nl}If Vakarine recovers, then Dionis would also recover.
 QUEST_LV_0200_20151001_009286	So you've come, savior.{nl}Fortunately, it seems that Hauberk doesn't want to go out through the space of the metastasis.{nl}Which means it is not complete yet enough to go out through the sapce.{nl}
 QUEST_LV_0200_20151001_009287	I think...{nl}In order to go out without going through the prison or the space of the metastasis..{nl}You should look for the space which has been weakened due to the collapse.{nl}
 QUEST_LV_0200_20151001_009288	Nevirau collapsed sphere is most weak so he probably went there.{nl}Please follow him, I will prepare for the next strategy.

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -7040,12 +7040,12 @@ QUEST_LV_0200_20150511_007043	It's suspicious that a wooden liquir barrel is lyi
 QUEST_LV_0200_20150511_007044	$Yoana wants to find out what the strange aura near Ramus Crossroads is. Attack the monster to drop its HP below 50% then bring it to the strange aura below the magic circle and try to talk to it.
 QUEST_LV_0200_20150511_007045	Goddess Vakarine's strength alone is not enough to close the gap of contamination. Talk to Goddess Vakarine.
 QUEST_LV_0200_20150511_007046	Nuaelle is gone from Velnias Prison and to stabilize it, Kupole Arune asked you defeat the remaining demons in 1st Isolation Area.
-QUEST_LV_0200_20150714_007047	$I really want to help the soldiers who are trying to clear the Forest of Thorns,{nl} but sadly I just don't have the means to.{nl} Could you do something about the Treegool that's harassing the soldiers?
+QUEST_LV_0200_20150714_007047	$I really want to help the soldiers who are trying to clear the Thorn Forest,{nl} but sadly I just don't have the means to.{nl} Could you do something about the Treegool that's harassing the soldiers?
 QUEST_LV_0200_20150714_007048	It's dangerous here, get back to the town.{nl} What are the soldiers even doing.{nl}
 QUEST_LV_0200_20150714_007049	$Ah, so you're the Revelator? {nl} I have a problem, but with you here it might not be so bad. {nl} Mind if I borrow some of your time?
 QUEST_LV_0200_20150714_007050	You are aware that we're the unit sent out to take care of the Gaigalas?{nl} Recruit! Take this report to Commander Williams.
 QUEST_LV_0200_20150714_007051	If we get rid of the Gaigalas we can smooth things out with them.{nl}Please make your way to the worried owl.
-QUEST_LV_0200_20150714_007052	Hunter Reconnaisance leader Minz  
+QUEST_LV_0200_20150714_007052	Hunter Reconnaisance leader Mintz  
 QUEST_LV_0200_20150714_007053	What a pain in the ass.{nl} How to convince those monks...
 QUEST_LV_0200_20150714_007054	Hey you, have you ever seen the one called "Ebony Pony"?
 QUEST_LV_0200_20150714_007055	I hope this that was the end of it.{nl}It seems that we Hunters have a bad reputation around these parts.
@@ -9420,11 +9420,11 @@ QUEST_LV_0200_20151001_009423	I am sorry, but could you block the monsters?
 QUEST_LV_0200_20151001_009424	Everyone is exhausted due to the coldness and the monsters.{nl}I don't know how much longer we would hold up.
 QUEST_LV_0200_20151001_009425	Thank you for your efforts.{nl}I think the monsters have gotten weaken because of your help.
 QUEST_LV_0200_20151001_009426	We are most worried about the coldness.{nl}We sill have the food, but we are worried about the clothes.{nl}Chilly air comes into the holes on the clothes.{nl}
-QUEST_LV_0200_20151001_009427	Can you hunt for Treefelia at Woozali Four Ways?{nl}Their hairy leathers are very warm.
+QUEST_LV_0200_20151001_009427	Can you hunt for Treepellia at Woozali Four Ways?{nl}Their hairy leathers are very warm.
 QUEST_LV_0200_20151001_009428	We should self supply as much as we could.{nl}Although this place is remote from the main land, we know what's going on in the kingdom. 
 QUEST_LV_0200_20151001_009429	Thanks.{nl}I already feel warm.
 QUEST_LV_0200_20151001_009430	Thanks for rescuing me. {nl}I saw you fighting while I was chasing after you and you are really great.{nl}
-QUEST_LV_0200_20151001_009431	I have a simple request to you.{nl}All my collegues are all exhausted. I am also exhausted as well. {nl}
+QUEST_LV_0200_20151001_009431	I have a simple request to you.{nl}All of my colleagues are exhausted. I am exhausted as well. {nl}
 QUEST_LV_0200_20151001_009432	To warm our bodies, we should light up the fire, but the flint can no longer be used.{nl}Can you get the flits from Tinaga stond mound?{nl}{nl}
 QUEST_LV_0200_20151001_009433	You haven't found them yet?{nl}Go to Tinaga stone mound at the upper end.
 QUEST_LV_0200_20151001_009434	Thanks. {nl}I owe you a lot.
@@ -9433,7 +9433,7 @@ QUEST_LV_0200_20151001_009436	While I was returning with the letter, we met a he
 QUEST_LV_0200_20151001_009437	For now, you are the only one we can trust.{nl}Please pass this letter to the commanding officer, Ades.{nl}
 QUEST_LV_0200_20151001_009438	Ah, if you are okay, please also defeat the monsters on your way.{nl}I have problem fighting against the monsters with the current status.
 QUEST_LV_0200_20151001_009439	I will be okay if I take little more rest.{nl}I am worried about the monsters and the letter.
-QUEST_LV_0200_20151001_009440	Stogas commanding offcier, Ades
+QUEST_LV_0200_20151001_009440	$Stogas Commanding Officer Ades
 QUEST_LV_0200_20151001_009441	You've brought the letter from Mesafasla?{nl}Then what happened to Roches?{nl}
 QUEST_LV_0200_20151001_009442	Ah... It's fortunate to hear that you are okay.
 QUEST_LV_0200_20151001_009443	You are a foreigner for a long time {nl}The supplies has been stopping from the kingdom, we don't know what's going on..{nl}
@@ -9442,11 +9442,11 @@ QUEST_LV_0200_20151001_009445	Pleaes get the meat from Beadbird around here.{nl}
 QUEST_LV_0200_20151001_009446	We will starve, if the Beadbird.{nl}Here is too cold, so only Potatos are growing.
 QUEST_LV_0200_20151001_009447	Thank you.{nl}Firsly, we have to complete it.
 QUEST_LV_0200_20151001_009448	Our lack is not only food.{nl}The weapons also needed to be changed because of no supplies from camp.
-QUEST_LV_0200_20151001_009449	But, there's more than ony way to skin a cat.{nl}We can make caltrops using the old prison fragmetns.{nl}
+QUEST_LV_0200_20151001_009449	But, there's more than ony way to skin a cat.{nl}We can make caltrops using the old prison fragments.{nl}
 QUEST_LV_0200_20151001_009450	If you are okay, please collect something useful?
-QUEST_LV_0200_20151001_009451	A long time ago, these prion was moving to Kalejimas.{nl}It is a unfortuate stuff in the Kadumel King years.
+QUEST_LV_0200_20151001_009451	A long time ago, these prion was moving to Kalezimas.{nl}It is a unfortunate stuff in the Kadumel King years.
 QUEST_LV_0200_20151001_009452	It will be okay, if it was moved since Ruklys rebelion.{nl}Before that, many people was taken to do forced labor forcibly.{nl}
-QUEST_LV_0200_20151001_009453	Is there Crystal mine nearby Klaipeda?{nl}Actually that place is one of the compulsion workhouse.{nl}Ashake prison nearby Orsa as well.
+QUEST_LV_0200_20151001_009453	Is the Crystal Mine nearby Klaipeda?{nl}Actually that place is one of the compulsion workhouse.{nl}Ashake prison nearby Orsa as well.
 QUEST_LV_0200_20151001_009454	I feel kind of my blood froze when looking at the fragments of prison.{nl}It is kind of feel the grudge..
 QUEST_LV_0200_20151001_009455	Thank you so much.{nl}
 QUEST_LV_0200_20151001_009456	

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -66,12 +66,12 @@ QUEST_LV_0200_20150317_000065	$Thank you. I hope I'm not giving you needless tro
 QUEST_LV_0200_20150317_000066	$Alright. We haven't received any word from our forces at Niurus Highway.{nl}I request you find them.
 QUEST_LV_0200_20150317_000067	$If you can't find them, return to us.
 QUEST_LV_0200_20150317_000068	$Soldier Kallus
-QUEST_LV_0200_20150317_000069	$There are still a number of our colleagues further in.{nl}Please help us.
+QUEST_LV_0200_20150317_000069	$There are still a few of our colleagues further in.{nl}Please help us.
 QUEST_LV_0200_20150317_000070	$Soldier Dainus
 QUEST_LV_0200_20150317_000071	$Ironbaum attacked us at the Drieza Waterland.{nl}There are still soldiers left that have not yet escaped.{nl}
 QUEST_LV_0200_20150317_000072	$I'm embarrassed to have escaped by myself.{nl}
 QUEST_LV_0200_20150317_000073	$Settled Owl Sculpture
-QUEST_LV_0200_20150317_000074	$I have something to ask of you.{nl}I'm worried about the soldiers suffering pain due to Ravinelarva.
+QUEST_LV_0200_20150317_000074	$I have something to ask of you.{nl}I'm worried about the soldiers suffering pain due to the Ravinelarva.
 QUEST_LV_0200_20150317_000075	Thank you.{nl}From now on, can our soldiers work comfortably?
 QUEST_LV_0200_20150317_000076	$I appreciate your kind help.{nl}One day, I will return the favor when I meet your soul form.
 QUEST_LV_0200_20150317_000077	{memo X}Are you the famous Revelator?{nl}Good, I'm puzzled with something. I need your help.
@@ -1953,9 +1953,9 @@ QUEST_LV_0200_20150317_001952	$Defeat the monsters threatening the soldier
 QUEST_LV_0200_20150317_001953	$Talk to the Settled Owl Sculpture
 QUEST_LV_0200_20150317_001954	$There is a hesitant-looking Owl Sculpture. Talk to the Settled Owl Sculpture.
 QUEST_LV_0200_20150317_001955	$Defeat nearby Woodgoblins
-QUEST_LV_0200_20150317_001956	$The Settled Owl Sculpture wants to repay the soldiers who saved it. To help the soldiers, please defeat nearby Ravinelarvae.
+QUEST_LV_0200_20150317_001956	$The Settled Owl Sculpture wants to repay the soldiers who saved it. To help the soldiers, please defeat the nearby Ravinelarvae.
 QUEST_LV_0200_20150317_001957	$You defeated all nearby Ravinelarvae. Talk to the Settled Owl Sculpture.
-QUEST_LV_0200_20150317_001958	$Defeat Ravinelarvae
+QUEST_LV_0200_20150317_001958	$Defeat Ravinelarva
 QUEST_LV_0200_20150317_001959	$Talk to Soldier Dainus
 QUEST_LV_0200_20150317_001960	$Soldier Dainus is trembling from fear. Talk to Soldier Dainus to look for the other soldiers.
 QUEST_LV_0200_20150317_001961	$Look for the other soldiers at Drieza Waterland

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -32,18 +32,18 @@ QUEST_LV_0200_20150317_000031	$The chief was also struggling like this..{nl}Neve
 QUEST_LV_0200_20150317_000032	Subordinate Owl 3
 QUEST_LV_0200_20150317_000033	We are always here at this place, but where is our Goddess who is always worried about us?
 QUEST_LV_0200_20150317_000034	Do we exist only for the Human's soul?
-QUEST_LV_0200_20150317_000035	$Soldier Dominique
+QUEST_LV_0200_20150317_000035	$Soldier Dominic
 QUEST_LV_0200_20150317_000036	$I've been ordered to protect this place with our lives and to do some reconnaissance at the same time.{nl}I don't know exactly what they expect us to do.
 QUEST_LV_0200_20150317_000037	$Next time I'm going to make sure they tell me exactly what they want me to do.{nl}No. wouldn't it be better to ask Julian?
-QUEST_LV_0200_20150317_000038	$If it's just monsters of that level, I guess I can report that there is no serious problem.{nl}Oh, if you happen to run into Sampson, please tell him to stop fooling around and continue scouting.
-QUEST_LV_0200_20150317_000039	$I will protect this area, so go patrol Veltui Crossroads. As for the reports, I will do them separately at a later time.
-QUEST_LV_0200_20150317_000040	$Soldier Sampson
-QUEST_LV_0200_20150317_000041	$Can you please help me find Dominique's engagement ring? {nl} I'm currently undertaking a mission, so I won't be able to leave this spot.
-QUEST_LV_0200_20150317_000042	$I tell you, she acts like that even though I bought her a roughly similar one. So stingy..
+QUEST_LV_0200_20150317_000038	$If it's just monsters of that level, I guess I can report that there is no serious problem.{nl}Oh, if you happen to run into Samson, please tell him to stop fooling around and continue scouting.
+QUEST_LV_0200_20150317_000039	$I will protect this area, so go patrol Veltui Crossroads.{nl}As for the reports, I will do them separately at a later time.
+QUEST_LV_0200_20150317_000040	$Soldier Samson
+QUEST_LV_0200_20150317_000041	$Can you please help me find Dominic's engagement ring? {nl} I'm currently undertaking a mission, so I won't be able to leave this spot.
+QUEST_LV_0200_20150317_000042	$I tell you, he acts like that even though I bought him a roughly similar one. So stingy..
 QUEST_LV_0200_20150317_000043	$What is this ugly thing? Oh, could the ring be inside?
 QUEST_LV_0200_20150317_000044	$A knife won't fit inside, and there's no other way to get it out.{nl}Right! Can't we burn it to retrieve what's inside?
 QUEST_LV_0200_20150317_000045	$Just make sure to bring me ones that aren't too thick.
-QUEST_LV_0200_20150317_000046	$This should be just right.{nl}Good. Now, how do I burn this while working and not get caught?
+QUEST_LV_0200_20150317_000046	$This should be just right.{nl}Good. Now, how do I burn this while I am working and not get caught?
 QUEST_LV_0200_20150317_000047	$There should be plenty of Dry Thorn Forest Wood at the edge of Ishisineti Cliff. {nl} I'm on patrol and don't have time, so I ask of you again.
 QUEST_LV_0200_20150317_000048	$Ah, you should be able to burn it secretly at the top of Ishisineti Cliff. {nl} This is my last request. You just need to make preparations for the fire.
 QUEST_LV_0200_20150317_000049	$I will never again care for another's wedding ceremony.
@@ -68,7 +68,7 @@ QUEST_LV_0200_20150317_000067	$If you can't find them, return to us.
 QUEST_LV_0200_20150317_000068	$Soldier Kallus
 QUEST_LV_0200_20150317_000069	$There are still a number of our colleagues further in.{nl}Please help us.
 QUEST_LV_0200_20150317_000070	$Soldier Dainus
-QUEST_LV_0200_20150317_000071	$Ironbaum attacked us at the Drieza Waterland.{nl}There are still soldiers that have not yet escaped.{nl}
+QUEST_LV_0200_20150317_000071	$Ironbaum attacked us at the Drieza Waterland.{nl}There are still soldiers left that have not yet escaped.{nl}
 QUEST_LV_0200_20150317_000072	$I'm embarrassed to have escaped by myself.{nl}
 QUEST_LV_0200_20150317_000073	$Settled Owl Sculpture
 QUEST_LV_0200_20150317_000074	$I have something to ask of you.{nl}I'm worried about the soldiers suffering pain due to Ravinelarva.
@@ -837,7 +837,7 @@ QUEST_LV_0200_20150317_000836	I can't help that the supplies or backup is delaye
 QUEST_LV_0200_20150317_000837	I'm afraid where the monsters will jump out from. {nl}I plan to run away if an unknown monster shows up.
 QUEST_LV_0200_20150317_000838	We're making up for the lacking supplies. {nl}If the supplies don't arrive, we have to cover for it on site.
 QUEST_LV_0200_20150317_000839	Somehow, at least sir Philipas' troops..
-QUEST_LV_0200_20150317_000840	There was another way that we used before. {nl}But this happened when the gigantic tree suddenly emerged. {nl}
+QUEST_LV_0200_20150317_000840	There was another way that we used before. {nl}But this happened when that gigantic tree suddenly emerged. {nl}
 QUEST_LV_0200_20150317_000841	We're clearing up the route to make it easy for the supplies but.. {nl}As if the monsters causing us isolation is not enough, now there is no news of supplies and the soldiers are becoming weary.
 QUEST_LV_0200_20150317_000842	$I'll be grateful if you can do that. {nl}If you relieve us from their attacks, it might even boost the troop's morale.
 QUEST_LV_0200_20150317_000843	$I want to let go of everything and just rest. {nl}But thinking of my men..
@@ -865,7 +865,7 @@ QUEST_LV_0200_20150317_000864	$What did I tell you. {nl}Thanks for your help but
 QUEST_LV_0200_20150317_000865	Soldier Aspas
 QUEST_LV_0200_20150317_000866	$I was careless. {nl}It would be big trouble if the monsters attacked now.
 QUEST_LV_0200_20150317_000867	$You saved me. {nl}Do you know what happened to my colleagues?
-QUEST_LV_0200_20150317_000868	$Meleech swallowed Dominique's engagement ring. {nl}I did lose it but that's too much.
+QUEST_LV_0200_20150317_000868	$Meleech swallowed Dominic's engagement ring. {nl}I did lose it, it's really terrible.
 QUEST_LV_0200_20150317_000869	$This place is too dangerous for citizens to go around. {nl}Go to a safe area.
 QUEST_LV_0200_20150317_000870	$I understand that you are strong but it's dangerous to go around alone here.
 QUEST_LV_0200_20150317_000871	$I could have supported O'Rourke and the troops, if only I was not injured..
@@ -1369,8 +1369,8 @@ QUEST_LV_0200_20150317_001368	Dangerous Throneweaver (3)
 QUEST_LV_0200_20150317_001369	I'll get rid of the Throneweaver
 QUEST_LV_0200_20150317_001370	Give me some time to prepare
 QUEST_LV_0200_20150317_001371	{memo X}Placing bait/SITGROPE/3/TRACK_BEFORE/None
-QUEST_LV_0200_20150317_001372	Do not enter
-QUEST_LV_0200_20150317_001373	Request support
+QUEST_LV_0200_20150317_001372	Do Not Enter
+QUEST_LV_0200_20150317_001373	Requesting Support
 QUEST_LV_0200_20150317_001374	I will protect it
 QUEST_LV_0200_20150317_001375	Stay hidden
 QUEST_LV_0200_20150317_001376	Welcomed uninvited guest
@@ -1893,17 +1893,17 @@ QUEST_LV_0200_20150317_001892	I can get them
 QUEST_LV_0200_20150317_001893	{memo X}Research(2)
 QUEST_LV_0200_20150317_001894	I can get them for sure
 QUEST_LV_0200_20150317_001895	I should go back
-QUEST_LV_0200_20150317_001896	$Talk to Soldier Dominique
-QUEST_LV_0200_20150317_001897	$I met Soldier Dominique, who seems to be puzzled. Talk with Dominique.
+QUEST_LV_0200_20150317_001896	$Talk to Soldier Dominic
+QUEST_LV_0200_20150317_001897	$I met Soldier Dominic, who seems to be puzzled. Talk with Dominic.
 QUEST_LV_0200_20150317_001898	$Patrol Veltui Crossroads
-QUEST_LV_0200_20150317_001899	$Soldier Dominique seems to be puzzled by two different conflicting orders. Help Dominique by patrolling Veltui Crossroads for her.
-QUEST_LV_0200_20150317_001900	$I ran into monsters, but they were easy. Return to Soldier Dominique and talk with her again.
+QUEST_LV_0200_20150317_001899	$Soldier Dominic seems to be puzzled by two different conflicting orders. Help Dominic by patrolling Veltui Crossroads for him.
+QUEST_LV_0200_20150317_001900	$I ran into monsters, but they were easy. Return to Soldier Dominic and talk with him again.
 QUEST_LV_0200_20150317_001901	$Defeat the monsters that appeared near the Crossroads
 QUEST_LV_0200_20150317_001902	$Talk to Soldier Samson
 QUEST_LV_0200_20150317_001903	$Soldier Samson seems to be troubled. Talk with Soldier Samson.
 QUEST_LV_0200_20150317_001904	$Look for the engagement ring in Meleech's stomach
-QUEST_LV_0200_20150317_001905	$Soldier Samson says that he is too tired to be ordered around by Dominique. As Samson requested, defeat Meleech and look for her engagement ring.
-QUEST_LV_0200_20150317_001906	$Send it to Soldier Samson
+QUEST_LV_0200_20150317_001905	$Soldier Samson says that he is too tired to be ordered around by Dominic. As Samson requested, defeat Meleech and look for the engagement ring.
+QUEST_LV_0200_20150317_001906	$Give it to Soldier Samson
 QUEST_LV_0200_20150317_001907	$I found a sticky lump with the ring in it. Return to Soldier Samson and give it to him.
 QUEST_LV_0200_20150317_001908	$Meleech that swallowed the engagement ring
 QUEST_LV_0200_20150317_001909	$An object that looks like a ring is visible through the disgusting lump, but I have no way of taking it out. Talk with Soldier Samson.
@@ -1958,7 +1958,7 @@ QUEST_LV_0200_20150317_001957	$You defeated all nearby Ravinelarvae. Talk to the
 QUEST_LV_0200_20150317_001958	$Defeat Ravinelarvae
 QUEST_LV_0200_20150317_001959	$Talk to Soldier Dainus
 QUEST_LV_0200_20150317_001960	$Soldier Dainus is trembling from fear. Talk to Soldier Dainus to look for the other soldiers.
-QUEST_LV_0200_20150317_001961	$Look for the other soldiers at Drieza Waterland.
+QUEST_LV_0200_20150317_001961	$Look for the other soldiers at Drieza Waterland
 QUEST_LV_0200_20150317_001962	$Soldier Dainus told you that there may be other soldiers at Drieza Waterland. Go to Drieza Waterland and look for the soldiers there.
 QUEST_LV_0200_20150317_001963	$Defeat Ironbaum
 QUEST_LV_0200_20150317_001964	Find the grave at the Sunset Flag Forest
@@ -2207,7 +2207,7 @@ QUEST_LV_0200_20150317_002206	Talk with Soldier Rudolfas
 QUEST_LV_0200_20150317_002207	Defeat the Meleech that suddenly appeared
 QUEST_LV_0200_20150317_002208	The Mellich appeared while you were talking to Soldier Rudolfas. Defeat Mellich.
 QUEST_LV_0200_20150317_002209	Defeat the interfering monsters
-QUEST_LV_0200_20150317_002210	Defeat Soldier Aspas
+QUEST_LV_0200_20150317_002210	Talk to Soldier Aspas
 QUEST_LV_0200_20150317_002211	The wounded soldier, Aspas is looking for someone's help.
 QUEST_LV_0200_20150317_002212	The monsters are attacking Aspas. Defeat the monsters for Aspas.
 QUEST_LV_0200_20150317_002213	You've protected Soldier Aspas from the monsters. Talk to Soldier Aspas again.
@@ -3410,10 +3410,10 @@ QUEST_LV_0200_20150323_003409	{memo X}As the baron ordered me, I am observing th
 QUEST_LV_0200_20150323_003410	{memo X}Okay then, please get me the poison from it.{nl}This solution is too strong.{nl}And I also don't feel good about sharing it.
 QUEST_LV_0200_20150323_003411	{memo X}Do not repeatitively hit it even if it is unconcious.{nl}Just get closer to it slowly..{nl}Ah that's not it.. just get close to it and talk to it.
 QUEST_LV_0200_20150323_003412	Okay this is it.{nl}Just wait a min.
-QUEST_LV_0200_20150323_003413	{memo X}Now we should share this with the farmers here.{nl}Especially, Dalryus over there. He looks as though he is out of his energy these days.{nl}He's not doing his job and looks down..
+QUEST_LV_0200_20150323_003413	{memo X}Now we should share this with the farmers here.{nl}Especially, Dallus over there. He looks as though he is out of his energy these days.{nl}He's not doing his job and looks down..
 QUEST_LV_0200_20150323_003414	{memo X}You should take a leaf of sweet herb on your way.{nl}Even if you diluted it, it's too strong to be eaten alone.{nl}There are many sweet herbs around here so you won't have a trouble finding it.
 QUEST_LV_0200_20150323_003415	{memo X}I didn't miss anything.{nl}Please move fast.
-QUEST_LV_0200_20150323_003416	Dalryus
+QUEST_LV_0200_20150323_003416	$Dallus
 QUEST_LV_0200_20150323_003417	{memo X}Who are you? and what's that?{nl}Stephas sent you?
 QUEST_LV_0200_20150323_003418	{memo X}He told me to take this?{nl}Nutritious tonic?{nl}I never expected this from him.
 QUEST_LV_0200_20150323_003419	{memo X}Ah, that..{nl}Maybe the medicine was too strong? or the poison of Scorpio got rotten.{nl}Well, don't think about it. You just continue on your way.
@@ -3423,7 +3423,7 @@ QUEST_LV_0200_20150323_003422	Maryus
 QUEST_LV_0200_20150323_003423	{memo X}I should bring him some food. He must be looking for a small plot of field where he could scatter the seeds across the bridge over there.{nl}Whenever I try to go there, the food gets rotten.{nl}Can you bring me some?
 QUEST_LV_0200_20150323_003424	{memo X}Come back whenever it gets rotten.{nl}But, since there are not many of them, please take care.{nl}I only have six left.
 QUEST_LV_0200_20150323_003425	{memo X}You came at the right time since I was hungry.{nl}Something strange has been keep delivered from the lower side so I was so heptic.{nl}I will be concious again if I eat that rice cake. Give to me fast.
-QUEST_LV_0200_20150323_003426	{memo X}Now it will be good if you bring that to Dalryus
+QUEST_LV_0200_20150323_003426	{memo X}Now it will be good if you bring that to Dallus
 QUEST_LV_0200_20150323_003427	{memo X}What are you doing? Move fast..
 QUEST_LV_0200_20150323_003428	{memo X}Well.{nl}I don't understand why the food gets rotten whenever I cross there.{nl}.. Is it because of the smoke there?
 QUEST_LV_0200_20150323_003429	{memo X}{nl}How would I know about it. If you are going back to Maryus, then get rid of those strange things.{nl}I can't do it because I am scared.
@@ -5022,22 +5022,22 @@ QUEST_LV_0200_20150323_005021	{memo X}You've obtained the poison of Scorpio. Now
 QUEST_LV_0200_20150323_005022	{memo X}Talk with Stephas
 QUEST_LV_0200_20150323_005023	It seems that the nutritious tonic is well diluted. Talk to Stephas again.
 QUEST_LV_0200_20150323_005024	{memo X}Bring the nutritious tonic to the farmers
-QUEST_LV_0200_20150323_005025	{memo X}Stephas told you bring the nutritious tonic to Dalryus. Let's also bring the leaves of sweet herbs so he can eat more comfortably.
-QUEST_LV_0200_20150323_005026	{memo X}Hand over the medicine to Dalryus
-QUEST_LV_0200_20150323_005027	$Since you have sweet herb leaves now, hand the nutritious tonic to Dalryus
-QUEST_LV_0200_20150323_005028	Talk with Dalryus
-QUEST_LV_0200_20150323_005029	{memo X}Tell Dalryus to consume the tonic
+QUEST_LV_0200_20150323_005025	{memo X}Stephas told you bring the nutritious tonic to Dallus. Let's also bring the leaves of sweet herbs so he can eat more comfortably.
+QUEST_LV_0200_20150323_005026	{memo X}Hand over the medicine to Dallus
+QUEST_LV_0200_20150323_005027	$Since you have sweet herb leaves now, hand the nutritious tonic to Dallus
+QUEST_LV_0200_20150323_005028	Talk with Dallus
+QUEST_LV_0200_20150323_005029	{memo X}Tell Dallus to consume the tonic
 QUEST_LV_0200_20150323_005030	{memo X}Return to Stephas
-QUEST_LV_0200_20150323_005031	{memo X}You should report to Stephas that Dalryus has shown an irregular response after consuming the medicine!
+QUEST_LV_0200_20150323_005031	{memo X}You should report to Stephas that Dallus has shown an irregular response after consuming the medicine!
 QUEST_LV_0200_20150323_005032	Talk with Maryus
 QUEST_LV_0200_20150323_005033	Maryus needs someone's help. Get closer to him and talk to him.
-QUEST_LV_0200_20150323_005034	{memo X}Hand over the normal rice cake to Dalryus
-QUEST_LV_0200_20150323_005035	{memo X}Maryus gave you the rice cake and told you to pass it to Dalryus. But, since the rice cake gets spoiled quickly these days, it is important that you pass him the normal rice cake. If the rice cake gets spoiled on your way to Dalryus, just throw it away and get the new one from Maryus again.
-QUEST_LV_0200_20150323_005036	{memo X}Take the rice cake to Dalryus
-QUEST_LV_0200_20150323_005037	{memo X}You successfully arrived near Dalryus by avoiding the rice cake getting spoiled! Hand over the cake to Dalryus.
-QUEST_LV_0200_20150323_005038	{memo X}Now, talk to Dalryus again.
+QUEST_LV_0200_20150323_005034	{memo X}Hand over the normal rice cake to Dallus
+QUEST_LV_0200_20150323_005035	{memo X}Maryus gave you the rice cake and told you to pass it to Dallus. But, since the rice cake gets spoiled quickly these days, it is important that you pass him the normal rice cake. If the rice cake gets spoiled on your way to Dallus, just throw it away and get the new one from Maryus again.
+QUEST_LV_0200_20150323_005036	{memo X}Take the rice cake to Dallus
+QUEST_LV_0200_20150323_005037	{memo X}You successfully arrived near Dallus by avoiding the rice cake getting spoiled! Hand over the cake to Dallus.
+QUEST_LV_0200_20150323_005038	{memo X}Now, talk to Dallus again.
 QUEST_LV_0200_20150323_005039	Remove the strange trace
-QUEST_LV_0200_20150323_005040	{memo X}There were some strange things that were stuck into the ground as you were going to Dalryus from Maryus. It seems that they cause the food to get spoiled quickly. Let's try eliminating them on your way back to Maryus.
+QUEST_LV_0200_20150323_005040	{memo X}There were some strange things that were stuck into the ground as you were going to Dallus from Maryus. It seems that they cause the food to get spoiled quickly. Let's try eliminating them on your way back to Maryus.
 QUEST_LV_0200_20150323_005041	{memo X}Return to Maryus
 QUEST_LV_0200_20150323_005042	{memo X}You've eliminated the things that were stuck into the ground. Tell this to Maryus.
 QUEST_LV_0200_20150323_005043	Help Maryus
@@ -5616,7 +5616,7 @@ QUEST_LV_0200_20150401_005615	Since he also received the baron's order,{nl}Even 
 QUEST_LV_0200_20150401_005616	$This is the poison of Scorpio. {nl}It is nocturnal so it must be sleeping at the area where the cultivation is planned.{nl}Wake it up and extract the poison out from it. Easy, right?
 QUEST_LV_0200_20150401_005617	Walk slowly..{nl}If you attack too fast, it won't be effective.
 QUEST_LV_0200_20150401_005618	All done. {nl}Now, I will share this with the workers.{nl}
-QUEST_LV_0200_20150401_005619	$Especially Dalryus over there. He seems to always be exhausted these days.{nl}He's not doing his work and he looks exhausted.{nl}{nl}
+QUEST_LV_0200_20150401_005619	$Especially Dallus over there. He seems to always be exhausted these days.{nl}He's not doing his work and he looks exhausted.{nl}{nl}
 QUEST_LV_0200_20150401_005620	I will take one sweet herb leaf on my way.{nl}That medicine, it's disgusting to consume it.
 QUEST_LV_0200_20150401_005621	$The poison of Scorpio.{nl}Can humans consume it?
 QUEST_LV_0200_20150401_005622	Who are you? {nl}Stephas sent you?
@@ -5628,7 +5628,7 @@ QUEST_LV_0200_20150401_005627	$I should bring lunch to my brother who is working
 QUEST_LV_0200_20150401_005628	I swear that I will never lie.{nl}Can you take it on behalf of me?
 QUEST_LV_0200_20150401_005629	$Come back if it gets spoiled.{nl}But I only have two remaining breads so be careful.
 QUEST_LV_0200_20150401_005630	$Did my brother ask you to give this to me?{nl}Anyway, I am tired and I don't know why these kind of things keep occurring. At any rate, thanks.
-QUEST_LV_0200_20150401_005631	Is it okay now?{nl}Okay then hand it over to Dalryus.
+QUEST_LV_0200_20150401_005631	Is it okay now?{nl}Okay then hand it over to Dallus.
 QUEST_LV_0200_20150401_005632	Are you scared?
 QUEST_LV_0200_20150401_005633	Strange. Isn't it? How come the food gets spoiled whenever I cross there.{nl}Is it because of the smoke there?{nl}
 QUEST_LV_0200_20150401_005634	How would I know about it. {nl}If you are going back to my brother, please get rid of those strange things. I can't do it since I am scared.
@@ -5978,17 +5978,17 @@ QUEST_LV_0200_20150401_005981	$You need to extract venom to make nutritious toni
 QUEST_LV_0200_20150401_005982	Give it to Soldier Stephas
 QUEST_LV_0200_20150401_005983	Collected enough Scorpio venom. Give the venom to Stephas.
 QUEST_LV_0200_20150401_005984	Collect Sweet Herb
-QUEST_LV_0200_20150401_005985	$Soldier Stephas asked you to get Sweet Herb so that it will be easier for Dalryus to drink the the Nutritious tonic.
-QUEST_LV_0200_20150401_005986	$Give the tonic to Dalryus in Shlake Trails
-QUEST_LV_0200_20150401_005987	$Give tonic to Dalryus
-QUEST_LV_0200_20150401_005988	$Stephas asked you to put Sweet Herb in the Nutritious Tonic and deliver it to Dalryus.
-QUEST_LV_0200_20150401_005989	$Dalryus is acting strangely after drinking the Nutritious tonic. You better report it to Stephas.
-QUEST_LV_0200_20150401_005990	$Give unspoiled bread to Dalryus
-QUEST_LV_0200_20150401_005991	$Marius asked you to give the bread to his brother, Dalryus. If the bread spoils on the way, throw it away and get the bread again from Marius.
-QUEST_LV_0200_20150401_005992	$Deliver it to Dalryus
-QUEST_LV_0200_20150401_005993	$Arrived nearby Dalryus with the bread still good. Give the bread to Dalryus.
-QUEST_LV_0200_20150401_005994	$Delivered the bread. Talk to Dalryus again.
-QUEST_LV_0200_20150401_005995	$Dalryus says there is a weird smoke nearby which seems to be causing food to spoil. Remove that smoke on the way back to Marius.
+QUEST_LV_0200_20150401_005985	$Soldier Stephas asked you to get Sweet Herb so that it will be easier for Dallus to drink the the Nutritious tonic.
+QUEST_LV_0200_20150401_005986	$Give the tonic to Dallus in Shlake Trails
+QUEST_LV_0200_20150401_005987	$Give tonic to Dallus
+QUEST_LV_0200_20150401_005988	$Stephas asked you to put Sweet Herb in the Nutritious Tonic and deliver it to Dallus.
+QUEST_LV_0200_20150401_005989	$Dallus is acting strangely after drinking the Nutritious tonic. You better report it to Stephas.
+QUEST_LV_0200_20150401_005990	$Give unspoiled bread to Dallus
+QUEST_LV_0200_20150401_005991	$Marius asked you to give the bread to his brother, Dallus. If the bread spoils on the way, throw it away and get the bread again from Marius.
+QUEST_LV_0200_20150401_005992	$Deliver it to Dallus
+QUEST_LV_0200_20150401_005993	$Arrived nearby Dallus with the bread still good. Give the bread to Dallus.
+QUEST_LV_0200_20150401_005994	$Delivered the bread. Talk to Dallus again.
+QUEST_LV_0200_20150401_005995	$Dallus says there is a weird smoke nearby which seems to be causing food to spoil. Remove that smoke on the way back to Marius.
 QUEST_LV_0200_20150401_005996	Removed the irritating things. Tell Marius about it.
 QUEST_LV_0200_20150401_005997	$Get back the seed pouch from Tvora Road
 QUEST_LV_0200_20150401_005998	Seems like Allerno's monsters stole the seeds. Get back the seed pouch from the monsters around Baron Allerno's territory.
@@ -7045,7 +7045,7 @@ QUEST_LV_0200_20150714_007048	It's dangerous here, get back to the town.{nl} Wha
 QUEST_LV_0200_20150714_007049	$Ah, so you're the Revelator? {nl} I have a problem, but with you here it might not be so bad. {nl} Mind if I borrow some of your time?
 QUEST_LV_0200_20150714_007050	You are aware that we're the unit sent out to take care of the Gaigalas?{nl} Recruit! Take this report to Commander Williams.
 QUEST_LV_0200_20150714_007051	If we get rid of the Gaigalas we can smooth things out with them.{nl}Please make your way to the worried owl.
-QUEST_LV_0200_20150714_007052	Hunter Tracking Leader Mintz
+QUEST_LV_0200_20150714_007052	$Hunter Tracking Leader Mintz
 QUEST_LV_0200_20150714_007053	What a pain in the ass.{nl} How to convince those monks...
 QUEST_LV_0200_20150714_007054	Hey you, have you ever seen the one called Evoniphon?
 QUEST_LV_0200_20150714_007055	I hope this that was the end of it.{nl}It seems that we Hunters have a bad reputation around these parts.
@@ -9430,7 +9430,7 @@ QUEST_LV_0200_20151001_009433	You haven't found them yet?{nl}Go to Tinaga stone 
 QUEST_LV_0200_20151001_009434	Thanks. {nl}I owe you a lot.
 QUEST_LV_0200_20151001_009435	Are you going to the camping ground?{nl}Ah, I am Roches and I am responsible for the contacting Mesafasla and Stogas squads.{nl}
 QUEST_LV_0200_20151001_009436	While I was returning with the letter, we met a herd of monsters.{nl}I think I will be recovered if I take a rest for a while, but I have to deliver the letter quickly...{nl}
-QUEST_LV_0200_20151001_009437	For now, you are the only one we can trust.{nl}Please pass this letter to the commanding officer, Ades.{nl}
+QUEST_LV_0200_20151001_009437	For now, you are the only one we can trust.{nl}Please pass this letter to the Commanding Officer Ades.{nl}
 QUEST_LV_0200_20151001_009438	Ah, if you are okay, please also defeat the monsters on your way.{nl}I have problem fighting against the monsters with the current status.
 QUEST_LV_0200_20151001_009439	I will be okay if I take little more rest.{nl}I am worried about the monsters and the letter.
 QUEST_LV_0200_20151001_009440	$Stogas Commanding Officer Ades
@@ -9438,14 +9438,14 @@ QUEST_LV_0200_20151001_009441	You've brought the letter from Mesafasla?{nl}Then 
 QUEST_LV_0200_20151001_009442	Ah... It's fortunate to hear that you are okay.
 QUEST_LV_0200_20151001_009443	You are a foreigner for a long time {nl}The supplies has been stopping from the kingdom, we don't know what's going on..{nl}
 QUEST_LV_0200_20151001_009444	Even I'm trying to stand by doing self-sufficiency, but It's hard to alive only myself.{nl}If you are okay, please solve the lack of foods.
-QUEST_LV_0200_20151001_009445	Pleaes get the meat from Beadbird around here.{nl}Horas told me It has a good taste.{nl}
+QUEST_LV_0200_20151001_009445	Please get the meat from Beadbird around here.{nl}Horas told me It has a good taste.{nl}
 QUEST_LV_0200_20151001_009446	We will starve, if the Beadbird.{nl}Here is too cold, so only Potatos are growing.
 QUEST_LV_0200_20151001_009447	Thank you.{nl}Firsly, we have to complete it.
-QUEST_LV_0200_20151001_009448	Our lack is not only food.{nl}The weapons also needed to be changed because of no supplies from camp.
+QUEST_LV_0200_20151001_009448	We are not only lacking food.{nl}The weapons also needed to be changed because of no supplies from camp.
 QUEST_LV_0200_20151001_009449	But, there's more than ony way to skin a cat.{nl}We can make caltrops using the old prison fragments.{nl}
 QUEST_LV_0200_20151001_009450	If you are okay, please collect something useful?
 QUEST_LV_0200_20151001_009451	A long time ago, these prion was moving to Kalezimas.{nl}It is a unfortunate stuff in the Kadumel King years.
-QUEST_LV_0200_20151001_009452	It will be okay, if it was moved since Ruklys rebelion.{nl}Before that, many people was taken to do forced labor forcibly.{nl}
+QUEST_LV_0200_20151001_009452	It will be okay, if it was moved since Ruklys rebellion.{nl}Before that, many people was taken to do forced labor forcibly.{nl}
 QUEST_LV_0200_20151001_009453	Is the Crystal Mine nearby Klaipeda?{nl}Actually that place is one of the compulsion workhouse.{nl}Ashake prison nearby Orsa as well.
 QUEST_LV_0200_20151001_009454	I feel kind of my blood froze when looking at the fragments of prison.{nl}It is kind of feel the grudge..
 QUEST_LV_0200_20151001_009455	Thank you so much.{nl}

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -2130,10 +2130,10 @@ QUEST_LV_0200_20150317_002129	$Ellom Leaves
 QUEST_LV_0200_20150317_002130	$The Spirit told you that he will go to Grobis Crossroads. Go there and talk to the Spirit.
 QUEST_LV_0200_20150317_002131	$Complete the last mission using the decoy at Grobis Crossroads
 QUEST_LV_0200_20150317_002132	$This will be the last mission. Defeat the demons that killed the Officer and his soldiers using the decoy.
-QUEST_LV_0200_20150317_002133	$You've defeated the monsters using the decoy. Go talk to the Spirit again.
+QUEST_LV_0200_20150317_002133	$You've defeated the monsters using the decoy. Talk to the Spirit again.
 QUEST_LV_0200_20150317_002134	$Defeat 10 monsters within 1 minute and 30 seconds
 QUEST_LV_0200_20150317_002135	$Talk with the Scouts
-QUEST_LV_0200_20150317_002136	$It seems that the Scouts have differing opinions on whether Deadborn is nearby. Go talk to the Scouts again.
+QUEST_LV_0200_20150317_002136	$It seems that the Scouts have differing opinions on whether Deadborn is nearby. Talk to the Scouts again.
 QUEST_LV_0200_20150317_002137	$Defeat Deadborn
 QUEST_LV_0200_20150317_002138	$Deadborn suddenly attacked. Defeat Deadborn.
 QUEST_LV_0200_20150317_002139	$Officer Danus doesn't know what to do. Talk to Officer Danus.
@@ -2529,12 +2529,12 @@ QUEST_LV_0200_20150317_002528	Scatter seeds at Radanja Farm
 QUEST_LV_0200_20150317_002529	Ris should scatter seeds on the fields near the village, but he is scared of the monster. Scatter the seeds for him.
 QUEST_LV_0200_20150317_002530	You've scattered all the seeds. Return to Ris and let him know.
 QUEST_LV_0200_20150317_002531	Talk with Disciple Raely
-QUEST_LV_0200_20150317_002532	The disciple Ralie seems to be quite angry. Go meet Disciple Raely.
+QUEST_LV_0200_20150317_002532	The disciple Ralie seems to be quite angry. Meet Disciple Raely.
 QUEST_LV_0200_20150317_002533	Collect the branches of Bee trees.
 QUEST_LV_0200_20150317_002534	The disciple, Raelie needs the branches of Bee trees that the villagers have ruined. Collect the branches of bee trees near the village.
 QUEST_LV_0200_20150317_002535	You've collected enough branches. Return to Disciple Raely.
 QUEST_LV_0200_20150317_002536	{memo X}Obtain %s using the branches
-QUEST_LV_0200_20150317_002537	It seems that Disciple Raely has something to say. Go meet Disciple Raely.
+QUEST_LV_0200_20150317_002537	It seems that Disciple Raely has something to say. Meet Disciple Raely.
 QUEST_LV_0200_20150317_002538	Activate the protecting stone
 QUEST_LV_0200_20150317_002539	The disciple Raelie told you that the demons would soon come here. Activate the protecting stones and block against the demons.
 QUEST_LV_0200_20150317_002540	The monster's attacks stopped. Return to Disciple Raely.
@@ -2549,14 +2549,14 @@ QUEST_LV_0200_20150317_002548	You've filled all the divine magic energies to the
 QUEST_LV_0200_20150317_002549	The divine magic energies gathered enough in the marble of ashes. Ask Disciple Raely what to do next with this.
 QUEST_LV_0200_20150317_002550	Restore the weak sealed tower
 QUEST_LV_0200_20150317_002551	Restore the weak sealed tower at Stula Highway. The demons may come to break the seal so you should hurry.
-QUEST_LV_0200_20150317_002552	Talk with the Austeja goddess
-QUEST_LV_0200_20150317_002553	As you restored the sealed tower which was changed by the demons, Austeja goddess has appeared. Listen to the story of Austeja goddess.
-QUEST_LV_0200_20150317_002554	Listen to the story of Austeja goddess
-QUEST_LV_0200_20150317_002555	Austeja goddess told you that the everything that is occuring at the apiary is the act of the demons that are trying to release the seal that is placed upon the Demon Lord.
+QUEST_LV_0200_20150317_002552	Talk with the Austeja Goddess
+QUEST_LV_0200_20150317_002553	As you restored the sealed tower which was changed by the demons, Austeja Goddess has appeared. Listen to the story of Austeja Goddess.
+QUEST_LV_0200_20150317_002554	Listen to the story of Austeja Goddess
+QUEST_LV_0200_20150317_002555	Austeja Goddess told you that the everything that is occuring at the apiary is the act of the demons that are trying to release the seal that is placed upon the Demon Lord.
 QUEST_LV_0200_20150317_002556	The disciple, Raelie is worrying about something. Ask him what to do.
 QUEST_LV_0200_20150317_002557	Check the gigantic transformed plant
 QUEST_LV_0200_20150317_002558	The gigantic grass looks somewhat dangerous. Look carefully on it.
-QUEST_LV_0200_20150317_002559	The gigantic transformed plant was Kurumis. Go meet Disciple Raely.
+QUEST_LV_0200_20150317_002559	The gigantic transformed plant was Kurumis. Meet Disciple Raely.
 QUEST_LV_0200_20150317_002560	Check the weakened sealed tower
 QUEST_LV_0200_20150317_002561	Check the sealed tower that became weak due to the attacks from the demons
 QUEST_LV_0200_20150317_002562	{memo X}Defeat the Demon Lord Tautrimas
@@ -3224,8 +3224,8 @@ QUEST_LV_0200_20150323_003223	I am not normal myself, but I want to help you som
 QUEST_LV_0200_20150323_003224	I was going to release the spirits that were locked in this altar.{nl}But, it didn't work. Was there something wrong with my prayer?
 QUEST_LV_0200_20150323_003225	I was so sensitive before I moved out from the line due to an injury.{nl}After I saw those demons' marching.{nl}
 QUEST_LV_0200_20150323_003226	{memo X}That night.. I hid behind the grass forest and had to look at everything. {nl}Everyone was pointing guns at each other. They were so close to each other..{nl}
-QUEST_LV_0200_20150323_003227	{memo X}And they were so absorbed with madness even after their death so they could not even return to the goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
-QUEST_LV_0200_20150323_003228	Maybe, everything here was my destiny to become a disciple. Ah goddesses..
+QUEST_LV_0200_20150323_003227	{memo X}And they were so absorbed with madness even after their death so they could not even return to the Goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
+QUEST_LV_0200_20150323_003228	Maybe, everything here was my destiny to become a disciple. Ah Goddesses..
 QUEST_LV_0200_20150323_003229	I can't move with my legs like this.{nl}How could this be.. the only one I can trust is you.
 QUEST_LV_0200_20150323_003230	Before I left for my pilgrimage, I overheard the stories of the Revelators.{nl}And you are really special among them. Can you listen to me little more?
 QUEST_LV_0200_20150323_003231	{memo X}It was really horrible. Those brothers who used to be keen to each other hurt each other..{nl}And the demons cheated on those brothers who died.{nl}
@@ -3238,7 +3238,7 @@ QUEST_LV_0200_20150323_003237	I remembered what's missing. Scripture!{nl}One of 
 QUEST_LV_0200_20150323_003238	Unfortunately, I lost my scripture in the mess.{nl}If I have it, I should have remembered it right away.
 QUEST_LV_0200_20150323_003239	This is it. Many mysteries are being solved because of you.{nl}Let's see, why don't we try other methods as well?
 QUEST_LV_0200_20150323_003240	{memo X}The spirits inside the monsters' stomach will shine when you use this medicine this time.{nl}When you defeat that monster, the spirits that were tied there will be freed.{nl}
-QUEST_LV_0200_20150323_003241	{memo X}My brothers are blaming each other and crying out in madness even after their death.{nl}At the altar of the goddesses.{nl}
+QUEST_LV_0200_20150323_003241	{memo X}My brothers are blaming each other and crying out in madness even after their death.{nl}At the altar of the Goddesses.{nl}
 QUEST_LV_0200_20150323_003242	Even the living being like me can't forgive it, how would the spirits feel?{nl}How can I make disciples do something like that, those who should spread the love of the Goddesses?
 QUEST_LV_0200_20150323_003243	They would also definitely thank you.{nl}I hope the blessing of the Goddess lights your way.{nl}
 QUEST_LV_0200_20150323_003244	This method will be effective for sure.{nl}It must be. If not..
@@ -3313,7 +3313,7 @@ QUEST_LV_0200_20150323_003312	The stream of silence
 QUEST_LV_0200_20150323_003313	(This stream needs to be purified)
 QUEST_LV_0200_20150323_003314	They did the same thing as the people I used to hate would do.{nl}I am sorry. I would have thrown away my anger, were I to be released like this..{nl}
 QUEST_LV_0200_20150323_003315	How could they do this to you..{nl}Yes.. Thanks for saving me. I am at peace.
-QUEST_LV_0200_20150323_003316	When I thought about the moment when this scripture had been ripped into pieces, {n1}I became so enraged that I ended up trapping myself here.{nl}But, now I am able to rest because of you.{nl}
+QUEST_LV_0200_20150323_003316	When I thought about the moment when this scripture had been ripped into pieces, {nl}I became so enraged that I ended up trapping myself here.{nl}But, now I am able to rest because of you.{nl}
 QUEST_LV_0200_20150323_003317	I really appreciate the effort you took, finding this precious scripture. {nl}But, it is meaningless to me now. Bye..
 QUEST_LV_0200_20150323_003318	{memo X}I realized that all deaths of my colleagues were due to the revenge.{nl}I don't need it anymore.. Thanks.
 QUEST_LV_0200_20150323_003319	Who are you? Become the slave of the Succubus!
@@ -3331,12 +3331,12 @@ QUEST_LV_0200_20150323_003330	I will find out why monsters are making mess here.
 QUEST_LV_0200_20150323_003331	Maybe we touched something that we shoudn't touch.{nl}I think we did..
 QUEST_LV_0200_20150323_003332	The disciple is very angry.{nl}Damn, it would have been better if he told me about the altar.
 QUEST_LV_0200_20150323_003333	The villagers told us that they can't trust the disciples anymore so they are doing it themselves.{nl}Me.. I don't care if the monsters get taken care of.
-QUEST_LV_0200_20150323_003334	Where did Austeja goddess go in this kind of time?
+QUEST_LV_0200_20150323_003334	Where did Austeja Goddess go in this kind of time?
 QUEST_LV_0200_20150323_003335	I know that the disciples try their best, but we should protect our village.{nl}We have a trouble living on due to those monsters so we can't just do nothing.
 QUEST_LV_0200_20150323_003336	The disciples never tell us what's wrong.{nl}We know that they are afraid that we would feel unstable.. But still we want to know.
 QUEST_LV_0200_20150323_003337	I know its not the right thing to tell you, but I will count on you.{nl}I don't know what to tell to the disciples.. I am sorry to the Revelator.
 QUEST_LV_0200_20150323_003338	So we created the incident.{nl}Because of us.. I am so sorry.{nl}
-QUEST_LV_0200_20150323_003339	Austeja goddess would protect our village..{nl}But, I am more scared of the monsters in front of us.
+QUEST_LV_0200_20150323_003339	Austeja Goddess would protect our village..{nl}But, I am more scared of the monsters in front of us.
 QUEST_LV_0200_20150323_003340	I refuse to wait for disciples only.{nl}I refuse to be driven by those monsters anymore.
 QUEST_LV_0200_20150323_003341	I don't want to suspect the Goddesses anymore.{nl}But the disciples don't tell us.. isn't it strange?
 QUEST_LV_0200_20150323_003342	There's so much distrust between our disciples and the villagers.{nl}I don't want to create a mess..{nl}
@@ -3357,7 +3357,7 @@ QUEST_LV_0200_20150323_003356	What should I do about it to save the spirits?
 QUEST_LV_0200_20150323_003357	These are not Maven's lessons.{nl}They are just Naktis' curse.
 QUEST_LV_0200_20150323_003358	We have four more necklaces besides this necklace, each with a lesson of Maven.{nl}They are all useless to me.
 QUEST_LV_0200_20150323_003359	We all promised each other to become good disciples.{nl}That feels like it was the day before yesterday.. just a meaningless dream.
-QUEST_LV_0200_20150323_003360	Withus finally.. went back to the goddess.{nl}This is all due to the curse so you shouldn't feel guilty about it.{nl}
+QUEST_LV_0200_20150323_003360	Withus finally.. went back to the Goddess.{nl}This is all due to the curse so you shouldn't feel guilty about it.{nl}
 QUEST_LV_0200_20150323_003361	Ah, if you see the tree of body and mind, please restore it.{nl}I heard that tree blocks the energy of the curse.
 QUEST_LV_0200_20150323_003362	If it weren't for you, Maven's lesson would have been left cursed til the end.{nl}You saved this land. The spirit of Withus as well.
 QUEST_LV_0200_20150323_003363	I heard that all the necklaces of Maven can be combined together through a special method.{nl}I heard the crafting manual is present somewhere, but I don't know where it is.
@@ -3370,7 +3370,7 @@ QUEST_LV_0200_20150323_003369	I tried my best to hide Maven's secret, but..{nl}N
 QUEST_LV_0200_20150323_003370	Disciple Goda
 QUEST_LV_0200_20150323_003371	The Great Cathedral has collapsed, but it still keeps its beauty.{nl}Especially, the secrets of Maven, the great bishop, looks amazing everytime we see them.
 QUEST_LV_0200_20150323_003372	Maven, the great bishop, contributed everything builiding this Great Cathedral.{nl}All that was collapsed on Medis Diena.. destiny is too harsh.
-QUEST_LV_0200_20150323_003373	Farewell is short, but the relationship lasts long.{nl}Someday we will meet again in the goddess.
+QUEST_LV_0200_20150323_003373	Farewell is short, but the relationship lasts long.{nl}Someday we will meet again in the Goddess.
 QUEST_LV_0200_20150323_003374	Disciple Prosit
 QUEST_LV_0200_20150323_003375	Do you think the Great Cathedral will come back to its normal status one day?{nl}I mean at least before I close my eyes.
 QUEST_LV_0200_20150323_003376	I want to say to them that we should retrieve the Great Cathedral.{nl}But, I know we are not ready yet..
@@ -3437,7 +3437,7 @@ QUEST_LV_0200_20150323_003436	{memo X}Long time ago, this place was full of vita
 QUEST_LV_0200_20150323_003437	{memo X}It's simple. Please investigate that place a bit, and make sure the crops are growing well.
 QUEST_LV_0200_20150323_003438	{memo X}Is the task that I requested to you not done yet?
 QUEST_LV_0200_20150323_003439	{memo X}Ah, is that so. They are really like that as the baron and Limas told so.{nl}Thank you.
-QUEST_LV_0200_20150323_003440	{memo X}Then, we should remove that energy.{nl}I will give you some woods first so please make the magic field using that woods on that place.{nl}Like me, you don't seem to have skill to create a magic field.
+QUEST_LV_0200_20150323_003440	{memo X}Then, we should remove that energy.{nl}I will give you some woods first so please make the magic circle using that woods on that place.{nl}Like me, you don't seem to have skill to create a magic circle.
 QUEST_LV_0200_20150323_003441	{memo X}{nl}I will give you this spell scroll. First make it by tieing it with woods and burn it.
 QUEST_LV_0200_20150323_003442	{memo X}I am counting on you.{nl}I think feel more tired due to the energy in this place..
 QUEST_LV_0200_20150323_003443	{memo X}Ah, I am tired..
@@ -3445,7 +3445,7 @@ QUEST_LV_0200_20150323_003444	{memo X}Yes? The crops died?{nl}Was the spell too 
 QUEST_LV_0200_20150323_003445	{memo X}Wizard Limas
 QUEST_LV_0200_20150323_003446	{memo X}Are you the Revelator?{nl}Please do not think about the machine behind me.{nl}Unless you help me with one of my tasks.
 QUEST_LV_0200_20150323_003447	{memo X}This machine is being used for an important task.{nl}It is related to the past that isn't that long ago.{nl}The portal that would bring the eternal life and the power that sustains the eternal life..
-QUEST_LV_0200_20150323_003448	{memo X}You can only minimize the strange energy surrounding this place by enhancing the seal magic field.{nl}To do so, we need those empty bottles.{nl}Good luck.
+QUEST_LV_0200_20150323_003448	{memo X}You can only minimize the strange energy surrounding this place by enhancing the seal magic circle.{nl}To do so, we need those empty bottles.{nl}Good luck.
 QUEST_LV_0200_20150323_003449	{memo X}Is everything going alright?
 QUEST_LV_0200_20150323_003450	{memo X}Very nice.{nl}The machine is going well for sure.{nl}Its all because of you.{nl}And that strange energy is influencing the growth of the crops here.
 QUEST_LV_0200_20150323_003451	{memo X}I activate the power generator using the fuel that we accumulated in that storage.{nl}That's why we needed more grains.
@@ -3473,9 +3473,9 @@ QUEST_LV_0200_20150323_003472	{memo X}I don't know who took it. We should catch 
 QUEST_LV_0200_20150323_003473	{memo X}I don't know anymore.{nl}If he could share me a small plot of field, that would be good.
 QUEST_LV_0200_20150323_003474	{memo X}Yes. That's right. Thanks.
 QUEST_LV_0200_20150323_003475	{memo X}Now we have some seeds. Thank you so much.
-QUEST_LV_0200_20150323_003476	{memo X}Ah, that's right.{nl}There are many ways to enhance the magic field.{nl}It is always a problem that I can't go since I can't leave the baron and this magic power generator behind.
+QUEST_LV_0200_20150323_003476	{memo X}Ah, that's right.{nl}There are many ways to enhance the magic circle.{nl}It is always a problem that I can't go since I can't leave the baron and this magic power generator behind.
 QUEST_LV_0200_20150323_003477	{memo X}{nl}Okay. Take these and scatter them.{nl}This is one of the methods for the enhancement. I made it to prepare times like this.
-QUEST_LV_0200_20150323_003478	{memo X}Use the poison to enhance the magic field?..{nl}I am not sure if its right, but let's try it anyways.
+QUEST_LV_0200_20150323_003478	{memo X}Use the poison to enhance the magic circle?..{nl}I am not sure if its right, but let's try it anyways.
 QUEST_LV_0200_20150323_003479	{memo X}I've collected that poison from the monsters.{nl}The monsters are very vicious and hard.
 QUEST_LV_0200_20150323_003480	{memo X}Venews
 QUEST_LV_0200_20150323_003481	{memo X}There are Manticens which the baron takes care at the Mirukis farm.{nl}I was little bit worried that they only do what they want to do..{nl}Anyways, yesterday, I fed them. Little big one.{nl}Their habit is to eat something after hiding somewhere.
@@ -3527,11 +3527,11 @@ QUEST_LV_0200_20150323_003526	{memo X}Over the fence, there is an altar that the
 QUEST_LV_0200_20150323_003527	{memo X}I can only guess.{nl}I am sure that something serious is going on here.
 QUEST_LV_0200_20150323_003528	{memo X}Be careful.{nl}It is very vicious.{nl}I am keep trying, but I always failed.
 QUEST_LV_0200_20150323_003529	{memo X}Oh my god!{nl}Thank you so much!
-QUEST_LV_0200_20150323_003530	{memo X}The seal magic field which was discoverd in the A area.. We should eliminate it.{nl}This is the hard stone that we obtained from the monsters.{nl}If we throw this, we may able to break the field.{nl}
+QUEST_LV_0200_20150323_003530	{memo X}The seal magic circle which was discoverd in the A area.. We should eliminate it.{nl}This is the hard stone that we obtained from the monsters.{nl}If we throw this, we may able to break the field.{nl}
 QUEST_LV_0200_20150323_003531	{memo X}I am the one who should have finished this job..{nl}I am sorry that I passed this job to you..
 QUEST_LV_0200_20150323_003532	{memo X}Cheer up! Revelator!
 QUEST_LV_0200_20150323_003533	{memo X}Ohoh, you succeeded!{nl}Now this place is going back to its normal status.
-QUEST_LV_0200_20150323_003534	{memo X}There's a magic field in this region as well.{nl}We should break that.{nl}But, the monsters are always disturbing us..
+QUEST_LV_0200_20150323_003534	{memo X}There's a magic circle in this region as well.{nl}We should break that.{nl}But, the monsters are always disturbing us..
 QUEST_LV_0200_20150323_003535	{memo X}Just think that the monsters don't have brains.{nl}They are not on the baron side and they are also not on our side.{nl}They always cause troubles and they disturb our tasks.
 QUEST_LV_0200_20150323_003536	{memo X}I feel so relieved to see that you are so enthusiastic.
 QUEST_LV_0200_20150323_003537	{memo X}We are almost there! The moment of restoration!
@@ -3544,20 +3544,20 @@ QUEST_LV_0200_20150323_003543	{memo X}{nl}I feel.. I feel like ruining the divin
 QUEST_LV_0200_20150323_003544	{memo X}We don't have enough sticky fluid.
 QUEST_LV_0200_20150323_003545	{memo X}Okay that would be enough. Give it to me.{nl}I will try to glue them together.
 QUEST_LV_0200_20150323_003546	{memo X}To prepare the big task that we will do in the near future, I am collecting the clues to persuade the farmers.{nl}I mean.. since the baron is wrong, I am telling you to get a revenge on the plunderings and the cruelties.{nl}.. I will tell you that much.
-QUEST_LV_0200_20150323_003547	{memo X}I mean, we should take the monster to the magic field down there.{nl}In order to succeed the experiment, it would be better to extract the half of the blood from it.{nl}And then make it react to the magic field.
+QUEST_LV_0200_20150323_003547	{memo X}I mean, we should take the monster to the magic circle down there.{nl}In order to succeed the experiment, it would be better to extract the half of the blood from it.{nl}And then make it react to the magic circle.
 QUEST_LV_0200_20150323_003548	{memo X}You are understanding correctly right?
 QUEST_LV_0200_20150323_003549	{memo X}Yes.{nl}It really was like that. Monsters fall into the eternal sleep.. dying..{nl}The monsters are dying due to the energy coming from there..
 QUEST_LV_0200_20150323_003550	{memo X}Yonaris
-QUEST_LV_0200_20150323_003551	{memo X}From the one day, the crops here do not grow anymore.{nl}Even after I scatter the seeds a lot.{nl}So I am thinking maybe the reason of it is related to the magic field that was created by the fellows of the baron.{nl}Can you help me?
+QUEST_LV_0200_20150323_003551	{memo X}From the one day, the crops here do not grow anymore.{nl}Even after I scatter the seeds a lot.{nl}So I am thinking maybe the reason of it is related to the magic circle that was created by the fellows of the baron.{nl}Can you help me?
 QUEST_LV_0200_20150323_003552	{memo X}As you can see, this place is full of water.{nl}The place full of water means that this land is very fertile.{nl}But, you can see it right? The crops at some places are not growing.{nl}It's not that all the fields are like that.
-QUEST_LV_0200_20150323_003553	{memo X}When you see the place near the magic field, you will see the monsters with flames on them.{nl}Long time ago, I was able to put the flames on some of them in order to eliminate the magic field, but after that I was so busy here.{nl}When you go there and put them into the magic field, the field will break.
+QUEST_LV_0200_20150323_003553	{memo X}When you see the place near the magic circle, you will see the monsters with flames on them.{nl}Long time ago, I was able to put the flames on some of them in order to eliminate the magic circle, but after that I was so busy here.{nl}When you go there and put them into the magic circle, the field will break.
 QUEST_LV_0200_20150323_003554	{memo X}Still not completed?
 QUEST_LV_0200_20150323_003555	{memo X}Wow amazing.{nl}Thanks!
-QUEST_LV_0200_20150323_003556	{memo X}But, the magic fields are still left.{nl}Is there some way we could borrow the mighty power of the goddesses..{nl}Only if there were the statues of the goddesses..
-QUEST_LV_0200_20150323_003557	{memo X}Starting from the one day, those barons' plunderings increased a lot and many magic fields were created a lot. Somehow, some of them were less shiny.{nl}Anyways, when you get near the bright ones, it will be hard to eliminate them since you may get hurt.{nl}Of course, the most difficult task is to avoid the eyes of the barons and continue to do this task.
+QUEST_LV_0200_20150323_003556	{memo X}But, the magic circles are still left.{nl}Is there some way we could borrow the mighty power of the Goddesses..{nl}Only if there were the statues of the Goddesses..
+QUEST_LV_0200_20150323_003557	{memo X}Starting from the one day, those barons' plunderings increased a lot and many magic circles were created a lot. Somehow, some of them were less shiny.{nl}Anyways, when you get near the bright ones, it will be hard to eliminate them since you may get hurt.{nl}Of course, the most difficult task is to avoid the eyes of the barons and continue to do this task.
 QUEST_LV_0200_20150323_003558	{memo X}{nl}I don't know exactly who you are, but you are the perfect candidate to help us since you are not well known here.
-QUEST_LV_0200_20150323_003559	{memo X}Yoana has it?{nl}If we put them in the magic field, don't you think the field would break?
-QUEST_LV_0200_20150323_003560	{memo X}You came well at the right time. I tied them up with the sticky fluid.{nl}.. As I expected. This is the statue of the goddess.{nl}You tied them up with the fluid from the monsters.. I am so sorry..
+QUEST_LV_0200_20150323_003559	{memo X}Yoana has it?{nl}If we put them in the magic circle, don't you think the field would break?
+QUEST_LV_0200_20150323_003560	{memo X}You came well at the right time. I tied them up with the sticky fluid.{nl}.. As I expected. This is the statue of the Goddess.{nl}You tied them up with the fluid from the monsters.. I am so sorry..
 QUEST_LV_0200_20150323_003561	{memo X}{nl}You need this? Take it.
 QUEST_LV_0200_20150323_003562	{memo X}I am counting on you.
 QUEST_LV_0200_20150323_003563	{memo X}Really?{nl}My predictions are all correct.{nl}Thank you.
@@ -3566,10 +3566,10 @@ QUEST_LV_0200_20150323_003565	Jugas
 QUEST_LV_0200_20150323_003566	{memo X}Master, have you seen my seed pocket that the monsters took away from me?{nl}I am begging you.. please find the seed pocket for me.
 QUEST_LV_0200_20150323_003567	{memo X}It's lacking.
 QUEST_LV_0200_20150323_003568	{memo X}Ah, thank you.
-QUEST_LV_0200_20150323_003569	{memo X}There is an unstable sealed magic field down there. {nl}The baron told me that the seal which prevents the strange energy spurting out from the places nearby is not perfect yet so the energy is leaking out. However, the problem is that it doesn't look like that.{nl}It is suspicious.{nl}Now we have to tie up these pieces, so can you find more about the energy on behalf of me?
+QUEST_LV_0200_20150323_003569	{memo X}There is an unstable sealed magic circle down there. {nl}The baron told me that the seal which prevents the strange energy spurting out from the places nearby is not perfect yet so the energy is leaking out. However, the problem is that it doesn't look like that.{nl}It is suspicious.{nl}Now we have to tie up these pieces, so can you find more about the energy on behalf of me?
 QUEST_LV_0200_20150323_003570	Hmm.. It is almost completed now.{nl}We have enough reasons.. the food, almost everything.{nl}Now, we just have one more to go..
 QUEST_LV_0200_20150323_003571	My wish is not something big. We just want to live.{nl}Harvest for one year and stay full until the next harvest. {nl}We, farmers want only that.
-QUEST_LV_0200_20150323_003572	{memo X}{nl}If that one thing doesn't get accomplished, we have no choice, but to stand up.{nl}Against the source of the plunderings.{nl}Also if the process of the plunderings ruin the mighty power of the goddess, and the objective of the plunderings results from the greed of one person, we do have to get mad about it.
+QUEST_LV_0200_20150323_003572	{memo X}{nl}If that one thing doesn't get accomplished, we have no choice, but to stand up.{nl}Against the source of the plunderings.{nl}Also if the process of the plunderings ruin the mighty power of the Goddess, and the objective of the plunderings results from the greed of one person, we do have to get mad about it.
 QUEST_LV_0200_20150323_003573	We do have to check whether the farmers would particpate.{nl}I will give you the sheet so please get their signatures on the sheet.{nl}Along with the date for the execution, this sheet confirms that we all act together for the same purpose.
 QUEST_LV_0200_20150323_003574	{nl}How could I request this to you..{nl}I am so sorry. If this gets completed, we will do the rest ourselves.
 QUEST_LV_0200_20150323_003575	This task will give you some trouble.{nl}The farmers are not that simple.
@@ -3594,7 +3594,7 @@ QUEST_LV_0200_20150323_003593	Disciple Ruodell
 QUEST_LV_0200_20150323_003594	{memo X}Hmm, I know it is an order from the congregation, but we should first retrieve the Great Cathedral..{nl}Then we would be able to get an answer for the curse as well.
 QUEST_LV_0200_20150323_003595	I don't know when would we able to find the way to unleash the curse if it continues like this.{nl}If I only have the power, I would have driven all demons out from the Great Cathedral.
 QUEST_LV_0200_20150323_003596	Disciple Yosana
-QUEST_LV_0200_20150323_003597	The congregation told us that they will retrieve the Great Cathedral if the curse of Naktis gets solved.{nl}It doesn't make sense to leave the Great Cathedral, which supports the goddesses like that for 4 years.
+QUEST_LV_0200_20150323_003597	The congregation told us that they will retrieve the Great Cathedral if the curse of Naktis gets solved.{nl}It doesn't make sense to leave the Great Cathedral, which supports the Goddesses like that for 4 years.
 QUEST_LV_0200_20150323_003598	We lost many documents in the Great Cathedral due to the subordinates of Naktis.{nl}When I think about that right now, I feel so bad that we lost them.. Those were over hundred years old..
 QUEST_LV_0200_20150323_003599	Disciple Alisha
 QUEST_LV_0200_20150323_003600	Thistles are not ready yet?{nl}If they come late, the medicine would dry out.
@@ -3605,50 +3605,50 @@ QUEST_LV_0200_20150323_003604	Pilgrim Orville
 QUEST_LV_0200_20150323_003605	Please help me.{nl}I ran away to this place by avoding the monsters, but I can't see my friends who came with me.
 QUEST_LV_0200_20150323_003606	{memo X}Please find my friend.{nl}I lived so hard until now, so I can't just die here.
 QUEST_LV_0200_20150323_003607	Disciple Roana
-QUEST_LV_0200_20150323_003608	{memo X}Thanks for helping us.{nl}The goddess help the ones who try their best, and I think it was you, the Revelator.
+QUEST_LV_0200_20150323_003608	{memo X}Thanks for helping us.{nl}The Goddess help the ones who try their best, and I think it was you, the Revelator.
 QUEST_LV_0200_20150323_003609	It is getting stronger.
 QUEST_LV_0200_20150323_003610	{memo X}So the true nature of the curse was Chapparitions.{nl}I was busy with the curse of Naktis so I think its so fortunate.{nl}
 QUEST_LV_0200_20150323_003611	Ah, can you send this report to Aden if you get a chance to go back to the main church?{nl}
 QUEST_LV_0200_20150323_003612	The revelation is being protected by the five keys of Maven.{nl}To get the keys, you should solve more secrets.{nl}
 QUEST_LV_0200_20150323_003613	{memo X}Then I should go back to your small pocket for a minute.{nl}Do not trust anyone.
-QUEST_LV_0200_20150323_003614	{memo X}The goddesses want you and Hauberk to defeat the pawns of Blud so that the 1st zone gets released from the control of the demons.{nl}To do so, you should disturb the conciousness of the subordinates who try to free the bluds.{nl}Could you defeat the monsters at the gathering place of Rituala?
+QUEST_LV_0200_20150323_003614	{memo X}The Goddesses want you and Hauberk to defeat the pawns of Blud so that the 1st zone gets released from the control of the demons.{nl}To do so, you should disturb the conciousness of the subordinates who try to free the bluds.{nl}Could you defeat the monsters at the gathering place of Rituala?
 QUEST_LV_0200_20150323_003615	{memo X}Blut's
 QUEST_LV_0200_20150323_003616	{memo X}They tried to break the loosened barriers and run away outside.{nl}Get some help from Hauberks if you can.
 QUEST_LV_0200_20150323_003617	{memo X}Well done. I feel that the barriers in this region are more enhanced now.
 QUEST_LV_0200_20150323_003618	{memo X}You have big ambition..{nl}I can feel the strong spirit in you,.
-QUEST_LV_0200_20150323_003619	{memo X}I am the Demon Lord, Hauberk. I will tell you the story that you may be interested in..{nl}About Vakarine, the goddess of night star.. I will tell you where she is.{nl}You want to find Vakarine?
-QUEST_LV_0200_20150323_003620	{memo X}So you want to save the goddesses? You made a clever decision.
+QUEST_LV_0200_20150323_003619	{memo X}I am the Demon Lord, Hauberk. I will tell you the story that you may be interested in..{nl}About Vakarine, the Goddess of night star.. I will tell you where she is.{nl}You want to find Vakarine?
+QUEST_LV_0200_20150323_003620	{memo X}So you want to save the Goddesses? You made a clever decision.
 QUEST_LV_0200_20150323_003621	{memo X}Unlike the other guys, I can't possess your body.{nl}So please carry my pieces of the seal now and enter inside.{nl}I will guide you from there.
 QUEST_LV_0200_20150323_003622	{memo X}Bluts are facing against Kupole Giderone at Nujicalti Hall.{nl}Giderone would try his best to resist, but I can't keep them anymore with our power only.
 QUEST_LV_0200_20150323_003623	{memo X}The only way to weaken Blut is to get the secreting glands that Blut shared with his subordinates and weaken his influence.{nl}There are Blut's guys near Byeaulleo Hideout. Get the secreting glands of Bluts from them.
-QUEST_LV_0200_20150323_003624	{memo X}The goddess is facing against the Demon Lord somewhere in the prison.{nl}She desperately needs help from you and Hauberk.
+QUEST_LV_0200_20150323_003624	{memo X}The Goddess is facing against the Demon Lord somewhere in the prison.{nl}She desperately needs help from you and Hauberk.
 QUEST_LV_0200_20150323_003625	{memo X}Good. I will eliminate this from this world.{nl}Blut would feel like as if he lost it's feelers.{nl}It will be a big help to Gidrone.
 QUEST_LV_0200_20150323_003626	{memo X}The battle with Blut will be hard for us.{nl}Hauberk should help us. We should grant the substance to Hauberk again.
 QUEST_LV_0200_20150323_003627	{memo X}{nl}Blut sealed his power at his altar for his escape.{nl}If Hauberk could absorb that, it will be a great help to us.{nl}Go to the concentrated area. Control the altar there.
 QUEST_LV_0200_20150323_003628	{memo X}{nl}If you succeed on granting substance to Hauberk, please go see Gidrone.{nl}We are really running out of time now.
-QUEST_LV_0200_20150323_003629	{memo X}The power of the demons reject the power of the goddesses. Only Hauberk can do this.
-QUEST_LV_0200_20150323_003630	{memo X}Were you able to grant the substance to Hauberk? It is so fortunate.{nl}Everything will go as the goddesses wish..
+QUEST_LV_0200_20150323_003629	{memo X}The power of the demons reject the power of the Goddesses. Only Hauberk can do this.
+QUEST_LV_0200_20150323_003630	{memo X}Were you able to grant the substance to Hauberk? It is so fortunate.{nl}Everything will go as the Goddesses wish..
 QUEST_LV_0200_20150323_003631	{memo X}I locked Blut in the barrier of the prison, but it won't stand long.{nl}When we are prepared, we should defeat it with Hauberk.{nl}If we lose, Vakarine also would fall down.
 QUEST_LV_0200_20150323_003632	{memo X}Go to the 2nd area of the prison. Norgaille is waitng for you and Hauberk there.
 QUEST_LV_0200_20150323_003633	{memo X}Blut and his followers want to escape to the external world. Can you defeat them?
-QUEST_LV_0200_20150323_003634	{memo X}The power of the goddesses should control here again..
+QUEST_LV_0200_20150323_003634	{memo X}The power of the Goddesses should control here again..
 QUEST_LV_0200_20150323_003635	{memo X}Well done. Now I am relieved.
 QUEST_LV_0200_20150323_003636	{memo X}The investigation team formed by humans came here lately.{nl}However, they could not get out and died here.{nl}The demons carry their belongings like their booties.
 QUEST_LV_0200_20150323_003637	{memo X}{nl}If you could retrieve them, I will hand them over to their families when this place becomes stabilized.
 QUEST_LV_0200_20150323_003638	{memo X}No humans can come to this place.
 QUEST_LV_0200_20150323_003639	{memo X}Thanks. I hope there are no more sacrifices like this..
-QUEST_LV_0200_20150323_003640	{memo X}It's hasn't been that long when the subordinates of Nuaele started to encroach this place.{nl}But, because of some guy who planned this meticulously, the barriers of the goddesses are collapsing from all over the places.
+QUEST_LV_0200_20150323_003640	{memo X}It's hasn't been that long when the subordinates of Nuaele started to encroach this place.{nl}But, because of some guy who planned this meticulously, the barriers of the Goddesses are collapsing from all over the places.
 QUEST_LV_0200_20150323_003641	{memo X}{nl}In order to destroy the power of Nuaele here, we should eliminate his subordinates.{nl}At the 1st isolated zone, there's some guy who is waiting for Nuaele to defeat Kupole Aldona.{nl}Please defeat them.
 QUEST_LV_0200_20150323_003642	{memo X}I am worried about Aldona at Nuaele's place..
 QUEST_LV_0200_20150323_003643	{memo X}Even if we fail to defeat Nuaele, we reduced the number of his followers who would listen to his orders so I think it would be safe for some time..
 QUEST_LV_0200_20150323_003644	{memo X}All demons here were the followers of Hauberk at this place.{nl}Hauberk knows well about that. {nl}Hauberk was granted with the substance, but I am sure he is still unstable.
 QUEST_LV_0200_20150323_003645	{memo X}Hauberk wants to retrieve his manes that he shared with the demons.{nl}Please make Hauberk more stronger. He must also want that.{nl}Please go to the 2nd isolated zone.
-QUEST_LV_0200_20150323_003646	{memo X}Long time ago, when Helgasercle was ripped in pieces and sealed, his followers also were kicked out from the demon worlds.{nl}The demons who lost their owner started to trample upon humans and the goddesses locked them up here.
+QUEST_LV_0200_20150323_003646	{memo X}Long time ago, when Helgasercle was ripped in pieces and sealed, his followers also were kicked out from the demon worlds.{nl}The demons who lost their owner started to trample upon humans and the Goddesses locked them up here.
 QUEST_LV_0200_20150323_003647	{memo X}{nl}Ferocious Nuaele has the seal pieces of Hauberk.{nl}They are following Nuaele as if he is Hauberk.{nl}If you retrieve the manes of Hauberk and give them back to Hauberk, they won't at least follow Nuaele.
 QUEST_LV_0200_20150323_003648	{memo X}Before Hauberk's seal pieces return to Hauberk, I expect the demons would be in confusion for a while.{nl}Hauberk must regain his power.
-QUEST_LV_0200_20150323_003649	{memo X}Nuaele had many chances to use the accumulated power to go out into the world by breaking into the weakened power of the goddesses.{nl}But, he is waiting something. We don't know what he is waiting for.{nl}We should interrogate the subordinates of Nuaele to find out what that is.
-QUEST_LV_0200_20150323_003650	{memo X}{nl}I will give you this marble that I received from the goddesses.{nl}Kupoles can't use this anymore since the control of the goddesses in the prison became weak.{nl}But since Hauberk helps you, you will be able to read the minds of the demons.
-QUEST_LV_0200_20150323_003651	{memo X}When the power of the goddesses get weak, the power of us, Kupoles also get weak.
+QUEST_LV_0200_20150323_003649	{memo X}Nuaele had many chances to use the accumulated power to go out into the world by breaking into the weakened power of the Goddesses.{nl}But, he is waiting something. We don't know what he is waiting for.{nl}We should interrogate the subordinates of Nuaele to find out what that is.
+QUEST_LV_0200_20150323_003650	{memo X}{nl}I will give you this marble that I received from the Goddesses.{nl}Kupoles can't use this anymore since the control of the Goddesses in the prison became weak.{nl}But since Hauberk helps you, you will be able to read the minds of the demons.
+QUEST_LV_0200_20150323_003651	{memo X}When the power of the Goddesses get weak, the power of us, Kupoles also get weak.
 QUEST_LV_0200_20150323_003652	{memo X}They were thinking of making the demon prison into their demon world from the first place.{nl}If this place falls into the hands of him, even Ausrine won't be able to do anything.{nl}You just told me an important information. Thank you.
 QUEST_LV_0200_20150323_003653	{memo X}There's * monster at the 4th isolated area. Hauberk used to trust him the most, but as Hauberk was sealed, he went to Nuaele's side.{nl}If you could defeat him, then its like you are eliminating one of strongest weapons of Nuaele.
 QUEST_LV_0200_20150323_003654	{memo X}Hauberk would welcome this. We don't need that kind of subordinates anymore.
@@ -3659,45 +3659,45 @@ QUEST_LV_0200_20150323_003658	{memo X}Hauberk and Nuaele will become symbolic fi
 QUEST_LV_0200_20150323_003659	{memo X}Because of you, this place was able to be stabilized a lot.
 QUEST_LV_0200_20150323_003660	{memo X}Many sisters who fought against Monster * at the 4th isolated area were killed a lot.{nl}The demons stole the necklaces from them and collecting them as if they are medals.{nl}Please help us so that those demons would not underestimate us again.
 QUEST_LV_0200_20150323_003661	{memo X}Many sisters are being sacrificed even at this moment at other prisons where your help can not reach.{nl}Please help us. Revelator..
-QUEST_LV_0200_20150323_003662	{memo X}I will pass these necklaces to Vakarine when this place gets okay.{nl}I hope the goddesses always protect you..
+QUEST_LV_0200_20150323_003662	{memo X}I will pass these necklaces to Vakarine when this place gets okay.{nl}I hope the Goddesses always protect you..
 QUEST_LV_0200_20150323_003663	{memo X}Nuaele is planning something.{nl}Please go see Aldona. He will take you to Nuaele's area.
 QUEST_LV_0200_20150323_003664	{memo X}We don't have enough time to catch him and ask what he is planning!
 QUEST_LV_0200_20150323_003665	{memo X}I can feel that Nuaele has disappeared.{nl}Please go to the 3rd district.{nl}Vakarine is waiting for your help.
 QUEST_LV_0200_20150323_003666	{memo X}Because of you, Gidrone Aldona was able to help me.{nl}Thank you Revelator and Hauberk.
-QUEST_LV_0200_20150323_003667	{memo X}{nl}I will restore my Dionys to its previous status now.{nl}Go meet Gidrone. Please help her to complete my key.
-QUEST_LV_0200_20150323_003668	{memo X}The goddesses are trying to calm down the violent Dionys and trying to help her to come back to her previous status.{nl}To do so, we should accumulate the power of the goddesses that are scattered across this region.{nl}We can collect that power using the key of night star. But we will definitely need your help.
+QUEST_LV_0200_20150323_003667	{memo X}{nl}I will restore my Dionys to its previous status now.{nl}Meet Gidrone. Please help her to complete my key.
+QUEST_LV_0200_20150323_003668	{memo X}The Goddesses are trying to calm down the violent Dionys and trying to help her to come back to her previous status.{nl}To do so, we should accumulate the power of the Goddesses that are scattered across this region.{nl}We can collect that power using the key of night star. But we will definitely need your help.
 QUEST_LV_0200_20150323_003669	{memo X}Due to the space that was created near the Orualma, the great hall, the place where the key should be recharged, it's pretty hard to do the ritual normally. {nl}Deactivate the space at the scar of tranformation.
-QUEST_LV_0200_20150323_003670	{memo X}Dionys was the family of the goddesses and her companion.{nl}The goddesses are very sad after sacrificing Dionys to seal her up with the chains.
+QUEST_LV_0200_20150323_003670	{memo X}Dionys was the family of the Goddesses and her companion.{nl}The Goddesses are very sad after sacrificing Dionys to seal her up with the chains.
 QUEST_LV_0200_20150323_003671	{memo X}We can start the ritual again. When the key of the night star gets completed, we would be able to restore Dionys who became violent to her normal status.
 QUEST_LV_0200_20150323_003672	{memo X}Let's go to Orualma, the great hall. As I am recharging this key, you should protect me.
 QUEST_LV_0200_20150323_003673	{memo X}{nl}Are you ready?
-QUEST_LV_0200_20150323_003674	{memo X}Please bring this key to Aldona.{nl}On behalf of tired goddesses, Aldona is preventing the escape of Dionys.{nl}Please hurry.
-QUEST_LV_0200_20150323_003675	{memo X}We can't stand anymore. Dionys can't be faced by the Kupoles.{nl}You and Hauberk should help. And one more thing..{nl}You should unleash the power of the seal that the goddesses have prepared for the worst moment.
+QUEST_LV_0200_20150323_003674	{memo X}Please bring this key to Aldona.{nl}On behalf of tired Goddesses, Aldona is preventing the escape of Dionys.{nl}Please hurry.
+QUEST_LV_0200_20150323_003675	{memo X}We can't stand anymore. Dionys can't be faced by the Kupoles.{nl}You and Hauberk should help. And one more thing..{nl}You should unleash the power of the seal that the Goddesses have prepared for the worst moment.
 QUEST_LV_0200_20150323_003676	{memo X}Please unleash Rwalda, Casa and Rada seals that are near the magic suppressor using the key of night star that you received from Gidrone.{nl}You will have easier time facing against Dionys.
-QUEST_LV_0200_20150323_003677	{memo X}The goddesses prepared for the everything that could occur.{nl}The problem is time. If we arrive late, then even Vakarine won't be able to do anything.
-QUEST_LV_0200_20150323_003678	{memo X}As the seal unleashes, the lights of the goddesses are coming to the magic suppressor.{nl}Now, everything is ready. We also have enough time.
+QUEST_LV_0200_20150323_003677	{memo X}The Goddesses prepared for the everything that could occur.{nl}The problem is time. If we arrive late, then even Vakarine won't be able to do anything.
+QUEST_LV_0200_20150323_003678	{memo X}As the seal unleashes, the lights of the Goddesses are coming to the magic suppressor.{nl}Now, everything is ready. We also have enough time.
 QUEST_LV_0200_20150323_003679	{memo X}I will persuade Dionys first, but it won't be effective.{nl}Dionys has the chains that Gitine had created.{nl}That's why she is breaking everything she sees.
 QUEST_LV_0200_20150323_003680	{memo X}If we fail, Dinois will escape from this place.{nl}It will be the same thing as unleashing tens of Demon Lords to this world.{nl}Tell me when you are ready.
-QUEST_LV_0200_20150323_003681	{memo X}We just ran into a problem. The reason why the goddesses helped Hauberk to regain his energy was because Hauberk is the key who can quiet down this mess.{nl}The goddesses tried to close the space that was opened from the demon world using the chains and the spirits of Hauberk.
-QUEST_LV_0200_20150323_003682	{memo X}I am sorry to deceive you. But, I can't tell you the truth as long as Hauberk is with you.{nl}Hauberk ran away to the 4th district. Please tell this to the goddess as quickly as possible.
+QUEST_LV_0200_20150323_003681	{memo X}We just ran into a problem. The reason why the Goddesses helped Hauberk to regain his energy was because Hauberk is the key who can quiet down this mess.{nl}The Goddesses tried to close the space that was opened from the demon world using the chains and the spirits of Hauberk.
+QUEST_LV_0200_20150323_003682	{memo X}I am sorry to deceive you. But, I can't tell you the truth as long as Hauberk is with you.{nl}Hauberk ran away to the 4th district. Please tell this to the Goddess as quickly as possible.
 QUEST_LV_0200_20150323_003683	{memo X}Okay.. so that's why.{nl}Do not lose your hope savior, it's not too late as long as you are alive.{nl}Hauberk ran away to the 4th district which is like a mae in this prison.
 QUEST_LV_0200_20150323_003684	{memo X}Look for Daiva there. She will guide you to Hauberk.{nl}I will observe Dionys from here.{nl}If you or Kupoles seal Hauberk, we will meet again at the 5th district.
-QUEST_LV_0200_20150323_003685	{memo X}The dimensional door that was opened from the demon world. The metastasis space can't be closed even by the goddesses.{nl}We should control the metastasis space using Hauberk and eliminate with the chains.{nl}But in that process, Hauberk was completely eliminated. Before he ran away like that, I had to lock him up..{nl}{nl}I am so sorry to see the goddesses again.{nl}
+QUEST_LV_0200_20150323_003685	{memo X}The dimensional door that was opened from the demon world. The metastasis space can't be closed even by the Goddesses.{nl}We should control the metastasis space using Hauberk and eliminate with the chains.{nl}But in that process, Hauberk was completely eliminated. Before he ran away like that, I had to lock him up..{nl}{nl}I am so sorry to see the Goddesses again.{nl}
 QUEST_LV_0200_20150323_003686	{memo X}As Baltrus disappeared, the demons were confused who used to receive orders from him.{nl}That caused the demons more violent whose behaviours were already unpredictable.{nl}Can you defeat those who are coming to Orualma, the great hall?
-QUEST_LV_0200_20150323_003687	{memo X}Even if the goddesses are not here, the Kupoles won't be violent.{nl}We are the symbol of rules and disciplines.
-QUEST_LV_0200_20150323_003688	{memo X}The great hall is one of the places which the goddesses could easily regain their energies.{nl}So it should be safe from the demons all the time.{nl}Thanks for taking care of that.
+QUEST_LV_0200_20150323_003687	{memo X}Even if the Goddesses are not here, the Kupoles won't be violent.{nl}We are the symbol of rules and disciplines.
+QUEST_LV_0200_20150323_003688	{memo X}The great hall is one of the places which the Goddesses could easily regain their energies.{nl}So it should be safe from the demons all the time.{nl}Thanks for taking care of that.
 QUEST_LV_0200_20150323_003689	{memo X}The demons that ran away after being attacked by Dionys are hiding near the Rwalda seal.{nl}The fragments of Dionys that are stuck on them
 QUEST_LV_0200_20150323_003690	{memo X}The toe nails of the spirits
-QUEST_LV_0200_20150323_003691	{memo X}Retrieve them.{nl}It will help the goddesses to restore Dionys.
-QUEST_LV_0200_20150323_003692	{memo X}Dionys is not normal. {nl}The goddesses rescued her when she was being persecuted by the demons and became the Dionys nowadays.{nl}She temporarily lost her conciousness due to the chains, but you should not suspect her belief.
-QUEST_LV_0200_20150323_003693	{memo X}Thanks. I will pass these toe nails to the goddesses.
+QUEST_LV_0200_20150323_003691	{memo X}Retrieve them.{nl}It will help the Goddesses to restore Dionys.
+QUEST_LV_0200_20150323_003692	{memo X}Dionys is not normal. {nl}The Goddesses rescued her when she was being persecuted by the demons and became the Dionys nowadays.{nl}She temporarily lost her conciousness due to the chains, but you should not suspect her belief.
+QUEST_LV_0200_20150323_003693	{memo X}Thanks. I will pass these toe nails to the Goddesses.
 QUEST_LV_0200_20150323_003694	{memo X}Dionys was trying to destroy Rada seal before she was locked up inside the magic suppressor.{nl}Luckily, we were able to lock it before..{nl}At then, it released its power to various places.
-QUEST_LV_0200_20150323_003695	{memo X}Please collect the symbols of the stars that Dionys scattered near Rama seal.{nl}It will be a big help to the goddesses who want to restore Dionys to it's previous status.
+QUEST_LV_0200_20150323_003695	{memo X}Please collect the symbols of the stars that Dionys scattered near Rama seal.{nl}It will be a big help to the Goddesses who want to restore Dionys to it's previous status.
 QUEST_LV_0200_20150323_003696	{memo X}The damages that were caused by Dionys were so great. {nl}Hundreds of demon prisoners were dead and the violent Baltrus ran away before the Kupoles locked up Dionys.{nl}There were more than tens of Kupoles that were dead by the toe nails of Dionys at then.
 QUEST_LV_0200_20150323_003697	{memo X}Thank you. I will try my best to restore Dionys.
-QUEST_LV_0200_20150323_003698	{memo X}I've been wating for you. Hauberk is near here.{nl}He is trying to escape from Nevirau by attacking the barriers of the goddesses.{nl}I hope you resist him.
+QUEST_LV_0200_20150323_003698	{memo X}I've been wating for you. Hauberk is near here.{nl}He is trying to escape from Nevirau by attacking the barriers of the Goddesses.{nl}I hope you resist him.
 QUEST_LV_0200_20150323_003699	{memo X}Now is the only chance to restore everything back to its previous status.{nl}Please catch him.
-QUEST_LV_0200_20150323_003700	{memo X}You should chase him til the end to catch him.{nl}And even a slightest energy should be left in him so that he could share it with his subordinates.{nl}The goddesses want Hauberk in perfect shape.
+QUEST_LV_0200_20150323_003700	{memo X}You should chase him til the end to catch him.{nl}And even a slightest energy should be left in him so that he could share it with his subordinates.{nl}The Goddesses want Hauberk in perfect shape.
 QUEST_LV_0200_20150323_003701	{memo X}Hauberk is recruiting his subordinates and allocating them here again.{nl}The guys who were roaming around the various places in the prison are coming to Hauberk again.{nl}Hauberk is sharing the pieces of his spirit to his subordinates to deceive our eyes while he is running away.
 QUEST_LV_0200_20150323_003702	{memo X}Even one piece is important to us since Hauberk should be in perfect shape.{nl}Defeat the subordinates of Hauberk at the inner isolated area and collect the pieces of Hauberk's spirit.
 QUEST_LV_0200_20150323_003703	{memo X}When we catch Hauberk, we will give him the pieces of his spirit back to him which he shared with his subordinates.{nl}You should not let Hauberk run away from this place.
@@ -3718,15 +3718,15 @@ QUEST_LV_0200_20150323_003717	{memo X}Hauberk is protesting inside the poison ro
 QUEST_LV_0200_20150323_003718	{memo X}{nl}Tell me when you are ready to attack.
 QUEST_LV_0200_20150323_003719	Something that was not in the plan occured.
 QUEST_LV_0200_20150323_003720	{memo X}There were so many sacrifices. Everything that was caused by the metastasis space is collapsing this place.
-QUEST_LV_0200_20150323_003721	{memo X}We've done it. Please go to the goddess in the 5th district.{nl}We will send the sealed Hauberk to the goddess when we need it.
+QUEST_LV_0200_20150323_003721	{memo X}We've done it. Please go to the Goddess in the 5th district.{nl}We will send the sealed Hauberk to the Goddess when we need it.
 QUEST_LV_0200_20150323_003722	{memo X}After catching Hauberk, his subordinates ran away to various places in the prison.{nl}If we relase them, we don't know what they will do later so we should find them and get rid of them.{nl}Could you defeat Hauberk's demons that ran away to Aklaga isolated place?
 QUEST_LV_0200_20150323_003723	{memo X}The influence that started to spread fom the capital city of the humans would disturb the control of Vakarine more and more.{nl}In order to prepare for that, we should get rid of the subordinates who used to follow the Demon Lord.
 QUEST_LV_0200_20150323_003724	{memo X}Thanks. I will stay here and chase after the rest of them.
 QUEST_LV_0200_20150323_003725	{memo X}Right before you succeeded on sealing Hauberk, some of the subordinates of Hauberk ran away to Ishidebi hideout by disobeying the order of Hauberk.{nl}The conspiracy that Nuaele planned occured because we failed to catch him before he ran away.
 QUEST_LV_0200_20150323_003726	{memo X}{nl}That should never occur again. Please get rid of the betrayers near Ishidebi hideout.
 QUEST_LV_0200_20150323_003727	{memo X}I can't forget that my sisters were killed by Nuaele..
-QUEST_LV_0200_20150323_003728	{memo X}Well done. I will find those guys so that they can't resist against the goddesses.{nl}Even if the goddesses use all her power, we will still defeat them so that they can't resist against us..
-QUEST_LV_0200_20150323_003729	{memo X}The goddesses may not agree, but I want to get the revenge.{nl}The influence of the disaster that occured at the capital city of the humans is spreading quickly here.{nl}As the demons killed our sisters and took away their belongings, we also have to do the same thing.
+QUEST_LV_0200_20150323_003728	{memo X}Well done. I will find those guys so that they can't resist against the Goddesses.{nl}Even if the Goddesses use all her power, we will still defeat them so that they can't resist against us..
+QUEST_LV_0200_20150323_003729	{memo X}The Goddesses may not agree, but I want to get the revenge.{nl}The influence of the disaster that occured at the capital city of the humans is spreading quickly here.{nl}As the demons killed our sisters and took away their belongings, we also have to do the same thing.
 QUEST_LV_0200_20150323_003730	{memo X}{nl}Could you defeat the demons at the intersection of Huradeti and collect the teeth of those demons?{nl}
 QUEST_LV_0200_20150323_003731	{memo X}This is cute compared to what they did.
 QUEST_LV_0200_20150323_003732	{memo X}Thanks. Please keep it secret to the Goddesses.
@@ -3804,7 +3804,7 @@ QUEST_LV_0200_20150323_003803	The monsters became vicious and the poison..{nl}Th
 QUEST_LV_0200_20150323_003804	Your skills are as I heard.{nl}Could you wait a sec? It shouldn't take that long to check.
 QUEST_LV_0200_20150323_003805	I can feel the energy of the spell with a mysterious poison.{nl}I am sure that their true nature lies somewhere on the land..
 QUEST_LV_0200_20150323_003806	I can feel something scary from the samples.{nl}Please be careful..
-QUEST_LV_0200_20150323_003807	The leather and the dagger with the magic field engraved on them.{nl}Unfortunately, they are not my specialities so I don't know about them well.
+QUEST_LV_0200_20150323_003807	The leather and the dagger with the magic circle engraved on them.{nl}Unfortunately, they are not my specialities so I don't know about them well.
 QUEST_LV_0200_20150323_003808	$From here on, it will be better if we ask the Bokor Master.{nl}No one can compete with her in terms of spells.
 QUEST_LV_0200_20150323_003809	$You want to know what spell is cast upon these objects?{nl}Hmm. It is a very filthy spell.{nl}
 QUEST_LV_0200_20150323_003810	$I see. This spell spreads a poison that is pasted on the dagger.{nl} To everything near it.
@@ -4250,13 +4250,13 @@ QUEST_LV_0200_20150323_004249	{memo X}Notice/!/The monsters are coming near the 
 QUEST_LV_0200_20150323_004250	I will purify the sanctum
 QUEST_LV_0200_20150323_004251	Give up on the purification since it looks dangerous
 QUEST_LV_0200_20150323_004252	{memo X}Scattering the divine water/STANDSPINKLE/3/TRACK_BEFORE/None
-QUEST_LV_0200_20150323_004253	{memo X}Notice/!/The statue of the Goddess does not show any responses.{nl}Go meet Tesla at Vieta Gorge who created the statue#3
+QUEST_LV_0200_20150323_004253	{memo X}Notice/!/The statue of the Goddess does not show any responses.{nl}Meet Tesla at Vieta Gorge who created the statue#3
 QUEST_LV_0200_20150323_004254	{memo X}Explaining about the statue at Purple Tree Fault Forest/TALK/3/TRACK_BEFORE/None
 QUEST_LV_0200_20150323_004255	Go to repair the statue of the Goddess
 QUEST_LV_0200_20150323_004256	Stop it since it looks dangerous
 QUEST_LV_0200_20150323_004257	{memo X}Notice/!/You've found a severe crack on the stand of the statue.{nl}First, obtain the materials that Tesla told you.#3
 QUEST_LV_0200_20150323_004258	The truthful statue of the Goddess(4)
-QUEST_LV_0200_20150323_004259	{memo X}Notice/!/The repaired statue has exploded and created the demon magic field near it! {nl}Since you don't know what's going to come out from it, destroy the magic field!#7
+QUEST_LV_0200_20150323_004259	{memo X}Notice/!/The repaired statue has exploded and created the demon magic circle near it! {nl}Since you don't know what's going to come out from it, destroy the magic circle!#7
 QUEST_LV_0200_20150323_004260	{memo X}Explaining about the task of the sanctum/TALK/3/TRACK_BEFORE/None
 QUEST_LV_0200_20150323_004261	Ask him about the way to purify the sanctum
 QUEST_LV_0200_20150323_004262	{memo X}You better step back since it looks dangerous
@@ -4369,26 +4369,26 @@ QUEST_LV_0200_20150323_004368	Passing it along(2)
 QUEST_LV_0200_20150323_004369	Your curiosity should end here
 QUEST_LV_0200_20150323_004370	{memo X}About the machine behind
 QUEST_LV_0200_20150323_004371	Get rid of the strange energy(1)
-QUEST_LV_0200_20150323_004372	{memo X}Looking closely at the magic field/LOOK_SIT/2/TRACK_BEFORE/None
-QUEST_LV_0200_20150323_004373	{memo X}Notice/!/As you looked closely at the magic field, the jewels appeared from the four directions! Break up the jewels!#%
-QUEST_LV_0200_20150323_004374	{memo X}Notice/!/You should first collect the energies of the monsters so that you could enhance the magic field#5
-QUEST_LV_0200_20150323_004375	{memo X}Notice/As the jewels disappeared, the magic field has been successfully enhanced!!#5
+QUEST_LV_0200_20150323_004372	{memo X}Looking closely at the magic circle/LOOK_SIT/2/TRACK_BEFORE/None
+QUEST_LV_0200_20150323_004373	{memo X}Notice/!/As you looked closely at the magic circle, the jewels appeared from the four directions! Break up the jewels!#%
+QUEST_LV_0200_20150323_004374	{memo X}Notice/!/You should first collect the energies of the monsters so that you could enhance the magic circle#5
+QUEST_LV_0200_20150323_004375	{memo X}Notice/As the jewels disappeared, the magic circle has been successfully enhanced!!#5
 QUEST_LV_0200_20150323_004376	Get rid of the strange energy(2)
 QUEST_LV_0200_20150323_004377	{memo X}Looking closely at it/LOOK_SIT/2/TRACK_BEFORE/None
-QUEST_LV_0200_20150323_004378	{memo X}Notice/!/Collect the vicious energies of the monsters into the empty bottles that Wizard Limas gave you and then bury them on the each side of the magic field!#5
-QUEST_LV_0200_20150323_004379	{memo X}Notice/!/Collect the vicious energy into the bottles and bury them beside the each side of the magic field!#5
-QUEST_LV_0200_20150323_004380	{memo X}Notice/The magic field has been successfully enhanced!#5
+QUEST_LV_0200_20150323_004378	{memo X}Notice/!/Collect the vicious energies of the monsters into the empty bottles that Wizard Limas gave you and then bury them on the each side of the magic circle!#5
+QUEST_LV_0200_20150323_004379	{memo X}Notice/!/Collect the vicious energy into the bottles and bury them beside the each side of the magic circle!#5
+QUEST_LV_0200_20150323_004380	{memo X}Notice/The magic circle has been successfully enhanced!#5
 QUEST_LV_0200_20150323_004381	The trouble in front of the storage
 QUEST_LV_0200_20150323_004382	{memo X}About the power generator and it's fuel
 QUEST_LV_0200_20150323_004383	{memo X}Looking closely at the storage/LOOK/2/TRACK_BEFORE/None
 QUEST_LV_0200_20150323_004384	Recharge the energy(1)
-QUEST_LV_0200_20150323_004385	{memo X}Looking closely at the magic field/LOOK_SIT/2/TRACK_BEFORE/None
+QUEST_LV_0200_20150323_004385	{memo X}Looking closely at the magic circle/LOOK_SIT/2/TRACK_BEFORE/None
 QUEST_LV_0200_20150323_004386	{memo X}Notice/!/You should report the situation to Wizard Limas#5
 QUEST_LV_0200_20150323_004387	{memo X}Sprinkling the poison/STANDSPINKLE/3/TRACK_BEFORE/None
 QUEST_LV_0200_20150323_004388	Recharge the energy(2)
 QUEST_LV_0200_20150323_004389	Anything that is alive
-QUEST_LV_0200_20150323_004390	{memo X}Look closely at the magic field/LOOK_SIT/3/TRACK_BEFORE/None
-QUEST_LV_0200_20150323_004391	{memo X}Notict/!/Bring the monsters near the magic field!#5
+QUEST_LV_0200_20150323_004390	{memo X}Look closely at the magic circle/LOOK_SIT/3/TRACK_BEFORE/None
+QUEST_LV_0200_20150323_004391	{memo X}Notict/!/Bring the monsters near the magic circle!#5
 QUEST_LV_0200_20150323_004392	What is the food
 QUEST_LV_0200_20150323_004393	{memo X}About what happened to Venews
 QUEST_LV_0200_20150323_004394	$Unexpected Discovery (1)
@@ -4409,7 +4409,7 @@ QUEST_LV_0200_20150323_004408	$Positive Evidence (1)
 QUEST_LV_0200_20150323_004409	{memo X}About the aqueduct region
 QUEST_LV_0200_20150323_004410	$Positive Evidence (2)
 QUEST_LV_0200_20150323_004411	{memo X}I know something similar to the pieces of the statue of the Goddess
-QUEST_LV_0200_20150323_004412	{memo X}About the magic field here
+QUEST_LV_0200_20150323_004412	{memo X}About the magic circle here
 QUEST_LV_0200_20150323_004413	Increase the desire!
 QUEST_LV_0200_20150323_004414	$Weapons Supply (1)
 QUEST_LV_0200_20150323_004415	{memo X}About Horaceus
@@ -4775,7 +4775,7 @@ QUEST_LV_0200_20150323_004774	Lure the monsters to the sanctum and defeat them
 QUEST_LV_0200_20150323_004775	You need a sacrifice in order to receive the blessing. Lure the monsters near the sanctum and defeat them.
 QUEST_LV_0200_20150323_004776	You've contributed enough monsters as sacrifices. Pray to receive the blessings.
 QUEST_LV_0200_20150323_004777	{memo X}Monsters rushed in as you prayed in front of the sanctum. You better defeat the monsters first.
-QUEST_LV_0200_20150323_004778	We should look for a way to purify the sanctum. Go meet the Priest Master who is the manager of the sanctum.
+QUEST_LV_0200_20150323_004778	We should look for a way to purify the sanctum. Meet the Priest Master who is the manager of the sanctum.
 QUEST_LV_0200_20150323_004779	We should first purify the polluted sanctum on Pamaish Hills. Talk to the Priest Master what to do.
 QUEST_LV_0200_20150323_004780	Purify the sanctum using the divine water
 QUEST_LV_0200_20150323_004781	The Priest Master asked you to purify the sanctum on Pamaish Hills using the divine water. Return to the Forest of Prayer and purify the polluted sanctum.
@@ -4784,7 +4784,7 @@ QUEST_LV_0200_20150323_004783	There is the statue of the Goddess near the grave 
 QUEST_LV_0200_20150323_004784	This statue was a fake. Defeat Sparnashorn, who was disguised as a Goddess Statue.
 QUEST_LV_0200_20150323_004785	There is the statue of the Goddess at the lower side of Marone Forest Way. Let's find what is real among these statues.
 QUEST_LV_0200_20150323_004786	Get some advices from the Sculptor Tesla
-QUEST_LV_0200_20150323_004787	This statue seems to have some kind of problem. Go meet Tesla who created the statue and ask him what to do.
+QUEST_LV_0200_20150323_004787	This statue seems to have some kind of problem. Meet Tesla who created the statue and ask him what to do.
 QUEST_LV_0200_20150323_004788	Talk with Tesla about the statue that does now show any responses
 QUEST_LV_0200_20150323_004789	Return to the Forest of Prayer
 QUEST_LV_0200_20150323_004790	You've heard how to repair the statue from the Sculptor Tesla. Return to the Forest of Prayer to repair the statue.
@@ -4988,8 +4988,8 @@ QUEST_LV_0200_20150323_004987	You can see Orville who doesn't know what to do. T
 QUEST_LV_0200_20150323_004988	Search through Orville's friend
 QUEST_LV_0200_20150323_004989	Orville told you that he lost his friend while being chased by the monsters. Find Orville's friend.
 QUEST_LV_0200_20150323_004990	Orville's friend is dead. You should pass this sad story to Orville.
-QUEST_LV_0200_20150323_004991	{memo X}Go meet Tadas
-QUEST_LV_0200_20150323_004992	Someone needs your help at the land of Baron Allerno. Go meet him.
+QUEST_LV_0200_20150323_004991	{memo X}Meet Tadas
+QUEST_LV_0200_20150323_004992	Someone needs your help at the land of Baron Allerno. Meet him.
 QUEST_LV_0200_20150323_004993	Get some tough string
 QUEST_LV_0200_20150323_004994	{memo X}Tadas asked you to get some rope since there isn't enough rope to tie the sacks of grains. Hunt the monsters to get some rope.
 QUEST_LV_0200_20150323_004995	{memo X}Take the tough rope to him
@@ -5057,42 +5057,42 @@ QUEST_LV_0200_20150323_005056	{memo X}Tell Arunas that there's no problem at the
 QUEST_LV_0200_20150323_005057	Talk with Arunas
 QUEST_LV_0200_20150323_005058	{memo X}Talk with Arunas
 QUEST_LV_0200_20150323_005059	{memo X}The tasks that Arunas ordered you to do
-QUEST_LV_0200_20150323_005060	{memo X}Arunas told you that you should block the strange energy in that place and gave you a few pieces of wooden sticks and a doll to be used for spells. Make the magic field at the place where the strange energy exists and burn the doll to block the energy.
+QUEST_LV_0200_20150323_005060	{memo X}Arunas told you that you should block the strange energy in that place and gave you a few pieces of wooden sticks and a doll to be used for spells. Make the magic circle at the place where the strange energy exists and burn the doll to block the energy.
 QUEST_LV_0200_20150323_005061	{memo X}Report to Arunas
-QUEST_LV_0200_20150323_005062	{memo X}You've created the magic field that eliminates the strange enery and burned the doll, but it seems that the crops are withering. Anyways, report to Arunas that you successfully created the magic field.
+QUEST_LV_0200_20150323_005062	{memo X}You've created the magic circle that eliminates the strange enery and burned the doll, but it seems that the crops are withering. Anyways, report to Arunas that you successfully created the magic circle.
 QUEST_LV_0200_20150323_005063	{memo X}Meet the Wizard Limas
-QUEST_LV_0200_20150323_005064	{memo X}There is Wizard Limas. Go talk to him.
-QUEST_LV_0200_20150323_005065	{memo X}Enhance the magic field
-QUEST_LV_0200_20150323_005066	{memo X}Would the attitude of Limas change after you enhance the magic fields at each side?
+QUEST_LV_0200_20150323_005064	{memo X}There is Wizard Limas. Talk to him.
+QUEST_LV_0200_20150323_005065	{memo X}Enhance the magic circle
+QUEST_LV_0200_20150323_005066	{memo X}Would the attitude of Limas change after you enhance the magic circles at each side?
 QUEST_LV_0200_20150323_005067	{memo X}Report to Limas
-QUEST_LV_0200_20150323_005068	{memo X}You successfully enhanced the two magic fields. Tell this to Limas.
-QUEST_LV_0200_20150323_005069	Look closely at the magic fields
-QUEST_LV_0200_20150323_005070	{memo X}Look closely at the magic fields first in order to eliminate the strange energy
+QUEST_LV_0200_20150323_005068	{memo X}You successfully enhanced the two magic circles. Tell this to Limas.
+QUEST_LV_0200_20150323_005069	Look closely at the magic circles
+QUEST_LV_0200_20150323_005070	{memo X}Look closely at the magic circles first in order to eliminate the strange energy
 QUEST_LV_0200_20150323_005071	{memo X}Eliminate the protective jewel
-QUEST_LV_0200_20150323_005072	{memo X}As you were looking closely at the magic field, the objects which resemble jewels came out from the lower side of the magic field and scattered to various places nearby. It seems that they were protecting the strange energy. It seems that the magic field would be enhanced when you break those jewels.
-QUEST_LV_0200_20150323_005073	{memo X}Enhance the magic field
-QUEST_LV_0200_20150323_005074	{memo X}You've collected all the energies of the monsters into the empty bottles. Now, sprinkle the energies of the monsters to the magic field.
-QUEST_LV_0200_20150323_005075	{memo X}Get closer to the magic field and find out why the magic field is not stable.
-QUEST_LV_0200_20150323_005076	{memo X}Collect the energies of the monsters into the bottles and bury them under each side of the magic field.
-QUEST_LV_0200_20150323_005077	{memo X}When you bury the bottles at each side of the magic field after putting the energies of the monsters into them, the sealed magic field will be enhanced.
+QUEST_LV_0200_20150323_005072	{memo X}As you were looking closely at the magic circle, the objects which resemble jewels came out from the lower side of the magic circle and scattered to various places nearby. It seems that they were protecting the strange energy. It seems that the magic circle would be enhanced when you break those jewels.
+QUEST_LV_0200_20150323_005073	{memo X}Enhance the magic circle
+QUEST_LV_0200_20150323_005074	{memo X}You've collected all the energies of the monsters into the empty bottles. Now, sprinkle the energies of the monsters to the magic circle.
+QUEST_LV_0200_20150323_005075	{memo X}Get closer to the magic circle and find out why the magic circle is not stable.
+QUEST_LV_0200_20150323_005076	{memo X}Collect the energies of the monsters into the bottles and bury them under each side of the magic circle.
+QUEST_LV_0200_20150323_005077	{memo X}When you bury the bottles at each side of the magic circle after putting the energies of the monsters into them, the sealed magic circle will be enhanced.
 QUEST_LV_0200_20150323_005078	{memo X}Talk to Limas
 QUEST_LV_0200_20150323_005079	{memo X}Talk to Limas
 QUEST_LV_0200_20150323_005080	{memo X}Protect the storage
 QUEST_LV_0200_20150323_005081	{memo X}The monsters sometimes steal from the storage that contains the fuel of the power generator behind. Help Limas.
 QUEST_LV_0200_20150323_005082	{memo X}You've defeated the monsters that were about to attack the storage. Go to Limas and tell him about it.
 QUEST_LV_0200_20150323_005083	Defeat the monsters that are trying to attack the storage
-QUEST_LV_0200_20150323_005084	{memo X}Get near to the magic field and look closely into it.
+QUEST_LV_0200_20150323_005084	{memo X}Get near to the magic circle and look closely into it.
 QUEST_LV_0200_20150323_005085	Explain to Limas about the situation
-QUEST_LV_0200_20150323_005086	{memo X}The magic field is vibrating stragely. Report Limas about this.
-QUEST_LV_0200_20150323_005087	{memo X}Sprinkle the poison to the magic field
-QUEST_LV_0200_20150323_005088	{memo X}Take the poison bottle that Limas gave to you and go to the magic field to sprinkle it. I don't understand why the vicious energy of the monsters enhance the magic field, but get some more information by doing as Limas told you to do so.
-QUEST_LV_0200_20150323_005089	{memo X}The magic field will now be enhanced since you sprinkled the poison onto it. Go there and take a look at it.
-QUEST_LV_0200_20150323_005090	Defeat the monsters that rushed in to the magic field
-QUEST_LV_0200_20150323_005091	{memo X}As you were about to enhance the magic field, the monsters suddenly rushed in! It seems that it's due to the poison that was sprinkled onto the magic field. Defeat the monsters first.
+QUEST_LV_0200_20150323_005086	{memo X}The magic circle is vibrating stragely. Report Limas about this.
+QUEST_LV_0200_20150323_005087	{memo X}Sprinkle the poison to the magic circle
+QUEST_LV_0200_20150323_005088	{memo X}Take the poison bottle that Limas gave to you and go to the magic circle to sprinkle it. I don't understand why the vicious energy of the monsters enhance the magic circle, but get some more information by doing as Limas told you to do so.
+QUEST_LV_0200_20150323_005089	{memo X}The magic circle will now be enhanced since you sprinkled the poison onto it. Go there and take a look at it.
+QUEST_LV_0200_20150323_005090	Defeat the monsters that rushed in to the magic circle
+QUEST_LV_0200_20150323_005091	{memo X}As you were about to enhance the magic circle, the monsters suddenly rushed in! It seems that it's due to the poison that was sprinkled onto the magic circle. Defeat the monsters first.
 QUEST_LV_0200_20150323_005092	Defeat the monsters that rushed in after smelling it
-QUEST_LV_0200_20150323_005093	There seems to be an unstable magic field. Enhance the magic field before the strange energy spreads anymore.
+QUEST_LV_0200_20150323_005093	There seems to be an unstable magic circle. Enhance the magic circle before the strange energy spreads anymore.
 QUEST_LV_0200_20150323_005094	Absorb the monsters
-QUEST_LV_0200_20150323_005095	{memo X}In order to enhance the magic field, you should bring the monsters near the magic field. Bring the monsters that are alive.
+QUEST_LV_0200_20150323_005095	{memo X}In order to enhance the magic circle, you should bring the monsters near the magic circle. Bring the monsters that are alive.
 QUEST_LV_0200_20150323_005096	{memo X}Talk to the man
 QUEST_LV_0200_20150323_005097	{memo X}There is a man standing who seems to be related to the baron. Talk to him.
 QUEST_LV_0200_20150323_005098	{memo X}Go there by bringing the meats
@@ -5133,21 +5133,21 @@ QUEST_LV_0200_20150323_005132	{memo X}Obtain the sticky liquid from the monsters
 QUEST_LV_0200_20150323_005133	{memo X}Meet Yoana
 QUEST_LV_0200_20150323_005134	{memo X}It seems that Yoana has some tasks to do. Get closer to her and ask her what's the matter.
 QUEST_LV_0200_20150323_005135	The verification of the strange energy
-QUEST_LV_0200_20150323_005136	{memo X}There's some energy coming out from the specific place, and Yoana wants to find out what that is. Decrease the Monster's HP into the half and talk to the magic field to see what happens.
+QUEST_LV_0200_20150323_005136	{memo X}There's some energy coming out from the specific place, and Yoana wants to find out what that is. Decrease the Monster's HP into the half and talk to the magic circle to see what happens.
 QUEST_LV_0200_20150323_005137	Report to Yoana
 QUEST_LV_0200_20150323_005138	{memo X}It seems that the energy is not negative since you can see the monsters disappearing. Tell this to Yoana.
 QUEST_LV_0200_20150323_005139	{memo X}Talk with Yonaras
 QUEST_LV_0200_20150323_005140	{memo X}Someone seems have many things to do here. Get closer to him and find out if he has some information that you would be able to obtain.
-QUEST_LV_0200_20150323_005141	{memo X}Burn the magic field
-QUEST_LV_0200_20150323_005142	{memo X}Let's eliminate the magic field using the monsters near the magic field. If you throw the burning monsters into the magic field, don't you think the magic field would also burn?
+QUEST_LV_0200_20150323_005141	{memo X}Burn the magic circle
+QUEST_LV_0200_20150323_005142	{memo X}Let's eliminate the magic circle using the monsters near the magic circle. If you throw the burning monsters into the magic circle, don't you think the magic circle would also burn?
 QUEST_LV_0200_20150323_005143	{memo X}Report to Yonaris
-QUEST_LV_0200_20150323_005144	{memo X}Tell Yonaris that you successfully eliminated the sealed magic field.
+QUEST_LV_0200_20150323_005144	{memo X}Tell Yonaris that you successfully eliminated the sealed magic circle.
 QUEST_LV_0200_20150323_005145	{memo X}Talk to Yonaris
-QUEST_LV_0200_20150323_005146	{memo X}It seems that Yonaris has a plan to eliminate the magic field at the other place. Get close to him and listen to his plan.
-QUEST_LV_0200_20150323_005147	{memo X}Get the statue of the Goddess and put it on the magic field
-QUEST_LV_0200_20150323_005148	{memo X}Yonaris told you that in order to eliminate the magic field, the mighty power of the Goddesses would be enough. Check whether the pieces of the statue are well glued together and try putting it on the magic field.
+QUEST_LV_0200_20150323_005146	{memo X}It seems that Yonaris has a plan to eliminate the magic circle at the other place. Get close to him and listen to his plan.
+QUEST_LV_0200_20150323_005147	{memo X}Get the statue of the Goddess and put it on the magic circle
+QUEST_LV_0200_20150323_005148	{memo X}Yonaris told you that in order to eliminate the magic circle, the mighty power of the Goddesses would be enough. Check whether the pieces of the statue are well glued together and try putting it on the magic circle.
 QUEST_LV_0200_20150323_005149	{memo X}Report to Yonaris
-QUEST_LV_0200_20150323_005150	{memo X}The magic field has been successfully removed and the sprouts started to grow from the fields beside! Tell this to Yonaris.
+QUEST_LV_0200_20150323_005150	{memo X}The magic circle has been successfully removed and the sprouts started to grow from the fields beside! Tell this to Yonaris.
 QUEST_LV_0200_20150323_005151	{memo X}Meet Jugas
 QUEST_LV_0200_20150323_005152	{memo X}There is a farmer who needs your help. Get closer to him and meet.
 QUEST_LV_0200_20150323_005153	{memo X}Retrieve the seeds
@@ -5208,18 +5208,18 @@ QUEST_LV_0200_20150323_005207	Report to Albina
 QUEST_LV_0200_20150323_005208	{memo X}Tell Albina that you've defeated Krimeleech that was pushing down the altar.
 QUEST_LV_0200_20150323_005209	{memo X}Discuss with Albina
 QUEST_LV_0200_20150323_005210	{memo X}Discuss whether there's anything you can do to help the reconstruction of Tenants' farm.
-QUEST_LV_0200_20150323_005211	{memo X}Remove the seal magic field
-QUEST_LV_0200_20150323_005212	{memo X}The seal magic field has been discovered at XX region. But, if you touch the seal magic field, you will receive some damages due to the effects of the magic field. Throw the hard, black stones that Albina gave to you and break the seal magic field.
+QUEST_LV_0200_20150323_005211	{memo X}Remove the seal magic circle
+QUEST_LV_0200_20150323_005212	{memo X}The seal magic circle has been discovered at XX region. But, if you touch the seal magic circle, you will receive some damages due to the effects of the magic circle. Throw the hard, black stones that Albina gave to you and break the seal magic circle.
 QUEST_LV_0200_20150323_005213	{memo X}Report to Albina
-QUEST_LV_0200_20150323_005214	{memo X}You've eliminated the seal magic field successfully. Tell Albina about it.
+QUEST_LV_0200_20150323_005214	{memo X}You've eliminated the seal magic circle successfully. Tell Albina about it.
 QUEST_LV_0200_20150323_005215	{memo X}Discuss with Albina
 QUEST_LV_0200_20150323_005216	{memo X}Talk to Albina about the reconstruction of the Tenants' farm. It seems that there's something that she needs to request to you.
-QUEST_LV_0200_20150323_005217	Break the magic field
-QUEST_LV_0200_20150323_005218	{memo X}You would be able to restore this region to its previous state if you break the magic field. Break the magic field in this region.
-QUEST_LV_0200_20150323_005219	{memo X}You've eliminated the magic field in this region! Tell this to Albina!
-QUEST_LV_0200_20150323_005220	{memo X}Eliminate the seal magic field
+QUEST_LV_0200_20150323_005217	Break the magic circle
+QUEST_LV_0200_20150323_005218	{memo X}You would be able to restore this region to its previous state if you break the magic circle. Break the magic circle in this region.
+QUEST_LV_0200_20150323_005219	{memo X}You've eliminated the magic circle in this region! Tell this to Albina!
+QUEST_LV_0200_20150323_005220	{memo X}Eliminate the seal magic circle
 QUEST_LV_0200_20150323_005221	Discuss with Horaceus
-QUEST_LV_0200_20150323_005222	$It seems that Horaceus has something to discuss with you. Go meet him.
+QUEST_LV_0200_20150323_005222	$It seems that Horaceus has something to discuss with you. Meet him.
 QUEST_LV_0200_20150323_005223	Distribute the joint signature seal
 QUEST_LV_0200_20150323_005224	$The day Horaceus planned for is nearing. The last thing to do is to receive consent from the farmers of Tenants' Farm. Get their signature on Horaceus' hand written letter and joint signature seal. You should receive eight signatures.
 QUEST_LV_0200_20150323_005225	Hand over the joint signature seal
@@ -5302,7 +5302,7 @@ QUEST_LV_0200_20150323_005301	Retrieve the monster suppression device
 QUEST_LV_0200_20150323_005302	Gares told you that the device which suppresses the proliferation of the monsters also influenced the crops. Retrieve the device.
 QUEST_LV_0200_20150323_005303	You've retrieved the device. Report to Gares.
 QUEST_LV_0200_20150323_005304	Talk to Asta
-QUEST_LV_0200_20150323_005305	Go meet Asta at Aqueduct restricted area.
+QUEST_LV_0200_20150323_005305	Meet Asta at Aqueduct restricted area.
 QUEST_LV_0200_20150323_005306	Talk to the Demon Lord, Hauberk
 QUEST_LV_0200_20150323_005307	The Demon Lord, Hauberk whose spirit was inside Asta appeared. Hauberk told you that he knows where the Goddess, Vakarine is. Ask him the location of the Goddess, Vakarine.
 QUEST_LV_0200_20150323_005308	You've found that the Goddess, Vakarine is in trouble. Hauberk told you that if you could take him to the demons' prison that is across the portal, he will cooperate with you so that you could meet Vakarine. Listen for more details from Hauberk.
@@ -5341,10 +5341,10 @@ QUEST_LV_0200_20150323_005340	{memo X}Defeat the monsters
 QUEST_LV_0200_20150323_005341	{memo X}Talk to Kupole Aldona
 QUEST_LV_0200_20150323_005342	{memo X}Talk to Kupole Aldona and hunt for Nuaele
 QUEST_LV_0200_20150323_005343	{memo X}Defeat Nuaele
-QUEST_LV_0200_20150323_005344	Go meet the Goddess, Vakarine
-QUEST_LV_0200_20150323_005345	The Goddess, Vakarine is waiting for your help at the monitoring area in the demons' prison.
-QUEST_LV_0200_20150323_005346	Talk to the Goddess, Vakarine
-QUEST_LV_0200_20150323_005347	Talk to the Goddess, Vakarine
+QUEST_LV_0200_20150323_005344	Meet with Goddess Vakarine
+QUEST_LV_0200_20150323_005345	Goddess Vakarine is waiting for your help at the monitoring area in the demons' prison.
+QUEST_LV_0200_20150323_005346	Talk to Goddess Vakarine
+QUEST_LV_0200_20150323_005347	Talk to Goddess Vakarine
 QUEST_LV_0200_20150323_005348	{memo X}Eliminate the small metastasis
 QUEST_LV_0200_20150323_005349	{memo X}Eliminate the small metastasis which is disturbing the recharging of the night star key of Kupole Gidrone
 QUEST_LV_0200_20150323_005350	{memo X}Transform the night star key
@@ -5354,12 +5354,12 @@ QUEST_LV_0200_20150323_005353	{memo X}Install the night star key
 QUEST_LV_0200_20150323_005354	{memo X}Use the night star key to unleash the seals of Rwalda, Casa, and Rada.
 QUEST_LV_0200_20150323_005355	Defeat Dionys
 QUEST_LV_0200_20150323_005356	Talk to Kupole Daiva
-QUEST_LV_0200_20150323_005357	{memo X}Go meet Kupole Daiva at the 4th district in the demons' prison
+QUEST_LV_0200_20150323_005357	{memo X}Meet Kupole Daiva at the 4th district in the demons' prison
 QUEST_LV_0200_20150323_005358	Chase after Hauberk
 QUEST_LV_0200_20150323_005359	{memo X}Kupole Daiva told you to resist the Demon Lord, Hauberk that is breaking the barrier at Nevirau Collapsed Area.
 QUEST_LV_0200_20150323_005360	{memo X}Talk to Kupole Daiva
 QUEST_LV_0200_20150323_005361	Defeat the subordinates of Hauberk
-QUEST_LV_0200_20150323_005362	Collect the pieces of the spirit of Hauberk
+QUEST_LV_0200_20150323_005362	Collect the pieces of Hauberk's Soul
 QUEST_LV_0200_20150323_005363	{memo X}Kupole Daiva told you to defeat the demons that are gathered at the internal isolated division. He told you to collect the pieces of Hauberk's spirit.
 QUEST_LV_0200_20150323_005364	{memo X}Talk to Kupole Daiva in front of the entrance of the poisonous room of Idinga
 QUEST_LV_0200_20150323_005365	Retrieve the pieces of the spirit of Hauberk
@@ -5373,7 +5373,7 @@ QUEST_LV_0200_20150323_005372	{memo X}Talk to Kupole Sigita
 QUEST_LV_0200_20150323_005373	Talk to Kupole Sigita at the entrance of the poisonous room of Galutin at the 4th district of the demons' prison.
 QUEST_LV_0200_20150323_005374	{memo X}Suppress Hauberk
 QUEST_LV_0200_20150323_005375	Suppress Hauberk who is resisting inside the poisonous room of Galutin with Kupole Sigita and seal him.
-QUEST_LV_0200_20150323_005376	{memo X}Go meet the Goddess, Vakarine
+QUEST_LV_0200_20150323_005376	{memo X}Meet the Goddess, Vakarine
 QUEST_LV_0200_20150323_005377	Collect the traces of the metastasis
 QUEST_LV_0200_20150323_005378	{memo X}The Goddess, Vakarine told you to defeat the monsters at Aushura worship place and collect the traces of the mestastasis.
 QUEST_LV_0200_20150323_005379	{memo X}Collect %s from the demons
@@ -5517,15 +5517,15 @@ QUEST_LV_0200_20150323_005516	The private soldier Gedson still has some tasks to
 QUEST_LV_0200_20150323_005517	{memo X}Defeat green drake
 QUEST_LV_0200_20150323_005518	{memo X}The private soldier, Gedson wants you to defeat green drakes. Defeat drakes at Ishikla farm road.
 QUEST_LV_0200_20150323_005519	{memo X}You've defeated all drakes. Tell this to the private soldier, drake.
-QUEST_LV_0200_20150323_005520	Talk with the tenant, Charlotte
+QUEST_LV_0200_20150323_005520	Talk with Tenant Charlotte
 QUEST_LV_0200_20150323_005521	The tenant, Charlotte is desperately looking for your help. Listen to her story.
 QUEST_LV_0200_20150323_005522	{memo X}Sprinkle the weed killer on the grape vine
 QUEST_LV_0200_20150323_005523	{memo X}It is so horrible to plant the polluted grapes anymore. Sprinkle the weed killer on the polluted grapes.
-QUEST_LV_0200_20150323_005524	You've ruined the grape vine enough. Return to the tenant, Charlotte.
+QUEST_LV_0200_20150323_005524	You've ruined the grape vine enough. Return to Tenant Charlotte.
 QUEST_LV_0200_20150323_005525	The tenant, Charlotte looks serious. Ask him what happened.
 QUEST_LV_0200_20150323_005526	{memo X}Defeat gray Chupacabra
 QUEST_LV_0200_20150323_005527	{memo X}Charlotte told you that many Chupacabras are gathered in front of the polluted grapes due to their smell. Defeat Chupacabras that are coming out from the vines.
-QUEST_LV_0200_20150323_005528	{memo X}You've defeated most of the Chupacabras. Return to the tenant, Charlotte.
+QUEST_LV_0200_20150323_005528	{memo X}You've defeated most of the Chupacabras. Return to Tenant Charlotte.
 QUEST_LV_0200_20150323_005529	{memo X}Defeat Chupacabras
 QUEST_LV_0200_20150323_005530	{memo X}Talk to Louise
 QUEST_LV_0200_20150323_005531	{memo X}Louise seems to be in a trouble. Talk to Louise.
@@ -5640,8 +5640,8 @@ QUEST_LV_0200_20150401_005639	{memo X}Limas said the crops here not growing well
 QUEST_LV_0200_20150401_005640	{memo X}Anyways, I received the report that the strange energy was definitely at the place you took a look at while ago.{nl}I will give the doll and some woods, use them to burn the doll.{nl}You will be prepared for some strange energy that may appear.
 QUEST_LV_0200_20150401_005641	{memo X}What? The crops died after doing what you were told to do?{nl}Was the curse of the doll little strong?
 QUEST_LV_0200_20150401_005643	{memo X}Are you the Revelator? {nl}I don't care about that, I am a bit busy right now so could you help my task?
-QUEST_LV_0200_20150401_005644	{memo X}There are some magic fields around here that we put after receiving the order of Baron Allerno.{nl}The magic field blocks the strange energy in this region and supplies the magical power onto this generator.{nl}But, since the power of the magic field is weak, we need to enhance it.
-QUEST_LV_0200_20150401_005645	{memo X}{nl}The true Revelator would find the way to enhance the magic field just by looking at it.{nl}Take the bottles since you may need them.
+QUEST_LV_0200_20150401_005644	{memo X}There are some magic circles around here that we put after receiving the order of Baron Allerno.{nl}The magic circle blocks the strange energy in this region and supplies the magical power onto this generator.{nl}But, since the power of the magic circle is weak, we need to enhance it.
+QUEST_LV_0200_20150401_005645	{memo X}{nl}The true Revelator would find the way to enhance the magic circle just by looking at it.{nl}Take the bottles since you may need them.
 QUEST_LV_0200_20150401_005646	{memo X}The power generator works by using the grains that are piled up at the storage over there.{nl}That's why I needed them a lot.
 QUEST_LV_0200_20150401_005647	{memo X}{nl}The tenants are cooperating with us without any resistance.{nl}.. Anyways, I am worried since that storage gets attacked by the monsters frequently these days.{nl}I guess that's not strange since we piled up the grains like that.
 QUEST_LV_0200_20150401_005648	{memo X}I can only say it's the power generator that helps the important gate which connects the two places to be stayed open.
@@ -5676,30 +5676,30 @@ QUEST_LV_0200_20150401_005677	{memo X}The food storage is at Vinoga Brewery.
 QUEST_LV_0200_20150401_005678	I am counting on you for the storage
 QUEST_LV_0200_20150401_005679	{memo X}I am working for that day.
 QUEST_LV_0200_20150401_005680	{memo X}You've defeated all the monsters that were attacking the storage!{nl}Thanks.{nl}As we were about to attack, the storage keeper hid well since you helped.{nl}I should tell him to protect the storage well.
-QUEST_LV_0200_20150401_005681	{memo X}Are you the Revelator?{nl}I often hear your stories even when I am in this kind of rural area.{nl}I am removing the magic fields that are stuck in the tenants' farm.
+QUEST_LV_0200_20150401_005681	{memo X}Are you the Revelator?{nl}I often hear your stories even when I am in this kind of rural area.{nl}I am removing the magic circles that are stuck in the tenants' farm.
 QUEST_LV_0200_20150401_005682	{memo X}{nl}We are doing this kind of tasks to help Horaceus.{nl}Of course, I am doing the tasks for me as well.
 QUEST_LV_0200_20150401_005683	{memo X}I've doing this job til now..{nl}Now, we have about 3 left.
-QUEST_LV_0200_20150401_005684	{memo X}The seal magic field that was discovered in the fallow ground.. We should eliminate them.{nl}I can't break them since they have protective barrier.{nl}I will give you the stone of the blessing so try to break it by throwing this.{nl}
-QUEST_LV_0200_20150401_005685	{memo X}There's a magic field at the entrance of Tarvas.{nl}You should break that first.{nl}But the monsters always disturb it..
+QUEST_LV_0200_20150401_005684	{memo X}The seal magic circle that was discovered in the fallow ground.. We should eliminate them.{nl}I can't break them since they have protective barrier.{nl}I will give you the stone of the blessing so try to break it by throwing this.{nl}
+QUEST_LV_0200_20150401_005685	{memo X}There's a magic circle at the entrance of Tarvas.{nl}You should break that first.{nl}But the monsters always disturb it..
 QUEST_LV_0200_20150401_005686	{memo X}Now we are almost done!{nl}Thank you so much!
 QUEST_LV_0200_20150401_005687	{memo X}It seems that the pieces that he gave to me belong to the statue of the Goddess.{nl}This must be.. the trace of those barons manipulating something on this ground and breaking it afterwards.{nl}You who collected these..
 QUEST_LV_0200_20150401_005688	{memo X}I am collecting the traces here.{nl}I can't tell you in details, but I am preparing for something big.{nl}To do that, I need to persuade the tenant farmers.{nl}So I am collecting those.
-QUEST_LV_0200_20150401_005689	{memo X}There's a magic field before you reach Ramus Intersection.{nl}And the smoke is coming up from the ground.{nl}That's called the strange energy.
+QUEST_LV_0200_20150401_005689	{memo X}There's a magic circle before you reach Ramus Intersection.{nl}And the smoke is coming up from the ground.{nl}That's called the strange energy.
 QUEST_LV_0200_20150401_005691	{memo X}Monsters fall into the eternal sleep.. dying..{nl}The monsters die due to the energy that is coming out from there..{nl}The monsters are tiresome and vicious.
 QUEST_LV_0200_20150401_005692	{memo X}{nl}The monsters fall into the eternal sleep due to that energy, that proves that the energy is not bad.
-QUEST_LV_0200_20150401_005693	{memo X}The amount of the crops after harvesting reduced a lot from some point of time in the past.{nl}Even if we care a lot, the crops wither easily.{nl}I think it may be due to the magic field that the barons created on this land.{nl}Could you help me out?
+QUEST_LV_0200_20150401_005693	{memo X}The amount of the crops after harvesting reduced a lot from some point of time in the past.{nl}Even if we care a lot, the crops wither easily.{nl}I think it may be due to the magic circle that the barons created on this land.{nl}Could you help me out?
 QUEST_LV_0200_20150401_005694	{memo X}{nl}That's why the amount of the crops was reduced.{nl}I am trying to find the reason for it.
-QUEST_LV_0200_20150401_005695	{memo X}This magic field has some kind of protective barrier so it's not easy to break it.{nl}So I am trying to light it up.{nl}To break the shield, I should maintain the flame.
+QUEST_LV_0200_20150401_005695	{memo X}This magic circle has some kind of protective barrier so it's not easy to break it.{nl}So I am trying to light it up.{nl}To break the shield, I should maintain the flame.
 QUEST_LV_0200_20150401_005696	{memo X}{nl}Should we kill those orange Dandells and throw kindlings on them?{nl}Try it.
-QUEST_LV_0200_20150401_005697	{memo X}The barons are pludering a lot these days and the magic fields like that have been created a lot across this region. Some of them are less shiny.{nl}Anyways, you get hurt from the ones that shine more so it's hard to eliminate them.
+QUEST_LV_0200_20150401_005697	{memo X}The barons are pludering a lot these days and the magic circles like that have been created a lot across this region. Some of them are less shiny.{nl}Anyways, you get hurt from the ones that shine more so it's hard to eliminate them.
 QUEST_LV_0200_20150401_005698	{memo X}You came at the right time. I connected the pieces with some sticky stuff.{nl}.. As I expected. This is the statue of the Goddess.{nl}I could only glue them like this with my skill.. It will break again if I don't do it well.{nl}I am sorry that I just glued them like this..
 QUEST_LV_0200_20150401_005699	{memo X}{nl}Hey, take it.
 QUEST_LV_0200_20150401_005700	{memo X}Oh really?{nl}Very well done!{nl}Too bad about the statue.. but the Goddesses would forgive this.
-QUEST_LV_0200_20150401_005701	{memo X}There's a uncompleted seal magic field down there.{nl}The seal is not complete yet so the strange energy is coming out from it, but the problem is that it doesn't look like that.
+QUEST_LV_0200_20150401_005701	{memo X}There's a uncompleted seal magic circle down there.{nl}The seal is not complete yet so the strange energy is coming out from it, but the problem is that it doesn't look like that.
 QUEST_LV_0200_20150401_005702	{memo X}{nl}It is suspicious.{nl}I have to connect these pieces, so can you find out more about the energy?
 QUEST_LV_0200_20150401_005703	{memo X}To accomplish a big task..{nl}You should first collect the clues.{nl}You can only persuade the tenant farmers with them.
 QUEST_LV_0200_20150401_005704	{memo X}The crops aren't growing.. There aren't anything to eat..
-QUEST_LV_0200_20150401_005705	{memo X}The enhancement of the magic field and the magical power supply are closely related to each other.
+QUEST_LV_0200_20150401_005705	{memo X}The enhancement of the magic circle and the magical power supply are closely related to each other.
 QUEST_LV_0200_20150401_005706	{memo X}We are keep going to do the task to find ours and let the truth spreads.{nl}But, your task will end here.{nl}You can go on your way.{nl}I really thank you for helping us this far.
 QUEST_LV_0200_20150401_005707	{memo X}Revelator.{nl}We are now ready.{nl}Now, we are going to do our work.
 QUEST_LV_0200_20150401_005708	Then, I will go into your small pocket.{nl}Don't forget. Trust no one.
@@ -5772,7 +5772,7 @@ QUEST_LV_0200_20150401_005775	{memo X}If it continues like this, the demons will
 QUEST_LV_0200_20150401_005776	{memo X}The demons look down on us.{nl}It will take a long time before the rules here get established here.
 QUEST_LV_0200_20150401_005777	{memo X}I will pass these necklaces to the sisters myself.{nl}May the Goddesses protect you.
 QUEST_LV_0200_20150401_005778	{memo X}Nuaele is having the ritual ceremony to summon the demons in his district.{nl}But, all of his arms are legs are disconnected so its going to be easy to defeat him.{nl}
-QUEST_LV_0200_20150401_005779	{memo X}Go meet Aldona. {nl}He would take you to the area of Nuaele.
+QUEST_LV_0200_20150401_005779	{memo X}Meet Aldona. {nl}He would take you to the area of Nuaele.
 QUEST_LV_0200_20150401_005780	Without Aldona's help, you will never enter the area of Nuaele.{nl}You should be guided by Aldona.
 QUEST_LV_0200_20150401_005781	{memo X}Nuaele's behavior was something that can't be accepted.{nl}If he stayed quietly, he would have been forgiven.{nl}
 QUEST_LV_0200_20150401_005782	{memo X}Let's go to 3rd district.{nl}Vakarine is waiting for your help.
@@ -6333,14 +6333,14 @@ QUEST_LV_0200_20150406_006336	I will help if it's related to the purification
 QUEST_LV_0200_20150406_006337	Tell him to take some rest since you will do it for him
 QUEST_LV_0200_20150406_006338	I will help if it's related to the purification
 QUEST_LV_0200_20150406_006339	About the power generator in front
-QUEST_LV_0200_20150406_006340	{memo X}Notice/!/Some strange essence came out from the magic field. Get rid of the strange essence.#5
-QUEST_LV_0200_20150406_006341	{memo X}Notice/!/You should collect the magical power of the monsters into the bottles and bury each of them at each end of the magic field.#5
+QUEST_LV_0200_20150406_006340	{memo X}Notice/!/Some strange essence came out from the magic circle. Get rid of the strange essence.#5
+QUEST_LV_0200_20150406_006341	{memo X}Notice/!/You should collect the magical power of the monsters into the bottles and bury each of them at each end of the magic circle.#5
 QUEST_LV_0200_20150406_006342	I will protect the storage
 QUEST_LV_0200_20150406_006343	About the relationship between the power generator and the grains
-QUEST_LV_0200_20150406_006344	Forgotten magic field(1)
-QUEST_LV_0200_20150406_006345	{memo X}Notice/!/Return to Limas and report him about the magic field.#5
+QUEST_LV_0200_20150406_006344	Forgotten magic circle(1)
+QUEST_LV_0200_20150406_006345	{memo X}Notice/!/Return to Limas and report him about the magic circle.#5
 QUEST_LV_0200_20150406_006346	{memo X}Sprinkling murky purifying liquid/STANDSPINKLE/1/TRACK_BEFORE/None
-QUEST_LV_0200_20150406_006347	{memo X}Notice/!/The magic field wants the monsters strongly!#5
+QUEST_LV_0200_20150406_006347	{memo X}Notice/!/The magic circle wants the monsters strongly!#5
 QUEST_LV_0200_20150406_006348	$About Manticen
 QUEST_LV_0200_20150406_006349	{memo X}Notice/!/It looks like the head of the sculpture.{nl}Dig it from the ground.#5
 QUEST_LV_0200_20150406_006350	{memo X}Digging the head part of the sculpture/SITGROPE/2/TRACK_BEFORE/None
@@ -6350,12 +6350,12 @@ QUEST_LV_0200_20150406_006353	{memo X}Notice/!/If you open it carelessly, the ob
 QUEST_LV_0200_20150406_006354	{memo X}Looking at the wing shaped fragment/LOOK/3/TRACK_BEFORE/None
 QUEST_LV_0200_20150406_006355	About the things that are occuring here
 QUEST_LV_0200_20150406_006356	I will find it out for him
-QUEST_LV_0200_20150406_006357	I will eliminate the magic field for him
-QUEST_LV_0200_20150406_006358	Tell him to leave it since it may be the purification magic field
-QUEST_LV_0200_20150406_006359	About the magic field
+QUEST_LV_0200_20150406_006357	I will eliminate the magic circle for him
+QUEST_LV_0200_20150406_006358	Tell him to leave it since it may be the purification magic circle
+QUEST_LV_0200_20150406_006359	About the magic circle
 QUEST_LV_0200_20150406_006360	Tell him that Yoana may have it
 QUEST_LV_0200_20150406_006361	Tell him that it won't be here
-QUEST_LV_0200_20150406_006362	About the possibility that the magic field may be for the purification
+QUEST_LV_0200_20150406_006362	About the possibility that the magic circle may be for the purification
 QUEST_LV_0200_20150406_006363	About the arrogance of the baron
 QUEST_LV_0200_20150406_006364	I can't help with such task
 QUEST_LV_0200_20150406_006365	I can't agree with that thought
@@ -6370,7 +6370,7 @@ QUEST_LV_0200_20150406_006373	Reject since it's scary
 QUEST_LV_0200_20150406_006374	About the reason that the monster sit down
 QUEST_LV_0200_20150406_006375	I don't want to do it
 QUEST_LV_0200_20150406_006376	About Albina
-QUEST_LV_0200_20150406_006377	I will destroy the magic field
+QUEST_LV_0200_20150406_006377	I will destroy the magic circle
 QUEST_LV_0200_20150406_006378	You don't need to listen to it anymore
 QUEST_LV_0200_20150406_006379	You can't deceive me
 QUEST_LV_0200_20150406_006380	Disturbing monster
@@ -6378,41 +6378,41 @@ QUEST_LV_0200_20150406_006381	Manage the people of the baron
 QUEST_LV_0200_20150406_006382	Defeat %s who ruined the brewery business
 QUEST_LV_0200_20150406_006383	Check the Gaudeji altar at the right side
 QUEST_LV_0200_20150406_006384	Maras doesn't know what this piece is, but he told you there's another altar like this so check the Gaudeji altar on the right.
-QUEST_LV_0200_20150406_006385	You've found a fragment with the same shape at Gaudeji altar on the right side. Go meet Ramar as Maras told you.
+QUEST_LV_0200_20150406_006385	You've found a fragment with the same shape at Gaudeji altar on the right side. Meet Ramar as Maras told you.
 QUEST_LV_0200_20150406_006386	The land where Austeja Goddess used to manage is full of divine magical power. Go to Parama cliff and put the marble of the remnants near Austeja altar to recharge its energies.
 QUEST_LV_0200_20150406_006387	Arunas, the secretary of the baron is very tired and wants your help. Talk to Arunas.
 QUEST_LV_0200_20150406_006388	{memo X}Arunas, the secretary of the baron wants you to check the strange energy and the crops. Go investigate the place where Arunas pointed.
 QUEST_LV_0200_20150406_006389	There's some strange energy, but it seems nothing special is going on. Tell Arunas that there's nothing special.
 QUEST_LV_0200_20150406_006390	There's no strange energy as Arunas told you, but Arunas still looks tired. Talk with Arunas.
 QUEST_LV_0200_20150406_006391	Start the ritual to eliminate the strange energy
-QUEST_LV_0200_20150406_006392	{memo X}Arunas requested you to do the ritual to eliminate the strange energy. Pile up the magic field where there's strange energy and burn the spell doll.
+QUEST_LV_0200_20150406_006392	{memo X}Arunas requested you to do the ritual to eliminate the strange energy. Pile up the magic circle where there's strange energy and burn the spell doll.
 QUEST_LV_0200_20150406_006393	{memo X}You burnt the spell doll, but strangely the crops withered. Report this to Arunas.
 QUEST_LV_0200_20150406_006394	$Talk to Limas
 QUEST_LV_0200_20150406_006395	$Limas needs your help. Talk to Limas.
-QUEST_LV_0200_20150406_006396	Look for the magic field that needs to be enhanced
-QUEST_LV_0200_20150406_006397	Look for the magic field that needs to be enhanced among the magic fields that is blocking the strange energy.
+QUEST_LV_0200_20150406_006396	Look for the magic circle that needs to be enhanced
+QUEST_LV_0200_20150406_006397	Look for the magic circle that needs to be enhanced among the magic circles that is blocking the strange energy.
 QUEST_LV_0200_20150406_006398	Eliminate the strage crystal
-QUEST_LV_0200_20150406_006399	Strange crystals have come out from the magic field. This magic field is working properly so let's just eliminate the strange crystals.
-QUEST_LV_0200_20150406_006400	Check the magic field
-QUEST_LV_0200_20150406_006401	You've eliminated the strange crystals. Check the magic field again.
-QUEST_LV_0200_20150406_006402	Look closely at the other magic fields
-QUEST_LV_0200_20150406_006403	You should find the weak magic fields and enhance them. Look for the magic fields that are not working properly.
-QUEST_LV_0200_20150406_006404	{memo X}Collect the magical power of the monsters and bury them near the magic field
-QUEST_LV_0200_20150406_006405	{memo X}In order to enhance the magic fields, you should put the magical power into the bottles and bury them near the magic fields. Each bottle could only contain one kind of magical power.
+QUEST_LV_0200_20150406_006399	Strange crystals have come out from the magic circle. This magic circle is working properly so let's just eliminate the strange crystals.
+QUEST_LV_0200_20150406_006400	Check the magic circle
+QUEST_LV_0200_20150406_006401	You've eliminated the strange crystals. Check the magic circle again.
+QUEST_LV_0200_20150406_006402	Look closely at the other magic circles
+QUEST_LV_0200_20150406_006403	You should find the weak magic circles and enhance them. Look for the magic circles that are not working properly.
+QUEST_LV_0200_20150406_006404	{memo X}Collect the magical power of the monsters and bury them near the magic circle
+QUEST_LV_0200_20150406_006405	{memo X}In order to enhance the magic circles, you should put the magical power into the bottles and bury them near the magic circles. Each bottle could only contain one kind of magical power.
 QUEST_LV_0200_20150406_006406	$Report to Limas
-QUEST_LV_0200_20150406_006407	$You've enhanced the magic fields. Return to Limas and report.
-QUEST_LV_0200_20150406_006408	$Limas told you that there are lots of other things to care about besides the magic fields. Talk to Limas.
+QUEST_LV_0200_20150406_006407	$You've enhanced the magic circles. Return to Limas and report.
+QUEST_LV_0200_20150406_006408	$Limas told you that there are lots of other things to care about besides the magic circles. Talk to Limas.
 QUEST_LV_0200_20150406_006409	Protect the storage from the monsters
 QUEST_LV_0200_20150406_006410	$Limas told you that the monsters are going after the storage where the fuel of the power generator is stored. Help Limas.
 QUEST_LV_0200_20150406_006411	$You've defeated the monsters that were about to attack the storage. Tell Limas about it.
-QUEST_LV_0200_20150406_006412	$It seems there are more magic fields besides the ones that Limas told you about. Get closer to the magic fields to look more carefully.
-QUEST_LV_0200_20150406_006413	$The magic field is vibrating strangely unlike a while ago. First, go back to Limas and ask.
-QUEST_LV_0200_20150406_006414	Sprinkle the murky purification liquid on the magic fields
-QUEST_LV_0200_20150406_006415	$Take the murky purification liquid that Limas gave you and sprinkle it on the magic fields. You don't know why the vicious energies are enhancing the magic fields, but let's get some more information by doing what he told you.
-QUEST_LV_0200_20150406_006416	Check the magic fields again
-QUEST_LV_0200_20150406_006417	$The magic fields will now be enhanced since you sprinkled the murky purification liquid that Limas gave to you. Let's take a look at it again.
-QUEST_LV_0200_20150406_006418	When the magic field was about to be enhanced, the monsters suddenly rushed in! It seems that they are lured to the murky purification liquid. Go defeat the monsters first.
-QUEST_LV_0200_20150406_006419	{memo X}This magic field strongly wants the monsters. Bring the monsters near the magic fields and defeat them.
+QUEST_LV_0200_20150406_006412	$It seems there are more magic circles besides the ones that Limas told you about. Get closer to the magic circles to look more carefully.
+QUEST_LV_0200_20150406_006413	$The magic circle is vibrating strangely unlike a while ago. First, go back to Limas and ask.
+QUEST_LV_0200_20150406_006414	Sprinkle the murky purification liquid on the magic circles
+QUEST_LV_0200_20150406_006415	$Take the murky purification liquid that Limas gave you and sprinkle it on the magic circles. You don't know why the vicious energies are enhancing the magic circles, but let's get some more information by doing what he told you.
+QUEST_LV_0200_20150406_006416	Check the magic circles again
+QUEST_LV_0200_20150406_006417	$The magic circles will now be enhanced since you sprinkled the murky purification liquid that Limas gave to you. Let's take a look at it again.
+QUEST_LV_0200_20150406_006418	When the magic circle was about to be enhanced, the monsters suddenly rushed in! It seems that they are lured to the murky purification liquid. Go defeat the monsters first.
+QUEST_LV_0200_20150406_006419	{memo X}This magic circle strongly wants the monsters. Bring the monsters near the magic circles and defeat them.
 QUEST_LV_0200_20150406_006420	Talk to Veknews
 QUEST_LV_0200_20150406_006421	Veknews is looking for something desperately. Talk to Veknews.
 QUEST_LV_0200_20150406_006422	Search Manticen
@@ -6440,21 +6440,21 @@ QUEST_LV_0200_20150406_006443	You've obtained the sticky fluid from the monsters
 QUEST_LV_0200_20150406_006444	Collect %s from the monsters
 QUEST_LV_0200_20150406_006445	Obtain sticky fluid from the monsters
 QUEST_LV_0200_20150406_006446	It seems that Yoana still has some request. Talk to Yoana.
-QUEST_LV_0200_20150406_006447	{memo X}Yoana wants to find out the true nature of the strange energy that exists near the Ramus intersections. Reduce the HP of the monsters in half and take them to the lower side of the magic fields where the strange energy is coming from.
+QUEST_LV_0200_20150406_006447	{memo X}Yoana wants to find out the true nature of the strange energy that exists near the Ramus intersections. Reduce the HP of the monsters in half and take them to the lower side of the magic circles where the strange energy is coming from.
 QUEST_LV_0200_20150406_006448	The energy may not be bad since the monsters are disappearing. Tell this to Yoana.
 QUEST_LV_0200_20150406_006449	Talk to Baras
 QUEST_LV_0200_20150406_006450	It seems that Baras needs your help. Talk to Baras.
-QUEST_LV_0200_20150406_006451	Destroy the magic field
-QUEST_LV_0200_20150406_006452	Pile up the logs on the magic fields and light them to burn the magic fields. You can increase the lives of the flames by obtaining kindlings from the monsters.
+QUEST_LV_0200_20150406_006451	Destroy the magic circle
+QUEST_LV_0200_20150406_006452	Pile up the logs on the magic circles and light them to burn the magic circles. You can increase the lives of the flames by obtaining kindlings from the monsters.
 QUEST_LV_0200_20150406_006453	Report to Baras
-QUEST_LV_0200_20150406_006454	You've burnt the magic fields successfully. Return to Baras and report.
-QUEST_LV_0200_20150406_006455	Baras told you that there are more magic fields. Talk to Baras again.
+QUEST_LV_0200_20150406_006454	You've burnt the magic circles successfully. Return to Baras and report.
+QUEST_LV_0200_20150406_006455	Baras told you that there are more magic circles. Talk to Baras again.
 QUEST_LV_0200_20150406_006456	Obtain the statue of the Goddess from Yoana
-QUEST_LV_0200_20150406_006457	Baras told you that you would be able to eliminate the magic fields easily using the mighty power of the Goddesses. Obtain the statue of the Goddess from Yoana.
-QUEST_LV_0200_20150406_006458	{memo X}Put the statue of the Goddess on the magic field at Talia trail.
+QUEST_LV_0200_20150406_006457	Baras told you that you would be able to eliminate the magic circles easily using the mighty power of the Goddesses. Obtain the statue of the Goddess from Yoana.
+QUEST_LV_0200_20150406_006458	{memo X}Put the statue of the Goddess on the magic circle at Talia trail.
 QUEST_LV_0200_20150406_006459	Check the nearby crops
-QUEST_LV_0200_20150406_006460	As you put the statue of the Goddess on the magic field, the magic field disappeared with the statue of the Goddess. Check the status of the crops that Baras worried about.
-QUEST_LV_0200_20150406_006461	The crops became alive again. With the power of the statue of the Goddess, the magic fields have disappeared and the crops became alive again. Report this to Baras.
+QUEST_LV_0200_20150406_006460	As you put the statue of the Goddess on the magic circle, the magic circle disappeared with the statue of the Goddess. Check the status of the crops that Baras worried about.
+QUEST_LV_0200_20150406_006461	The crops became alive again. With the power of the statue of the Goddess, the magic circles have disappeared and the crops became alive again. Report this to Baras.
 QUEST_LV_0200_20150406_006462	Talk to Jugas
 QUEST_LV_0200_20150406_006463	There's a farmer who needs your help. Talk to Jugas.
 QUEST_LV_0200_20150406_006464	Look for the sacks of the grains
@@ -6491,17 +6491,17 @@ QUEST_LV_0200_20150406_006494	The monsters are trying to steal from the storage 
 QUEST_LV_0200_20150406_006495	You were able to protect the storage before it gets attacked. Tell Tauras that the storage is safe.
 QUEST_LV_0200_20150406_006496	Defeat the monsters that are trying to attack the food storage
 QUEST_LV_0200_20150406_006497	Albina needs your help. Talk to Albina.
-QUEST_LV_0200_20150406_006498	Albina needs your help to eliminate the magic fields. Listen for more details from Albina.
-QUEST_LV_0200_20150406_006499	Albina wants you to remove the remaining three magic fields. Talk to her about the magic field at Padeka altar among them.
+QUEST_LV_0200_20150406_006498	Albina needs your help to eliminate the magic circles. Listen for more details from Albina.
+QUEST_LV_0200_20150406_006499	Albina wants you to remove the remaining three magic circles. Talk to her about the magic circle at Padeka altar among them.
 QUEST_LV_0200_20150406_006500	{memo X}Protect Padeka altar
-QUEST_LV_0200_20150406_006501	$Krimeleech who is lured to the magic field near Padeka altar is sitting on the altar. Defeat Krimeleech and destroy the magic field near the altar.
-QUEST_LV_0200_20150406_006502	$You've defeated Krimeleech and the magic field. Tell Albina that you've retrieved the altar.
-QUEST_LV_0200_20150406_006503	Albina wants you to remove the remaining three magic fields. Talk to her about the magic field at the Fallow Ground among them.
-QUEST_LV_0200_20150406_006504	Albina told you that the magic field at the Fallow Ground could be broken by throwing the magical stone of the blessing at it.
-QUEST_LV_0200_20150406_006505	You've succesfully destroyed the magic field. Tell this to Albina.
-QUEST_LV_0200_20150406_006506	{memo X}Albina wants you to remove the remaining three magic fields. Among them, talk to her about the magic field at the Tarvas entrance.
-QUEST_LV_0200_20150406_006507	{memo X}She told you that the magic field at Tarvas entrance is hard to break due to many monsters there. Defeat the monsters that are rushing in and break the magic field.
-QUEST_LV_0200_20150406_006508	{memo X}You successfully destroyed the magic field at Tarvas entrance. Report to Albina.
+QUEST_LV_0200_20150406_006501	$Krimeleech who is lured to the magic circle near Padeka altar is sitting on the altar. Defeat Krimeleech and destroy the magic circle near the altar.
+QUEST_LV_0200_20150406_006502	$You've defeated Krimeleech and the magic circle. Tell Albina that you've retrieved the altar.
+QUEST_LV_0200_20150406_006503	Albina wants you to remove the remaining three magic circles. Talk to her about the magic circle at the Fallow Ground among them.
+QUEST_LV_0200_20150406_006504	Albina told you that the magic circle at the Fallow Ground could be broken by throwing the magical stone of the blessing at it.
+QUEST_LV_0200_20150406_006505	You've succesfully destroyed the magic circle. Tell this to Albina.
+QUEST_LV_0200_20150406_006506	{memo X}Albina wants you to remove the remaining three magic circles. Among them, talk to her about the magic circle at the Tarvas entrance.
+QUEST_LV_0200_20150406_006507	{memo X}She told you that the magic circle at Tarvas entrance is hard to break due to many monsters there. Defeat the monsters that are rushing in and break the magic circle.
+QUEST_LV_0200_20150406_006508	{memo X}You successfully destroyed the magic circle at Tarvas entrance. Report to Albina.
 QUEST_LV_0200_20150406_006509	It seems that Horaceus has something to say. Talk to Horaceus.
 QUEST_LV_0200_20150406_006510	Obtain the symbol of Hauberk
 QUEST_LV_0200_20150406_006511	{memo X}Among the subordinates of Nuaele, some of them used to be the subordinates of Hauberk and they once received the symbols with the power endowed in them. Defeat the subordinates of Nuaele at the 2nd Isolated Area and obtain the symbol of Hauberk.
@@ -6711,7 +6711,7 @@ QUEST_LV_0200_20150414_006714	Recently, I got sick and drowsy.{nl}It seems the c
 QUEST_LV_0200_20150414_006715	What can I say. I do not dislike the soldier much and the crops are not bad..{nl}Somehow, I don't feel good.
 QUEST_LV_0200_20150414_006716	{memo X}Thank you.{nl}We will collect the sealed Hoberg's power and take it to the Goddess.{nl}
 QUEST_LV_0200_20150414_006717	{memo X}The Goddess is waiting for you to Priosn District 5.{nl}Let's move on.
-QUEST_LV_0200_20150414_006718	{memo X}We don't know whether the Goddess is okay or not, but we need to show them a sample.{nl}Can you collect the Demon's Tooth in Heuradeti Instersection?
+QUEST_LV_0200_20150414_006718	{memo X}We don't know whether the Goddess is okay or not, but we need to show them a sample.{nl}Can you collect the Demon's Tooth in Hradeti Crossroads?
 QUEST_LV_0200_20150414_006719	{memo X}Hoberg..{nl}His life is too pitiful, but it should be removed.{nl}
 QUEST_LV_0200_20150414_006720	{memo X}Well. We came here because of you.{nl}We are holding the ceremony to close the contaminated gap, you need to be completely ready.
 QUEST_LV_0200_20150414_006721	{memo X}Receive the General Rune.{nl}Let's collect the Demon's Soul to use it and collected contaminated gap.
@@ -7065,7 +7065,7 @@ QUEST_LV_0200_20150714_007068	Marko brothers are at Viltis Forest and Guus is at
 QUEST_LV_0200_20150714_007069	I support the Hunters, but I don't know how other senior monks would think.{nl}However, I don't think it would be a problem if we get a decisive proof.
 QUEST_LV_0200_20150714_007070	Monk Wiley
 QUEST_LV_0200_20150714_007071	My heart aches to see our brothers feel the pains.{nl}I am taking care of them with my best, but I am somewhat scared.
-QUEST_LV_0200_20150714_007072	For me, our brothers come first instead of the Hunters or the Monastery.{nl}I am praying to the goddesses so that they can be cured quickly.{nl}
+QUEST_LV_0200_20150714_007072	For me, our brothers come first instead of the Hunters or the Monastery.{nl}I am praying to the Goddesses so that they can be cured quickly.{nl}
 QUEST_LV_0200_20150714_007073	Hunter Reina
 QUEST_LV_0200_20150714_007074	You should be careful when you are crossing this forest.{nl}The traps are everywhere in this forest.
 QUEST_LV_0200_20150714_007075	You don't seem like a monk... Do you know anything about Evoniphon?{nl}I heard they created a mess near the farm in Klaipeda.
@@ -7085,7 +7085,7 @@ QUEST_LV_0200_20150714_007088	Help whatever you could on what they are trying to
 QUEST_LV_0200_20150714_007089	I should've suggested to help retreving the monastery from the first place.{nl}I wasn't patient.
 QUEST_LV_0200_20150714_007090	I will take care for him so don't worry too much, but go to Laukyme Swampy place.
 QUEST_LV_0200_20150714_007091	You can go to Laukyme Swampy place by going up Glade Hillroad again.{nl}Please report to Mintz commander on your way back.
-QUEST_LV_0200_20150714_007092	Hunter Bastil
+QUEST_LV_0200_20150714_007092	Hunter Bastille
 QUEST_LV_0200_20150714_007093	Are you going to Tyla Monastery?{nl}The monsters are already worshipping there.
 QUEST_LV_0200_20150714_007094	Careless, careless.{nl}I was so careless...
 QUEST_LV_0200_20150714_007095	Monk Chad
@@ -7093,7 +7093,7 @@ QUEST_LV_0200_20150714_007096	Please do not get close to those Hunters.{nl}They 
 QUEST_LV_0200_20150714_007097	I don't like those Hunters.{nl}I hope they would not change their minds because we are protecting Evoniphon
 QUEST_LV_0200_20150714_007098	Senior Monk Guus
 QUEST_LV_0200_20150714_007099	If you are the pilgrim who came to see Tyla Monastery, I am so sorry.{nl}We lost the place to the monsters...
-QUEST_LV_0200_20150714_007100	I don't know what the goddesses would say if she sees this...{nl}Gloomy...
+QUEST_LV_0200_20150714_007100	I don't know what the Goddesses would say if she sees this...{nl}Gloomy...
 QUEST_LV_0200_20150714_007101	This is all I know about Evoniphon.{nl}I think there weren't anything special besides that.
 QUEST_LV_0200_20150714_007102	If you need to more about Evoniphon, please ask me anytime.{nl}I will answer everything I know about Evoniphon.
 QUEST_LV_0200_20150714_007103	Finally, we are near Tyla Monastery.{nl}We want to attack, but we should also think about the monks.
@@ -7108,7 +7108,7 @@ QUEST_LV_0200_20150714_007111	Hey! Wake up!{nl}Can you hear my voice?
 QUEST_LV_0200_20150714_007112	He is fainted, but fortunately he is breathing.{nl}But, the fracture is serious.
 QUEST_LV_0200_20150714_007113	Evoniphon, you cheap...
 QUEST_LV_0200_20150714_007114	Fortunatly, his inner organs seem alright.{nl}But, I can't cure him by transporting him to other places.
-QUEST_LV_0200_20150714_007115	I am going to take care of the outer edge of the monastery.{nl}In the name of the goddesses, I wish you the good luck.
+QUEST_LV_0200_20150714_007115	I am going to take care of the outer edge of the monastery.{nl}In the name of the Goddesses, I wish you the good luck.
 QUEST_LV_0200_20150714_007116	We are all ready here.{nl}Although I can't participate in saving the abbot, I will do my best here.
 QUEST_LV_0200_20150714_007117	The prayer room where the abbot is located is safe.{nl}But, we should save him anyways.
 QUEST_LV_0200_20150714_007118	Our preparations are done here.{nl}If you are ready, tell Guus.
@@ -7117,18 +7117,18 @@ QUEST_LV_0200_20150714_007120	Hunters can move whenever they want.{nl}I will do 
 QUEST_LV_0200_20150714_007121	Moheim is smart so he should've hid the crystal sphere well.
 QUEST_LV_0200_20150714_007122	You can't open it outside without the crystal sphere.{nl}Unless the abbot opens it himself...
 QUEST_LV_0200_20150714_007123	It's so good to hear that you are okay.{nl}While you are getting the crystal sphere, we should get ready to rescue the abbot.
-QUEST_LV_0200_20150714_007124	I would've bled a lot if it weren't you.{nl}The goddesses must have helped me.
+QUEST_LV_0200_20150714_007124	I would've bled a lot if it weren't you.{nl}The Goddesses must have helped me.
 QUEST_LV_0200_20150714_007125	Fortunately, the abbot seems to know nothing.{nl}I guess that's better. Anyways, the issues have been resolved.
 QUEST_LV_0200_20150714_007126	I am less worried to find out the abbot is okay.{nl}Now what should we do about Evoniphon...
 QUEST_LV_0200_20150714_007127	I am discussing with the abbot.{nl}Please wait beside Mintz for a while.
 QUEST_LV_0200_20150714_007128	We haven't finished discussing yet.{nl}Please wait little more.
-QUEST_LV_0200_20150714_007129	You will leave soon. May the goddesses bless you.{nl}Come to Tyla Monastery sometimes.
-QUEST_LV_0200_20150714_007130	I regret a bit since we should have allied together in the first place.{nl}I guess I forgot the lessons of the goddesses for a while.
+QUEST_LV_0200_20150714_007129	You will leave soon. May the Goddesses bless you.{nl}Come to Tyla Monastery sometimes.
+QUEST_LV_0200_20150714_007130	I regret a bit since we should have allied together in the first place.{nl}I guess I forgot the lessons of the Goddesses for a while.
 QUEST_LV_0200_20150714_007131	It is so fortunate that the abbot is okay.{nl}I... feel like crying.
 QUEST_LV_0200_20150714_007132	I kinda expected that he would be alright since he was in the prayer room...{nl}But seeing him okay with my own eyes comforts me more.
 QUEST_LV_0200_20150714_007133	Please wait beside Mintz for a while.{nl}I should explain everything so it may take little time.
 QUEST_LV_0200_20150714_007134	I've heard about Evoniphon's letter from Guus.{nl}Please wait little more since everything fits the situation.
-QUEST_LV_0200_20150714_007135	We've retrieved the monastery and the Hunters fulfilled what they wanted...{nl}These are all blessings of the goddesses.
+QUEST_LV_0200_20150714_007135	We've retrieved the monastery and the Hunters fulfilled what they wanted...{nl}These are all blessings of the Goddesses.
 QUEST_LV_0200_20150714_007136	Without your help, I am sure that it would've not gone so easy.{nl}I've heard the stories of many Revelators before, but you are the only one I saw in person.
 QUEST_LV_0200_20150714_007137	Monk Moheim
 QUEST_LV_0200_20150714_007138	It's so good that we've retrieved the monastery...{nl}But it's a mess.
@@ -7161,7 +7161,7 @@ QUEST_LV_0200_20150714_007164	Maybe... we could restore the time of the portal t
 QUEST_LV_0200_20150714_007165	What we are planning right now could lead us to the gallows.{nl}Please keep it secret.
 QUEST_LV_0200_20150714_007166	{memo X}When we were in the era of Premier Eminent, we were supported by the superior troops, lots of supplies and etc.{nl}But, 600 years have passed after Premier Eminent died.{nl}
 QUEST_LV_0200_20150714_007167	
-QUEST_LV_0200_20150714_007168	I heard the Dico Thieves were well known thieves.{nl}I heard that they were seperated on the day of divine tree... Anyways... what they are doing is like what bandits are doing.{nl}
+QUEST_LV_0200_20150714_007168	I heard the Dico Thieves were well known thieves.{nl}I heard that they were seperated on the Medis Diena... Anyways... what they are doing is like what bandits are doing.{nl}
 QUEST_LV_0200_20150714_007169	I also know that there are thieves called Amanda Thieves. They were quiet.{nl}I want to know if they really exist or not since I never saw them before.{nl}
 QUEST_LV_0200_20150714_007170	Both of them are criminals that we should catch when we receive more reinforcements.{nl}Especially, Dico Thieves.
 QUEST_LV_0200_20150714_007171	We are observing what the researchers of Kaliss Knitage are doing and while pretending to be their guards.{nl}Sabina was one of them.{nl}
@@ -7171,7 +7171,7 @@ QUEST_LV_0200_20150714_007174	This place is the cursed city of the traitor, Rukl
 QUEST_LV_0200_20150714_007175	We will allow you to enter since Kaliss Knitage requested us to do so{nl},but please stay at the place where our gaze remains.
 QUEST_LV_0200_20150714_007176	I don't know how great you were in the past{Nl}but here, you have to follow the rules of the kingdom.
 QUEST_LV_0200_20150714_007177	Benas asked us to secure the route that connects to the fortress of the earth.{nl}Ah, he is the ruler of the kingdoms soldiers in this region.{nl}
-QUEST_LV_0200_20150714_007178	If you could defeat the monsters in the ruins, that will be the way to contribute to the goddessses and the kingdom.{nl}Of course, I promise you some rewards in return.{nl}
+QUEST_LV_0200_20150714_007178	If you could defeat the monsters in the ruins, that will be the way to contribute to the Goddessses and the kingdom.{nl}Of course, I promise you some rewards in return.{nl}
 QUEST_LV_0200_20150714_007179	It will not be bad to show us a good impression.{nl}Because this land is ruled by the kingdom soldiers.
 QUEST_LV_0200_20150714_007180	It wasn't done by the thieves. We are moving the objects to the places where they could find more values.{nl}It will be way better than disappearing from here.
 QUEST_LV_0200_20150714_007181	Not bad.{nl}I guess the rumors don't always get exaggerated.
@@ -7199,7 +7199,7 @@ QUEST_LV_0200_20150714_007202	I took a sneak peek, but it seems they haven't ret
 QUEST_LV_0200_20150714_007203	Seems like Diko thieves are planning to do their business bigger than I thought. {nl}That's an enormous amount. Do you think they also have connections with the kingdom army?
 QUEST_LV_0200_20150714_007204	The terrible scene you can see in this city are the results of the rebellion that was carried out by Ruklys and the citizens 600 years ago.{nl}The Stone Frosts that started to blow after suppressing the rebellion turn everything into stones.{nl}
 QUEST_LV_0200_20150714_007205	The kingdom would've been destroyed already if Premier Eminent wasn't present.{nl}If he was still alive... We may have got over these hard times sooner.
-QUEST_LV_0200_20150714_007206	That's the scary wind that turns everything into stones.{nl}After the day of divine tree, the occurence of the wind changed irregularly.{nl}
+QUEST_LV_0200_20150714_007206	That's the scary wind that turns everything into stones.{nl}After the Medis Diena, the occurence of the wind changed irregularly.{nl}
 QUEST_LV_0200_20150714_007207	Once you encounter the curse of the Stone Frosts, you can't restore it.{nl}The sin of the traitor, Ruklys is that heavy.{nl}
 QUEST_LV_0200_20150714_007208	Kaliss Knightage is trying to find a remedy...{nl}The curse continued for 600 years. I don't think there's a remedy.
 QUEST_LV_0200_20150714_007209	Sparnashorn appears with the wind of Stone Frosts.{nl}To avoid the exhausted soldiers not get involved with it, we should avoid them fighting against Sparnashorn.{nl}
@@ -7225,7 +7225,7 @@ QUEST_LV_0200_20150714_007228	This city... you will find many interesting truths
 QUEST_LV_0200_20150714_007229	I don't want to be here either.{nl}I would not be here if I didn't receive the orders to support the Kalis knights...{nl}
 QUEST_LV_0200_20150714_007230	Kostas has not come back for days so I can't leave this place.{nl}Also the mosnters are running wild so I can't just stay still.
 QUEST_LV_0200_20150714_007231	We have to be here until Costas comes.{nl}There are lot of things to do, so I hope he comes here soon.
-QUEST_LV_0200_20150714_007232	The officers don't like the Kaliss knightage. {nl}As for lower rank guards like me, Kaliss knights give us supplies and supports so there's no reason for us to hate them.
+QUEST_LV_0200_20150714_007232	The officers don't like the Kaliss Knightage. {nl}As for lower rank guards like me, Kaliss knights give us supplies and supports so there's no reason for us to hate them.
 QUEST_LV_0200_20150714_007233	If we can find the Symbol of Schilt, then we would be able to enter the area without any problems.
 QUEST_LV_0200_20150714_007234	I can't hear anything from Costas.{nl}Ah... I don't know how I should report.
 QUEST_LV_0200_20150714_007235	The kingdom soldiers, Kaliss Knitage, and we, thieves are forming an excellent balance.{nl}That's why people can at least walk around.. Before that, this place was not a place to stay.
@@ -7310,7 +7310,7 @@ QUEST_LV_0200_20150714_007313	I don't understand how these heavy stuffs float do
 QUEST_LV_0200_20150714_007314	Whenever the Stone Frosts blow, the number of soldiers decreases, but the kingdom doesn't possess additional soldiers to support.{nl}That's why we ask the grave thieves or the refugees to join the military.{nl}
 QUEST_LV_0200_20150714_007315	Only thing I can do is to attach these leaflets around here.{nl}I hope you could help me by thinking that you are supporting the kingdom.
 QUEST_LV_0200_20150714_007316	I'm sure people taking the leaflets but the number of applicants have decreased recently. {nl}Is it because the grave thieves started checking inside. Isn't it suspicious?
-QUEST_LV_0200_20150714_007317	When a person like Premier Eminent appears again, I'm sure that the kingdom will flourish quickly.{nl}I will pray to the goddesses that you could be an important person like him.
+QUEST_LV_0200_20150714_007317	When a person like Premier Eminent appears again, I'm sure that the kingdom will flourish quickly.{nl}I will pray to the Goddesses that you could be an important person like him.
 QUEST_LV_0200_20150714_007318	The number of monsters in Kovos battlefield is increasing. {nl}We don't even know what is leading them here.{nl}
 QUEST_LV_0200_20150714_007319	We don't expect anything from the kingdom soldiers who were supposed to help us in the first place.{nl}If you could help us instead, then I will give you the rewards that I promised to give to the soldiers.
 QUEST_LV_0200_20150714_007320	We've investigated about the incident that was occuring in this city from a long time ago.{nl}We are trying to find hidden facts about the rebellion.
@@ -7438,7 +7438,7 @@ QUEST_LV_0200_20150714_007441	I just hope the monsters stay calm.{nl}Maybe I am 
 QUEST_LV_0200_20150714_007442	The blessings of the Goddesses has not reached at this city.{nl}Only the monsters and the criminals are full in this city.
 QUEST_LV_0200_20150714_007443	Please report to us when you see monsters.{nl}Especially, when they are grouped together or make a mess.
 QUEST_LV_0200_20150714_007444	I've written down what to do at the memo.{nl}First, find the demonic stone fusion device at Ritinis Underground Grave.
-QUEST_LV_0200_20150714_007445	Long time ago, I had serviced as a guard in the military like those guys.{nl}I was a junior officer who wanted become a strategist. At least before the day of divine tree.
+QUEST_LV_0200_20150714_007445	Long time ago, I had serviced as a guard in the military like those guys.{nl}I was a junior officer who wanted become a strategist. At least before the Medis Diena.
 QUEST_LV_0200_20150714_007446	If you find someone suspicious besides kingdom soldiers and Kaliss Knightage, please report to us.{nl}Especially, those grave thieves.
 QUEST_LV_0200_20150714_007447	Please do not touch anything. Just stay calm.
 QUEST_LV_0200_20150714_007448	If you find the old records that are negative to the kingdom, immediatly destroy them or report to us.
@@ -7476,11 +7476,11 @@ QUEST_LV_0200_20150714_007479	But, whenever we tried to do that, the monsters al
 QUEST_LV_0200_20150714_007480	When you obtain the guide stone of the wisdom, please show it to Hones at Raiduna Hall.{nl}If he finds out that I am the only one who could continue the research of the master, he would hand over the documents.
 QUEST_LV_0200_20150714_007481	Hones did not cooperate with us until now, but he would have to hand them over this time.{nl}As the master only left the orb to me, the guide stone of the wisdom can only be obtained by me.
 QUEST_LV_0200_20150714_007482	Hmm? Isn't that the guide stone of the wisdom?{nl}Who are you and why are you showing it to me?
-QUEST_LV_0200_20150714_007483	Damn, Raius is misunderstanding something.{nl}No. Maybe the master and the goddess guided us this far.{nl}
+QUEST_LV_0200_20150714_007483	Damn, Raius is misunderstanding something.{nl}No. Maybe the master and the Goddess guided us this far.{nl}
 QUEST_LV_0200_20150714_007484	Anyways, I have the guide stone of the wisdom as well.
 QUEST_LV_0200_20150714_007485	Raius... has a problem.{nl}I can't say it. Go to the hideout of the master. Then you would believe it.
 QUEST_LV_0200_20150714_007486	Maybe, it turned out better than we thought.{nl}I didn't expect Raius would help us.
-QUEST_LV_0200_20150714_007487	The master researched about the goddesses throughout his entire life.{nl}And then he discovered something important, but he said if it goes into the hands of the demons, it will be dangerous.{nl}
+QUEST_LV_0200_20150714_007487	The master researched about the Goddesses throughout his entire life.{nl}And then he discovered something important, but he said if it goes into the hands of the demons, it will be dangerous.{nl}
 QUEST_LV_0200_20150714_007488	As you saw, Raius is trying to find the remains of the research of the master due to his greed.{nl}But, they should never be exposed to the world.
 QUEST_LV_0200_20150714_007489	Ahah. Revelator. Maybe...{nl}The master said someone who is reliable should dispose of his research before he died.{nl}
 QUEST_LV_0200_20150714_007490	And the remains of the research are at the place where normal people like me or Raius can not reach.{nl}If you are really the Revelator, I want you to dispose of them.
@@ -7489,7 +7489,7 @@ QUEST_LV_0200_20150714_007492	With the guide stone of the wisdom you have, you w
 QUEST_LV_0200_20150714_007493	Even if you are not the Revelator, I am counting on you.{nl}I know the guide stone of the wisdom can't be obtained that easily.
 QUEST_LV_0200_20150714_007494	Good. With this, we've restored the eyes of the truth completely.
 QUEST_LV_0200_20150714_007495	Okay. With these eyes of the truth, we will find the crystal of the spirit.{nl}It is little complicated, but please think that is it is that important.{nl}
-QUEST_LV_0200_20150714_007496	Shadowgaoler in the Room of Lamentation has the Crystal of the Spirit, but you can't attack it with an usual method.{nl}It has an astral body so it is invisible.{nl}However, with the eyes of the truth, you would be able to see it.
+QUEST_LV_0200_20150714_007496	Shadowgaler in the Room of Lamentation has the Crystal of the Spirit, but you can't attack it with an usual method.{nl}It has an astral body so it is invisible.{nl}However, with the eyes of the truth, you would be able to see it.
 QUEST_LV_0200_20150714_007497	I didn't know why the master left such words since he doesn't know which person I would ask to get rid of the remains of the research.{nl}But, now I understand why he left such words since I've met you.
 QUEST_LV_0200_20150714_007498	The remains of the research can be found using the documents which Raius desperately wanted to have.{nl}
 QUEST_LV_0200_20150714_007499	Please look for the demonic stone fusion device with the guide stone of the wisdom and the crystal of the spirit.{nl}I will write downt the method for you.
@@ -7501,10 +7501,10 @@ QUEST_LV_0200_20150714_007504	Very good. You've found the remains of the master'
 QUEST_LV_0200_20150714_007505	I feel disappointed a bit, but I also feel comfortable in a way.{nl}Well... Raius... I hope he would be alright.
 QUEST_LV_0200_20150714_007506	Demonic Stone Fusion Device
 QUEST_LV_0200_20150714_007507	Please gather all spatial demonic stones.{nl}It is hard to understand the hidden rules of the spaces, but my knowledge would help you.
-QUEST_LV_0200_20150714_007508	My master, who was a Sorcerer, researched on the goddesses.{nl}It was about some special space. He said many knowledge can be obtained from the space.
+QUEST_LV_0200_20150714_007508	My master, who was a Sorcerer, researched on the Goddesses.{nl}It was about some special space. He said many knowledge can be obtained from the space.
 QUEST_LV_0200_20150714_007509	A part of the note of Hones
 QUEST_LV_0200_20150714_007510	The spatial demonic stone of the contract is in the reception room, but it was destroyed recently.{nl}The monsters must have the fragments of the stone.
-QUEST_LV_0200_20150714_007511	When you collect all fragments of the demonic stone, please go to the grave of the forgotten priest. {nl}You could restore the demonic stone at the preserved magic field.
+QUEST_LV_0200_20150714_007511	When you collect all fragments of the demonic stone, please go to the grave of the forgotten priest. {nl}You could restore the demonic stone at the preserved magic circle.
 QUEST_LV_0200_20150714_007512	A part of the note of Hones
 QUEST_LV_0200_20150714_007513	You will find the spatial demonic stone of the promise at Siaura Mine.{nl}Please use the crystal of the spirit to the monsters and collect the condensed resentment.{nl}
 QUEST_LV_0200_20150714_007514	With that, destroy the barrier stone at Siaura Mine.{nl}The black chaser would follow from the back, but you would be able to find the spatial demonic stone of the promise when you go to the end of the mine.
@@ -7512,7 +7512,7 @@ QUEST_LV_0200_20150714_007515	The temple shooter witch at the shrine of the memo
 QUEST_LV_0200_20150714_007516	Please... save me.{nl}I will be gone, but please save the others.{nl}Please save us... them... from the vicious demons.
 QUEST_LV_0200_20150714_007517	Cupol Vita
 QUEST_LV_0200_20150714_007518	You've saw it.{nl}Is there something here.{nl}
-QUEST_LV_0200_20150714_007519	Ah, I am called Cupol Vita.{nl}I am guiding the spirits on behalf of the disappeared goddess.
+QUEST_LV_0200_20150714_007519	Ah, I am called Cupol Vita.{nl}I am guiding the spirits on behalf of the disappeared Goddess.
 QUEST_LV_0200_20150714_007520	I've come here to look for the spirits that are disappeared.{nl}I've felt there are spirits that are out of their normal journey.{nl}
 QUEST_LV_0200_20150714_007521	But, I can hardly find any evidence.{nl}The spirits hardly talk to me.
 QUEST_LV_0200_20150714_007522	What? The spirit talked to you first?{nl}You must have something which enables you to save them.{nl}
@@ -7531,19 +7531,19 @@ QUEST_LV_0200_20150714_007534	Please gather the skeletons that are tied to the c
 QUEST_LV_0200_20150714_007535	Nutrients... The day of divine day even makes the people in the past to suffer.
 QUEST_LV_0200_20150714_007536	{memo X}My body. Unfortunatly, it is not mine anymore.{nl}I regret my fault in the past that I've committed due to my greed.
 QUEST_LV_0200_20150714_007537	The contract of the body is tied in Sataruti Hall.{nl}Please burn the contract and the skeletons with the sacred power.
-QUEST_LV_0200_20150714_007538	We've suffred a lot from regrets and failures for hundreds of years.{nl}The goddesses yet... Would we be saved.
+QUEST_LV_0200_20150714_007538	We've suffred a lot from regrets and failures for hundreds of years.{nl}The Goddesses yet... Would we be saved.
 QUEST_LV_0200_20150714_007539	I can feel it. I feel I am free from the contract that tied me.{nl}But, there is one more thing to do.
 QUEST_LV_0200_20150714_007540	The contract of the spirit is engraved on Master Gini in Garubingal Burial Chamber.{nl}I will be completely free when Master Gini gets defeated.
 QUEST_LV_0200_20150714_007541	{memo X}Please be safe.{nl}We are already dead, but you are not.
 QUEST_LV_0200_20150714_007542	Can I finally be free...{nl}This was the moment I've been waiting for hundreds of years... It feels like a dream.
-QUEST_LV_0200_20150714_007543	We, Cupols guide all the spirits to Ausrine Goddess.{nl}They rest in peace beside the goddesses eternally.{nl}
+QUEST_LV_0200_20150714_007543	We, Cupols guide all the spirits to Ausrine Goddess.{nl}They rest in peace beside the Goddesses eternally.{nl}
 QUEST_LV_0200_20150714_007544	But, they will all disappear if they become extinct.{nl}But, if the demons are involved... we could maybe use them for nutrients.{nl}
 QUEST_LV_0200_20150714_007545	Something is engraved with intaglios.{nl}To see what's written, you should obtain the materials to make rubber copies.
-QUEST_LV_0200_20150714_007546	Adriyus
+QUEST_LV_0200_20150714_007546	Adrius
 QUEST_LV_0200_20150714_007547	Oh, you must have saw my notice board.{nl}Well, I don't care if that's not how you came here. If you could get me the rubber copy of this region, I was told to give you adequate rewards.{nl}
 QUEST_LV_0200_20150714_007548	Let's see...
 QUEST_LV_0200_20150714_007549	You will be lost since the string of the destiny is disconnected
-QUEST_LV_0200_20150714_007550	?{nl}Is this Laima goddess...
+QUEST_LV_0200_20150714_007550	?{nl}Is this Laima Goddess...
 QUEST_LV_0200_20150714_007551	You will be lost since the string of the destiny is disconnected
 QUEST_LV_0200_20150714_007552	Oh, is that a rubber copy? Thank you so much. {nl}Let's see...
 QUEST_LV_0200_20150714_007553	The castle walls of the kingdom will last longer than the kingdom
@@ -7589,14 +7589,14 @@ QUEST_LV_0200_20150714_007592	The power may lead you to the answer that you are 
 QUEST_LV_0200_20150714_007593	I moved out without saying anything.{nl}But, I realized after I found myself sobbing sadly.{nl}{nl}
 QUEST_LV_0200_20150714_007594	When the sun goes down tomorrow, I will go meet Guiltine and tell her my determination.
 QUEST_LV_0200_20150714_007595	Archeologist Yustas
-QUEST_LV_0200_20150714_007596	I am so lucky. The goddesses helped me this time as well.
+QUEST_LV_0200_20150714_007596	I am so lucky. The Goddesses helped me this time as well.
 QUEST_LV_0200_20150714_007597	Ah, I am Yustas. I am excavating the records of Demetrius who is the historian from the ancient period.{nl}What has brought you here?
 QUEST_LV_0200_20150714_007598	Is that so... Revelator... Then you would like my research.{nl}Actually, I needed someone who would be my guard and assistant. Are you interested?
 QUEST_LV_0200_20150714_007599	This place are the ruins before the construction of the kingdom.{nl}But, I am not that interested in here.{nl}
 QUEST_LV_0200_20150714_007600	What I really want are the records of Demetrius.{nl}It is unique that it is recorded on a gold plate...It seems to contain an amazing story.{nl}
 QUEST_LV_0200_20150714_007601	Maybe we would be able to find out where we came from.{nl}Then we may be able to find out what would happen to us as well.
 QUEST_LV_0200_20150714_007602	Good. Good. I will give you the task of obtaining the bone pieces of Hallowventer curse speller.{nl}They are the best materials to use when you make an antirust agent.
-QUEST_LV_0200_20150714_007603	It is so fortunate to have a good assistant.{nl}The goddesses helped me on this as well.
+QUEST_LV_0200_20150714_007603	It is so fortunate to have a good assistant.{nl}The Goddesses helped me on this as well.
 QUEST_LV_0200_20150714_007604	There's a saying that geniuses are freaks. How should the people of the later generations do if the gold plate gets rusted.{nl}Anyways, the work is being done quickly because of you so I feel happy.
 QUEST_LV_0200_20150714_007605	I want to request to you to bring the gold plate on Ramive Hills.{nl}There are many plates that I could not bring due to the monsters. You can do it right?
 QUEST_LV_0200_20150714_007606	This place is too isolated so the monsters rush in.{nl}Be careful all the time.
@@ -7604,7 +7604,7 @@ QUEST_LV_0200_20150714_007607	Good!{nl}But, the status is too bad so it would ta
 QUEST_LV_0200_20150714_007608	What a view here right?{nl}But, more amazing things are hidden. The records of the historian, Demetrius.{nl}
 QUEST_LV_0200_20150714_007609	I am looking for the records of Demetrius that haven't been discovered yet.{nl}The monsters are dangerous, but I have a good feeling.
 QUEST_LV_0200_20150714_007610	Alruida is near Apsba Hall.{nl}We've been working together for a long time so even if we are far apart, we know each other well.
-QUEST_LV_0200_20150714_007611	Isn't it great to hear that humans, goddesses and demons may lived together for a long time?{nl}But, then how come there are no records remaining?
+QUEST_LV_0200_20150714_007611	Isn't it great to hear that humans, Goddesses and demons may lived together for a long time?{nl}But, then how come there are no records remaining?
 QUEST_LV_0200_20150714_007612	That is so shocking.{nl}A great scholar like Demetrius could had not recorded lies.
 QUEST_LV_0200_20150714_007613	Since we haven't found everything, we can't say this for sure, but...{nl}I think it's about where humans came from.
 QUEST_LV_0200_20150714_007614	Archeologist Alruida
@@ -7614,11 +7614,11 @@ QUEST_LV_0200_20150714_007617	If his records are real, it will make many people 
 QUEST_LV_0200_20150714_007618	I am chasing after the gold plate that is engraved with the records of Demetrius.{nl}I am keep getting interrupted by the monsters, but we have some results though.
 QUEST_LV_0200_20150714_007619	Ahah...
 QUEST_LV_0200_20150714_007620	I am looking for the disappeared spirits.{nl}The spirits that are out of their normal journey.{nl}
-QUEST_LV_0200_20150714_007621	After the day of divine tree, scary things are happening.{nl}The reason why the spirits lose their ways are related to it.
+QUEST_LV_0200_20150714_007621	After the Medis Diena, scary things are happening.{nl}The reason why the spirits lose their ways are related to it.
 QUEST_LV_0200_20150714_007622	The spirits don't say anything to me.{nl}Have you heard any stories of them?
 QUEST_LV_0200_20150714_007623	The only thing I could do was to depress for hundreds of years.{nl}I want to just disappear if I can.
 QUEST_LV_0200_20150714_007624	What can I do after losing the master and the body.{nl}Besides just watching the demons...
-QUEST_LV_0200_20150714_007625	I can't neither go beside the goddesses nor be eliminated.{nl}For what... I am doing... such...
+QUEST_LV_0200_20150714_007625	I can't neither go beside the Goddesses nor be eliminated.{nl}For what... I am doing... such...
 QUEST_LV_0200_20150714_007626	Collapsing Stone Tower
 QUEST_LV_0200_20150714_007627	The Stone Tower is collapsing by someone. Do you want to go to the Stone Tower?
 QUEST_LV_0200_20150714_007628	When I am still Eitbaras, I leave this record.{nl}-{nl}Everyone was in awe of them.{nl}A humble fairy like me couldn't be compared with them...{nl}{nl}
@@ -7634,7 +7634,7 @@ QUEST_LV_0200_20150714_007637	So, I will give you a bait box.{nl}They go crazy o
 QUEST_LV_0200_20150714_007638	When you find the sticky resin, please mix it with this coagulant before using it.{nl}Stones will be easily attached.
 QUEST_LV_0200_20150714_007639	{memo X}
 QUEST_LV_0200_20150714_007640	Ah. It definitely reacted this time.{nl}I would have spent a long time without your help. Thank you so much.
-QUEST_LV_0200_20150714_007641	Thanks for helping us.{nl}The goddess help the ones who try their best, and I think it was you, the Revelator.
+QUEST_LV_0200_20150714_007641	Thanks for helping us.{nl}The Goddess help the ones who try their best, and I think it was you, the Revelator.
 QUEST_LV_0200_20150714_007642	Lots of demons are gathering at Rituala to paricipate the ritual to free Bluts.{nl}Please first defeat them.
 QUEST_LV_0200_20150714_007643	Valtruss is defeated but its servants are still left in Orualma Grand Hall. {nl}I want you to let those demons pay for their sins.
 QUEST_LV_0200_20150714_007644	Even if you are the Revelator, you better not fool around. {nl}The pollution is not something for you to mind.
@@ -7660,7 +7660,7 @@ QUEST_LV_0200_20150714_007663	Are the peaceful days going to return like the old
 QUEST_LV_0200_20150714_007664	I want to bury Dalus under the Ramivi Cliffs where he can see his hometown.{nl}But there are so many monsters there. Please get rid of them.
 QUEST_LV_0200_20150714_007665	Aren't you the Revelator?{nl}
 QUEST_LV_0200_20150714_007666	Ah, so fortunate. Then, you must have traveled various places in the kingdom.{nl}I am sorry, but do you know anything about the mysterious girl?{nl}
-QUEST_LV_0200_20150714_007667	The girl left these trees before the day of divine tree.{nl}My master asked me to find about the trees, but I knew nothing about them... I want to get help from you.
+QUEST_LV_0200_20150714_007667	The girl left these trees before the Medis Diena.{nl}My master asked me to find about the trees, but I knew nothing about them... I want to get help from you.
 QUEST_LV_0200_20150714_007668	This farm's owner is Gina Green.{nl}They kindly lend this farm to us who lost the land since the day of Divine Tree.
 QUEST_LV_0200_20150714_007669	Hey you. Revelator. Don't just look at me. Help me.{nl}Please kick out Lizard men on my fields.
 QUEST_LV_0200_20150714_007670	You must know that there isn't enough food in the kingdom.{nl}If you are okay, can you help me with my investigation?
@@ -7680,7 +7680,7 @@ QUEST_LV_0200_20150714_007683	I am so sorry. {nl}Please first persuade Potos at 
 QUEST_LV_0200_20150714_007684	But, the monks shake their heads in denial when we mention Evoniphon...
 QUEST_LV_0200_20150714_007685	Do you know the Tower of the Stars?{nl}Starting with Lydia Schaffen, the greatest archers are all from that place.{nl}
 QUEST_LV_0200_20150714_007686	The head of the tower was murdered by Evoniphon.{nl}I've chased him upto here, but I can't do anything further due to those god damn religious rules.{nl}
-QUEST_LV_0200_20150714_007687	They protect the ones who are falsely charged.{nl}I thought that law was ineffective after the day of divine tree... I want to resolve it by avoiding a conflict with them.
+QUEST_LV_0200_20150714_007687	They protect the ones who are falsely charged.{nl}I thought that law was ineffective after the Medis Diena... I want to resolve it by avoiding a conflict with them.
 QUEST_LV_0200_20150714_007688	Hello. Traveller.{nl}What has brought you here?
 QUEST_LV_0200_20150714_007689	If you are going to ask about Hunters, I am sorry, but I can't tell you anything.{nl}
 QUEST_LV_0200_20150714_007690	The monastery is full of monsters and we should first cure the monks who've been hit by the paralysis needles.{nl}Now is not the time to get involved in a complicated matter.
@@ -7722,7 +7722,7 @@ QUEST_LV_0200_20150714_007725	Thank you so much.{nl}I will now pray for our brot
 QUEST_LV_0200_20150714_007726	Since I ran away from the monastery quickly, there aren't many things I've brought.{nl}We should somehow feed some nutrient food to our brothers who are suffering from the poison...
 QUEST_LV_0200_20150714_007727	Thank you so much.{nl}There's a mushroom called Tempas. It grows really fast.{nl}Please obtain some of them from Yuklas Sunny Place.
 QUEST_LV_0200_20150714_007728	You will find it when you walk diligently.{nl}They are usually hidden in the ground.
-QUEST_LV_0200_20150714_007729	Thanks.{nl}I will pray to the goddesses that they will be okay after eating this.
+QUEST_LV_0200_20150714_007729	Thanks.{nl}I will pray to the Goddesses that they will be okay after eating this.
 QUEST_LV_0200_20150714_007730	Since I am not that well now, I want to prepare in advance.{nl}If you are going to hunt for monsters near here, could you please listen to one of my requests?
 QUEST_LV_0200_20150714_007731	If you get Roctors, please collect their stone legs.{nl}I will use them for tips of arrows.
 QUEST_LV_0200_20150714_007732	The stone legs of Roctors near this are usable.{nl}Other things are somewhat soft.
@@ -7759,7 +7759,7 @@ QUEST_LV_0200_20150714_007762	I am going to absorb poison with this.{nl}I am goi
 QUEST_LV_0200_20150714_007763	You won't understand how embarassed and painful I am.{nl}My brother almost died due to the poisonn and I received help from the hunters that I kicked out...{nl}
 QUEST_LV_0200_20150714_007764	Good. You would have to persuade Guus at Laukyme Swampy Place.{nl}Please tell Marco that I've decided to go with Hunters.
 QUEST_LV_0200_20150714_007765	It's is so fortunate that it turned out alright.{nl}Please meet Mintz commander on your way to Laukyme Swampy Place and tell him that everything went alright.
-QUEST_LV_0200_20150714_007766	Senior monk, Guus is leading the brothers at Laukyme Swampy Place.{nl}If Evoniphon did all of these, the goddesses would also understand my rage.
+QUEST_LV_0200_20150714_007766	Senior monk, Guus is leading the brothers at Laukyme Swampy Place.{nl}If Evoniphon did all of these, the Goddesses would also understand my rage.
 QUEST_LV_0200_20150714_007767	It's so nice seeing you.{nl}So how did the task at Viltis Forest go?
 QUEST_LV_0200_20150714_007768	Go first.{nl}I will follow you to Laukyme Swampy Place if he gets alright.
 QUEST_LV_0200_20150714_007769	So that's it. We now have to persuade one of the monks and retrieve the monastery...{nl}After that, we would be able to contact with the father superior who would decide what to do with Evoniphon.
@@ -7773,12 +7773,12 @@ QUEST_LV_0200_20150714_007776	It's so fortunate that you came before the monster
 QUEST_LV_0200_20150714_007777	Good. Good. {nl}We should first survive before feeling embarassment. Thanks!
 QUEST_LV_0200_20150714_007778	We have lots of things to prepare.
 QUEST_LV_0200_20150714_007779	You are not... one of those hunters.{nl}Since I can't trust them, I have a request for you.{nl}
-QUEST_LV_0200_20150714_007780	I want to make an ointment for the wounded brothers.{nl}Can you make beehives with the blessing from the goddesses?
-QUEST_LV_0200_20150714_007781	It took so little time for monsters to sweep across the monastery.{nl}I think I was lucky enough to be alive with the blessing from the goddesses.
+QUEST_LV_0200_20150714_007780	I want to make an ointment for the wounded brothers.{nl}Can you make beehives with the blessing from the Goddesses?
+QUEST_LV_0200_20150714_007781	It took so little time for monsters to sweep across the monastery.{nl}I think I was lucky enough to be alive with the blessing from the Goddesses.
 QUEST_LV_0200_20150714_007782	You've tried hard, but... we should make a beeswas, but strangely, it doesn't beocme clear at all.{nl}What should we do about this...
 QUEST_LV_0200_20150714_007783	That's it. I am sorry, but can you help me with one more thing?{nl}If I only have the resin that is collected in the head of Wurudwa, I think I will be able to resolve it.
-QUEST_LV_0200_20150714_007784	I didn't expect I would meet someone other than those hunters.{nl}I am sure the goddesses haven't abondoned me yet.
-QUEST_LV_0200_20150714_007785	I wasn't able to do anything myself, but it is so fortunate that the goddesses have sent you.{nl}I will make a medicine. Thank you so much!
+QUEST_LV_0200_20150714_007784	I didn't expect I would meet someone other than those hunters.{nl}I am sure the Goddesses haven't abondoned me yet.
+QUEST_LV_0200_20150714_007785	I wasn't able to do anything myself, but it is so fortunate that the Goddesses have sent you.{nl}I will make a medicine. Thank you so much!
 QUEST_LV_0200_20150714_007786	Stranger...{nl}If you don't have any task here, please go back.
 QUEST_LV_0200_20150714_007787	The monastery is locked with the barriers of the monks so it won't be possible without the persuasion from Guus.{nl}But, I... it's too difficult.
 QUEST_LV_0200_20150714_007788	Hunters... they just won't give up.{nl}I've heard Marco and Potos are with the hunters.{nl}
@@ -7797,7 +7797,7 @@ QUEST_LV_0200_20150714_007800	What Guus said also makes sense.{nl}As they gather
 QUEST_LV_0200_20150714_007801	I think we would have enough time.{nl}I am sorry, but please go back to Guus and ask him what happened when Evoniphon was coming.
 QUEST_LV_0200_20150714_007802	You can't prove that he was a cruel assasin.{nl}We can't unlock the ones that are being protected in the castle by just guessing.{nl}
 QUEST_LV_0200_20150714_007803	What they said about the traps and the monsters that conquered the monastery are also the same.{nl}It's only an one-sided story that this was done by Evoniphon.{nl}
-QUEST_LV_0200_20150714_007804	We are the people who pray for the generosity of the goddesses.{nl}So to withdraw the protection of Evoniphon, you should show them some decisive evidences.
+QUEST_LV_0200_20150714_007804	We are the people who pray for the generosity of the Goddesses.{nl}So to withdraw the protection of Evoniphon, you should show them some decisive evidences.
 QUEST_LV_0200_20150714_007805	Hmm. I remember that clearly.{nl}One day, a guy called Evoniphon knocked on the door of the monastery. With his wounded body...{nl}
 QUEST_LV_0200_20150714_007806	After having him in the room, I started to cure him.{nl}He also requested to protect the sanctuary at then.
 QUEST_LV_0200_20150714_007807	That's right. Before he came on that day, one man who seemed to be addicted by the poison also came.{nl}He was in a severe status, so he passed away before I could even ask him a question.{nl}
@@ -7820,7 +7820,7 @@ QUEST_LV_0200_20150714_007823	Now, it is different. This letter is the evidence.
 QUEST_LV_0200_20150714_007824	This place is dangerous... I miss the monastery.
 QUEST_LV_0200_20150714_007825	I want to be safe until I go back to the monastery.{nl}But the monsters near here are very threatening.
 QUEST_LV_0200_20150714_007826	There are full of monsters if we move out a bit from the hills.{nl}I'll be counting on you.
-QUEST_LV_0200_20150714_007827	Now, I can relax until I go back to the monastery.{nl}Thank you so much. I hope the goddesses bless you...{nl}
+QUEST_LV_0200_20150714_007827	Now, I can relax until I go back to the monastery.{nl}Thank you so much. I hope the Goddesses bless you...{nl}
 QUEST_LV_0200_20150714_007828	We don't have enough water to drink here. It is strange since this place is full of water.{nl}After this place turned into a thorny forest, we can't drink it without purifying it.{nl}
 QUEST_LV_0200_20150714_007829	If we have Asilado water plant, we can purify it with that.{nl}But, I am too scared of the monsters... Can you obtain some of them?
 QUEST_LV_0200_20150714_007830	We would last for a while even if there's no food, but not without drinkable water.{nl}I hope you would help us.
@@ -7832,7 +7832,7 @@ QUEST_LV_0200_20150714_007835	There are more dangerous monsters inside the monas
 QUEST_LV_0200_20150714_007836	Thank you.{nl}But, I am worried since there are still many monsters left.
 QUEST_LV_0200_20150714_007837	Are you trying to help me more?{nl}If that's so, it will be really appreciated...
 QUEST_LV_0200_20150714_007838	We've cleaned up many monsters. {nl}One more thing... I want you to do the last task.
-QUEST_LV_0200_20150714_007839	Thanks for your efforts.{nl}When the monks ask me, I will tell them to pray to the goddesses to protect you.
+QUEST_LV_0200_20150714_007839	Thanks for your efforts.{nl}When the monks ask me, I will tell them to pray to the Goddesses to protect you.
 QUEST_LV_0200_20150714_007840	{memo X}
 QUEST_LV_0200_20150714_007841	We've recovered the hall. Let's continue on without taking a rest.{nl}Mintz... please take the back since the monsters may follow.
 QUEST_LV_0200_20150714_007842	It doesn't look easy from here.{nl}There are many monsters in the hallway so let's be careful.
@@ -7848,7 +7848,7 @@ QUEST_LV_0200_20150714_007851	It was really important object so I put it in the 
 QUEST_LV_0200_20150714_007852	I have to protect here so I can't go with you.{nl}There aren't many boxes so you will find it easily.
 QUEST_LV_0200_20150714_007853	Yes. That's the crystal sphere.{nl}Please bring it to Guus.
 QUEST_LV_0200_20150714_007854	Father Superior
-QUEST_LV_0200_20150714_007855	Thanks for resolving the crisis.{nl}I can feel the goddesses are protecting you.
+QUEST_LV_0200_20150714_007855	Thanks for resolving the crisis.{nl}I can feel the Goddesses are protecting you.
 QUEST_LV_0200_20150714_007856	So you've come. Soon, the father superior would come out.{nl}Please wait a bit here.
 QUEST_LV_0200_20150714_007857	Why is the monastery like this and why are you all gathered here?{nl}And you... you seem to have some business with me.
 QUEST_LV_0200_20150714_007858	He is the father superior of Tyla Monastery.
@@ -7860,11 +7860,11 @@ QUEST_LV_0200_20150714_007863	So it seems that their discussion is over.{nl}Let'
 QUEST_LV_0200_20150714_007864	We haven't finished our discussion.{nl}Please wait with the hunters.
 QUEST_LV_0200_20150714_007865	After we've discussed with the senior monks...{nl}We've decided to withdraw our declaration to protect Evoniphon.
 QUEST_LV_0200_20150714_007866	From this point on, Evoniphon won't be protected by Tyla Monastery and we request Evoniphon to leave at once.{nl}Also, we are not going to be involved with others' decision to punish him.
-QUEST_LV_0200_20150714_007867	I hope the goddessess will be with you on your rest of journey.
+QUEST_LV_0200_20150714_007867	I hope the Goddessess will be with you on your rest of journey.
 QUEST_LV_0200_20150714_007868	Besides from the expulsion, we can't forgive his actions that ruined the monastery.{nl}We should find him since he should be here somewhere.
 QUEST_LV_0200_20150714_007869	He made the monastery like this due to that letter. {nl}Please be careful.
 QUEST_LV_0200_20150714_007870	He is so cunning..{nl}The hunters are surrounding this place so he will get caught within a short period of time.
-QUEST_LV_0200_20150714_007871	We would have had hard time without your help.{nl}Thank you so much for your efforts. I pray that the goddesses be with you on your journey.
+QUEST_LV_0200_20150714_007871	We would have had hard time without your help.{nl}Thank you so much for your efforts. I pray that the Goddesses be with you on your journey.
 QUEST_LV_0200_20150714_007872	If it wasn't for your help, the circumstances would have not been like this.
 QUEST_LV_0200_20150714_007873	I've read it from the book before. {nl}Some smell has the power to pull the monsters.{nl}
 QUEST_LV_0200_20150714_007874	I should've noticed when Evoniphon brought that lump... I didn't expect that would be enlarged this big...{nl}We are eliminating them as we see them, but I want you to help us as well.{nl}
@@ -7875,7 +7875,7 @@ QUEST_LV_0200_20150714_007878	We were able to retrieve the monastery, but as you
 QUEST_LV_0200_20150714_007879	Orange Kowaks inside the monastery are most problematic.{nl}They are the most violent and vicious monsters amont the monsters that came into the monastery.
 QUEST_LV_0200_20150714_007880	They are still inside.{nl}Please eliminate the monsters including them.
 QUEST_LV_0200_20150714_007881	The number of monsters won't increase from this point on.{nl}But, in order to eliminate them completely, we would need lots of time.
-QUEST_LV_0200_20150714_007882	The goddesses helped us to retrieve the monastery.{nl}Lots of other sacred places are still occupied by many monsters.
+QUEST_LV_0200_20150714_007882	The Goddesses helped us to retrieve the monastery.{nl}Lots of other sacred places are still occupied by many monsters.
 QUEST_LV_0200_20150714_007883	It's a mess. {nl}The monsters are sweeping across the monastery so the books are all scattered.
 QUEST_LV_0200_20150714_007884	When would we able to gather all these books again and divide them into different categoris...{nl}If you pick up scriptures, please bring them to me.
 QUEST_LV_0200_20150714_007885	You don't have to try hard.{nl}I can collect them.
@@ -7897,10 +7897,10 @@ QUEST_LV_0200_20150714_007900	Tell him that you can't help
 QUEST_LV_0200_20150714_007901	Tell him that it's not the time
 QUEST_LV_0200_20150714_007902	Tell him that you can defeat monsters on behalf of him
 QUEST_LV_0200_20150714_007903	Cheer him up
-QUEST_LV_0200_20150714_007904	About Kaliss Knigtage
+QUEST_LV_0200_20150714_007904	About Kaliss Knightage
 QUEST_LV_0200_20150714_007905	About Costas
 QUEST_LV_0200_20150714_007906	{memo X}Tell him that you will collect the keepstakes for him
-QUEST_LV_0200_20150714_007907	About the kingdom soldiers and Kaliss knightage
+QUEST_LV_0200_20150714_007907	About the kingdom soldiers and the Kaliss Knightage
 QUEST_LV_0200_20150714_007908	A chance of recovery(1)
 QUEST_LV_0200_20150714_007909	Tell him that you would help
 QUEST_LV_0200_20150714_007910	About the symbol of Schilt
@@ -7948,7 +7948,7 @@ QUEST_LV_0200_20150714_007951	Looking at the altar
 QUEST_LV_0200_20150714_007952	Activating it
 QUEST_LV_0200_20150714_007953	Purifying the Sealed Tower
 QUEST_LV_0200_20150714_007954	{memo X}
-QUEST_LV_0200_20150714_007955	Endowing the power of the goddesses
+QUEST_LV_0200_20150714_007955	Endowing the power of the Goddesses
 QUEST_LV_0200_20150714_007956	{memo X}
 QUEST_LV_0200_20150714_007957	Searching through the stack of food
 QUEST_LV_0200_20150714_007958	{memo X}
@@ -7981,7 +7981,7 @@ QUEST_LV_0200_20150714_007984	{memo X}
 QUEST_LV_0200_20150714_007985	{memo X}
 QUEST_LV_0200_20150714_007986	{memo X}
 QUEST_LV_0200_20150714_007987	Looking at the machinery device
-QUEST_LV_0200_20150714_007988	The circumstances of the disciple, Raius
+QUEST_LV_0200_20150714_007988	The circumstances of Disciple Raius
 QUEST_LV_0200_20150714_007989	I am going to help the research if you are okay with me
 QUEST_LV_0200_20150714_007990	Comfort him and leave
 QUEST_LV_0200_20150714_007991	{memo X}
@@ -7991,7 +7991,7 @@ QUEST_LV_0200_20150714_007994	Tell him to do it himself from now on
 QUEST_LV_0200_20150714_007995	About the research of the master
 QUEST_LV_0200_20150714_007996	The guide of the wisdom
 QUEST_LV_0200_20150714_007997	Tell hiim that you would obtain the guide stone of the wisdom
-QUEST_LV_0200_20150714_007998	The circumstances of the disciple, Hones
+QUEST_LV_0200_20150714_007998	The circumstances of Disciple Hones
 QUEST_LV_0200_20150714_007999	{memo X}
 QUEST_LV_0200_20150714_008000	Ask him what he meant
 QUEST_LV_0200_20150714_008001	Preparations for dangerous search(1)
@@ -7999,7 +7999,7 @@ QUEST_LV_0200_20150714_008002	Ask him how you could help him
 QUEST_LV_0200_20150714_008003	Ask him to look for another person
 QUEST_LV_0200_20150714_008004	Preparations for dangerous search(2)
 QUEST_LV_0200_20150714_008005	Give up since there's nothing to do
-QUEST_LV_0200_20150714_008006	Mind of the disciple, Raius
+QUEST_LV_0200_20150714_008006	Mind of Disciple Raius
 QUEST_LV_0200_20150714_008007	Tell him what has happened so far
 QUEST_LV_0200_20150714_008008	Don't answer
 QUEST_LV_0200_20150714_008009	{memo X}
@@ -8324,54 +8324,54 @@ QUEST_LV_0200_20150714_008327	Defeat Tetraox, who was hiding in the altar.
 QUEST_LV_0200_20150714_008328	Tetraox was hiding in this altar, rather than the spirits of the pilgrims being restrained here. Defeat Tetraox.
 QUEST_LV_0200_20150714_008329	Defeat Tetraox that is hiding in the altar
 QUEST_LV_0200_20150714_008330	This sanctuary also seems contaminated. Go to the Pardoner Master for advice. You can move to the Pardoner Master easily if you buy the warp scroll from the stand right beside you.
-QUEST_LV_0200_20150714_008331	Talk to the disciple, Raius
+QUEST_LV_0200_20150714_008331	Talk to Disciple Raius
 QUEST_LV_0200_20150714_008332	The disciple, Raius is waiting for someone's help. Talk to Raius.
 QUEST_LV_0200_20150714_008333	Search for the orb that can contain vigor
 QUEST_LV_0200_20150714_008334	The disciple, Raius wants to complete the orb that can contain the vigor to look for the object which the master had left. {nl}First, look for the orb that can contain vigor from the box.
-QUEST_LV_0200_20150714_008335	Hand it over to the disciple, Raius
-QUEST_LV_0200_20150714_008336	You've found an orb that can contain vigor. Take it to the disciple, Raius.
-QUEST_LV_0200_20150714_008337	You've created an orb that can contain vigor. Ask the disciple, Raius how to use it from now on.
+QUEST_LV_0200_20150714_008335	Hand it over to Disciple Raius
+QUEST_LV_0200_20150714_008336	You've found an orb that can contain vigor. Take it to Disciple Raius.
+QUEST_LV_0200_20150714_008337	You've created an orb that can contain vigor. Ask Disciple Raius how to use it from now on.
 QUEST_LV_0200_20150714_008338	Absorb vigor from the monsters
-QUEST_LV_0200_20150714_008339	In order to summon the guide stone of the wisdom, the disciple, Raius told you that he would need the vigor of the dead one. Use the orb that can contain the vigor of the monsters to absorb the vigor.
+QUEST_LV_0200_20150714_008339	In order to summon the guide stone of the wisdom, Disciple Raius told you that he would need the vigor of the dead one. Use the orb that can contain the vigor of the monsters to absorb the vigor.
 QUEST_LV_0200_20150714_008340	The vigor has been accumulated enough. Talk to Raius what to do with the collected vigor.
 QUEST_LV_0200_20150714_008341	Listen from the disciple Raius what to do with the vigor that is collected in the orb.
 QUEST_LV_0200_20150714_008342	Inject the vigor into the crytal of the hardened astral body
 QUEST_LV_0200_20150714_008343	Inject the collected vigor into the crystal of the hardened astral body at Maras Stone Cahmber to summon the guide stone of the wisdom.
-QUEST_LV_0200_20150714_008344	Talk with the disciple, Hones
-QUEST_LV_0200_20150714_008345	You've obtained the guide stone of the wisdom. Go meet the disciple, Hones and talk to him.
+QUEST_LV_0200_20150714_008344	Talk with Disciple Hones
+QUEST_LV_0200_20150714_008345	You've obtained the guide stone of the wisdom. Meet Disciple Hones and talk to him.
 QUEST_LV_0200_20150714_008346	Obtain %s from the crystal of the hardened astral body
-QUEST_LV_0200_20150714_008347	Ask another disciple, Hones to give you a hint which the master left.
+QUEST_LV_0200_20150714_008347	Ask Disciple Hones to give you a hint which the master left.
 QUEST_LV_0200_20150714_008348	Check the records which the master left
 QUEST_LV_0200_20150714_008349	The disciple Hones told you that the disciple Raius is misunderstanding something. To find out the truth, please check various records from the master's hideout.
-QUEST_LV_0200_20150714_008350	It seems that what Hones told you is right as you looked at the records which the master left for you. Return to the disciple, Hones and talk to him again.
+QUEST_LV_0200_20150714_008350	It seems that what Hones told you is right as you looked at the records which the master left for you. Return to Disciple Hones and talk to him again.
 QUEST_LV_0200_20150714_008351	Preparations for dangerous search
-QUEST_LV_0200_20150714_008352	You may listen the truths from the the disciple, Hones. Talk to the disciple, Hones.
+QUEST_LV_0200_20150714_008352	You may listen the truths from Disciple Hones. Talk to Disciple Hones.
 QUEST_LV_0200_20150714_008353	Collect the fragments of the eyes of the truth
 QUEST_LV_0200_20150714_008354	The eyes of the truth that sees the astral body are destroyed due to the attacks of the monsters. Use the guide stone of the wisdom to defeat the monster that has the eyes of the truth and collect the fragments.
-QUEST_LV_0200_20150714_008355	Hand them over to the disciple, Hones
-QUEST_LV_0200_20150714_008356	You've collected all fragments of the eyes of the truth. Go see the disciple, Hones and restore the eyes of the truth.
-QUEST_LV_0200_20150714_008357	You've completed the eyes of the truth. Ask the disciple, Hones what you should see.
+QUEST_LV_0200_20150714_008355	Hand them over to Disciple Hones
+QUEST_LV_0200_20150714_008356	You've collected all fragments of the eyes of the truth. Go see Disciple Hones and restore the eyes of the truth.
+QUEST_LV_0200_20150714_008357	You've completed the eyes of the truth. Ask Disciple Hones what you should see.
 QUEST_LV_0200_20150714_008358	Obtain the crystal of the spirit by defeating ShadowGaoler
 QUEST_LV_0200_20150714_008359	{memo X}
-QUEST_LV_0200_20150714_008360	You've obtained the crystal of the spirit. Return to the disciple, Hones and listen to what he has to say.
+QUEST_LV_0200_20150714_008360	You've obtained the crystal of the spirit. Return to Disciple Hones and listen to what he has to say.
 QUEST_LV_0200_20150714_008361	Tell him about what you heard from Hones and the diary of the master.
 QUEST_LV_0200_20150714_008362	The spatial demonic stone of the contract
 QUEST_LV_0200_20150714_008363	Check the demonic stone fusion device
-QUEST_LV_0200_20150714_008364	According to the memo of the disciple, Hones, you should combine three spatial demonic stones into the demonic stone fusion device.{nl}Check the demonic stone fusion device.
+QUEST_LV_0200_20150714_008364	According to the memo of Disciple Hones, you should combine three spatial demonic stones into the demonic stone fusion device.{nl}Check the demonic stone fusion device.
 QUEST_LV_0200_20150714_008365	Retrieve the fragments of the spatial demonic stone of the contract
 QUEST_LV_0200_20150714_008366	The memo of Hones : The spatial demonic stone of the contract is in the reception room, but I heard it recently broke. Probably, the monsters would have those fragments.
 QUEST_LV_0200_20150714_008367	Retrieve %s from the reception room
-QUEST_LV_0200_20150714_008368	Activate the magic field of the preservation at the shrine of memories
+QUEST_LV_0200_20150714_008368	Activate the magic circle of the preservation at the shrine of memories
 QUEST_LV_0200_20150714_008369	{memo X}
-QUEST_LV_0200_20150714_008370	Protect the magic field of the preservation
+QUEST_LV_0200_20150714_008370	Protect the magic circle of the preservation
 QUEST_LV_0200_20150714_008371	Inject the spatial demonic stone into the demonic stone fusion device
-QUEST_LV_0200_20150714_008372	The Memo of Hones : If you find the spatial demonic stone, go back to the fusion device. When you insert all demonic stones, the way to find the research of the master will be opened.
+QUEST_LV_0200_20150714_008372	Hones's Memo : If you find the spatial demonic stone, go back to the fusion device. When you insert all demonic stones, the way to find the research of the master will be opened.
 QUEST_LV_0200_20150714_008373	Restore %s
 QUEST_LV_0200_20150714_008374	The spatial demonic stone of the contract
 QUEST_LV_0200_20150714_008375	Collect the condensed resentment
-QUEST_LV_0200_20150714_008376	The Memo of Hones : The spatial demonic stone of the contract can be found in the Siaura Mine. First, use the crystal of the psirit to the monsters and collecty the condensed resentment.
+QUEST_LV_0200_20150714_008376	Hones's Memo : The spatial demonic stone of the contract can be found in the Siaura Mine. First, use the crystal of the psirit to the monsters and collecty the condensed resentment.
 QUEST_LV_0200_20150714_008377	Destroy the barrier stone at Siaura Mine
-QUEST_LV_0200_20150714_008378	The Memo of Hones : Destroy the barrier stone at Siaura Mine with the condensed resentment. The black chaser would follow you from behind, but when you go to the end of the mine by avoiding that, you would be able to find the spatial demonic stone of the promise.
+QUEST_LV_0200_20150714_008378	Hones's Memo : Destroy the barrier stone at Siaura Mine with the condensed resentment. The black chaser would follow you from behind, but when you go to the end of the mine by avoiding that, you would be able to find the spatial demonic stone of the promise.
 QUEST_LV_0200_20150714_008379	Destroy the barrier stone
 QUEST_LV_0200_20150714_008380	The protective layer that was protecting the barrier stone has disappeared. Destroy the barrier stone and obtain the sealed spatial demonic stone.
 QUEST_LV_0200_20150714_008381	Retrieve the sealed spatial demonic stone by avoiding the black chaser
@@ -8443,19 +8443,19 @@ QUEST_LV_0200_20150714_008446	As you looked at the tombstone, the monsters rushe
 QUEST_LV_0200_20150714_008447	As you looked at the tombstone, the monsters suddenly rushed in. Defeat them and make rubber copies of the tombstone.
 QUEST_LV_0200_20150714_008448	Defeat the monsters that rushed in
 QUEST_LV_0200_20150714_008449	Since we've defeated all the monsters, make rubber copies now.
-QUEST_LV_0200_20150714_008450	Talk with Adriyus
-QUEST_LV_0200_20150714_008451	It seems that Adriyus has some more words to say. Talk with Adriyus.
-QUEST_LV_0200_20150714_008452	You've accepted his suggestion. Now, ask Adriyus how you can help.
+QUEST_LV_0200_20150714_008450	Talk with Adrius
+QUEST_LV_0200_20150714_008451	It seems that Adrius has some more words to say. Talk with Adrius.
+QUEST_LV_0200_20150714_008452	You've accepted his suggestion. Now, ask Adrius how you can help.
 QUEST_LV_0200_20150714_008453	The way to eat Kepa
-QUEST_LV_0200_20150714_008454	Talk with Adriyus at the central sanctum
-QUEST_LV_0200_20150714_008455	Collect the materials which Adriyus requested to you
+QUEST_LV_0200_20150714_008454	Talk with Adrius at the central sanctum
+QUEST_LV_0200_20150714_008455	Collect the materials which Adrius requested to you
 QUEST_LV_0200_20150714_008456	{memo X}
-QUEST_LV_0200_20150714_008457	Hand them over to Adriyus
-QUEST_LV_0200_20150714_008458	Hand over the acidic body fluid and the diluting solution to Adriyus
+QUEST_LV_0200_20150714_008457	Hand them over to Adrius
+QUEST_LV_0200_20150714_008458	Hand over the acidic body fluid and the diluting solution to Adrius
 QUEST_LV_0200_20150714_008459	Collect %s by throwing red poison bottles to monsters
-QUEST_LV_0200_20150714_008460	You've collected all materials. See what Adriyus does with the acidic body fluid and the diluting solution.
-QUEST_LV_0200_20150714_008461	Ask Adriyus what's written on the tombstone
-QUEST_LV_0200_20150714_008462	It seems that Adriyus successfully made rubber copies. Ask him what was written.
+QUEST_LV_0200_20150714_008460	You've collected all materials. See what Adrius does with the acidic body fluid and the diluting solution.
+QUEST_LV_0200_20150714_008461	Ask Adrius what's written on the tombstone
+QUEST_LV_0200_20150714_008462	It seems that Adrius successfully made rubber copies. Ask him what was written.
 QUEST_LV_0200_20150714_008463	The First Epitaph
 QUEST_LV_0200_20150714_008464	Look through the lump of soil
 QUEST_LV_0200_20150714_008465	There's a lump of soil that looks to be hard enough at the corner of the old garden. Look at the lump of soil.
@@ -8491,7 +8491,7 @@ QUEST_LV_0200_20150714_008494	Read the epitaph
 QUEST_LV_0200_20150714_008495	You've restored the tombstone so you could read it. Read what's written on the tombstone.
 QUEST_LV_0200_20150714_008496	The Third Epitaph
 QUEST_LV_0200_20150714_008497	Look at the tombstone in Nevieda Altar
-QUEST_LV_0200_20150714_008498	Look at the tombstone near Navieda Altar
+QUEST_LV_0200_20150714_008498	Look at the tombstone near Nevieda Altar
 QUEST_LV_0200_20150714_008499	Collect well dried bushes and oil
 QUEST_LV_0200_20150714_008500	You should cut down the bushes that are surrounding the tombstone to read the epitaph. Obtain some bushes nearby and the oil from monsters to burn them.
 QUEST_LV_0200_20150714_008501	Return to the tombstone near Nevieda Altar
@@ -8502,8 +8502,8 @@ QUEST_LV_0200_20150714_008505	You've collected all kindlings and the oil so burn
 QUEST_LV_0200_20150714_008506	Defeat the monsters while burning down the bushes
 QUEST_LV_0200_20150714_008507	The fire lighted well on the bushes, but the monsters rushed in after smelling the oil burning. Defeat the monsters while the bushes burn down.
 QUEST_LV_0200_20150714_008508	Only the tombstone remains after all the bushes burned down. Although it became sooty, you won't have problem reading the epitaph. Read the epitaph.
-QUEST_LV_0200_20150714_008509	Go meet the wings of Baibora at Klaipeda
-QUEST_LV_0200_20150714_008510	The tombstones contains the memoirs of one fairy. Some of the memoirs are hard to understand so look for someone who would understand. The wings of Baibora at Klaipeda should know well.
+QUEST_LV_0200_20150714_008509	Meet the Wing of Vibora in Klaipeda
+QUEST_LV_0200_20150714_008510	The tombstones contains the memoirs of one fairy. Some of the memoirs are hard to understand so look for someone who would understand. The Wing of Vibora at Klaipeda should know well.
 QUEST_LV_0200_20150714_008511	Another Tombstone
 QUEST_LV_0200_20150714_008512	Check the tombtone in Namew temple Ruins.
 QUEST_LV_0200_20150714_008513	Read the writings on the tombstone
@@ -8546,7 +8546,7 @@ QUEST_LV_0200_20150714_008549	The Researcher Monahan was sent to investigate the
 QUEST_LV_0200_20150714_008550	You've collected the lump of hairs of Rambear. Take it to Researcher Monahan.
 QUEST_LV_0200_20150714_008551	Investigate the bushes and defeat orange Tama
 QUEST_LV_0200_20150714_008552	A tenant Charlotte said that many monsters are gathered by the smell of grape seeds withering. Defeat orange Tama that appears from the bushes by investingating the bushes.
-QUEST_LV_0200_20150714_008553	You've defeated many monsters. Return to the tenant, Charlotte.
+QUEST_LV_0200_20150714_008553	You've defeated many monsters. Return to Tenant Charlotte.
 QUEST_LV_0200_20150714_008554	Talk with Hunter Commander, Mintz
 QUEST_LV_0200_20150714_008555	Hunter Commander, Mintz went to the central part of the hills. Talk with him who is at the camp which is at the inner garden of Diliti.
 QUEST_LV_0200_20150714_008556	Hunter Commander, Mintz wants you to cooperate with him for saving you. Listen for more details.
@@ -8565,20 +8565,20 @@ QUEST_LV_0200_20150714_008568	Hunter Reina lent you her companion, Jareth since 
 QUEST_LV_0200_20150714_008569	$You found Evoniphon's trap. Return to Reina with Jareth.
 QUEST_LV_0200_20150714_008570	You've found a trap which can be an evidence. Hand it over to Mintz.
 QUEST_LV_0200_20150714_008571	Show Evoniphon's trap to Potos. If Potos has good eyes, he may able to find an evidence of Evoniphon.
-QUEST_LV_0200_20150714_008572	Talk with Hunter, Natasha
-QUEST_LV_0200_20150714_008573	Mintz said after finish persuading Potos, you should help Natasha. Go meet Natasha in Viltis Forest.
-QUEST_LV_0200_20150714_008574	Talk with the monk Wiley
-QUEST_LV_0200_20150714_008575	The monk, Wiley seems to be in a trouble. Ask her if there's anything you could help.
+QUEST_LV_0200_20150714_008572	Talk with Hunter Natasha
+QUEST_LV_0200_20150714_008573	Mintz said after finish persuading Potos, you should help Natasha. Meet Natasha in Viltis Forest.
+QUEST_LV_0200_20150714_008574	Talk with Monk Wiley
+QUEST_LV_0200_20150714_008575	Monk Wiley seems to be in a trouble. Ask her if there's anything you could help.
 QUEST_LV_0200_20150714_008576	Collect the pages of the scripture
 QUEST_LV_0200_20150714_008577	Wiley asked you to collect the pages of the scripture that she lost by mistake. Collect the scattered pages of the scripture.
-QUEST_LV_0200_20150714_008578	Hand them over to the monk, Wiley
+QUEST_LV_0200_20150714_008578	Hand them over to the Monk Wiley
 QUEST_LV_0200_20150714_008579	You barely collected the pages of the scripture. Hand them over to Wiley.
-QUEST_LV_0200_20150714_008580	The monk, Wiley seems to be in a trouble. Ask her if there's anything you could help.
-QUEST_LV_0200_20150714_008581	The monk, Wiley told you that she can't cure due to the monsters. Defeat the monsters around and relax here.
+QUEST_LV_0200_20150714_008580	Monk Wiley seems to be in a trouble. Ask her if there's anything you could help.
+QUEST_LV_0200_20150714_008581	Monk Wiley told you that she can't cure due to the monsters. Defeat the monsters around and relax here.
 QUEST_LV_0200_20150714_008582	You've reduced the number of monsters a lot. Return to Wiley and let her know.
-QUEST_LV_0200_20150714_008583	The monk, Wiley seems to be in a trouble. Ask her what happened.
+QUEST_LV_0200_20150714_008583	Monk Wiley seems to be in a trouble. Ask her what happened.
 QUEST_LV_0200_20150714_008584	Collect Tempas Mushrooms
-QUEST_LV_0200_20150714_008585	The monk, Wiley said she doesn't have enough food to feed the brothers. Look for Tempas mushrooms near Yuklas sunny place.
+QUEST_LV_0200_20150714_008585	Monk Wiley said she doesn't have enough food to feed the brothers. Look for Tempas mushrooms near Yuklas sunny place.
 QUEST_LV_0200_20150714_008586	You've collected enough Tempas mushrooms. Hand them over to Wiley.
 QUEST_LV_0200_20150714_008587	It seems that Hunter Reina is still uncomfortable. Please help her.
 QUEST_LV_0200_20150714_008588	Collect the stone bridges of Rocters.
@@ -8596,15 +8596,15 @@ QUEST_LV_0200_20150714_008599	Natasha wants you to persuade Marco on bahalf of h
 QUEST_LV_0200_20150714_008600	Marco doesnt trust the hunters. Pass the words you heard from Natasha.
 QUEST_LV_0200_20150714_008601	The senior monk, Marco is trying his best to retrieve the monastery. Let Marco know that the hunters would help to retrieve the monastery.
 QUEST_LV_0200_20150714_008602	Talk to the monks
-QUEST_LV_0200_20150714_008603	Marco wants you to tell the monks who were sent to the lower area that the hunters are participating. Go meet the monks and talk to them.
-QUEST_LV_0200_20150714_008604	Marco is very nervous due to the young monk who has fallen down. Hunter, Natasha may know the way to improve the status of young monk.
+QUEST_LV_0200_20150714_008603	Marco wants you to tell the monks who were sent to the lower area that the hunters are participating. Meet the monks and talk to them.
+QUEST_LV_0200_20150714_008604	Marco is very nervous due to the young monk who has fallen down. Hunter Natasha may know the way to improve the status of young monk.
 QUEST_LV_0200_20150714_008605	The unknown poison
 QUEST_LV_0200_20150714_008606	Hunter Natasha asked your help to find out the ingredients of the poison. Ask her how you could help.
 QUEST_LV_0200_20150714_008607	Collect the poison of Chafperors
 QUEST_LV_0200_20150714_008608	Natasha wants you to bring the samples from three deadly poisons. Please obtain Chafperor's thorny poison, thick poison from the Thorny Trees, and the poison in the pond.
 QUEST_LV_0200_20150714_008609	Collect thick poison from the lower part of thorny trees
 QUEST_LV_0200_20150714_008610	Collect the poison in the pond
-QUEST_LV_0200_20150714_008611	Hand them over to Hunter, Natasha
+QUEST_LV_0200_20150714_008611	Hand them over to Hunter Natasha
 QUEST_LV_0200_20150714_008612	You've collected all samples of poisons requested by Natasha. Hand them over to her immediately.
 QUEST_LV_0200_20150714_008613	Fortunately, it seems that we have the right poison. Talk to hunter, Natasha.
 QUEST_LV_0200_20150714_008614	Collect the leaves of Urudwa
@@ -8614,12 +8614,12 @@ QUEST_LV_0200_20150714_008617	You were able to save the life of young monk. The 
 QUEST_LV_0200_20150714_008618	You've obtained the promise from Marco that you would cooperate. Tell Natasha about it.
 QUEST_LV_0200_20150714_008619	It seems that you would have to persuade the senior monk, Guus at Laukyme Swampy Place. First, report to Mintz, the hunter commander at Glade Hillroad.
 QUEST_LV_0200_20150714_008620	It seems that Minz is very satisfied with the progress. Now, go meet Natasha at Laukyme Swampy Place to persuade Guus.
-QUEST_LV_0200_20150714_008621	Talk with the hunter, Bastil
-QUEST_LV_0200_20150714_008622	It seems that Hunter Bastil is not well. Ask him what happened.
+QUEST_LV_0200_20150714_008621	Talk with Hunter Bastille
+QUEST_LV_0200_20150714_008622	It seems that Hunter Bastille is not well. Ask him what happened.
 QUEST_LV_0200_20150714_008623	Collect the herbs for detoxification
-QUEST_LV_0200_20150714_008624	Bastil requested you to look for detoxifying herbs to cure his paralysis. Collect the detoxifying herbs which Chevas found.
-QUEST_LV_0200_20150714_008625	Hand them over to Hunter, Bastil
-QUEST_LV_0200_20150714_008626	You've collected the herbs that Bastil needed. Return to him and cure his paralysis.
+QUEST_LV_0200_20150714_008624	Bastille requested you to look for detoxifying herbs to cure his paralysis. Collect the detoxifying herbs which Chevas found.
+QUEST_LV_0200_20150714_008625	Hand them over to Hunter Bastille
+QUEST_LV_0200_20150714_008626	You've collected the herbs that Bastille needed. Return to him and cure his paralysis.
 QUEST_LV_0200_20150714_008627	Talk to the monk, Chad
 QUEST_LV_0200_20150714_008628	It seems that Chad needs some help. Ask him what happened.
 QUEST_LV_0200_20150714_008629	Collect the beeswax
@@ -8693,7 +8693,7 @@ QUEST_LV_0200_20150714_008696	The hunters and the monks are gathered in front of
 QUEST_LV_0200_20150714_008697	The preparations to call
 QUEST_LV_0200_20150714_008698	The senior monk, Guus is preparing to call out the father superior in Prayer Room. Ask him if there's anything you could help.
 QUEST_LV_0200_20150714_008699	Talk to the monk, Moheim
-QUEST_LV_0200_20150714_008700	You would need a crystal sphere to open the door of Prayer Room. Go meet the monk, Moheim who hid the crystal sphere.
+QUEST_LV_0200_20150714_008700	You would need a crystal sphere to open the door of Prayer Room. Meet the monk, Moheim who hid the crystal sphere.
 QUEST_LV_0200_20150714_008701	It seems that the monk, Moheim knows the whereabouts of the crystal sphere. Ask him where you could find the location of the crystal sphere.
 QUEST_LV_0200_20150714_008702	Search for the crystal sphere from the wooden box in the reception room
 QUEST_LV_0200_20150714_008703	Moheim hid the crystal sphere in the wooden box in the reception room. Look for the wooden box in the monastery.
@@ -8759,7 +8759,7 @@ QUEST_LV_0200_20150717_008762	$The tower will collapse if we leave it like this.
 QUEST_LV_0200_20150717_008763	We should be careful from here.{nl}This place used to the place where the laboratory room of Antares was present.
 QUEST_LV_0200_20150717_008764	I feel unstable.{nl}Maybe, Antares was released due to the attacks of the demons...
 QUEST_LV_0200_20150717_008765	I will do the work until Gabiya retrieves her power.{nl}Go quickly!{nl}
-QUEST_LV_0200_20150717_008766	We have no choice.{nl}We should give up on the teleport magic field, but instead destroy the monsters that are rushing in.
+QUEST_LV_0200_20150717_008766	We have no choice.{nl}We should give up on the teleport magic circle, but instead destroy the monsters that are rushing in.
 QUEST_LV_0200_20150717_008767	$Well done.{nl}However, this jewel is just an empty shell.{nl}You can complete it by empowering it with various materials.
 QUEST_LV_0200_20150717_008768	$Lastly, we need to collect Flame Sources.{nl}You can obtain them from the monsters that possess the power of fire.
 QUEST_LV_0200_20150717_008769	I can feel strange energy.{nl}It seems that the status of the jewel of prominence is not well.
@@ -8837,7 +8837,7 @@ QUEST_LV_0200_20150717_008840	You've defeated Rubabos as requested by Saliamonas
 QUEST_LV_0200_20150717_008841	Defeat Arma that mocked the Sealed Stone
 QUEST_LV_0200_20150717_008842	The Sealed Stone asked you to defeat the Arma that mocked it. Defeat Arma for the Stone.
 QUEST_LV_0200_20150717_008843	Defeated Arma that mocked the Stone. Report to the Stone.
-QUEST_LV_0200_20150717_008844	Disciple Hones says that Shadow Gaoler has the Soul Crystal which is the key to finding the teacher's legacy. Use the Eye of Truth to find Shadow Gaoler and defeat it.
+QUEST_LV_0200_20150717_008844	Disciple Hones says that Shadowgaler has the Soul Crystal which is the key to finding the teacher's legacy. Use the Eye of Truth to find Shadowgaler and defeat it.
 QUEST_LV_0200_20150717_008845	Hones's Memo : Go to the Shrine of Remembrance if you've collected all the Magic Stone of Contract fragments. You can restore the Magic Stone in the preservation magic tile.
 QUEST_LV_0200_20150717_008846	Jane's spirit and Archon will be freed when you stop the Magic Stone of Interaction. You can weaken the Archon by using the seal that supress the Spell power on the Archon.
 QUEST_LV_0200_20150717_008847	You need to restore the weathered tombstone. Throw the red poison bottle to the monster to get Sticky Acid Fluid and get the diluent from the Item Merchant in Fedimian.
@@ -8968,19 +8968,19 @@ QUEST_LV_0200_20150908_008971	Looking at the sanctum
 QUEST_LV_0200_20150908_008972	The monsters are rushing in near the sanctum!
 QUEST_LV_0200_20150908_008973	Spraying the sacred water
 QUEST_LV_0200_20150908_008974	Purified the sanctum!
-QUEST_LV_0200_20150908_008975	{memo X}The statue of the goddess was fake! Defeat Sparnashorn!
-QUEST_LV_0200_20150908_008976	The statue of the goddess is not showing any reaction.{nl}Go meet the sculptor Tesla at the west forest of Siaulai
-QUEST_LV_0200_20150908_008977	Explaining about the statue of the goddess in the forest of birth
-QUEST_LV_0200_20150908_008978	There is a severe crack on the plate of the statue of the goddess.{nl}First, look for the materials which the sculptor Tesla told you.
-QUEST_LV_0200_20150908_008979	Repairing the statue of the goddess
-QUEST_LV_0200_20150908_008980	Looking at the statue of the goddess
-QUEST_LV_0200_20150908_008981	The repaired statue of the goddess has been exploded and creatd demonic magical field near it! {nl}Since you don't know what's going to come out, destroy the magic field!
+QUEST_LV_0200_20150908_008975	{memo X}The statue of the Goddess was fake! Defeat Sparnashorn!
+QUEST_LV_0200_20150908_008976	The statue of the Goddess is not showing any reaction.{nl}Meet the sculptor Tesla at the west forest of Siaulai
+QUEST_LV_0200_20150908_008977	Explaining about the statue of the Goddess in the forest of birth
+QUEST_LV_0200_20150908_008978	There is a severe crack on the plate of the statue of the Goddess.{nl}First, look for the materials which the sculptor Tesla told you.
+QUEST_LV_0200_20150908_008979	Repairing the statue of the Goddess
+QUEST_LV_0200_20150908_008980	Looking at the statue of the Goddess
+QUEST_LV_0200_20150908_008981	The repaired statue of the Goddess has been exploded and creatd demonic magical field near it! {nl}Since you don't know what's going to come out, destroy the magic circle!
 QUEST_LV_0200_20150908_008982	Pulling out the symbol
 QUEST_LV_0200_20150908_008983	You've found the symbol! Use the symbol to look for the hidden monsters!
 QUEST_LV_0200_20150908_008984	Burning the insignia
 QUEST_LV_0200_20150908_008985	The sanctum has been purified
 QUEST_LV_0200_20150908_008986	Worshipping with clean water
-QUEST_LV_0200_20150908_008987	The statue of the goddess is under attack as you worshipped in front of it!{nl}Eliminate the thorny vines that are restraining the statue of the goddess and protect the statue of the goddess from the monsters that are rushing in from everywhere!
+QUEST_LV_0200_20150908_008987	The statue of the Goddess is under attack as you worshipped in front of it!{nl}Eliminate the thorny vines that are restraining the statue of the Goddess and protect the statue of the Goddess from the monsters that are rushing in from everywhere!
 QUEST_LV_0200_20150908_008988	Putting the flowers in front of the sanctum
 QUEST_LV_0200_20150908_008989	The sanctum is not showing any reaction!
 QUEST_LV_0200_20150908_008990	Burning the place of purification
@@ -9022,11 +9022,11 @@ QUEST_LV_0200_20150908_009025	Using the spatial demonic stone
 QUEST_LV_0200_20150908_009026	Checking the inheritance
 QUEST_LV_0200_20150908_009027	You can feel dangerous energy!{nl}Return to Cupol Vita and tell him about the circumstances
 QUEST_LV_0200_20150908_009028	Observing
-QUEST_LV_0200_20150908_009029	You've found adequate materials to make rubber copies inside the booty pocket
+QUEST_LV_0200_20150908_009029	You have found adequate materials to make rubber copies inside the booty pocket
 QUEST_LV_0200_20150908_009030	Looking at the tombstone
 QUEST_LV_0200_20150908_009031	Monsters are attacking!{nl}We should first defeat the monsters to make a rubber copy!
 QUEST_LV_0200_20150908_009032	Gluing the grass juice
-QUEST_LV_0200_20150908_009033	The rubber copy didn't turn out alright.{nl}Please tell this to Adriyus
+QUEST_LV_0200_20150908_009033	The rubber copy didn't turn out alright.{nl}Please tell this to Adrius
 QUEST_LV_0200_20150908_009034	You've succeeded in creating a rubber copy!
 QUEST_LV_0200_20150908_009035	There is something inside the lump of soil and it is hardened{nl}Please make a hammer using the materials nearby!
 QUEST_LV_0200_20150908_009036	You would need a hammer to destroy the lump of soil!
@@ -9045,10 +9045,10 @@ QUEST_LV_0200_20150908_009048	The bushes were too sturdy so you hurt your hands.
 QUEST_LV_0200_20150908_009049	Don't touch it before you burn it!
 QUEST_LV_0200_20150908_009050	Lighting up the bushes
 QUEST_LV_0200_20150908_009051	Reading the epitaph
-QUEST_LV_0200_20150908_009052	I think you need to gather what was written on the tombstone.{nl}Go to the wings of Baibora at Klaipeda and ask.
+QUEST_LV_0200_20150908_009052	I think you need to gather what was written on the tombstone.{nl}Go to the Wing of Vibora in Klaipeda and ask.
 QUEST_LV_0200_20150908_009053	Go to the right side and pull the levers consecutively
 QUEST_LV_0200_20150908_009054	Pull the lever
-QUEST_LV_0200_20150908_009055	You've obtained the gold plate!
+QUEST_LV_0200_20150908_009055	You have obtained the gold plate!
 QUEST_LV_0200_20150908_009056	Monsters rushed in!{nl}It seems that you should defeat the monsters first and cut down the bushes!
 QUEST_LV_0200_20150908_009057	Use the detecting stick to find the place where the gold plate is buried!
 QUEST_LV_0200_20150908_009058	It seems that you touched on something that you shouldn't touch!{nl}Defeat Akon that was sealed!
@@ -9090,7 +9090,7 @@ QUEST_LV_0200_20150918_009093	If you use this medicine this time, the spirits th
 QUEST_LV_0200_20150918_009094	Have you found the rest to the restrained spirits?{nl}As I expected... the owner of this craft manual is you.{nl}
 QUEST_LV_0200_20150918_009095	$Thank you.{nl}Our colleagues were taken to the nest at the right side of the Ishrai Crossroads.
 QUEST_LV_0200_20150918_009096	$You should walk around as much as you can.{nl} Flame Vapor only appears for a moment.
-QUEST_LV_0200_20150918_009097	I've heard the story that they saw the spirits with resentment.{nl}Maybe, they are the spirits that could not reach Ausrine goddess... It's horrible.
+QUEST_LV_0200_20150918_009097	I've heard the story that they saw the spirits with resentment.{nl}Maybe, they are the spirits that could not reach Ausrine Goddess... It's horrible.
 QUEST_LV_0200_20150918_009098	So you are now one competent Rodelero.{nl}But, how about Collimencia... The one at the manor of Green Family.
 QUEST_LV_0200_20150918_009099	When there are some things lacking, it means there is some room to improve.{nl}Don't worry. I can fill that in.
 QUEST_LV_0200_20150918_009100	You would feel some weight of it.{nl}But, you should realize your deficiencies in order to become better Rodelero.{nl}
@@ -9158,67 +9158,67 @@ QUEST_LV_0200_20151001_009161	The Thaumaturge Master told me to give it to you.{
 QUEST_LV_0200_20151001_009162	I don't really mind the rumours but do people believe that spell can retain your youth? {nl}Well, maybe it can but.. {nl}Ah, I don't want to talk about it anymore.
 QUEST_LV_0200_20151001_009163	For the people who go on the way of the pilgrim with hope, this curse is so much pain for them.{nl}We don't even know the true nature of the curse so I am so mad.
 QUEST_LV_0200_20151001_009164	I was so mad that I am not a Revelator before.{nl}But, after listening that some Revelator saved Mage Tower, my thought changed.{nl}
-QUEST_LV_0200_20151001_009165	When they complete their duties and I complete my duties, I think the goddess may com back.
+QUEST_LV_0200_20151001_009165	I think the Goddess may come back when they complete their duties and I complete mine.
 QUEST_LV_0200_20151001_009166	I didn't expect that the true nature of the curse that is fallen down on this forest is going after the great cathedral.{nl}Fortunately, we were able to block the curse due to one Revelator, but I feel ashamed.
 QUEST_LV_0200_20151001_009167	The curse here is serious, but there are other places where the influences of the curse are more severe. {nl}The city of Ruklys... I heard everything turns into stones due to the curse of the petrification.
-QUEST_LV_0200_20151001_009168	I think it was my fault that I went out of Mage Tower to save the people after the day of divine tree.{nl}Maybe, I could save the tower and not the Revelator.
+QUEST_LV_0200_20151001_009168	I think it was my fault that I went out of Mage Tower to save the people after the Medis Diena.{nl}Maybe, I could save the tower and not the Revelator.
 QUEST_LV_0200_20151001_009169	I heard the story about the revaltor who blocked the Demon Lord who casted the curse in this region.{nl}I guess... there won't be any more people who would suffer from the curse.
 QUEST_LV_0200_20151001_009170	I've been to many places before in my life, but this place is really horrible.{nl}Even if I want to rescue the ones who are cursed, the only thing I can do is to help them fall asleep comfortably.
 QUEST_LV_0200_20151001_009171	I heard a Revelator defeated the Demon Lord who were attacking the Mage Tower.{nl}That's the most happy news I've heard lately.{nl}Other news I've heard were horrible.
 QUEST_LV_0200_20151001_009172	Is it true that some Revelator defeated the Demon Lord who casted the curse in this region?{nl}If that's true, it is so fortunate since we don't have to see these horrible things again.
 QUEST_LV_0200_20151001_009173	Damn. What was I doing?{nl}Ahah. My Lilija...{nl}
 QUEST_LV_0200_20151001_009174	Do not bother the placed food piles.{nl} They should have shuffled over here by now... just keep watching.
-QUEST_LV_0200_20151001_009175	While my brothers were on the their way to the training, they all died due to the tricks from the demons.{nl}I feel sorry for my brothers who can't return to the godddesses.{nl}
-QUEST_LV_0200_20151001_009176	And they were so obsessed with madness even after their death so they could not even return to the goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
-QUEST_LV_0200_20151001_009177	It was really horrible. Those brothers who used to be keen to each other hurt each other..{nl}And the demons cheated on those brothers who were not guided to the goddesses.{nl}
-QUEST_LV_0200_20151001_009178	My brothers are blaming each other and crying out in madness even after their deathes.{nl}At the altar of the goddesses.{nl}
+QUEST_LV_0200_20151001_009175	While my brothers were on the their way to the training, they all died due to the tricks from the demons.{nl}I feel sorry for my brothers who can't return to the Godddesses.{nl}
+QUEST_LV_0200_20151001_009176	And they were so obsessed with madness even after their death so they could not even return to the Goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
+QUEST_LV_0200_20151001_009177	It was really horrible. Those brothers who used to be keen to each other hurt each other..{nl}And the demons cheated on those brothers who were not guided to the Goddesses.{nl}
+QUEST_LV_0200_20151001_009178	My brothers are blaming each other and crying out in madness even after their deathes.{nl}At the altar of the Goddesses.{nl}
 QUEST_LV_0200_20151001_009179	Death may be the price I pay for my sin. {nl}Even if it is the curse of the demons, it is still a sin I've made.
 QUEST_LV_0200_20151001_009180	I don't want to.. die like this.. {nl}Mother..
-QUEST_LV_0200_20151001_009181	I realized after death that my colleagues' betrayals were because of the curse. {nl}This thing is now useless to me.. Thank you.
+QUEST_LV_0200_20151001_009181	I realized after my death that the betrayal of my colleagues were because of the curse. {nl}This thing is now useless to me.. Thank you.
 QUEST_LV_0200_20151001_009182	Our squad is all dead because of my incompetence.{nl}I'm the only one alive but I don't think I have much time left either.
 QUEST_LV_0200_20151001_009183	It looks like you've done more than Roy's part.{nl}If it wasn't for you, we would not have been successful.{nl}
-QUEST_LV_0200_20151001_009184	They're all dead or ran away.{nl}I guess I'm the only one left in this floor. Those cowards.
-QUEST_LV_0200_20151001_009185	My body... Unfortunately, it doesn't belong to me.{nl}I regret my faults that I'd committed in the past due to my greed.
+QUEST_LV_0200_20151001_009184	They're all dead or ran away.{nl}I guess I'm the only one left on this floor. Those cowards.
+QUEST_LV_0200_20151001_009185	My body... Unfortunately, it doesn't belong to me.{nl}I regret my faults that I'd committed in the past because of my greed.
 QUEST_LV_0200_20151001_009186	I hope you are okay.{nl}We are all done, but you are not.
 QUEST_LV_0200_20151001_009187	But...{nl}It won't work with this material alone.{nl}We should also have the tools...
 QUEST_LV_0200_20151001_009188	{nl}When you go to Orsha, there must be people who have the tools.{nl}Maybe the blacksmith or the equipment merchant...?{nl}Can you go there?
 QUEST_LV_0200_20151001_009189	Be careful on your journey
 QUEST_LV_0200_20151001_009190	The construction of the sanctum...
 QUEST_LV_0200_20151001_009191	{nl}Hmm...
-QUEST_LV_0200_20151001_009192	{nl}I would sell it by receiving the money, but I will just give it to you this time.{nl}But, since this is disposable after one use, just throw it away after using it.
+QUEST_LV_0200_20151001_009192	{nl}I would sell it by receiving the money, but I will just give it to you this time.{nl}However, just throw it away after using it since this is disposable after one use.
 QUEST_LV_0200_20151001_009193	I'm relieved we got it back. {nl}I finally get to see the holy relic after death.{nl}
 QUEST_LV_0200_20151001_009194	Please find my friend.{nl}I lived so hard until now, so I can't just die here.
-QUEST_LV_0200_20151001_009195	The spirit of Ruklys Army Officer
-QUEST_LV_0200_20151001_009196	Finally... the worst curse has been unleashed!
+QUEST_LV_0200_20151001_009195	Ruklys Army Officer's Spirit
+QUEST_LV_0200_20151001_009196	Finally... The worst curse has been unleashed!
 QUEST_LV_0200_20151001_009197	Good.{nl}Since the hideout is safe now, you can go out of the fortress of the great earth.
-QUEST_LV_0200_20151001_009198	That mean demon occupied our fortress.{nl}I feel so resentful. That magic field... If we could only have the magic field...{nl}
+QUEST_LV_0200_20151001_009198	That mean demon occupied our fortress.{nl}I feel so resentful. That magic circle... If we could only have the magic circle...{nl}
 QUEST_LV_0200_20151001_009199	Okay... I can feel the same energy that I felt from Ruklys from you.{nl}
 QUEST_LV_0200_20151001_009200	I will open the portal. {nl}I've hid the means to face against the demon across here.{nl}
 QUEST_LV_0200_20151001_009201	Please hurry to the hidden place!
-QUEST_LV_0200_20151001_009202	What is this? Protective magic field? {nl}Only the stories regarding the magic field are here.{nl}
-QUEST_LV_0200_20151001_009203	Damn... I shouldn't have expected it. {nl}There's nothing here. We better go to the other district.{nl}
+QUEST_LV_0200_20151001_009202	What is this? A protective magic circle? {nl}Only the stories regarding the magic circle are here.{nl}
+QUEST_LV_0200_20151001_009203	Oh... I shouldn't have expected it. {nl}There's nothing here. We better go to the other district.{nl}
 QUEST_LV_0200_20151001_009204	I will take a look around so let's meet at the habitants' district.
 QUEST_LV_0200_20151001_009205	Well, shall we take a look around Monocle?{nl}If you can see something special, there must be something important there.
 QUEST_LV_0200_20151001_009206	Can you bring more of these old bombs?{nl}I am not trying to use them negatively. I just want to do some research.
 QUEST_LV_0200_20151001_009207	I will give you the tools to dismantle the bomb.{nl}If you break the detonator with those, you can bring the bombs safely.{nl}
 QUEST_LV_0200_20151001_009208	I don't know how you found this bomb, but I think they've used the metal detector.{nl}When you investigate more with that, maybe we could find some remains.{nl}
 QUEST_LV_0200_20151001_009209	Find the bombs using the metal detector and use the tools I gave to you to break the detonator.{nl}Then you would able to bring them safely. I am counting on you!
-QUEST_LV_0200_20151001_009210	This must be more than a few hundreds years old.{nl}What are they trying to do with this bomb...{nl}Anyways, Thanks! 
+QUEST_LV_0200_20151001_009210	This must be more than a few hundreds years old.{nl}What are they trying to do with this bomb...{nl}Anyway, thanks! 
 QUEST_LV_0200_20151001_009211	By the way, why did you come here?{nl}Since you don't say anything about it, this must be important right?{nl}
-QUEST_LV_0200_20151001_009212	Anyways, let's enter more deep inside.{nl}You should tell me later. Okay?
+QUEST_LV_0200_20151001_009212	Anyway, let's enter more deep inside.{nl}You should tell me later. Okay?
 QUEST_LV_0200_20151001_009213	The demons didn't have special objects.{nl}What... you don't have them?
-QUEST_LV_0200_20151001_009214	Revelator. {nl}After the day of divine tree, Vakarine have become weak so we have to protect her.
+QUEST_LV_0200_20151001_009214	Revelator. {nl}After the Medis Diena, Vakarine have become weak so we have to protect her.
 QUEST_LV_0200_20151001_009215	This is not the world of humans nor the world of demons, but another space of Vakarine...{nl}We've locked the demons inside this prison who are evil to this world.{nl}
-QUEST_LV_0200_20151001_009216	But, after the day of divine tree, Vakarine doesn't have any power left to maintain this space.{nl}As you can see, the space is gradually collapsing and the space of the metastasis has gotten widen.{nl}
+QUEST_LV_0200_20151001_009216	But, after the Medis Diena, Vakarine doesn't have any power left to maintain this space.{nl}As you can see, the space is gradually collapsing and the space of the metastasis has gotten widen.{nl}
 QUEST_LV_0200_20151001_009217	The Demon Lords who are locked in this prison are trying to escape here.{nl}The demons who came here through the metastasis are joining as well.{nl}
 QUEST_LV_0200_20151001_009218	Vakarine desperately needs your help.{nl}Please help defeating the demons at the prison.
 QUEST_LV_0200_20151001_009219	Please first block the demons that are trying to release the Demon Lord, Blut that is locked here.
 QUEST_LV_0200_20151001_009220	The subordinates of Blut are trying to escape here. {nl}Hauberk's help will be useful this time.
-QUEST_LV_0200_20151001_009221	Right now, Blut is holding Kupole Giderone. {nl}But, since the power of Vakarine has weakend after the day of divine tree, we are not like before.{nl}
+QUEST_LV_0200_20151001_009221	Right now, Blut is holding Kupole Giderone. {nl}But, since the power of Vakarine has weakend after the Medis Diena, we are not like before.{nl}
 QUEST_LV_0200_20151001_009222	Fortunately, Blut hasn't been completely freed...{nl}But, we don't know how much longer we would endure ourselves.{nl}
 QUEST_LV_0200_20151001_009223	We have to somehow weaken the power of the Demon Lord, Blut.{nl}I am sure his allies set the camp near Byeaulleo Hideout.{nl}Please get the symbol of Blut that they have.
 QUEST_LV_0200_20151001_009224	Our original duty was to supervise and manage the prison originally.{nl}But... now, we are trying out best to block the demons. {nl}No matter what it takes.
-QUEST_LV_0200_20151001_009225	So you are the one who Vakarine talked about.{nl}Well done. Everything will be done with the wishes of the goddesses.
+QUEST_LV_0200_20151001_009225	So you are the one who Vakarine talked about.{nl}Well done. Everything will be done with the wishes of the Goddesses.
 QUEST_LV_0200_20151001_009226	We've locked Blut across this wall.{nl}
 QUEST_LV_0200_20151001_009227	There' no way that Blut knows the proson more than us even if Vakarine has been weakened.{nl}Blut is not completely freed yet so the only chance we have is now.{nl}
 QUEST_LV_0200_20151001_009228	But, if we don't defeat Blut quickly, this wall would collpase soon.{nl}Let's defeat it at once. Are you ready?{nl}
@@ -9246,11 +9246,11 @@ QUEST_LV_0200_20151001_009249	But... there's something that keeps attracting my 
 QUEST_LV_0200_20151001_009250	But, it seems that Nuaele is waiting for something.{nl}We should find out what they are planning.{nl}{nl}
 QUEST_LV_0200_20151001_009251	Please interrogate the subordinates of Nuaele.{nl}Since Hauberk is also a demon, it will be easy to read it's minds.{nl}Also if that's a spirit, it will be more easy.
 QUEST_LV_0200_20151001_009252	She planned to make this prison her world from the start. {nl}If her plans succeeded, even if Goddess Vakarine powers were restored, it would not have been enough.
-QUEST_LV_0200_20151001_009253	Go meet Aldona. {nl}He would take you to the area of Nuaele.
+QUEST_LV_0200_20151001_009253	Meet Aldona. {nl}He would take you to the area of Nuaele.
 QUEST_LV_0200_20151001_009254	Vakarine is waiting for you at the 3rd district.{nl}But, I feel somewhat uneasy since she is so stubborn.
 QUEST_LV_0200_20151001_009255	In the past, she told us that she can't just do nothing even if her power was weakened.{nl}We barely managed to persuade her.{nl} 
 QUEST_LV_0200_20151001_009256	To prevent something happening to Vakarine, please move to 3rd district as quickly as possible.{nl}
-QUEST_LV_0200_20151001_009257	The space of the metastasis and the Demon Lords... they were expected.{nl}I could feel my power was getting weak after the day of divine tree and I had to find another way.{nl}
+QUEST_LV_0200_20151001_009257	The space of the metastasis and the Demon Lords... they were expected.{nl}I could feel my power was getting weak after the Medis Diena and I had to find another way.{nl}
 QUEST_LV_0200_20151001_009258	I've given Dionis the power that should not be stolen by the Demon Lord.{nl}But, that power was so strong so it started to dominate Dionis...{nl}
 QUEST_LV_0200_20151001_009259	I can't tell you about the power in details at the moment.{nl}But, please just know that the power that is controlling Dionis is the only way to close the space of the metastasis.{nl}
 QUEST_LV_0200_20151001_009260	Please complete the Evening Star Key with Kupole Giderone.{nl}With the Evening Star Key, Dionis would withdraw that power.
@@ -9296,21 +9296,21 @@ QUEST_LV_0200_20151001_009299	Hauberk nowadays would be able to defeat me easily
 QUEST_LV_0200_20151001_009300	But, the way up from here is a dead end.{nl}Tell me if you are ready to catch Hauberk.
 QUEST_LV_0200_20151001_009301	Thank you.{nl}We will collect the sealed Hauberk's power and take it to Vakarine.{nl}
 QUEST_LV_0200_20151001_009302	Vakarine is getting ready to close the space of the metastasis with other Kupoles.{nl}She is waiting for you desperately so please hurry to the 5th district in the prison.
-QUEST_LV_0200_20151001_009303	We don't know whether the Goddess is okay or not, but we need to show them a sample.{nl}Can you collect the Demon's Tooth in Heuradeti Instersection?
+QUEST_LV_0200_20151001_009303	We don't know whether the Goddess is okay or not, but we need to show them a sample.{nl}Can you collect a Demon's Tooth in Hradeti Crossroads?
 QUEST_LV_0200_20151001_009304	Thank you. {nl}Please keep it a secret from Vakarine.
 QUEST_LV_0200_20151001_009305	Savior.{nl}We really appreciate for you for blocking Hauberk.{nl}Because of you, we were able to close the space of the metastasis and retrieve the spirit of Hauberk and the chain of the returning.{nl}
 QUEST_LV_0200_20151001_009306	Please do not feel sympathy towards Hauberk.{nl}It is sad that his destiny is torn apart, but it too is a demon to be eliminated.{nl}
-QUEST_LV_0200_20151001_009307	Good. Now is the last stage... We should close the space of the metastasis.{nl}With your help, we were able to block the catastrophe of the prison.{nl}
+QUEST_LV_0200_20151001_009307	Good. Now this is the last stage... We should close the space of the metastasis.{nl}With your help, we were able to block the catastrophe of the prison.{nl}
 QUEST_LV_0200_20151001_009308	Please be prepared since we will start the ritual to seal the space of the metastasis.
 QUEST_LV_0200_20151001_009309	We will add the power of demons to the sealed spirit of Hauberk.{nl}
-QUEST_LV_0200_20151001_009310	I will give you the Evening Star Rune, but it is the object which used my power...{nl}Which means it is not complete yet.{nl}
-QUEST_LV_0200_20151001_009311	Defeat the demons at Ausura worship hall and collect the traces of the metastasis.{nl}With this, I would be able to complement my lacking power and  complete Evening Star Rune.
+QUEST_LV_0200_20151001_009310	I will give you the Evening Star Rune, but this is an object that used my power...{nl}Which means it is not complete yet.{nl}
+QUEST_LV_0200_20151001_009311	Defeat the demons at Ausura Chapel and collect the traces of the metastasis.{nl}With this, I would be able to complement my lacking power and complete the Evening Star Rune.
 QUEST_LV_0200_20151001_009312	I was able to complete the Evening Star Rune because of you.{nl}Receive it. You should collect the spirits of the demons with Evening Star Rune.{nl}{nl}
-QUEST_LV_0200_20151001_009313	You have to go to the Rankina Isolation District, Ishsula Collapsed District and Etmesta Isolation District.{nl}I will send Kupoles if you could suppress the demons there using the power of Evening Star Rune.
+QUEST_LV_0200_20151001_009313	You have to go to the Lankine Separation District, Ishisula Broken District and Hehmastar Isolation District.{nl}I will send Kupoles if you could suppress the demons there using the power of Evening Star Rune.
 QUEST_LV_0200_20151001_009314	If you do so, they will receive the spirits that are needed to close the space of the metastasis.{nl}{nl}
 QUEST_LV_0200_20151001_009315	It's not allowed for humans to enter. {nl}But, you are allowed by Vakarine.
 QUEST_LV_0200_20151001_009316	Vakarine should recover soon...{nl}She was tired already and she has gotten weaker due to the battle with Nuaele.
-QUEST_LV_0200_20151001_009317	This prison was created by Ausrine Goddess.{nl}Vakarine comes here periodically and manages this place.
+QUEST_LV_0200_20151001_009317	This prison was created by Goddess Ausrine.{nl}Vakarine comes here periodically and manages this place.
 QUEST_LV_0200_20151001_009318	Oh..my poor Dionis..I'm so sorry for giving you this big burden.
 QUEST_LV_0200_20151001_009319	We weren't able to monitor all the demons in the prision.{nl}That's why we engraved the symbol of the seal on them so their power can't be unleashed.
 QUEST_LV_0200_20151001_009320	The spirit of Hauberk has become strong to handle the space of the metastasis because of your efforts.{nl}The chain of the returning is also ready.{nl}
@@ -9319,27 +9319,27 @@ QUEST_LV_0200_20151001_009322	We will try our best to seal the space of the meta
 QUEST_LV_0200_20151001_009323	To tell you again, it is the last chance for the counter attack for the demons.{nl}Until the space of the metastasis completely seals off, please block their attacks.{nl}{nl}
 QUEST_LV_0200_20151001_009324	All the disasters that were landed on this land are all gone now.{nl}Savior. We owe everything to you. {nl}
 QUEST_LV_0200_20151001_009325	Everything was caused from our arrogance.{nl}When Laima warned us that the time of hardship would come...{nl}I trusted myself too much so I could not understand what that means.{nl} 
-QUEST_LV_0200_20151001_009326	But, your sacred energy is telling me everything.{nl}I think your power and not us would save this world.{nl}
+QUEST_LV_0200_20151001_009326	But, your sacred energy is telling me everything.{nl}I think only your power and not us would save this world.{nl}
 QUEST_LV_0200_20151001_009327	I can't be any help at the moment.{nl}But, I will stay here and do my best until the day of the salvation.{nl}
 QUEST_LV_0200_20151001_009328	And one more thing.{nl}The space of the metastasis that is engraved here is being engraved on various places in the world.{nl}The most dangerous place among them is the bee farm...{nl}
 QUEST_LV_0200_20151001_009329	Austeya who is my sister is having a hard battle alone.{nl}Please also help her as you helped me.
 QUEST_LV_0200_20151001_009330	If Dionis gets recovered, Vakarine would feel less pressure.
 QUEST_LV_0200_20151001_009331	Thank you.{nl}If Dionis recovers completely, that's all because of you.
 QUEST_LV_0200_20151001_009332	Can you deal with the space of the metastasis at Gabara isolated sphere?
-QUEST_LV_0200_20151001_009333	Wait a min. {nl}Kaliss Knightage told us that the important thing is located deep inside the fortress.{nl}
+QUEST_LV_0200_20151001_009333	Wait a minute. {nl}The Kaliss Knightage told us that the important thing is located deep inside the fortress.{nl}
 QUEST_LV_0200_20151001_009334	We should go more deep inside to start the work on what I am looking for and what you are looking for.{nl}I will try looking for the outpost area with this monocle. {nl} 
 QUEST_LV_0200_20151001_009335	Hmm... there's nothing special.{nl}Instead, there are many kingdom soldiers.
 QUEST_LV_0200_20151001_009336	There are too many kingdom soldiers to go deep inside.
 QUEST_LV_0200_20151001_009337	We should lure the kingdom soldiers in order to go more deep inside,.{nl}Hmm...{nl}
 QUEST_LV_0200_20151001_009338	That's right. We have roar bombs!
-QUEST_LV_0200_20151001_009339	Roar bombs make really loud sounds although their explosiveness is not that great.{nl}When you detonate them at various places, the soldiers would move to the locations where the sounds come from.{nl}
+QUEST_LV_0200_20151001_009339	Roar bombs make really loud sounds although their explosiveness isn't that great.{nl}When you detonate them at various places, the soldiers would move to the locations where the sounds come from.{nl}
 QUEST_LV_0200_20151001_009340	I don't have roar bombs at the moment, but I can make them if I have necessary materials. {nl}For example, if I have Urechos and bombs. {nl} 
 QUEST_LV_0200_20151001_009341	I will look for the bombs so I want you to look for Urechos.{nl}Be careful not to be detected by the kingdom soldiers.{nl}
 QUEST_LV_0200_20151001_009342	When you collect all Urechos, let's meet at the lower side of the hallway at the upper floor.
 QUEST_LV_0200_20151001_009343	The kingdom soldiers are on patrol so you should be careful all the time.{nl}I am sure they are busy getting hit instead of explaining for the situation.
 QUEST_LV_0200_20151001_009344	You brought them well without getting detected by the kingdom soldiers.{nl}I am sorry. When they get hot, they make loud sounds.
 QUEST_LV_0200_20151001_009345	Okay. Shall we start the work of the grave thieves?{nl}I saw the kingdom guards have the bombs in tons.{nl}You know what we are trying to say right?{nl}
-QUEST_LV_0200_20151001_009346	No. no. We are not that kind of people. {nl}We don't mean to send them to the goddesses...{nl}
+QUEST_LV_0200_20151001_009346	No. no. We are not that kind of people. {nl}We don't mean to send them to the Goddesses...{nl}
 QUEST_LV_0200_20151001_009347	We just faint them and bring the bombs. {nl}You can do it right?
 QUEST_LV_0200_20151001_009348	I will get ready to make roar bombs.{nl}Just faint them and bring the bombs. Okay?
 QUEST_LV_0200_20151001_009349	Even if you get caught by the kingdom soldiers, don't tell them about me.
@@ -9389,32 +9389,32 @@ QUEST_LV_0200_20151001_009392	The disciples are only concentrating on the altars
 QUEST_LV_0200_20151001_009393	You will pay for your intent of obtaining the revelation.{nl}Of course, you should obtain the fourth key of Maven as well.
 QUEST_LV_0200_20151001_009394	We should find out whether that is just a symbol or endowed with some kind of power.{nl}First, I want you to collect the leathers of Lizardmen from the abondoned at the Grape Fields.
 QUEST_LV_0200_20151001_009395	Recently, we saw a similar looking girl at the crystal mine. {nl}But, strangely, she wasn't able to say anything.
-QUEST_LV_0200_20151001_009396	Lizardmen are the monsters that appeared a lot since the day of divine tree.{nl}If some kind of power is in this tree, it will definitely react to the leathers.
+QUEST_LV_0200_20151001_009396	Lizardmen are the monsters that appeared a lot since the Medis Diena.{nl}If some kind of power is in this tree, it will definitely react to the leathers.
 QUEST_LV_0200_20151001_009397	Revelator, this is astonishing!{nl}After I put the power of the tree into the leathers of the monster that you brought, it corroded right away.
 QUEST_LV_0200_20151001_009398	Please help us.{nl}We have to grow things like this, they will all die within a short period of time due to the poison.
 QUEST_LV_0200_20151001_009399	You are not...a messenger.{nl}This place is a military district, but we desperately need help these days.{nl}
 QUEST_LV_0200_20151001_009400	It seems that you are quite competent.{nl}Can you help us a bit?
 QUEST_LV_0200_20151001_009401	Thanks.{nl}There's one thing you need to know about this place.{nl}
 QUEST_LV_0200_20151001_009402	This place is the strategic location which was built when Ruklys caused the chaos.{nl}Eminent who was the prime minister at that time came up with it to block their marching route. {nl}
-QUEST_LV_0200_20151001_009403	They are maintained to block monsters or demons nowadays.{nl}But, since the day of divine tree, we are not receiving any supplies or orders from the kingdom.{nl}
-QUEST_LV_0200_20151001_009404	How could he just abondon his duty as a person who belongs to the kingdom?{nl}Anyways, our duty is to protect the magic field here when some incident occurs here.{nl}
+QUEST_LV_0200_20151001_009403	They are maintained to block monsters or demons nowadays.{nl}But, since the Medis Diena, we are not receiving any supplies or orders from the kingdom.{nl}
+QUEST_LV_0200_20151001_009404	How could he just abondon his duty as a person who belongs to the kingdom?{nl}Anyways, our duty is to protect the magic circle here when some incident occurs here.{nl}
 QUEST_LV_0200_20151001_009405	Actually, we were having hard time since we didn't have any forces to look for the subordinate who went missing after going there to repair it.{nl}His name is Hicks. Please look for him.
 QUEST_LV_0200_20151001_009406	Are you the one sent by the commanding officer?{nl}I'll be alright now!
 QUEST_LV_0200_20151001_009407	I think its near Woodringal empty lot.{nl}I am worried about whether he is wounded in this cold weather.
 QUEST_LV_0200_20151001_009408	While he was going to do his duty, he was attacked by monsters. {nl}It will be hard to carry out the mission in his status or go back alone.{nl}
 QUEST_LV_0200_20151001_009409	Please help me so that I would be able to return safely.
-QUEST_LV_0200_20151001_009410	I am thankful to the goddess that Hicks came back alive. {nl}But who would do his duty...
-QUEST_LV_0200_20151001_009411	I've told you before...{nl}The duty of our squad is to protect the magic field that can completely seals off this place.{nl}
-QUEST_LV_0200_20151001_009412	It was Hicks' duty to maintain the magic field, but he can't do it since he is wounded.{nl}And everyone is getting tired due to the coldness... I want you to help us.
-QUEST_LV_0200_20151001_009413	Among the four shrines of Romiva magic field, please activate one of them.{nl}However, in case monsters touch it and something bad occurs as a result, we will be in a trouble.{nl}
+QUEST_LV_0200_20151001_009410	I am thankful to the Goddess that Hicks came back alive. {nl}But who would do his duty...
+QUEST_LV_0200_20151001_009411	I've told you before...{nl}The duty of our squad is to protect the magic circle that can completely seals off this place.{nl}
+QUEST_LV_0200_20151001_009412	It was Hicks' duty to maintain the magic circle, but he can't do it since he is wounded.{nl}And everyone is getting tired due to the coldness... I want you to help us.
+QUEST_LV_0200_20151001_009413	Among the four shrines of Romuva magic circle, please activate one of them.{nl}However, in case monsters touch it and something bad occurs as a result, we will be in a trouble.{nl}
 QUEST_LV_0200_20151001_009414	So it changes all the time which one should be activated, but it won't be that hard.{nl}What do you think? Do you want to give it a try?
 QUEST_LV_0200_20151001_009415	You are doing better than Hicks.{nl}Can you help us one more time?
-QUEST_LV_0200_20151001_009416	Romiva isn't the only magic field.{nl}We've sent our subordinates to Neres magic field as well, but I think the magical power has ran out.{nl}
+QUEST_LV_0200_20151001_009416	Romuva isn't the only magic circle.{nl}We've sent our subordinates to Neres magic circle as well, but I think the magical power has ran out.{nl}
 QUEST_LV_0200_20151001_009417	It's not like we don't have any method, but the method is too much for our subordinates who've become weak...{nl}The only one I can trust is you now.
-QUEST_LV_0200_20151001_009418	Just defeat the monsters near the magic field. {nl}The vitality would be replaced to magical power. I am counting on you this time.
-QUEST_LV_0200_20151001_009419	The thing that bothers us the most is not monsters nor the maintenance of the magic field.{nl}The severe coldness is our biggest enemy.
+QUEST_LV_0200_20151001_009418	Just defeat the monsters near the magic circle. {nl}The vitality would be replaced to magical power. I am counting on you this time.
+QUEST_LV_0200_20151001_009419	The thing that bothers us the most is not monsters nor the maintenance of the magic circle.{nl}The severe coldness is our biggest enemy.
 QUEST_LV_0200_20151001_009420	We appreciate for your effors on behalf of the kingdom.{nl}They should work alright for some time.{nl}
-QUEST_LV_0200_20151001_009421	If you meet a person from the kingdom on your journey, please tell hm.{nl}That we are still diligently carrying out our duty here.{nl}Okay, then may the goddess protect you.{nl}
+QUEST_LV_0200_20151001_009421	If you meet a person from the kingdom on your journey, please tell hm.{nl}That we are still diligently carrying out our duty here.{nl}Okay, then may the Goddess protect you.{nl}
 QUEST_LV_0200_20151001_009422	The attacks of monsters won't just stop along with the supplies that are not coming.{nl}All we can do is just barely blocking their attacks. {nl}
 QUEST_LV_0200_20151001_009423	I am sorry, but could you block the monsters?
 QUEST_LV_0200_20151001_009424	Everyone is exhausted due to the coldness and the monsters.{nl}I don't know how much longer we would hold up.

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -67,7 +67,7 @@ QUEST_LV_0200_20150317_000066	Fine. We haven't received any word from our forces
 QUEST_LV_0200_20150317_000067	If you can't find them, come back to us.
 QUEST_LV_0200_20150317_000068	Soldier Carlos
 QUEST_LV_0200_20150317_000069	There are still a number of our colleagues on the inside.{nl}Please help us.
-QUEST_LV_0200_20150317_000070	Soldier Daniels
+QUEST_LV_0200_20150317_000070	$Soldier Dainus
 QUEST_LV_0200_20150317_000071	Ironbaum attacked us at the Drieza Waterland.{nl}There are still soldiers that have not yet escaped.{nl}
 QUEST_LV_0200_20150317_000072	I'm embarrassed to have escaped by myself.{nl}
 QUEST_LV_0200_20150317_000073	Settled Owl Sculpture
@@ -408,7 +408,7 @@ QUEST_LV_0200_20150317_000407	{memo X}It's nothing much, really. {nl}The symbol 
 QUEST_LV_0200_20150317_000408	{memo X}Nevermind if you can't. {nl}But if you can, that'd be awesome.
 QUEST_LV_0200_20150317_000409	{memo X}Oh, you got it... {nl}Well, aren't reckless challenges the fun in life?
 QUEST_LV_0200_20150317_000410	The monsters are eating my colleagues. {nl}I still have the divine power received from the Goddess but it won't last long.
-QUEST_LV_0200_20150317_000411	Officer Danius
+QUEST_LV_0200_20150317_000411	Officer Danus
 QUEST_LV_0200_20150317_000412	If we don't get back this forest, many cities will be isolated. {nl}But the situation isn't on our side.
 QUEST_LV_0200_20150317_000413	This forest doesn't even have owl statues. {nl}Makes you feel like you really don't want to come back.
 QUEST_LV_0200_20150317_000414	$Soldier Roy
@@ -416,7 +416,7 @@ QUEST_LV_0200_20150317_000415	$I heard the Rearguard Unit was surrounded. How di
 QUEST_LV_0200_20150317_000416	$Commander Johan
 QUEST_LV_0200_20150317_000417	I'm a commander who sent his men first. What words can I say? {nl}I feel miserable.
 QUEST_LV_0200_20150317_000418	This battle was a shameful one as a commander. {nl}I don't know what would have happened if it wasn't for you..
-QUEST_LV_0200_20150317_000419	Danius' Scout
+QUEST_LV_0200_20150317_000419	Danus' Scout
 QUEST_LV_0200_20150317_000420	It's too scary to patrol the area full of monsters. {nl}But I can't keep relying on other people either..
 QUEST_LV_0200_20150317_000421	Ruklys and I were taught by the same teacher.{nl}That's why I know what he is trying to achieve.
 QUEST_LV_0200_20150317_000422	$Land with deep stories also have a lot of resentment. {nl}It cannot be any better than studying necromancy.
@@ -794,7 +794,7 @@ QUEST_LV_0200_20150317_000793	$Thank you. I can feel relieved for the time being
 QUEST_LV_0200_20150317_000794	{memo X}We didn't just stay put when we were sieged by the mosnters. {nl}We sent out scouts to get away from here but no one came back. {nl}{NP}If it's okay with you, I'd like to ask you to search for them. {nl}
 QUEST_LV_0200_20150317_000795	$We need every man we have. {nl}I hope nothing happened to them..
 QUEST_LV_0200_20150317_000796	$You're really trustworthy. {nl}They went up north.
-QUEST_LV_0200_20150317_000797	$Were you sent by Sir Danius? {nl}You're too late. The others were taken out already.
+QUEST_LV_0200_20150317_000797	$Were you sent by Danus? {nl}You're too late. The others were taken out already.
 QUEST_LV_0200_20150317_000798	$The monsters will come to attack again soon. {nl}But I can't move right now.
 QUEST_LV_0200_20150317_000799	$You saved me. I won't ask you to bring me back to camp, though. {nl}Thank you for saving my life!
 QUEST_LV_0200_20150317_000800	$This is a method I used when I was alive. {nl}It was mostly successful back then.
@@ -804,13 +804,13 @@ QUEST_LV_0200_20150317_000803	$Are you from the Rearguard Unit? {nl}I'm sorry we
 QUEST_LV_0200_20150317_000804	$But we are all very tired. {nl}If you want to us back at the Rearguard Unit Camp, please help us gather the scattered supplies.
 QUEST_LV_0200_20150317_000805	$All kinds of monsters attack us when we have supplies. {nl}We need more soldiers, but there are no news, no matter how much backup we requested.
 QUEST_LV_0200_20150317_000806	$Thank you. {nl}This will be enough to cover for us.
-QUEST_LV_0200_20150317_000807	$Right now, it would be best for our troops to join with Danius' troops. {nl} We will join them soon after a little rest so please deliver them the food supplies first.
+QUEST_LV_0200_20150317_000807	$Right now, it would be best for our troops to join with Danus' troops. {nl} We will join them soon after a little rest so please deliver them the food supplies first.
 QUEST_LV_0200_20150317_000808	$We are sorry for delivering the supplies late. {nl}But this is the situation of most supply troops.
 QUEST_LV_0200_20150317_000809	$What happened? {nl}Is the Supply Squad well on their way? {nl}
 QUEST_LV_0200_20150317_000810	$At least the food supplies were delivered first. {nl}Good work. {nl}
-QUEST_LV_0200_20150317_000811	$Sir Danius ordered me to return? {nl}I can't return until I collect a Puragi's Hook.
+QUEST_LV_0200_20150317_000811	$Danus ordered me to return? {nl}I can't return until I collect a Puragi's Hook.
 QUEST_LV_0200_20150317_000812	$My mission is more important than his order to return. {nl}If we were to consider priorities, I mean.
-QUEST_LV_0200_20150317_000813	$Thank you for your help. {nl}But do I just return to Danius' troops?
+QUEST_LV_0200_20150317_000813	$Thank you for your help. {nl}But do I just return to Danus' troops?
 QUEST_LV_0200_20150317_000814	$Have you seen a soldier named Roy? {nl}
 QUEST_LV_0200_20150317_000815	$You mean you returned him to the Rearguard? {nl}That's bad. We're short on men. You are partly responsible for that now, so you better cooperate.
 QUEST_LV_0200_20150317_000816	$Blood will be shed soon. {nl}I pity you for going in Roy's stead.
@@ -1956,11 +1956,11 @@ QUEST_LV_0200_20150317_001955	Defeat Wood Goblins around
 QUEST_LV_0200_20150317_001956	The owl that is settled wants to pay back to the soldiers who saved it. To help the soldiers, please defeat nearby RavineLervas.
 QUEST_LV_0200_20150317_001957	You defeated all nearby RavineLervas. Talk with the settled owl.
 QUEST_LV_0200_20150317_001958	Defeat RavineLervas
-QUEST_LV_0200_20150317_001959	Talk with the soldier Danius
-QUEST_LV_0200_20150317_001960	The soldier Dainews is trembling from the fear. To look for the other soldiers, Talk with Dainews.
+QUEST_LV_0200_20150317_001959	Talk with Soldier Dainus
+QUEST_LV_0200_20150317_001960	Soldier Dainus is trembling from the fear. To look for the other soldiers, Talk with Dainus.
 QUEST_LV_0200_20150317_001961	Look for the other soldiers in Drieza dried fields.
 QUEST_LV_0200_20150317_001962	Soldier Danius told you that there may be other soldiers on Drieza dried fields. Go to Drieza dried fields and look for the soldiers there.
-QUEST_LV_0200_20150317_001963	Defeat ronbaum
+QUEST_LV_0200_20150317_001963	Defeat Ironbaum
 QUEST_LV_0200_20150317_001964	Find the grave at the Sunset Flag Forest
 QUEST_LV_0200_20150317_001965	Find the grave at the Sunset Flag Forest
 QUEST_LV_0200_20150317_001966	Defeat the gigantic monster at Kaklas Cliffs
@@ -2053,11 +2053,11 @@ QUEST_LV_0200_20150317_002052	Talk with the desperate owl sculpture
 QUEST_LV_0200_20150317_002053	I can see the shade from the desperate owl. Talk with the desperate owl.
 QUEST_LV_0200_20150317_002054	The desperate owl is scared of dying in the flames of Sequoia. Extinguish the flames of Sequoia for the desperate owl.
 QUEST_LV_0200_20150317_002055	It seems that the flames of Sequoia are not strong anymore. Return to the desperate owl.
-QUEST_LV_0200_20150317_002056	$Talk to Commander Danius
-QUEST_LV_0200_20150317_002057	$You can see an exhausted Commander Danius. Talk to him.
+QUEST_LV_0200_20150317_002056	$Talk to Officer Danus
+QUEST_LV_0200_20150317_002057	$You can see an exhausted Officer Danus. Talk to him.
 QUEST_LV_0200_20150317_002058	$Defeat the monsters that are attacking the Readguard Unit
-QUEST_LV_0200_20150317_002059	$Commander Danius says that his squad has been cut off due to the monsters. Defeat the monsters nearby for Danius' Squad.
-QUEST_LV_0200_20150317_002060	I think the squad can be freed from the monsters now. Talk to Commander Danius.
+QUEST_LV_0200_20150317_002059	$Officer Danus says that his squad has been cut off due to the monsters. Defeat the monsters nearby for Danus' Squad.
+QUEST_LV_0200_20150317_002060	I think the squad can be freed from the monsters now. Talk to Officer Danus.
 QUEST_LV_0200_20150317_002061	$Talk to the Weak Owl Sculpture
 QUEST_LV_0200_20150317_002062	$There are many Owl Sculptures that guide souls in Kateen Forest. Listen to the story of the Weak Owl Sculpture.
 QUEST_LV_0200_20150317_002063	$Collect the soldiers' corpses
@@ -2136,18 +2136,18 @@ QUEST_LV_0200_20150317_002135	$Talk with the Scouts
 QUEST_LV_0200_20150317_002136	$It seems that the Scouts have differing opinions on whether Deadborn is nearby. Go talk to the Scouts again.
 QUEST_LV_0200_20150317_002137	$Defeat Deadborn
 QUEST_LV_0200_20150317_002138	$Deadborn suddenly attacked. Defeat Deadborn.
-QUEST_LV_0200_20150317_002139	$Commander Danius doesn't know what to do. Go talk to Danius.
-QUEST_LV_0200_20150317_002140	$Look for Danius' scouts 
-QUEST_LV_0200_20150317_002141	$Commander Danius told you that the scouts who were sent to find out what's going on around here were all lost. Look for the scouts who went to the Crossroads.
-QUEST_LV_0200_20150317_002142	$Talk to Danius' Scout
-QUEST_LV_0200_20150317_002143	$It seems that you found one of the scouts that were lost. Go talk to the Scout.
+QUEST_LV_0200_20150317_002139	$Officer Danus doesn't know what to do. Talk to Officer Danus.
+QUEST_LV_0200_20150317_002140	$Look for Danus' scouts 
+QUEST_LV_0200_20150317_002141	$Officer Danus told you that the scouts who were sent to find out what's going on around here were all lost. Look for the scouts who went to the Crossroads.
+QUEST_LV_0200_20150317_002142	$Talk to Danus' Scout
+QUEST_LV_0200_20150317_002143	$It seems that you found one of the scouts that were lost. Talk to the Scout.
 QUEST_LV_0200_20150317_002144	$Defeat the monsters that are rushing in.
 QUEST_LV_0200_20150317_002145	$The Scout said that the monsters would soon attack. Defeat the monsters that are rushing in.
 QUEST_LV_0200_20150317_002146	$You've defeated all the monsters that are rushing in. Talk to the Scout again.
 QUEST_LV_0200_20150317_002147	$Defeat Bites
-QUEST_LV_0200_20150317_002148	$Commander Danius seems to be waiting for someone. Talk to Commander Danius again.
+QUEST_LV_0200_20150317_002148	$Officer Danus seems to be waiting for someone. Talk to Officer Danus again.
 QUEST_LV_0200_20150317_002149	$Look for the Supply Officer
-QUEST_LV_0200_20150317_002150	$Commander Danius is desperately looking for the Supply Squad. At the lower end of the Rearguard Unit Camp look for the Supply Officer and talk to him.
+QUEST_LV_0200_20150317_002150	$Officer Danus is desperately looking for the Supply Squad. At the lower end of the Rearguard Unit Camp look for the Supply Officer and talk to him.
 QUEST_LV_0200_20150317_002151	$Talk to the Supply Officer
 QUEST_LV_0200_20150317_002152	$You've found the Supply Squad. Talk to the Supply Officer again.
 QUEST_LV_0200_20150317_002153	$Retrieve the Supplies
@@ -2155,8 +2155,8 @@ QUEST_LV_0200_20150317_002154	$The Supply Officer told you that the soldiers are
 QUEST_LV_0200_20150317_002155	$Hand it over to the Supply Officer
 QUEST_LV_0200_20150317_002156	$You've retrieved all the scattered Supplies. Give them to the Supply Officer.
 QUEST_LV_0200_20150317_002157	$Since you've retrieved all the Supplies, talk to the Supply Officer so that the Supply Squad can unite with the Rearguard Unit.
-QUEST_LV_0200_20150317_002158	$Hand over the supplies to Commander Danius
-QUEST_LV_0200_20150317_002159	$The Supply Officer told you that since the soldiers are exhausted, it will be hard for the Supply Squad to move right away. So when you hand over the Supplies, the complaints from the Rearguard will be reduced. Hand over the supplies to Commander Danius on behalf of the Supply Squad.
+QUEST_LV_0200_20150317_002158	$Hand over the supplies to Officer Danus
+QUEST_LV_0200_20150317_002159	$The Supply Officer told you that since the soldiers are exhausted, it will be hard for the Supply Squad to move right away. So when you hand over the Supplies, the complaints from the Rearguard will be reduced. Hand over the supplies to Officer Danus on behalf of the Supply Squad.
 QUEST_LV_0200_20150317_002160	$Talk to Soldier Roy
 QUEST_LV_0200_20150317_002161	$It seems that you found Soldier Roy. Talk to Soldier Roy.
 QUEST_LV_0200_20150317_002162	$Obtain a Puragi's Hook

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1067,10 +1067,10 @@ SKILL_20150317_001066	{memo X}${#993399}{ol}[Magic]{/}{/}{nl} Attack a target wi
 SKILL_20150317_001067	{memo X}Attack #{SkillAtkAdd}#{nl}Cast Time 1 second{nl}Splash #{SkillSR}#
 SKILL_20150317_001068	$Lethargy
 SKILL_20150317_001069	{memo X}Inflict lethargy upon the target.
-SKILL_20150317_001070	$Physical Attack -#{CaptionRatio}#{nl}Magic Attack -#{CaptionRatio}#{nl}Evasion -#{CaptionRatio2}#{nl}{#339999}{ol}[Lethargy]{/}{/} duration #{CaptionTime}# sec
+SKILL_20150317_001070	$Physical Attack: -#{CaptionRatio}#{nl}Magic Attack: -#{CaptionRatio}#{nl}Evasion: -#{CaptionRatio2}#{nl}{#339999}{ol}[Lethargy]{/}{/} Duration: #{CaptionTime}# seconds
 SKILL_20150317_001071	$Sleep
 SKILL_20150317_001072	{memo X}Inflicts sleep upon targets. Enemies will awake upon taking a certain number of hits, or once sleep runs out.
-SKILL_20150317_001073	${#339999}{ol}[Sleep]{/}{/} duration: #{SkillFactor}# seconds{nl}Attack Threshold: #{CaptionRatio}#
+SKILL_20150317_001073	${#339999}{ol}[Sleep]{/}{/} Duration: #{SkillFactor}# seconds{nl}Attack Threshold: #{CaptionRatio}#
 SKILL_20150317_001074	$Reflect Shield
 SKILL_20150317_001075	{memo X}$Creates a protective shield that reflects the amplified damage to the target.
 SKILL_20150317_001076	$Damage Reflection #{CaptionRatio}#{nl}Duration #{CaptionTime}# seconds{nl}Reflects #{CaptionRatio2}# times
@@ -1137,7 +1137,7 @@ SKILL_20150317_001136	$Magnetic Force
 SKILL_20150317_001137	{memo X}${#993399}{ol}[Magic]{/}{/}{nl}Inflicts damage by drawing in the target at a specified location. 
 SKILL_20150317_001138	$Raise
 SKILL_20150317_001139	{memo X}Lift targets into the air.
-SKILL_20150317_001140	$Targets #{CaptionRatio}#{nl}Duration #{CaptionRatio2}# seconds
+SKILL_20150317_001140	$Targets: #{CaptionRatio}#{nl}Duration: #{CaptionRatio2}# seconds
 SKILL_20150317_001141	$Gravity Pole
 SKILL_20150317_001142	{memo X}Create a gravitational field that pulls all nearby enemies.
 SKILL_20150317_001143	{memo X}Target #{CaptionRatio}#{nl}Max. duration 5 seconds
@@ -1205,7 +1205,7 @@ SKILL_20150317_001204	{memo X}{#6644FF}{ol}[Fire]{/}{/}Attribute {nl} Attack #{S
 SKILL_20150317_001205	$Stop
 SKILL_20150317_001206	{memo X}Monsters hold their current state. All monsters in the area will stop their actions.
 SKILL_20150317_001207	$Slow
-SKILL_20150317_001208	{memo X}Movement Speed -#{CaptionRatio}#%{nl}Slow duration 5 seconds {nl}Consume #{SpendSP}# SP
+SKILL_20150317_001208	{memo X}Movement Speed -#{CaptionRatio}#%{nl}Slow Duration: 5 seconds {nl}Consumes #{SpendSP}# SP
 SKILL_20150317_001209	$Haste
 SKILL_20150317_001210	$Back Masking
 SKILL_20150317_001211	{memo X}Reverses time in target area to a previous state.
@@ -1449,7 +1449,7 @@ SKILL_20150317_001448	{memo X}{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Create a m
 SKILL_20150317_001449	{memo X}Attack #{SkillAtkAdd}#{nl}Attack #{CaptionRatio}# times {nl}Magic circle Duration 30 seconds
 SKILL_20150317_001450	$Divine Stigma
 SKILL_20150317_001451	{memo X}Mark monster. The player that kills the monster will get increased STR and INT.
-SKILL_20150317_001452	$STR, INT: +#{CaptionRatio}#{nl}Effect duration: 30 seconds{nl}Stigma duration: #{CaptionRatio2}# seconds
+SKILL_20150317_001452	$STR, INT: +#{CaptionRatio}#{nl}Effect Duration: 30 seconds{nl}Stigma Duration: #{CaptionRatio2}# seconds
 SKILL_20150317_001453	$Melstis
 SKILL_20150317_001454	{memo X}Create magic circle that retains buffs for party members.
 SKILL_20150317_001455	{memo X}Max. duration 20 seconds {nl} #{CaptionRatio}#% of SP consumed per second
@@ -1472,7 +1472,7 @@ SKILL_20150317_001471	$Protection
 SKILL_20150317_001472	$Dodola
 SKILL_20150317_001473	$Hexing
 SKILL_20150317_001474	{memo X}Curse an enemy and decrease its magic defense.
-SKILL_20150317_001475	$Magic Defense: -#{CaptionRatio}#{nl}Hexing duration: #{CaptionTime}# seconds
+SKILL_20150317_001475	$Magic Defense: -#{CaptionRatio}#{nl}Hexing Duration: #{CaptionTime}# seconds
 SKILL_20150317_001476	$Effigy
 SKILL_20150317_001477	{memo X}{#993399}{ol}[Magic] - [Dark]{/}{/}{nl}Damage enemies affected by Hexing. The third attack deals additional damage.
 SKILL_20150317_001478	{memo X}Attack #{SkillAtkAdd}#{nl}Attack bonus on 3rd attack #{CaptionRatio}# times ~ #{CaptionRatio2}#times
@@ -1484,7 +1484,7 @@ SKILL_20150317_001483	{memo X}Create a magic circle on the ground. Enemies kille
 SKILL_20150317_001484	$Magic Circle Duration: #{CaptionTime}# {nl}Maximum Zombie Summons: #{CaptionRatio}#
 SKILL_20150317_001485	$Mackangdal
 SKILL_20150317_001486	{memo X}Throw amulet on target. Becomes invincible while under effect but receive accumulated damage when effect is gone.
-SKILL_20150317_001487	$Invincibility duration: #{CaptionTime}# seconds
+SKILL_20150317_001487	$Invincibility Duration: #{CaptionTime}# seconds
 SKILL_20150317_001488	$Bwa Kayiman
 SKILL_20150317_001489	{memo X}{#DD5500}{ol}[Physical] [Strike]{/}{/}{nl}Zombies roam around target area. Enemies are pushed away and damaged when toufching the zombies.
 SKILL_20150317_001490	{memo X}Attack #{SkillAtkAdd}#{nl}Summoned zombie required
@@ -1595,7 +1595,7 @@ SKILL_20150317_001594	{memo X}Continuously restore HP to surrounding allies.
 SKILL_20150317_001595	{memo X}Enemies have chance of being debuffed when you are attacked.
 SKILL_20150317_001596	{memo X}Decrease skill cooldown of party member by n%
 SKILL_20150317_001597	Stun
-SKILL_20150317_001598	Can't move
+SKILL_20150317_001598	Unable to move
 SKILL_20150317_001599	Fear
 SKILL_20150317_001600	While, after the falter, attack is low.
 SKILL_20150317_001601	$Bleeding
@@ -1609,7 +1609,7 @@ SKILL_20150317_001608	Recover HP, SP by 5% per second
 SKILL_20150317_001609	Discovery
 SKILL_20150317_001610	Discovery.
 SKILL_20150317_001611	Rest
-SKILL_20150317_001612	$Increases the recovery of HP, SP and STA.
+SKILL_20150317_001612	$Increased the recovery of HP, SP and STA.
 SKILL_20150317_001613	Safety
 SKILL_20150317_001614	Safety.
 SKILL_20150317_001615	Chilled
@@ -3813,7 +3813,7 @@ SKILL_20150414_003812	Level 1 Master
 SKILL_20150414_003813	Looking
 SKILL_20150414_003814	Install Perch
 SKILL_20150414_003815	Install a perch where the hawk can wait. The hawk waits for the owner's order on the perch. It disappears when you move away from it.
-SKILL_20150414_003816	Range #{CaptionRatio}#{nl}Torch duration #{CaptionRatio2}# seconds
+SKILL_20150414_003816	Range: #{CaptionRatio}#{nl}Torch Duration: #{CaptionRatio2}# seconds
 SKILL_20150414_003817	Circling
 SKILL_20150414_003818	{memo X}Fly circling around target area. Range defense of enemies within target area decreases.
 SKILL_20150414_003819	{memo X}Range defense rate -#{CaptionRatio}# {nl}Duration 0 seconds
@@ -4066,10 +4066,10 @@ SKILL_20150428_004065	{memo X}Attack #{SkillAtkAdd}#{nl}Physical Defense -#{Capt
 SKILL_20150428_004066	{memo X}Attack #{SkillAtkAdd}#{nl}Duration 10 seconds{nl}Use 1 Magic Arrow
 SKILL_20150428_004067	{memo X}Attack #{SkillAtkAdd}#{nl}Duration 10 seconds{nl}Use 1 Gather Corpse
 SKILL_20150428_004068	$Hanging Shot
-SKILL_20150428_004069	$Guardian Saint duration: #{CaptionTime}# seconds{nl}Chance on hit: 50%{nl}Charges: #{CaptionRatio}#
+SKILL_20150428_004069	$Guardian Saint Duration: #{CaptionTime}# seconds{nl}Chance on Hit: 50%{nl}Charges: #{CaptionRatio}#
 SKILL_20150428_004070	$Creates a magic circle in front of you that increases the DEX of allies and decreases the enemy's evasion and physical defense. Party members will receive the effect without stepping on the magic circle.
 SKILL_20150428_004071	$Gives a blessing providing additional damage to the attacks of your party members and allies.
-SKILL_20150428_004072	$Additional Damage: +#{CaptionRatio}#{nl}Number of Hits: #{CaptionRatio2}#{nl}Allies affected: #{CaptionTime}#{nl}Duration: 45 seconds{nl}Consumes 1 Holy Powder
+SKILL_20150428_004072	$Additional Damage: +#{CaptionRatio}#{nl}Number of Hits: #{CaptionRatio2}#{nl}Affected Allies: #{CaptionTime}#{nl}Duration: 45 seconds{nl}Consumes 1 Holy Powder
 SKILL_20150428_004073	{memo X}Body's moving range #{CaptionRatio}#{nl}Body's attack +#{CaptionRatio2}#
 SKILL_20150428_004074	{memo X}Reflect as much as target's Physical attack{nl}Additional damage reflected #{SkillAtkAdd}#{nl}Max. duration #{CaptionTime}# seconds{nl}Range projectile, Magic defense not possible
 SKILL_20150428_004075	{memo X}Attack #{SkillAtkAdd}#{nl}Use 2 Stamina
@@ -4708,7 +4708,7 @@ SKILL_20150714_004707	{memo X}The monster that is transformed by [Change] would 
 SKILL_20150714_004708	$Increases the knockback power of [Thrust] by 50 per attribute level.
 SKILL_20150714_004709	When the enemies in the air by [Wagon Wheel] fall to ground receive of 50% of character's damage.
 SKILL_20150714_004710	$Increases the number of times of using [Repair] by 1 per level.
-SKILL_20150717_004711	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}{#339999}{ol}[Stun]{/}{/} duration: 1 second
+SKILL_20150717_004711	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}{#339999}{ol}[Stun]{/}{/} Duration: 1 second
 SKILL_20150717_004712	$Movement Speed: +#{CaptionRatio}#{nl}Duration: #{CaptionTime}# seconds
 SKILL_20150717_004713	{memo X}Your attack hits target but chance of critical and critical evasion decreases.
 SKILL_20150717_004714	{memo X}Critical Chance -#{CaptionRatio}#%{nl}Critical Resistance -#{CaptionRatio}#%{nl}Duration #{CaptionTime}# seconds
@@ -4716,7 +4716,7 @@ SKILL_20150717_004715	$Shout a warcry that causes your enemies to panic and drop
 SKILL_20150717_004716	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Tramp down on enemy while on air or jumping. Attack damage will be decided,according to the Character's height and Shoes's defense.
 SKILL_20150717_004717	$Capture Time: #{CaptionRatio}# seconds
 SKILL_20150717_004718	$Attack: -#{CaptionRatio}#% {nl}Increased defense equal to the decreased attack{nl}Additonal Defense: #{CaptionRatio2}#%{nl}Consumes 1% SP per 2 seconds
-SKILL_20150717_004719	Attack #{SkillAtkAdd}#{nl}Attribute Attack #{CaptionRatio}#%{nl}Duration #{CaptionRatio2}#seconds{nl}AoE Attack Ratio #{SkillSR}#
+SKILL_20150717_004719	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}Duration: #{CaptionRatio2}# seconds{nl}AoE Attack Ratio: #{SkillSR}#
 SKILL_20150717_004720	{memo X}Summon the devil of card inserted in Grimore. The attack and defense of summoned devil will be decided according to character's INT, SPR. Grimore can only equip Devil type monster card.
 SKILL_20150717_004721	Summon Demon type boss{nl}Demon additional attack #{CaptionRatio}#{nl}Demon additional defense #{CaptionRatio2}#
 SKILL_20150717_004722	{memo X}Movement speed - #{CaptionRatio}# {nl}Magic circle duration #{CaptionRatio2}#seconds{nl}{#339999}{ol}[Slow]{/}{/} Duration 5 seconds
@@ -4839,14 +4839,14 @@ SKILL_20150717_004838	$Decreases the enemy's physical defense by 30% with a chan
 SKILL_20150717_004839	$Decreases the SP cost of [Vashita Siddhi] by 10. 
 SKILL_20150717_004840	$Enemies within the range of [Vashita Siddhi] have a chance to be afflicted with Confusion. Increases the chance by 10% per attribute level.
 SKILL_20150717_004841	{memo X}HP recovery effect of [Restoration] increases per attribute level
-SKILL_20150717_004842	Instant death probability of skill [Turn Undead] also affects your spirit.
+SKILL_20150717_004842	$The instant death chance of [Turn Undead] is proportional to your SPR.
 SKILL_20150717_004843	{memo X}Damage that will be reflected off from [Iron Skin] will be added 20% of Physical ATK per Attribute level.
-SKILL_20150717_004844	An enemy that is shot by [Palm Strike] will fall into [Bleeding] for 8 secs. Duration of [Bleeding] will increase by 1 sec per Attribute level.
-SKILL_20150717_004845	[Pardoner] Make despeller
+SKILL_20150717_004844	$Enemies hit by [Palm Strike] will be affected by [Bleeding] for 8 seconds. Increases the duration of [Bleeding] by 1 second per attribute level. Bleeding damage is proportional to your physical attack.
+SKILL_20150717_004845	$Craft a dispeller to prevent from getting harmful effects. Craft Dispeller is only possible in Rest Mode.
 SKILL_20150717_004846	When you endow the effect that is registered at [Spell Shop] to your colleague, the duration will be increased. Duration will increase by 3 mins per Attribute level.
-SKILL_20150717_004847	Enemies nearby receive Holy damage when using [Arcane Energy]. Damage increases per attribute level.
-SKILL_20150717_004848	Duration of [Forecast] will increase by 1 sec per Attribute level.
-SKILL_20150717_004849	The monster that is transformed by [Change] would have Item Jackpot Buff with 0.05% probability per Attribute level.
+SKILL_20150717_004847	$Nearby enemies receive Holy damage equal to the attribute level when using [Arcane Energy]
+SKILL_20150717_004848	$Increases the duration of [Forecast] by 1 second per attribute level.
+SKILL_20150717_004849	$A monster that is transformed by [Change] will have the Item Jackpot Effect with a 0.05% chance per attribute level.
 SKILL_20150717_004850	The hand equipped the shield and dagger of party member
 SKILL_20150717_004851	Shield, Physical/Magic Defense: +#{CaptionRatio}#{nl}Dagger, Physical/Magic Attack: +#{CaptionRatio2}#{nl}No effect when equipping other secondary weapons.{nl}Duration: #{CaptionTime}# seconds
 SKILL_20150717_004852	{memo X}Attribute Attack #{CaptionRatio}#%{nl}Throw#{CaptionRatio2}#{nl}Caldrop duration #{CaptionTime}#seconds{nl}{#339999}{ol}[Slow]{/}{/} duration 10 seconds
@@ -4996,13 +4996,13 @@ SKILL_20150730_004995	$Physical Defense: -#{CaptionRatio}# {nl}Additional Critic
 SKILL_20150803_004996	$Quick Cast
 SKILL_20150803_004997	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Sit down to increase focus. ATK, speed and range increases.
 SKILL_20150803_004998	$Physical Damage: +#{CaptionRatio}#{nl} Range: +#{CaptionRatio2}# Attack speed: +#{CaptionTime}#
-SKILL_20150803_004999	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}#Number of caltrops: {CaptionRatio2}#{nl}Caltrop duration: #{CaptionTime}# seconds
+SKILL_20150803_004999	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}Number of Caltrops: #{CaptionRatio2}#{nl}Caltrop Duration: #{CaptionTime}# seconds
 SKILL_20150803_005000	$Attack: 150% +#{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}{#339999}{ol}[Stun]{/}{/} Duration: #{CaptionTime}# seconds{nl}Consumes 1 Stone Bullet
-SKILL_20150803_005001	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}Trap duration: 15seconds{nl}Consumes 3 Ash Wood
+SKILL_20150803_005001	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio}#%{nl}Trap Duration: 15seconds{nl}Consumes 3 Ash Wood
 SKILL_20150803_005002	$Maximum Duration: #{CaptionRatio}# seconds
 SKILL_20150803_005003	$Creates a magic circle that turns a dead enemy into a zombie. The HP of the created zombie is based on the caster's SPR.
-SKILL_20150803_005004	$Maximum HP: +#{CaptionRatio}#{nl}Movement Speed: +#{CaptionRatio2}#% Duration: #{CaptionTime}# seconds{nl}Glyph duration: 15 seconds
-SKILL_20150803_005005	$STR: +#{CaptionRatio}#{nl}Duration: #{CaptionRatio2}#{nl}Glyph duration: 15 seconds
+SKILL_20150803_005004	$Maximum HP: +#{CaptionRatio}#{nl}Movement Speed: +#{CaptionRatio2}#% Duration: #{CaptionTime}# seconds{nl}Glyph Duration: 15 seconds
+SKILL_20150803_005005	$STR: +#{CaptionRatio}#{nl}Duration: #{CaptionRatio2}#{nl}Glyph Duration: 15 seconds
 SKILL_20150803_005006	$Attribute Attack: #{CaptionRatio2}#%{nl}Additional Damage to Plant-type monsters: +#{CaptionRatio}#{nl}Drop rate for statue materials: #{CaptionTime}#%
 SKILL_20150803_005007	$Can use monster's skill{nl}Maximum Duration: #{CaptionTime}# seconds
 SKILL_20150803_005008	$Effigy Enhance

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -4165,7 +4165,7 @@ SKILL_20150714_004164	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRat
 SKILL_20150714_004165	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionTime}#%{nl}AoE Attack Ratio: #{CaptionRatio}#{nl}Consumes #{CaptionRatio2}#% SP per second
 SKILL_20150714_004166	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio2}#%{nl}Number of Hits: #{CaptionRatio}#{nl}Duration: #{CaptionTime}# seconds
 SKILL_20150714_004167	$Attack: #{SkillAtkAdd}#{nl}Attribute Attack: #{CaptionRatio2}#%{nl}Number of Targets: #{CaptionRatio}#
-SKILL_20150714_004168	$Duration: #{CaptionTime}# seconds{nl}Number of targets: #{CaptionRatio}#
+SKILL_20150714_004168	$Duration: #{CaptionTime}# seconds{nl}Number of Targets: #{CaptionRatio}#
 SKILL_20150714_004169	{memo X}Attack #{SkillAtkAdd}#{nl}Attribute Attack #{CaptionRatio}#%{nl}Duration 15 seconds
 SKILL_20150714_004170	{memo X}Attack #{SkillAtkAdd}#{nl}Attribute Attack #{CaptionRatio}#%{nl}Casting Time #{CaptionTime}#seconds{nl}AoE Attack Ratio #{SkillSR}#
 SKILL_20150714_004171	{memo X}Duration #{CaptionTime}#seconds{nl}Move speed decreases 10%{nl}{#DD5500}{ol}Eletric{/}{/}Attribute Attack Additional Damage{nl}{#DD5500}{ol}Flame{/}{/}Attribute Target #{SkillAtkAdd}#

--- a/UI.tsv
+++ b/UI.tsv
@@ -960,7 +960,7 @@ UI_20150317_000959	{@St41b}Price
 UI_20150317_000960	{@St41b}State
 UI_20150317_000961	{@St44}New Character{/}
 UI_20150317_000962	{@St41b}{s22}$Select Character Class{/}
-UI_20150317_000963	{@St41b}Go Back{/}
+UI_20150317_000963	{@St41b}Return{/}
 UI_20150317_000964	{@St59}Go back to your Lodge without creating a character
 UI_20150317_000965	Change Character
 UI_20150317_000966	{@St41}Character{/}

--- a/UI.tsv
+++ b/UI.tsv
@@ -991,7 +991,7 @@ UI_20150317_000990	{@st59}Cleric{/}
 UI_20150317_000991	{@St41b}Visit Barrack {/}
 UI_20150317_000992	{@St59}Visit the Barrack of another player.{/}
 UI_20150317_000993	{@St41b}Logout{/}
-UI_20150317_000994	{@St59}Move to login screen{/}
+UI_20150317_000994	{@St59}Move to the login screen{/}
 UI_20150317_000995	{@St41b}Exit Game{/}
 UI_20150317_000996	{@St59}Exit Tree of Savior{/}
 UI_20150317_000997	{@st41b}Select Channel{/}
@@ -1022,7 +1022,7 @@ UI_20150317_001021	{@st59}Enter your Account ID{/}
 UI_20150317_001022	Password
 UI_20150317_001023	{@St59}Enter your password{/}
 UI_20150317_001024	{@St43}Enter{/}
-UI_20150317_001025	{@St59}Connect to selected server{/}
+UI_20150317_001025	{@St59}Connect to the selected server{/}
 UI_20150317_001026	{@st41b}Replay{/}
 UI_20150317_001027	{@st41b}Single Mode{/}
 UI_20150317_001028	{@St41b}Exit Game{/}

--- a/UI.tsv
+++ b/UI.tsv
@@ -1736,7 +1736,7 @@ UI_20150729_001735	Height
 UI_20150729_001736	Weight
 UI_20150729_001737	{@st43}Gem Roasting{/}
 UI_20150729_001738	{@st59b}Item Crafting{nl}{@st59s} - An item can be crafted by using a recipe.{nl} - Place the recipe and required materials in the slot to begin crafting an item. {nl} - You can attach a unique name and memo to the item.{/}
-UI_20150729_001739	{@st59}Close Arrow Crafting.{/}
+UI_20150729_001739	{@st59}Close Arrow Crafting{/}
 UI_20150729_001740	{memo X}Fragments needed : Mutant %s / Beast %s / Plant %s
 UI_20150729_001741	${@st42b}         Swordsman classes can sprint by                        double-tapping a directional key{/}
 UI_20150729_001742	{@st41}Party Settings

--- a/UI.tsv
+++ b/UI.tsv
@@ -427,7 +427,7 @@ UI_20150317_000426	How to Play
 UI_20150317_000427	${@st42b}          Move once with each of the keys{/}
 UI_20150317_000428	${@st42b}         Use a basic attack{/}
 UI_20150317_000429	${@st42b}                Jump up{/}
-UI_20150317_000430	{@st42b}Use two keys together to move diagonally{/}
+UI_20150317_000430	{@st42b}     Use two keys together to move diagonally{/}
 UI_20150317_000431	Fog Map Tool
 UI_20150317_000432	Tool for killing monsters
 UI_20150317_000433	Tool for making minimap
@@ -1738,7 +1738,7 @@ UI_20150729_001737	{@st43}Gem Roasting{/}
 UI_20150729_001738	{@st59b}Item Crafting{nl}{@st59s} - An item can be crafted by using a recipe.{nl} - Place the recipe and required materials in the slot to begin crafting an item. {nl} - You can attach a unique name and memo to the item.{/}
 UI_20150729_001739	{@st59}Close Arrow Crafting.{/}
 UI_20150729_001740	{memo X}Fragments needed : Mutant %s / Beast %s / Plant %s
-UI_20150729_001741	${@st42b}         Swordsman classes can sprint by                        double-tapping a directional key.{/}
+UI_20150729_001741	${@st42b}         Swordsman classes can sprint by                        double-tapping a directional key{/}
 UI_20150729_001742	{@st41}Party Settings
 UI_20150729_001743	{@st41}Party Recruit Settings
 UI_20150729_001744	{@st42}Search for Party Members{/}


### PR DESCRIPTION
Miscellanous fixes, including edits in the new translated lines provided by IMC. This is a big pull request because of the mass replacement to avoid inconsistencies and incorrect translations as well as add standardization in the game.
- Renamed 'Quarrelshooter Master' to 'Quarrel Shooter Master'
- Renamed 'Soldier Daniels' to 'Soldier Dainus'
- Renamed 'Commander Danius' to 'Officer Danus'
- Renamed 'Adriyus' to 'Adrius'
- Renamed 'Shadow Gaoler' and 'Shadowgaoler' to 'Shadowgaler'
- Renamed 'ramyvie Cliff' to 'Ramybe Cliff' (please update Wiki)
- Renamed 'Haubuck' to 'Hauberk'
- Renamed 'Dionis' to 'Dionys'
- Renamed 'Lylia' to 'Liliya'
- Renamed 'day of divine tree' to 'Medis Diena'
- Renamed 'Rankina Isolation District' to 'Lankine Separation District'
- Renamed 'Ishsula Collapsed District' to 'Ishisula Broken District' 
- Renamed 'Etmesta Isolation District' to 'Hehmastar Isolation District' according to the wiki - Is the last one the correct term?
- Renamed 'Heuderati Instersection' to 'Hradeti Crossroads'
- Renamed 'Ausura Chaple' to 'Ausura Chapel' <- Update wiki, please.
- Renamed 'magic field' to 'magic circle'
- Renamed 'Kalejimas' to 'Kalezimas'
- Renamed 'Akorn' to 'Archon'
- Renamed 'Crest of Space' to 'Seal of Space'
- Renamed 'Owl Statue' to 'Owl Sculpture'
- Renamed 'forest of thorns' to 'Thorn Forest'
- Renamed 'Dalyrus' to 'Dallus'
- Renamed 'reconnaissance leader', 'commander' of NPC Mintz to 'Hunter Tracking Captain' - Mintz is a highly ranked person of the Hunters, a group wanting to cooperate with the monks.
- Renamed 'Cupols' to 'Kupoles'
- Renamed a lot more...
- Shortened 'Go talk', 'Go meet' etc.
- Fixed a few NPC names from "disciple, X" to "Disciple X" 
- Fixed erroneous sentences (in gameplay until Crystal Mine 1F)
- Fixed a few skill descriptions
- Fixed item descriptions to have the correct NPC names and item names
- Capitalized 'demon lord' to 'Demon Lord'
- Capitalized 'revelator' to 'Revelator'
- Capitalized 'goddess' to 'Goddess'
- Changed 'Follower' to 'Believer' (신도) to all Sirdgela Forest NPCs + instances where it specifically said 'followers' in a normal sentence
- Changed the capitalization for skills variables in descriptions (e.g. Number of hits -> Number of Hits)
- Added couple of new translated strings 

Important questions for @imcgames:
1. What is the exact term for 누아엘레? Wiki says 'Nuahella', yet in the newly translated lines by you it says 'Nuaele', there are also instances of 'Nuaelle' in the files. I need to know the final name for consistency. Please update the wiki as well for this one.
2. 구원자 means Savior. However, in a few new lines you've translated it as 'Revelator'. Are they both the same? It's confusing. 
   Was '구원자' used in the early concept, but then switched to '계시자'? ‘Revelator’ is linguistically correct, but ‘Savior’ is synonymous with the intended meaning and easier for a wider audience to easily understand, plus the title of the game is 'Tree of Savior'. 
3. 왕의 고 is referred as 'Plateau of Rex' in the Wiki. In the newly translated lines, it is referred as "King's Plateau", which is just the real translation. 
   I assume Rex was named after Rexipher? What should we do about this? For now, I'll change it to Plateau of Rex, but "King's Plateau" is the most suitable translation for it, though.
4. Can you please respond to this Issue https://github.com/Treeofsavior/EnglishTranslation/issues/1148 - This might be a bug?
5. Have you given thought about the 'Cabin Medium' font? There's many advantages to use this in the game, because it is also a bit smaller and it doesn't space things too wide which 
   is perfect for the game. Please try it out in iCBT2 and check player feedback. It's closed beta, so it's not final yet, right? :wink: You would do us, the contributors, a good favor. 
