### PR TITLE
Update SKILL.tsv - several changes

### DIFF
--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -9388,10 +9388,10 @@ QUEST_LV_0100_20151001_009383	Hauberk told you that he needs to keep the promise
 QUEST_LV_0100_20151001_009384	Endless deals
 QUEST_LV_0100_20151001_009385	Talk to Squire Williya
 QUEST_LV_0100_20151001_009386	Squire Williya and Pardone Erikas are having disputes at Mochia Forest. Talk to Squire, Williya what's going on.
-QUEST_LV_0100_20151001_009387	Collect blue paint
-QUEST_LV_0100_20151001_009388	Squire Williya told you that as a return for handing over the scroll for the dead, Pardoner Erikas wants blue paint. Defeat the monsters at Apgaudin Three Ways and collect blue paint.
+QUEST_LV_0100_20151001_009387	Collect Blue Paint
+QUEST_LV_0100_20151001_009388	Squire Williya told you that as a return for handing over the scroll for the dead, Pardoner Erikas wants Blue Paint. Defeat the monsters at Apgaudin Three Ways and collect Blue Paint.
 QUEST_LV_0100_20151001_009389	Hand them over to Pardoner Erikas
-QUEST_LV_0100_20151001_009390	You've obtained enough Blue paints which Pardoner Erikas has requested. Hand over Blue paints to Erikas and receive the scroll for the deads.
+QUEST_LV_0100_20151001_009390	You've obtained enough Blue Paint which Pardoner Erikas has requested. Hand over the Blue Paint to Erikas and receive the scroll for the deads.
 QUEST_LV_0100_20151001_009391	Squire Williya wants to wake up Gailus Legwyn with the scroll for the deads and listen to the truth. Talk to Squire, Williya.
 QUEST_LV_0100_20151001_009392	Look for the spirit of Gailyus Legwyn
 QUEST_LV_0100_20151001_009393	Squire Williya told you that she can't trust Pardoner Erikas. Use the scroll for the deads which you've dealt with Erikas in front of the unknown tombstone in Mires Grave Field to look for the spirit of Gailus Legwyn. 
@@ -9841,8 +9841,7 @@ QUEST_LV_0100_20151016_009836	{memo X}
 QUEST_LV_0100_20151016_009837	{memo X}
 QUEST_LV_0100_20151016_009838	
 QUEST_LV_0100_20151016_009839	{memo X}
-QUEST_LV_0100_20151016_009840	{memo X}
- 그걸 먹은 페릿은 다신 식량을 훔치러 오지 않을 걸요?{nl}일단 오염된 붉은 물을 떠다주세요.{nl}오염된 붉은 물은 마을 구석에 있는 오래된 우물에서 뜰 수 있어요.	
+QUEST_LV_0100_20151016_009840	{memo X}	
 QUEST_LV_0100_20151016_009841	
 QUEST_LV_0100_20151016_009842	
 QUEST_LV_0100_20151016_009843	{memo X}
@@ -9874,7 +9873,6 @@ QUEST_LV_0100_20151016_009868	{memo X}
 QUEST_LV_0100_20151016_009869	{memo X}
 QUEST_LV_0100_20151016_009870	
 QUEST_LV_0100_20151016_009871	{memo X}
-아마 페릿 부족과 자연스럽게 대화도 가능할겁니다. {nl}페릿 부족과 대화해서 페릿이 마족 편에 동조하고 있는 이유를 알아봐 주세요.	
 QUEST_LV_0100_20151016_009872	
 QUEST_LV_0100_20151016_009873	
 QUEST_LV_0100_20151016_009874	{memo X}
@@ -9882,8 +9880,7 @@ QUEST_LV_0100_20151016_009875	{memo X}
 QUEST_LV_0100_20151016_009876	{memo X}
 QUEST_LV_0100_20151016_009877	{memo X}
 QUEST_LV_0100_20151016_009878	{memo X}
-QUEST_LV_0100_20151016_009879	{memo X}
-하지만 당장 페릿을 어떻게 할 수가 없으니 쫓아내기라도 해야겠어요.{nl}저에게 페릿들이 싫어하는 지독한 향이 있어요.{nl}모닥불을 피워두고 지독한 향을 태우면 페릿들이 냄새를 맡고 도망갈겁니다.{nl}사람한테도 조금.. 고약한 냄새지만 참고 부탁드리겠습니다..	
+QUEST_LV_0100_20151016_009879	{memo X}	
 QUEST_LV_0100_20151016_009880	{memo X}
 QUEST_LV_0100_20151016_009881	{memo X}
 QUEST_LV_0100_20151016_009882	

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -9143,7 +9143,7 @@ QUEST_LV_0100_20151001_009138	Fortunately, you were able to restore the sanctum.
 QUEST_LV_0100_20151001_009139	{memo X}Go to the camp of Anastopa
 QUEST_LV_0100_20151001_009140	{memo X}As Damijonas has told you, let's go to the camp of Anastos if there is someone called Albinas in Anastos.
 QUEST_LV_0100_20151001_009141	{memo X}Retrieve the research materials
-QUEST_LV_0100_20151001_009142	{memo X}It seems that you will have to bring important materials to Gedas to obtain some information regarding Albinas. Please find the research materials from the monsters nearby. You would be able to obtain them by defeating them, but it will be helpful to press space bar to check which monsters has many research documents.
+QUEST_LV_0100_20151001_009142	{memo X}It seems that you will have to bring important materials to Gedas to obtain some information regarding Albinas. Please find the research materials from the monsters nearby. You would be able to obtain them by defeating them, but it will be helpful to press the space bar key to check which monsters has many research documents.
 QUEST_LV_0100_20151001_009143	{memo X}Bring research documents
 QUEST_LV_0100_20151001_009144	You've found all research materials which Gedas was looking for. Now, bring them to Gedas.
 QUEST_LV_0100_20151001_009145	Talk to Gedas

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -434,7 +434,7 @@ QUEST_LV_0100_20150317_000429	$)}My husband used to be a miner. I am relieved th
 QUEST_LV_0100_20150317_000430	$)}Many refugees came from fallen towns.{nl}Our food supplies are running short but we still have to help each other.
 QUEST_LV_0100_20150317_000431	$I may not bring in the items of the best quality, but isn't having all items necessary a skill of its own?{nl}I've got to work hard to get through tough times.
 QUEST_LV_0100_20150317_000432	{memo X}$I think the best weapons and armor are the ones that you get used to over a long period time.{nl}In order to do so, you must first start by buying good items.
-QUEST_LV_0100_20150317_000433	$I used to pack my things and go around travelling in the past but I guess that would be difficult now.
+QUEST_LV_0100_20150317_000433	$I used to pack my things and go around traveling in the past but I guess that would be difficult now.
 QUEST_LV_0100_20150317_000434	$Try using a variety of weapons. Eventually, you'll find one that fits you.
 QUEST_LV_0100_20150317_000435	$The armors that suit you guarantee your safety.
 QUEST_LV_0100_20150317_000436	$A single armor piece can mean the difference between life and death. Look around to see if you have everything you need.
@@ -690,7 +690,7 @@ QUEST_LV_0100_20150317_000685	The manual for the secret place
 QUEST_LV_0100_20150317_000686	$We hid the secret treasures for the Revelator who would come someday.{nl}Find and absorb the Guardians' hidden energy to open the secret door.
 QUEST_LV_0100_20150317_000687	$The hideout of my brother, whom I used to serve, is located at the Abandoned Farm up north.{nl}Please get my brother's diary there.
 QUEST_LV_0100_20150317_000688	Grita
-QUEST_LV_0100_20150317_000689	{memo X}It seems that there are more monsters here now compared to the number monsters that were present before I lost my conciousness.{nl}Did something happen to Gabija?
+QUEST_LV_0100_20150317_000689	{memo X}It seems that there are more monsters here now compared to the number monsters that were present before I lost my consciousness.{nl}Did something happen to Gabija?
 QUEST_LV_0100_20150317_000690	{memo X}It may be better for Gabija to let her know that we are here.{nl}There's a pole that we can ignite light on. Let's go.
 QUEST_LV_0100_20150317_000691	{memo X}Good. Since she knows that we came, she will recover her health.{nl}Let's go up to see Gabija.{nl}{nl}
 QUEST_LV_0100_20150317_000692	$Guardian of the Kingdom's Secret Treasures
@@ -977,7 +977,7 @@ QUEST_LV_0100_20150317_000972	I hope the monsters haven't broken the magic circl
 QUEST_LV_0100_20150317_000973	{memo X}Damn.{nl}They broke it. It is unfixable.
 QUEST_LV_0100_20150317_000974	{memo X}When you activate the device which sets barriers, monsters won't be able to come in.{nl}The supply device for demons' power is broken, but we can input the power with other methods.
 QUEST_LV_0100_20150317_000975	{memo X}I hope that crazy magician, Antares, won't disturb us.
-QUEST_LV_0100_20150317_000976	{memo X}He set a trap so well.{nl}I didn't like him even he was concious.
+QUEST_LV_0100_20150317_000976	{memo X}He set a trap so well.{nl}I didn't like him even he was conscious.
 QUEST_LV_0100_20150317_000977	{memo X}We have to be careful from here.{nl}This is the place where Antares, a dangerous magician, was imprisoned.{nl}We should move up to the next floor quickly.
 QUEST_LV_0100_20150317_000978	{memo X}He was a great magician before.{nl}But, his ideology was too dangerous.
 QUEST_LV_0100_20150317_000979	Oh my goodness, why now..{nl}
@@ -1495,7 +1495,7 @@ QUEST_LV_0100_20150317_001490	If I didn't have this wound, that monster would be
 QUEST_LV_0100_20150317_001491	Thanks.{nl}Since I got all those supplies back, I will try cheer up myself one more time.
 QUEST_LV_0100_20150317_001492	$The wound is deeper than I thought, and I can hardly move.{nl}I heard Canyon Apynys is good for alleviating the pain.
 QUEST_LV_0100_20150317_001493	$Good job. That's Canyon Apynys.{nl}I am worried about the side effects, but I hope they go away soon.
-QUEST_LV_0100_20150317_001494	$Do you have the Canyon Apynys?{nl}I feel like I will lose my conciousness even when I just breathe.
+QUEST_LV_0100_20150317_001494	$Do you have the Canyon Apynys?{nl}I feel like I will lose my consciousness even when I just breathe.
 QUEST_LV_0100_20150317_001495	The blood has stopped, but my body feels numb.{nl}Can you defeat the monsters nearby so I can return safely?
 QUEST_LV_0100_20150317_001496	It is aching more than I thought.{nl}I'll have to give up a little strength to move quickly.
 QUEST_LV_0100_20150317_001497	After I regain more energy, I should go back to the commander.{nl}Thank you so much.
@@ -1608,7 +1608,7 @@ QUEST_LV_0100_20150317_001603	It seems that the Guide Owl finally made a decisio
 QUEST_LV_0100_20150317_001604	{memo X}Anyways, It's good.{nl}I need the Essence of Spirit from the spirit that is wandering around the grave of unknown warrior.{nl}You can do anything, just bring us the Essence.
 QUEST_LV_0100_20150317_001605	The spirits that were wandering for a long time are like monsters.
 QUEST_LV_0100_20150317_001606	Wow, you collected those Essences.{nl}When you go back to the Guide Owl, it will empower your weapon with the power of spirits.{nl}I am not sure if that will result in a positive outcome..Only Goddess will know.
-QUEST_LV_0100_20150317_001607	It is a personal matter, but there is an angry owl at Cross Hill near here.{nl}But, after it fell into a deep sleep due to an incident, it is obsessed with evil power.{nl}Please wake up that angry owl and persuade it to gain it's conciousness again.{nl}
+QUEST_LV_0100_20150317_001607	It is a personal matter, but there is an angry owl at Cross Hill near here.{nl}But, after it fell into a deep sleep due to an incident, it is obsessed with evil power.{nl}Please wake up that angry owl and persuade it to gain it's consciousness again.{nl}
 QUEST_LV_0100_20150317_001608	If it doesn't listen to you..{nl}Then just destroy it and let it go to the Goddess.
 QUEST_LV_0100_20150317_001609	I will do anything to bring it back to it's normal status.
 QUEST_LV_0100_20150317_001610	This is the symbol of the Guide Owl which guided his spirit.{nl}When it sleeps for a long time, it gets influenced by monsters.{nl}Many of its allies changed like that.{nl}
@@ -2056,7 +2056,7 @@ QUEST_LV_0100_20150317_002051	$Okay, show me that you can stand against those th
 QUEST_LV_0100_20150317_002052	{memo X}
 QUEST_LV_0100_20150317_002053	$I don't know if it's the thorny vines or the evil energy, but... {nl}this forest makes people very depressed.
 QUEST_LV_0100_20150317_002054	$I personally believe that one day this forest will be okay again.
-QUEST_LV_0100_20150317_002055	Are you okay?{nl}I almost lost my conciousness due to that voice.{nl}Who is he anyways..
+QUEST_LV_0100_20150317_002055	Are you okay?{nl}I almost lost my consciousness due to that voice.{nl}Who is he anyways..
 QUEST_LV_0100_20150317_002056	{memo X}
 QUEST_LV_0100_20150317_002057	$The evil energy is becoming stronger and the Believers are getting tired. It's a bad situation.
 QUEST_LV_0100_20150317_002058	$Thanks.{nl}I wonder what would have happened if you weren't here.
@@ -2166,7 +2166,7 @@ QUEST_LV_0100_20150317_002161	The Tanus in Zvelgian Vacant Lot carry Purifying S
 QUEST_LV_0100_20150317_002162	$Just like there are many demons, the same goes for the Goddesses. {nl} The five Goddesses are just the ones who became well known.
 QUEST_LV_0100_20150317_002163	$Our village serves the Goddess Saule, who overlooks the sun. {nl}We used to go see her a lot through the portal, but one day that portal closed.
 QUEST_LV_0100_20150317_002164	{memo X}I haved carved the owls for a long time.{nl}At one point in time, they got their lives and determination.{nl}
-QUEST_LV_0100_20150317_002165	{memo X}When I gained my conciousness, a few hundreds of years have passed.
+QUEST_LV_0100_20150317_002165	{memo X}When I gained my consciousness, a few hundreds of years have passed.
 QUEST_LV_0100_20150317_002166	{memo X}Carvers should be careful not to exaggerate their skills. They should be humble.
 QUEST_LV_0100_20150317_002167	$It is a good sign that you, the Revelator, came here.{nl}We've been waiting for you for a long time.
 QUEST_LV_0100_20150317_002168	$Please come to our village.{nl}The villagers will really like you.{nl}For sure.
@@ -6707,7 +6707,7 @@ QUEST_LV_0100_20150428_006702	$Thank you so much for your support.{nl}Turn left 
 QUEST_LV_0100_20150428_006703	{memo X}Vubbe Fighter is hiding deep in the Nudegi Felled Area. {nl} We got the orders to kill but it may be safer to wait for additional troops.
 QUEST_LV_0100_20150428_006704	$We should check it by rubbing Hallowventer Charcoal.{nl}The next epitaph is at the right side of Negyvas Field.
 QUEST_LV_0100_20150428_006705	$We can suppress the evil forces if the magic of the Royal Mausoleum is released.{nl}This requires a number of activating stones located inside active Guardians.
-QUEST_LV_0100_20150428_006706	{memo X}It seems that there are more monsters here now compared to the number monsters that were present before I lost my conciousness.{nl}Did something happen to Gabija?
+QUEST_LV_0100_20150428_006706	{memo X}It seems that there are more monsters here now compared to the number monsters that were present before I lost my consciousness.{nl}Did something happen to Gabija?
 QUEST_LV_0100_20150428_006707	It may be better for Gabija to let her know that we are here.{nl}There's a place where we can ignite a signal light. Let's go.
 QUEST_LV_0100_20150428_006708	Good. Since she knows that we came, she will recover her health.{nl}Let's go up to see Gabija.{nl}
 QUEST_LV_0100_20150428_006709	I could handle it myself. {nl}Those weaklings would come trembling on their knees to return the parts. {nl} But what if more thieves come while I'm at it?
@@ -6967,7 +6967,7 @@ QUEST_LV_0100_20150714_006962	$Put the Matsum's Flower Stamens in this potion an
 QUEST_LV_0100_20150714_006963	This place is too dangerous. {nl}Please go to a safe area.
 QUEST_LV_0100_20150714_006964	Clymen... I can feel its presence at the Ishpirki Access Road.{nl}Please defeat it.
 QUEST_LV_0100_20150714_006965	$Bramble..{nl}It is a pity that it went against its own fate.{nl}
-QUEST_LV_0100_20150714_006966	When I gained my conciousness, a few hundreds of years have passed.
+QUEST_LV_0100_20150714_006966	When I regained consciousness, a few hundred years had passed.
 QUEST_LV_0100_20150714_006967	Jane's Spirit
 QUEST_LV_0100_20150714_006968	I saved nothing.{nl}Master, Mage Tower, and my peace??nl}
 QUEST_LV_0100_20150714_006969	You have no reason to help me, but it's been such a long time that I saw a man alive.{nl}Can you listen to my story if you are okay?
@@ -8432,7 +8432,7 @@ QUEST_LV_0100_20151001_008427	{memo X}Albi...nas...?
 QUEST_LV_0100_20151001_008428	{memo X}{nl}Uh...
 QUEST_LV_0100_20151001_008429	{memo X}{nl}Nope. I can't think of anyone on Anastos with that name. {nl}Moreover, he hold you go burn and destroy the Nestos sanctuary? {nl}Oh my god...
 QUEST_LV_0100_20151001_008430	{memo X}{nl}Nonsense. We don't do such a thing. {nl}I think we need to investigate on that matter. {nl}We give danger signal fires when we send out people for investigation {nl}and we ran out of it just now. {nl}Can you find some firepowder that are used to make the danger signal fires? 
-QUEST_LV_0100_20151001_008431	We all servce the Goddess. That is why we're on the pilgrimages. {nl}It's just a small difference in how we see the world. 
+QUEST_LV_0100_20151001_008431	We all service the Goddess. That is why we're on the pilgrimages. {nl}It's just a small difference in how we see the world. 
 QUEST_LV_0100_20151001_008432	{nl}Nestos people say that we should believe in the Goddesses unconditionally even if they disappeared, {nl}while we, the Anastos, pursue something more practical. 
 QUEST_LV_0100_20151001_008433	{nl}Defeating demons, improving the qualities of human lives... we have to aim for those things.
 QUEST_LV_0100_20151001_008434	{memo X}Monsters are all around so it will be difficult to obtain the materials.
@@ -8441,13 +8441,13 @@ QUEST_LV_0100_20151001_008436	Okay, good. That's enough.{nl}Now, we will make fl
 QUEST_LV_0100_20151001_008437	We've completed the flame bomb... Now I will call my colleague.{nl}He is called Fabius.
 QUEST_LV_0100_20151001_008438	{memo X}Fabius is a moderatist among Anastos, so he won't have problem even if he meets one of Nestos on his way.
 QUEST_LV_0100_20151001_008439	{memo X}Since Fabius left... we would somehow get some answer.{nl}But, I don't feel good about it. Is there any information...
-QUEST_LV_0100_20151001_008440	{memo X}{nl}Ah! Barte over ther must know something.{nl}He arrived here while travelling various locations.{nl}How about we ask about Albinas there?
+QUEST_LV_0100_20151001_008440	{memo X}{nl}Ah! Barte over ther must know something.{nl}He arrived here while traveling various locations.{nl}How about we ask about Albinas there?
 QUEST_LV_0100_20151001_008441	It's just a different perspective of looking at the world. {nl}The topic they cover the most...
-QUEST_LV_0100_20151001_008442	{nl}The disappearances of the Goddesses were done spontaneously so are we going to still follow then after they abondoned us...{nl}Another problem is whether we, humans should continue to manage the world where the Goddesses have disappeared...
+QUEST_LV_0100_20151001_008442	{nl}The disappearances of the Goddesses were done spontaneously so are we going to still follow then after they abandoned us...{nl}Another problem is whether we, humans should continue to manage the world where the Goddesses have disappeared...
 QUEST_LV_0100_20151001_008443	{nl}Are we going to aim for the truth or trust the Goddessses and pray... that will be the difference.{nl}But, they are just conflicting each other and they don't deny each others' existences.
 QUEST_LV_0100_20151001_008444	{memo X}She is rather progressive.{nl}So since she is not close to me... I want you to go to her.
 QUEST_LV_0100_20151001_008445	Barte
-QUEST_LV_0100_20151001_008446	{memo X}{nl}Ah, yes. I am called Barte.{nl}I was on a journey until recently. I am thinking about leaving againn.
+QUEST_LV_0100_20151001_008446	{memo X}{nl}Ah, yes. I am called Barte.{nl}I was on a journey until recently. I am thinking about leaving again.
 QUEST_LV_0100_20151001_008447	{memo X}Albinas... Is that him?{nl}When we arrived at the camp recently, one man was wearing the same outfit like us so I was going to say hello, but then I felt something was not right so I decided not to.{nl}He was giggling as he was looking at the leathers that were engraved with writings and he ripped off those leathers.
 QUEST_LV_0100_20151001_008448	{memo X}{nl}I was scared since that wasn't the power of a human, but he threw all those leathers on the ground and disappeared down there. The monsters thought that was the time and ate all the leathers. Was the smell of blood on those leathers?...
 QUEST_LV_0100_20151001_008449	{memo X}{nl}It was scary. {nl}Ah, I think the monsters there could've not digested the leathers as yet... {nl}Can you bring them? I am curious too.
@@ -8472,7 +8472,7 @@ QUEST_LV_0100_20151001_008467	It's bad enough that they were killed by the Vubbe
 QUEST_LV_0100_20151001_008468	Thank you. {nl} My comrades will now be able to rest in peace.
 QUEST_LV_0100_20151001_008469	It hurts to think about giving these keepsakes to my dead comrades' families.
 QUEST_LV_0100_20151001_008470	Thank you very much. {nl} My comrades can now rest in peace with the Goddesses.
-QUEST_LV_0100_20151001_008471	{memo X}Damn. {nl}It's too wide so let's move seperately.{nl}
+QUEST_LV_0100_20151001_008471	{memo X}Damn. {nl}It's too wide, so let's move separately.{nl}
 QUEST_LV_0100_20151001_008472	{memo X}First, you go deep into that place.{nl}Who knows? The demons with the special power may possess something.{nl}
 QUEST_LV_0100_20151001_008473	{memo X}I am so mad.{nl}There isn't anything special and the demons didn't have anything.{nl}
 QUEST_LV_0100_20151001_008474	Did we search an empty area?
@@ -8481,7 +8481,7 @@ QUEST_LV_0100_20151001_008476	How about you?{nl}Have you obtained anything?
 QUEST_LV_0100_20151001_008477	{memo X}Wait!{nl}I can sense something big from Monocle.{nl}
 QUEST_LV_0100_20151001_008478	{memo X}It looks to be very big. Go there and check yourself.{nl}I will hide here since the battles are not my type.{nl}I don't know what to do if a strong demon comes out.
 QUEST_LV_0100_20151001_008479	{memo X}Monocle is looking for the hidden object that is hidden inside the special power. It is a big object.
-QUEST_LV_0100_20151001_008480	{memo X}Go there and chek.{nl}Like a while ago, the demons may appear and there may be really strong demons there... I will hide myself here.
+QUEST_LV_0100_20151001_008480	{memo X}Go there and check.{nl}Like a while ago, the demons may appear and there may be really strong demons there... I will hide myself here.
 QUEST_LV_0100_20151001_008481	{memo X}An outsider comes here... Who are you?{nl}How did you come here?
 QUEST_LV_0100_20151001_008482	{memo X}It is really big so you will recognize it when you see it.
 QUEST_LV_0100_20151001_008483	{memo X}I will introduce myself first.{nl}I am the manager of the Fortress of the Great Earth.{nl}Who are you?{nl}
@@ -8491,7 +8491,7 @@ QUEST_LV_0100_20151001_008486	You can't say no nor ask for reasons to the kingdo
 QUEST_LV_0100_20151001_008487	The kingdom order told us to ban anyone's entrance here, but I think the Goddess made us to meet each other here.{nl}The Goddess is not under the kingdom.{nl}
 QUEST_LV_0100_20151001_008488	{memo X}If it is about the Goddess, then I will do the guide.{nl}At least, there aren't anything here so let's go to the next area.
 QUEST_LV_0100_20151001_008489	{memo X}Ah, I totally forgot.{nl}I've prepared many things to block the intruders, but I totally forgot about them.{nl}
-QUEST_LV_0100_20151001_008490	I need a cerificate.{nl}It was created to attack the ones who are not permitted ferociously.{nl}
+QUEST_LV_0100_20151001_008490	I need a certificate.{nl}It was created to attack the ones who are not permitted ferociously.{nl}
 QUEST_LV_0100_20151001_008491	{memo X}To make a certificate, we first need a mushroom.{nl}There are many mushrooms at the lower area so please get me one.
 QUEST_LV_0100_20151001_008492	I will help anything that is related to the Goddesses.{nl}Finally, an opportunity has come in my boring life.
 QUEST_LV_0100_20151001_008493	They are enough to make the certificate.{nl}Please wait a bit.
@@ -8517,7 +8517,7 @@ QUEST_LV_0100_20151001_008512	{memo X}To execute the power, the bones of the dem
 QUEST_LV_0100_20151001_008513	Even I failed to pull out the memories of the spirits.{nl}I feel reliable since you are with me.
 QUEST_LV_0100_20151001_008514	{memo X}Well done.{nl}We only have to do the last step in order to complete the token of the restraint.
 QUEST_LV_0100_20151001_008515	As I told you before, I've tried to look at the memories of the spirits.{nl}The resistances from the spirits were too aggressive at then, so I failed that time.{nl}
-QUEST_LV_0100_20151001_008516	But, now I have you and the token of the restraint.{nl}If we could bring the spirtis, we may able to read the memories with the soul stones that are beside me.
+QUEST_LV_0100_20151001_008516	But, now I have you and the token of restraint.{nl}If we could bring the spirits, we may able to read the memories with the soul stones that are beside me.
 QUEST_LV_0100_20151001_008517	Please bring the spirits here with the token of the restraint.{nl}I will get prepared.
 QUEST_LV_0100_20151001_008518	Please bring the spirits fast.{nl}I am also curious.
 QUEST_LV_0100_20151001_008519	{memo X}They are breaking something after receiving an order from Ruklys.{nl}I think that may be related to the revelation of the Goddesses.
@@ -8532,8 +8532,8 @@ QUEST_LV_0100_20151001_008527	Good. {nl}That's the token of the restraint.{nl}
 QUEST_LV_0100_20151001_008528	Don't care that much even if we use the demons.{nl}What's important is that we should look for the revelation of the Goddess.
 QUEST_LV_0100_20151001_008529	Are there spirits that are wandering around the Fortress of the Great Earth without going to the Goddesses?{nl}I can't see them suffering anymore.
 QUEST_LV_0100_20151001_008530	I can only help you to make the owl sculptures.{nl}Those owls would guide the spirits that lost their ways.
-QUEST_LV_0100_20151001_008531	Can you put the sculptures of the owls at the Fortress of the Great Earth?{nl}If you guide the spirits to the owl sculptures, then you would be able to go beside the Goddesses.
-QUEST_LV_0100_20151001_008532	I can't quit carving the owl scuptures.{nl}When I stop carving, then that means the peaceful days have come.
+QUEST_LV_0100_20151001_008531	Can you put the owl sculptures at the Fortress of the Great Earth?{nl}If you guide the spirits to the owl sculptures, then you would be able to go beside the Goddesses.
+QUEST_LV_0100_20151001_008532	I can't quit carving the owl sculptures.{nl}When I stop carving, then that means the peaceful days have come.
 QUEST_LV_0100_20151001_008533	Thanks.{nl}The Goddesses must have given use long lives to fulfill these.
 QUEST_LV_0100_20151001_008534	{memo X}I don't have time to think about those treasures.{nl}I also care for the kingdom. I know that the revelation should not fall into the hands of the demons.{nl}
 QUEST_LV_0100_20151001_008535	{memo X}I should meet Eminent around here.{nl}Let's check with Monocle without being noticed by Eminent.
@@ -8552,8 +8552,8 @@ QUEST_LV_0100_20151001_008547	Have you collected all the parts?{nl}Give it to me
 QUEST_LV_0100_20151001_008548	I want you to meet the revelation of the Goddess fast.{nl}To fulfill my lifelong wish...
 QUEST_LV_0100_20151001_008549	{memo X}I will not hide it anymore.{nl}I am Premier Eminent and I used to serve King Kadumel.{nl}
 QUEST_LV_0100_20151001_008550	{memo X}It's up to you to believe, but I want you to give me an opportunity to at least explain this.
-QUEST_LV_0100_20151001_008551	I am sure that you know this place is the last battlefield where Ruklys resisted til his death.{nl}And Ruklys was also the guardian of the revelation like his master, Maven.{nl}
-QUEST_LV_0100_20151001_008552	But, as the defeat came, he crossed the line which he should've not crossed.{nl}He made an alliance with the demons.{nl}
+QUEST_LV_0100_20151001_008551	I am sure that you know this place is the last battlefield where Ruklys resisted until his death.{nl}And Ruklys was also the guardian of the revelation like his master, Maven.{nl}
+QUEST_LV_0100_20151001_008552	But, as the defeat came, he crossed the line which he should not have crossed.{nl}He made an alliance with the demons.{nl}
 QUEST_LV_0100_20151001_008553	{memo X}The Fortress of the Great Earth is full of vicious demons and monsters. {nl}That's why I brought my army here.{nl}
 QUEST_LV_0100_20151001_008554	{memo X}It was a long battle. But the battle ended with my victory.{nl}And then the voices of the Goddess was heard. To protect the revelation.{nl}
 QUEST_LV_0100_20151001_008555	But, I don't know how Ruklys hid the revelation.{nl}He is just a half guardian.{nl}
@@ -8565,7 +8565,7 @@ QUEST_LV_0100_20151001_008560	{memo X}Ah, you still haven't left?{nl}
 QUEST_LV_0100_20151001_008561	I've thought about it a lot. {nl}I am sure that the person who've been to this deep is just me among the grave thieves!{nl}
 QUEST_LV_0100_20151001_008562	We should record this historic moment.{nl}Can you bring some stones where I could record my achievements?
 QUEST_LV_0100_20151001_008563	What should I write on the stones? {nl}If you have any thoughts, please let me know.
-QUEST_LV_0100_20151001_008564	I know that it is hard to bring somethig that is that big.{nl}Thank you. I will think what to write on it.
+QUEST_LV_0100_20151001_008564	I know that it is hard to bring something that is that big.{nl}Thank you. I will think what to write on it.
 QUEST_LV_0100_20151001_008565	{memo X}Isn't this the diary of Ruklys? {nl}I am sure that more than this. Can you look for more?
 QUEST_LV_0100_20151001_008566	{memo X}When you bring this to Wilhelmina Carriot, she will pay you accordingly.
 QUEST_LV_0100_20151001_008567	Okay. This is enough.{nl}
@@ -8604,7 +8604,7 @@ QUEST_LV_0100_20151001_008599	Eventually, everyone dedicated their lives to seal
 QUEST_LV_0100_20151001_008600	I can feel some sacred power within you.{nl}If you could eliminate that demon, we will help.{nl}Please complete the task that we couldn't complete...
 QUEST_LV_0100_20151001_008601	There was some pitiful girl that I was taking care of.{nl}She didn't have families and she was so quiet.{nl}
 QUEST_LV_0100_20151001_008602	As she started to stay in my mansion, the demons started to appear near the mansion...{nl}
-QUEST_LV_0100_20151001_008603	And an incident occured where one of my subordinates was killed by poison. {nl}Of course, everyone suspected that girl.{nl}
+QUEST_LV_0100_20151001_008603	And an incident occurred where one of my subordinates was killed by poison. {nl}Of course, everyone suspected that girl.{nl}
 QUEST_LV_0100_20151001_008604	Eventually, that girl ran away. {nl}I don't know why, but deep inside my heart, there was some voice echoing to protect her.{nl}
 QUEST_LV_0100_20151001_008605	Since we were able to tie up the hunter of Kartas here, she was able to run away safely.{nl}Although, it turned out like this, I don't have any regrets.{nl}
 QUEST_LV_0100_20151001_008606	It's not that I did that for good faith.{nl}But, I feel sorry for my family... that they couldn't see Justina.
@@ -8624,12 +8624,12 @@ QUEST_LV_0100_20151001_008619	Place the Wrongful Teeth near the seal. {nl}Then, 
 QUEST_LV_0100_20151001_008620	Everything is over...{nl}It is so fortunate that it ended even after our deaths
 QUEST_LV_0100_20151001_008621	Thanks. Please pass this crystal to my daughter's friend.{nl}Now, I will return to the Goddesses with my subordinates.{nl}
 QUEST_LV_0100_20151001_008622	When you meet my daughter, please tell her that I am so sorry.{nl}And that I love her... please don't forget.
-QUEST_LV_0100_20151001_008623	Who is that girl who Legwyn tried to protect til his death?{nl}But, I am sure that he will rest in peace. Since his last mission has been fulfilled.{nl}
+QUEST_LV_0100_20151001_008623	Who is that girl who Legwyn tried to protect until his death?{nl}But, I am sure that he will rest in peace. Since his last mission has been fulfilled.{nl}
 QUEST_LV_0100_20151001_008624	Now, I will return this to Erikas.{nl}I really appreciate for your help on behalf of my friend, Justina Legwyn.
 QUEST_LV_0100_20151001_008625	I can tell this to you freely.{nl}The keepsakes of Lydia Schaffen... I came out from the Star Tower with my colleagues to protect them.{nl}
 QUEST_LV_0100_20151001_008626	The predecessor leader died suspiciously and Ignas became the next leader of the tower of stars.{nl}And then his tyranny started.{nl}
-QUEST_LV_0100_20151001_008627	He told everyone that the old rules of Lydia Schaffen should be abondoned and everything should start again...{nl}He told us to eliminate everything that was related to Lydia Schaffen.{nl}
-QUEST_LV_0100_20151001_008628	But, Lydia Schaffen was the everything of the Star Tower and she was the symbolic figure of all archers.{nl}After we gained our conciousness, we were running away with our colleagues with the keepsakes.{nl}
+QUEST_LV_0100_20151001_008627	He told everyone that the old rules of Lydia Schaffen should be abandoned and everything should start again...{nl}He told us to eliminate everything that was related to Lydia Schaffen.{nl}
+QUEST_LV_0100_20151001_008628	But, Lydia Schaffen was the everything of the Star Tower and she was the symbolic figure of all archers.{nl}After we regained consciousness, we ran away with our colleagues and the keepsakes.{nl}
 QUEST_LV_0100_20151001_008629	Right now... I can hardly move due to the injury.{nl}But, if I stay like this, the chasers would find out about it.
 QUEST_LV_0100_20151001_008630	I think we should move.{nl}Can you lure the chasers so that I could go to Guoda Empty Lot?{nl}
 QUEST_LV_0100_20151001_008631	When we fire this disposable signal bomb, they will follow you.{nl}I am counting on you...
@@ -8655,26 +8655,26 @@ QUEST_LV_0100_20151001_008650	Who are you?{nl}You don't seem to be the chaser of
 QUEST_LV_0100_20151001_008651	Ah... You've already met Irmantas and Grazina.{nl}That's good. I have to meet Irmantas right away since I have the words to pass him!
 QUEST_LV_0100_20151001_008652	I've seen it for sure.{nl}The demons were among the chasers of Ignas.{nl}They seemed to be close to each other.{nl}
 QUEST_LV_0100_20151001_008653	I am sure Ignas has colluded with the demons.{nl}I think eliminating the keepsakes of Lydia Schaffen is a part of that collusion.{nl}
-QUEST_LV_0100_20151001_008654	But, I was badly hurt as wel...{nl}I am not sure if I can meet Irmantas again in my life.{nl}
+QUEST_LV_0100_20151001_008654	But, I was badly hurt as well...{nl}I am not sure if I can meet Irmantas again in my life.{nl}
 QUEST_LV_0100_20151001_008655	Can you defeat the monsters around here so I can get to him?{nl}If you reduce the number of monsters, then the possibility of getting detected by monsters will be lowered.
 QUEST_LV_0100_20151001_008656	At first, I thought the chasers that were following from the Star Tower were subordinates of Ignas.{nl}But, they weren't. There's something we don't know yet!
 QUEST_LV_0100_20151001_008657	It noisy around here so I guess the chasers are near.{nl}We should move fast.
 QUEST_LV_0100_20151001_008658	If we just stay here, then we would get attacked without notifying anything...{nl}
 QUEST_LV_0100_20151001_008659	Please take me to Irmantas.{nl}We have to tell the ones who are following the determination of Lydia Schaffen that they are colluded with the demons!
-QUEST_LV_0100_20151001_008660	If only I didn't get this injury, they are easy to defeat...{nl}Where is Irmantas now?
-QUEST_LV_0100_20151001_008661	No... I feel like I am going to lose my conciousness if I walk little more.{nl}I feel like I am hearing the voices... of the Goddess.{nl}
+QUEST_LV_0100_20151001_008660	If only I didn't get this injury, they would be easy to defeat...{nl}Where is Irmantas now?
+QUEST_LV_0100_20151001_008661	No... I feel like I am going to lose consciousness if I walk little more.{nl}I feel like I am hearing the voice... of the Goddess.{nl}
 QUEST_LV_0100_20151001_008662	After I ran away from the Star Tower, I've never seen a person who is so kind and reliable like you.{nl}If something happens to me... {nl}
 QUEST_LV_0100_20151001_008663	Please tell Irmantas about the plot of Iganas with this letter.{nl}
 QUEST_LV_0100_20151001_008664	Let's go. {nl}I will cheer myself up a bit.{nl}
 QUEST_LV_0100_20151001_008665	What happened?{nl}I think I've heard a some noise from down there...{nl}
 QUEST_LV_0100_20151001_008666	{memo X}Illina... was attacked?{nl}How can Ignas do something without going crazy!{nl}
 QUEST_LV_0100_20151001_008667	{memo X}I will follow the words of Lydia Schaffen on behalf of Illina.{nl}I will arrive at Orsha no matter what takes.{nl}
-QUEST_LV_0100_20151001_008668	To you... I want to give you some rewards since you've protected me til the end.{nl}I am sure Illina and Lydia Schaffen also want me to do that.
+QUEST_LV_0100_20151001_008668	To you... I want to give you some rewards since you've protected me until the end.{nl}I am sure Illina and Lydia Schaffen also want me to do that.
 QUEST_LV_0100_20151001_008669	Please feed that black herb to Agatas.{nl}As it gets detoxified, the weak body of a human will suffer severe pains, but that will be better than dying.{nl}
 QUEST_LV_0100_20151001_008670	Go your way after saving the life of Agatas.{nl}In the name of the Demon Lord Hauberk, I will never forget you since you've saved my contractor.
 QUEST_LV_0100_20151001_008671	You are the one with a strong spirit.{nl}When they rushed in, I thought my revenge towards Giltine has ended.{nl}
 QUEST_LV_0100_20151001_008672	They followed here to obtain the power of my spirit.{nl}You and Agastas will be in danger...
-QUEST_LV_0100_20151001_008673	I think Agatas would not gain the conciousness for a while...{nl}For this innocent human and yourself, I want you to do something.{nl}
+QUEST_LV_0100_20151001_008673	I think Agatas would not gain the consciousness for a while...{nl}For this innocent human and yourself, I want you to do something.{nl}
 QUEST_LV_0100_20151001_008674	I have a way to eliminate the head of the demons.{nl}Please take care of the piece of my spirit which Agatas has for a while.{nl}
 QUEST_LV_0100_20151001_008675	In order to move my spirit piece, I need the crystal that possesses the demonic energy.{nl}Please get the shadow essence from the demons at Pakavi fields.
 QUEST_LV_0100_20151001_008676	With that power, I will be with you.
@@ -8682,7 +8682,7 @@ QUEST_LV_0100_20151001_008677	I can't quit this journey.{nl}Only I can eliminate
 QUEST_LV_0100_20151001_008678	As you ripped me off, I will get a revenge on them...
 QUEST_LV_0100_20151001_008679	This will be enough.{nl}I promise to you. If you help me, I will fight against the demons for the Goddesses and the humans.{nl}
 QUEST_LV_0100_20151001_008680	If you hate the demons, then you can trust me.{nl}The ones who've been betrayed will never forget.{nl}
-QUEST_LV_0100_20151001_008681	When the spirit was ripped in pieces, I decided myself.{nl}If I would have to look for my spirit for thousands of years, I will never forget them...
+QUEST_LV_0100_20151001_008681	When the spirit was ripped into pieces, I decided myself.{nl}If I would have to look for my spirit for thousands of years, I will never forget them...
 QUEST_LV_0100_20151001_008682	The power of the spirit if gradually recovering with the demonic power.{nl}The knowledge I've forgotten is gradually coming back.{nl}
 QUEST_LV_0100_20151001_008683	The head of the ones who are chasing me should be looking for me now.{nl}For the start of the new journey, I will make them feel the fear of the ones who are being chased...
 QUEST_LV_0100_20151001_008684	Defeat the demons using the power of my soul stone.{nl}If you defeat them, I will use them as the source to call out my subordinates.{nl}
@@ -8696,7 +8696,7 @@ QUEST_LV_0100_20151001_008691	But, I promise. {nl}That would never happen.
 QUEST_LV_0100_20151001_008692	1st Page of the Roxona Conflict
 QUEST_LV_0100_20151001_008693	Lydia Schaffen was a master of archery.{nl}She could even hit the feelers of a small insect.{nl}She stood in front of the great knight Ruklys.{nl}She held her breath and slowly drew her bow.{nl}It wasn't that long ago when Lydia Schaffen stood against Ruklys who used to be her lover.{nl} 
 QUEST_LV_0100_20151001_008694	It was a day in the winter time.{nl}The tyranny of Kadumel King started getting extreme.{nl}Never-ending labor, starving people, corrupted landlords and a violent king...{nl}Ruklys could not stand what he was seeing in the kingdom.{nl}Revolt.{nl}Everyone in Roxona believed that Ruklys will win.{nl}
-QUEST_LV_0100_20151001_008695	The spring had come and Ruklys was still in high spirits.{nl}Ruklys obtained the information that there was a village where the thieves who'd collided with the kingdom soldiers are living.{nl}The soldiers were so corrupted...{nl}Ruklys decided to attack the village with his subordinates.{nl}
+QUEST_LV_0100_20151001_008695	The spring had come and Ruklys was still in high spirits.{nl}Ruklys obtained the information that there was a village where the thieves who'd collided with the kingdom soldiers were living.{nl}The soldiers were so corrupted...{nl}Ruklys decided to attack the village with his subordinates.{nl}
 QUEST_LV_0100_20151001_008696	He was just fighting against the thieves, but some unknown tension made Ruklys to hold his sword more firmly.{nl}A few of his colleagues fell down with the blood bursting out from their chests.{nl}At the same time, Ruklys and his subordinates ran towards the village.{nl}They didn't need to horn the pipe to let everyone know the battle has started.{nl}
 QUEST_LV_0100_20151001_008697	They possessed a decent level of archery and martial arts.{nl}The doubts which Ruklys had in his mind also disappeared.{nl}It was certain that they were not normal thieves...{nl}Ruklys held his sword on his other hand.{nl}He noticed something strange as the time passed by, but that was after many people died.{nl}In the darkness, the battle continued.{nl}Ruklys managed to win the battle at the end, but he felt somewhat uncomfortable.{nl}Long after the battle, he found out that the village was the hometown of Lydia Schaffen.
 QUEST_LV_0100_20151001_008698	The ones who've been betrayed would never forget about anything.{nl}
@@ -8707,12 +8707,12 @@ QUEST_LV_0100_20151001_008702	Pull him out!{nl}I will be with you soon.
 QUEST_LV_0100_20151001_008703	If you are afraid, you could give up. I will complete the betrayal alone.{nl}I just hope that my contractor would not be hurt again...
 QUEST_LV_0100_20151001_008704	Thanks for fighting with me, companion.{nl}I will be with you when you and your colleagues fall into great pains and danger.
 QUEST_LV_0100_20151001_008705	Agatas carried out the contract diligently.{nl}I will leave him and start the journey of the revenge.{nl}
-QUEST_LV_0100_20151001_008706	The pieces of me that are spreaded all over this world...{nl}They will become one spirit with me some day.{nl}
+QUEST_LV_0100_20151001_008706	The pieces of me that are spread all over this world...{nl}They will become one spirit with me some day.{nl}
 QUEST_LV_0100_20151001_008707	If you meet them on your journey, please help them.{nl}My spirits will rely on you.
 QUEST_LV_0100_20151001_008708	This is the reward for the contract I've made with Agatas.{nl}Please put that in his pocket.{nl}
 QUEST_LV_0100_20151001_008709	Farewell, companion.{nl}I will never forget you.
 QUEST_LV_0100_20151001_008710	I will look for whereabouts of my other spirits here.{nl}Companion, we will meet again.
-QUEST_LV_0100_20151001_008711	I've put the spirit seperation potion{nl}into my pocket.
+QUEST_LV_0100_20151001_008711	I've put the spirit separation potion{nl}into my pocket.
 QUEST_LV_0100_20151001_008712	{memo X}Oh, you're here. {nl}Let's trace back what was seen in the soul's memory. {nl}If we could revive the Ruklys's device, then it will guide us to the revelation. 
 QUEST_LV_0100_20151001_008713	{memo X}I know where the device of Ruklys is but we need its parts to fix it. {nl}I will check on the left side so you check on the right. 
 QUEST_LV_0100_20151001_008714	{memo X}We'll need the parts to repair the device. {nl}Look for it on the right side. 
@@ -8722,7 +8722,7 @@ QUEST_LV_0100_20151001_008717	{memo X}I figured the location of the magic circle
 QUEST_LV_0100_20151001_008718	{memo X}First, the magic circle under Slypti Watchtower. {nl}The writings on the pole were erased so the magic circle is not working. {nl}
 QUEST_LV_0100_20151001_008719	{memo X}It will work when you write on it again. {nl}I'll take care of the magic circle below so I'll leave this to you. 
 QUEST_LV_0100_20151001_008720	{memo X}Be sure not to be caught by Eminent. 
-QUEST_LV_0100_20151001_008721	{memo X}I saw the magic circles activate. Are you ok? {nl}What about Eminent? {nl}
+QUEST_LV_0100_20151001_008721	{memo X}I saw the magic circles activate. Are you OK? {nl}What about Eminent? {nl}
 QUEST_LV_0100_20151001_008722	You defeated Eminent and obtained the revelation? {nl}Wow, you're way better than I thought... {nl}
 QUEST_LV_0100_20151001_008723	Anyway, I also feel like I've helped bring peace to the world and it beats my heart. {nl}But I still have some work to do. You know, right? 
 QUEST_LV_0100_20151001_008724	I feel lucky to have met you among the many Revelators. {nl}You saved the world, right? 
@@ -8748,10 +8748,10 @@ QUEST_LV_0100_20151001_008743	Divine object that you can't even approach... {nl}
 QUEST_LV_0100_20151001_008744	The people from Tree Order or something were here first before that Bokor Juta guy. {nl}They claimed that they were officially acknowledged by Goddess Zemyna or something? {nl}
 QUEST_LV_0100_20151001_008745	They said they'd carry out the will of the Goddess Zemyna since this land was blessed by her. {nl}How could I have stopped that. {nl}
 QUEST_LV_0100_20151001_008746	But since their arrival, the dead started to rise again. {nl}If that was on purpose, there couldn't have been an insult worse than that! {nl}
-QUEST_LV_0100_20151001_008747	That was giving me a headache already then some Bokor comes along breaking the coffins. {nl}Breaking the coffins to purify the dead does not show any respect for the dead!
+QUEST_LV_0100_20151001_008747	That was giving me a headache already, and then some Bokor comes along breaking the coffins. {nl}Breaking the coffins to purify the dead does not show any respect for the dead!
 QUEST_LV_0100_20151001_008748	That is not important. {nl}I want to calm all this fuss as soon as possible. {nl}
-QUEST_LV_0100_20151001_008749	If you help me, then I will believe you that the Bokor didn't come here with bad intentions. {nl}
-QUEST_LV_0100_20151001_008750	Burying it back on the ground is not all. {nl}Pay respect to the dead using this match and cremate their bodies. 
+QUEST_LV_0100_20151001_008749	If you help me, then I will believe that the Bokor didn't come here with bad intentions. {nl}
+QUEST_LV_0100_20151001_008750	Burying it back in the ground is not all. {nl}Pay respect to the dead using this match and cremate their bodies. 
 QUEST_LV_0100_20151001_008751	What are you waiting for! Move quickly! {nl}I cannot.. handle it anymore. 
 QUEST_LV_0100_20151001_008752	Sorry for being sharp a while ago. I was a bit sensitive. {nl}Actually, having to point the blades to people whom I should take care of as a gravekeeper is not something I am comfortable with. {nl}
 QUEST_LV_0100_20151001_008753	Thank you for giving them peace for me. 
@@ -8760,7 +8760,7 @@ QUEST_LV_0100_20151001_008755	Maybe that is why the dead rose... {nl}I had my su
 QUEST_LV_0100_20151001_008756	Ah! That's right. {nl}Since long time ago, some Bokor or Necromancer not in their sane minds used to come here secretly. {nl}They used to do insane experiments on the dead who are rested in here. {nl}
 QUEST_LV_0100_20151001_008757	So my father learned how to make shaman dolls from the guards nearby Klaipeda. {nl}He said if you put spells on the shaman dolls, it finds the power that messes with the grave and destroys it or something? {nl}
 QUEST_LV_0100_20151001_008758	There is a box in Kansias Stone Chamber with my father's belongings. {nl}There should be a shaman doll in it. {nl}I don't think I can.. make it through the bodies. 
-QUEST_LV_0100_20151001_008759	Our family has been gravekeepers for generations. {nl}My father passed away during the disaster on Medzio Diena so I took his place since then. {nl}
+QUEST_LV_0100_20151001_008759	Our family has been gravekeepers for generations. {nl}My father passed away during the disaster on Medzio Diena, so I have taken his place since then. {nl}
 QUEST_LV_0100_20151001_008760	I only learned over hid shoulders... {nl}But I am the gravekeeper of this place now. 
 QUEST_LV_0100_20151001_008761	Right! This is it.{nl}It wasn't used for a long time, but it should work well since father made it. 
 QUEST_LV_0100_20151001_008762	Done. Now go to the divine object. {nl}If that divine object is the reason behind the dead rising here, the shaman doll will break the barrier and destroy the divine object. 
@@ -8776,9 +8776,9 @@ QUEST_LV_0100_20151001_008771	Thank you for saving me. I almost went to the Godd
 QUEST_LV_0100_20151001_008772	The object of the Goddess would not summon such a monster. {nl}I smell something fishy with that Tree of Truth order. 
 QUEST_LV_0100_20151001_008773	Since the object here was not real, now we must find the trace of Goddess Zemyna from somewhere else. {nl}It's ok. If something like this makes me frustrated, then I would not have kept my journey until here. {nl}
 QUEST_LV_0100_20151001_008774	But before I leave, I must help the gravekeeper and keep the fuss down. {nl}Now that the evil object is gone, my abilities will help keep this place calm. {nl}
-QUEST_LV_0100_20151001_008775	I want to show my sincerity to the gravekeeper, but the image of him being angry at me holds me back. {nl}If you're on the way to the gravekeeper, can you send him my sincerity as well? 
+QUEST_LV_0100_20151001_008775	I want to show my sincerity to the gravekeeper, but, the image of him being angry at me holds me back. {nl}If you're on the way to the gravekeeper, can you send him my sincerity as well? 
 QUEST_LV_0100_20151001_008776	{memo X}No wonder. That object wasn't that of the Goddess. {nl}Using the name of the Goddess into tricks like this. They have crossed the line. {nl}
-QUEST_LV_0100_20151001_008777	I want to go and make them pay for it right away. {nl}But as a gravekeeper, keeping this place secure comes first. {nl}
+QUEST_LV_0100_20151001_008777	I want to go and make them pay for it right away. {nl}However, as a gravekeeper, keeping this place secure comes first. {nl}
 QUEST_LV_0100_20151001_008778	Was that Bokor's name Juta? {nl}His ability powers will be of much help. {nl}
 QUEST_LV_0100_20151001_008779	The Tree of Truth order went in to the Kalail Mausoluem. {nl}They said they will find something to carry out their order or something...{nl}
 QUEST_LV_0100_20151001_008780	If ever you go to Kalail Mausoleum, be careful about them. {nl}No matter how much I think about it, they are not in their right minds. {nl}
@@ -8789,25 +8789,25 @@ QUEST_LV_0100_20151001_008784	We, the Tree of Truth order, believe in the Divine
 QUEST_LV_0100_20151001_008785	Our order will be the appointed ones of the Divine Tree and guide the world in opening a new age. {nl}Right. Are you interested in joining our order? {nl}
 QUEST_LV_0100_20151001_008786	You are really strong, just as someone sent by the Divine Tree should be. {nl}Such strength should be used for something bigger. 
 QUEST_LV_0100_20151001_008787	I am collecting the spirit of the dead that rose back, as the order told me to. {nl}Margiris can read the memories of the dead when they were alive from the spirit stones. 
-QUEST_LV_0100_20151001_008788	She find the sins of the dead from their memories and forgives it to purify the sins in this world. {nl}
-QUEST_LV_0100_20151001_008789	But I seem to have sprained my ankle while running away from the dead. I can't walk. {nl}Can you help me by any chance? 
+QUEST_LV_0100_20151001_008788	She finds the sins of the dead from their memories and forgives them to purify the sins in this world. {nl}
+QUEST_LV_0100_20151001_008789 I seem to have sprained my ankle while running away from the dead. I can't walk. {nl}Can you help me by any chance? 
 QUEST_LV_0100_20151001_008790	I'm sure my prayers reached the Divine Tree to send you here. {nl}
 QUEST_LV_0100_20151001_008791	Brother. {nl}By this, your sins have become lighter. 
 QUEST_LV_0100_20151001_008792	There is something you need to help us with. {nl}Think of it as a test and do your best. {nl}
 QUEST_LV_0100_20151001_008793	Carrying out sacred missions can get you to some trouble like just a while ago. {nl}You can also lose your life. {nl}
 QUEST_LV_0100_20151001_008794	Bodies of followers are brought to Seima Stone Chamber and their sins are purified. {nl}But because of Margiris' sacred abilities, some actually get their life back. {nl}
-QUEST_LV_0100_20151001_008795	The followers who rise back can't throw away their regrets in life and keep roaming around this place. {nl}Please use this flint to cremate the regrets and souless bodies of the dead. 
+QUEST_LV_0100_20151001_008795	The followers who rise back can't throw away their regrets in life and keep roaming around this place. {nl}Please use this flint to cremate the regrets and soulless bodies of the dead. 
 QUEST_LV_0100_20151001_008796	Margiris told us salvation is not something we can get so easily. {nl}
 QUEST_LV_0100_20151001_008797	This work purifies the sins of the foolish as well as ours. {nl}Those who die during the process is because their belief is not enough. {nl}
 QUEST_LV_0100_20151001_008798	Only those who stand it will earn salvation. 
-QUEST_LV_0100_20151001_008799	Poor Gintas... {nl}You've stood the despair of death alone. 
+QUEST_LV_0100_20151001_008799	Poor Gintas... {nl}You've dealt with the despair of death alone. 
 QUEST_LV_0100_20151001_008800	Hey. If you are thinking of joining the order, don't bother. {nl}I, myself, used to be a follower of Margiris. {nl}
 QUEST_LV_0100_20151001_008801	I used to focus on purifying the sins of the dead like Gintas. {nl}I thought I would earn salvation. {nl}
 QUEST_LV_0100_20151001_008802	But one day, I saw the record books of Margiris. {nl}As far as I knew, those book keep a record of the process of purifying the sins of the dead. {nl}
 QUEST_LV_0100_20151001_008803	But it was actually a record of land ownership. {nl}And I also found out that he was looking for the record of the Kalail in here. 
 QUEST_LV_0100_20151001_008804	When I read until that part of the books, Margiris killed me. 
 QUEST_LV_0100_20151001_008805	Amazing. Did righteousness bring you here?{nl}Look. Defeating Margiris does not mean anything. {nl}
-QUEST_LV_0100_20151001_008806	If Margiris' mission fails, the order will send someone else in here... {nl}And innnocent disciples will turn like this agian. {nl}Nothing will change. 
+QUEST_LV_0100_20151001_008806	If Margiris' mission fails, the order will send someone else in here... {nl}And innnocent disciples will turn like this again. {nl}Nothing will change. 
 QUEST_LV_0100_20151001_008807	If you really want to stop the order, then you need to find out their true objective. {nl}Find the record of Kalail first. {nl}You need to stop the order from getting their hands on Kalail's records.
 QUEST_LV_0100_20151001_008808	What? {nl}You met a soul of follower in there? {nl}
 QUEST_LV_0100_20151001_008809	Ah. I think it's the follower that I know of. {nl}It's body with regrets keeping it from leaving and just roams around. {nl}
@@ -8815,8 +8815,8 @@ QUEST_LV_0100_20151001_008810	But don't worry. {nl}The souls that are forgiven w
 QUEST_LV_0100_20151001_008811	Thank you for helping until here. {nl}Here, let me give you a seal of Truth. {nl}
 QUEST_LV_0100_20151001_008812	Margiris is along the way to Kalail's grave. {nl}If you bring this to him, he will acknowledge your contributions. 
 QUEST_LV_0100_20151001_008813	Don't tell Gintas about the story of Kalail. {nl}He won't believe it. {nl}
-QUEST_LV_0100_20151001_008814	I want to save you buy I don't know how... 
-QUEST_LV_0100_20151001_008815	Who are you? {nl}Ah, it's the Gintas's Seal of Truth. {nl}
+QUEST_LV_0100_20151001_008814	I want to save you, but I don't know how... 
+QUEST_LV_0100_20151001_008815	Who are you? {nl}Ah, it's Gintas' Seal of Truth. {nl}
 QUEST_LV_0100_20151001_008816	There are too many people who want to join the order for salvation. {nl}Anyway, welcome. 
 QUEST_LV_0100_20151001_008817	I think my ankle is getting better so a little more rest will do. {nl}Please be careful and may we meet again. 
 QUEST_LV_0100_20151001_008818	Sorry to ask you when you've just joined the order, but there is something we need you to do. {nl}We are cleansing the sins of those who have died here. {nl}
@@ -8826,13 +8826,13 @@ QUEST_LV_0100_20151001_008821	To save his soul, we must find the hidden document
 QUEST_LV_0100_20151001_008822	Can you try to persuade Kalail? {nl}Since he doesn't know your face, try to act as if you're not part of the order. {nl}
 QUEST_LV_0100_20151001_008823	If you find out the whereabouts of the documents, I will bless you with the grace of Divine Tree. 
 QUEST_LV_0100_20151001_008824	You just won't give up, do you. {nl}I don't know who you are or what you want. {nl}
-QUEST_LV_0100_20151001_008825	What are you asking from me and bugging me when you don't even tell me what it is for.
+QUEST_LV_0100_20151001_008825	Why are you pestering me when you won't even tell me what it is for?
 QUEST_LV_0100_20151001_008826	I will understand if you play rough with him in case he doesn't listen to you. 
 QUEST_LV_0100_20151001_008827	What are you? {nl}Why are you disturbing other people's gravesites? {nl}
 QUEST_LV_0100_20151001_008828	I have lived my life honestly.{nl}And you think I have hidden some document with the record of my sins?{nl}Stop speaking nonsense and go away! 
-QUEST_LV_0100_20151001_008829	If you are really on the Goddess' side, then you have no reason to stand seeing something that disgrace her name. {nl}What are you waiting for? {nl} 
-QUEST_LV_0100_20151001_008830	Such awful peopel. {nl}Setting that up as a sacred object... {nl}
-QUEST_LV_0100_20151001_008831	I think that seal has weakend the energy of that thing. {nl}It must have thought that we're on the same side. {nl}
+QUEST_LV_0100_20151001_008829	If you are really on the Goddess' side, then you have no reason to stand seeing something that disgraces her name. {nl}What are you waiting for? {nl} 
+QUEST_LV_0100_20151001_008830	Such awful people. {nl}Setting that up as a sacred object... {nl}
+QUEST_LV_0100_20151001_008831	I think that seal has weakened the energy of that thing. {nl}It must have thought that we're on the same side. {nl}
 QUEST_LV_0100_20151001_008832	Anyway, since you've taken care of that horrible thing, I will believe what you say. 
 QUEST_LV_0100_20151001_008833	No wonder it was suspicious. That leader wasn't human! {nl}Right, that thing wasn't human... {nl}
 QUEST_LV_0100_20151001_008834	Why are they making such a fuss in this grave. What are they after? 
@@ -8842,8 +8842,8 @@ QUEST_LV_0100_20151001_008837	I suspected something like this to happen and hid 
 QUEST_LV_0100_20151001_008838	The villa ownership is supposed to be managed by the next generation of deputies... {nl}But he was not someone to be trusted so I requested that the manuscript of records be buried with me when I die in my will. {nl}
 QUEST_LV_0100_20151001_008839	He may look like a good guy but he even as a public official, he had private meetings with unknown people... {nl}And I caught him forging records at one point.  
 QUEST_LV_0100_20151001_008840	It bring chills thinking that they could have found the records. {nl}If they are preying on each province records like this, then only Kaliss but the whole kingdom will fall under the hands of the demons soon. 
-QUEST_LV_0100_20151001_008841	Good thing you're her. {nl}That is the record of land owners in Kaliss province. 
-QUEST_LV_0100_20151001_008842	Now we have to engrave the shaman doll with the energy that messes the grave. {nl}I saw the site where they cremated the dead a shile ago and there was a black crystal that I've never seen before. {nl}
+QUEST_LV_0100_20151001_008841	Good thing you're her. {nl}That is the record of land owners in the Kaliss province. 
+QUEST_LV_0100_20151001_008842	Now, we have to engrave the shaman doll with the energy that messes the grave. {nl}I saw the site where they cremated the dead a while ago and there was a black crystal that I've never seen before. {nl}
 QUEST_LV_0100_20151001_008843	I'm sure the black crystals are the traces of evil magic that woke up the dead. {nl}Can you get more of it from the dead that rose? 
 QUEST_LV_0100_20151001_008844	Ah, I will take care of the fallen dead bodies. {nl}For now there is something more important to do. 
 QUEST_LV_0100_20151001_008845	Yeah, this will be enough. {nl}I will prepare the shaman doll right away. Hold on. 
@@ -8858,7 +8858,7 @@ QUEST_LV_0100_20151001_008853	Villa ownership is actually a very sensitive matte
 QUEST_LV_0100_20151001_008854	Only the current deputy knows that I have handled the records. {nl}How did they know about this place... 
 QUEST_LV_0100_20151001_008855	But it is strange. {nl}To have a barrier blocking people from approaching the divine object.{nl}
 QUEST_LV_0100_20151001_008856	Even if it is sacred, if that is how it is, no one can approach it. {nl}I mean, it's as if it doesn't want anybody to come near it. 
-QUEST_LV_0100_20151001_008857	Place this Soul Stone then defeat the dead nearby.{nl}The souls of the dead will be absorbedinto this stone.{nl}
+QUEST_LV_0100_20151001_008857	Place this Soul Stone then defeat the dead nearby.{nl}The souls of the dead will be absorbed into this stone.{nl}
 QUEST_LV_0100_20151001_008858	This cleanses the sins of the dead and yours too. {nl}Also, Margiris will be very happy about it. {nl}
 QUEST_LV_0100_20151001_008859	Good luck then. 
 QUEST_LV_0100_20151001_008860	Ashak Underground Prison
@@ -9143,15 +9143,15 @@ QUEST_LV_0100_20151001_009138	Fortunately, you were able to restore the sanctum.
 QUEST_LV_0100_20151001_009139	{memo X}Go to the camp of Anastopa
 QUEST_LV_0100_20151001_009140	{memo X}As Damijonas has told you, let's go to the camp of Anastos if there is someone called Albinas in Anastos.
 QUEST_LV_0100_20151001_009141	{memo X}Retrieve the research materials
-QUEST_LV_0100_20151001_009142	{memo X}It seems that you would have to bring important materials to Gedas to obtain some information regarding Albinas. Please find the research materials from the monsters nearby. You would be able to obtain them by defeating them, but it will be helpful when you press Spacebar to check which monsters has many research documents.
+QUEST_LV_0100_20151001_009142	{memo X}It seems that you will have to bring important materials to Gedas to obtain some information regarding Albinas. Please find the research materials from the monsters nearby. You would be able to obtain them by defeating them, but it will be helpful to press space bar to check which monsters has many research documents.
 QUEST_LV_0100_20151001_009143	{memo X}Bring research documents
 QUEST_LV_0100_20151001_009144	You've found all research materials which Gedas was looking for. Now, bring them to Gedas.
 QUEST_LV_0100_20151001_009145	Talk to Gedas
-QUEST_LV_0100_20151001_009146	Talk to Gedas who seems to be releaxed after finding all the materials.
+QUEST_LV_0100_20151001_009146	Talk to Gedas who seems to be relaxed after finding all the materials.
 QUEST_LV_0100_20151001_009147	{memo X}Find the materials for the danger signal bomb
 QUEST_LV_0100_20151001_009148	{memo X}Gedas told you that in order to find the identity of Albinas, he would investigate the true nature behind him. When you send your colleagues to investigate the true nature, signal bombs are needed in case they fall in danger so you were asked to obtain the materials for the signal bombs. Obtain Flame Bomb powder which is a material to make signal bombs from the monsters.
 QUEST_LV_0100_20151001_009149	{memo X}Return to Gedas
-QUEST_LV_0100_20151001_009150	You've obtaind Flame Powders. Now, return to Gedas.
+QUEST_LV_0100_20151001_009150	You've obtained Flame Powders. Now, return to Gedas.
 QUEST_LV_0100_20151001_009151	Obtain Flame Powders
 QUEST_LV_0100_20151001_009152	Ask Gedas about signal bombs and the investigation.
 QUEST_LV_0100_20151001_009153	Talk to Gedas about more about Anastos.
@@ -9248,7 +9248,7 @@ QUEST_LV_0100_20151001_009243	{memo X}Make the sanctum according to Antanas' ins
 QUEST_LV_0100_20151001_009244	{memo X}It seems that you've made the sanctum well. Now is the time to say goodbye and leave.
 QUEST_LV_0100_20151001_009245	The list of goods that are needed for the compilation of the scriptures
 QUEST_LV_0100_20151001_009246	Talk to Giedra
-QUEST_LV_0100_20151001_009247	{memo X}Let's talk with Giedra who is another member of Rud religious body.
+QUEST_LV_0100_20151001_009247	{memo X}Let's talk with Giedra, who is another member of Rud religious body.
 QUEST_LV_0100_20151001_009248	{memo X}Obtain a trasparent shell
 QUEST_LV_0100_20151001_009249	{memo X}Giedra is collecting various goods to make the scriptures, but he now needs the transparent shell of the monsters. Defeat the monsters and collect the tranparent shells.
 QUEST_LV_0100_20151001_009250	{memo X}Return to Giedra
@@ -9384,19 +9384,19 @@ QUEST_LV_0100_20151001_009379	Demon Lord Hauberk told you that he is now ready t
 QUEST_LV_0100_20151001_009380	You've defeated the boss of the chasers. Talk to Hauberk.
 QUEST_LV_0100_20151001_009381	Defeat the boss monster
 QUEST_LV_0100_20151001_009382	Hauberk is getting ready to say goodbye.
-QUEST_LV_0100_20151001_009383	Hauberk told you that he needs to keep the promise he made with Agatas so he asked you to hand over the spirit seperating potion to him. If Agatas is still unconcious, put it inside his pocket.
+QUEST_LV_0100_20151001_009383	Hauberk told you that he needs to keep the promise he made with Agatas so he asked you to hand over the spirit separating potion to him. If Agatas is still unconscious, put it inside his pocket.
 QUEST_LV_0100_20151001_009384	Endless deals
 QUEST_LV_0100_20151001_009385	Talk to Squire Williya
 QUEST_LV_0100_20151001_009386	Squire Williya and Pardone Erikas are having disputes at Mochia Forest. Talk to Squire, Williya what's going on.
-QUEST_LV_0100_20151001_009387	Collect Blue paints
-QUEST_LV_0100_20151001_009388	Squire Williya told you taht as a return for handing over the scroll for the deads, Pardoner Erikas wants Blue paints. Defeat the monsters at Apgaudin Three Ways and collect Blue paints.
+QUEST_LV_0100_20151001_009387	Collect blue paint
+QUEST_LV_0100_20151001_009388	Squire Williya told you that as a return for handing over the scroll for the dead, Pardoner Erikas wants blue paint. Defeat the monsters at Apgaudin Three Ways and collect blue paint.
 QUEST_LV_0100_20151001_009389	Hand them over to Pardoner Erikas
 QUEST_LV_0100_20151001_009390	You've obtained enough Blue paints which Pardoner Erikas has requested. Hand over Blue paints to Erikas and receive the scroll for the deads.
 QUEST_LV_0100_20151001_009391	Squire Williya wants to wake up Gailus Legwyn with the scroll for the deads and listen to the truth. Talk to Squire, Williya.
 QUEST_LV_0100_20151001_009392	Look for the spirit of Gailyus Legwyn
 QUEST_LV_0100_20151001_009393	Squire Williya told you that she can't trust Pardoner Erikas. Use the scroll for the deads which you've dealt with Erikas in front of the unknown tombstone in Mires Grave Field to look for the spirit of Gailus Legwyn. 
 QUEST_LV_0100_20151001_009394	Talk to the spirit of Gailus Legwyn
-QUEST_LV_0100_20151001_009395	You've foudn the spirit of Gailus Legwyn. Talk to his spirit.
+QUEST_LV_0100_20151001_009395	You've found the spirit of Gailus Legwyn. Talk to his spirit.
 QUEST_LV_0100_20151001_009396	Gailus Legwyn wants to know why you woke him up. Talk to Gailus Legwyn.
 QUEST_LV_0100_20151001_009397	Collect the spirit scents from Mochia Fields
 QUEST_LV_0100_20151001_009398	Since the blessed crystal is sealing the hunter of Kartas, Gailus Legwyn told you that you can't find the crystal again unless you defeat that demon. To wake up the subordinates of Legwyn family who would face against the hunter of Kartas, please collect the spirit scent from Mochia fields. 
@@ -9425,11 +9425,11 @@ QUEST_LV_0100_20151001_009420	Mortimer wants to send the keepstakes of his colle
 QUEST_LV_0100_20151001_009421	You better give the old military scrip to Mortimer. Hand it over to Mortimer.
 QUEST_LV_0100_20151001_009422	Talk to Bokor Juta
 QUEST_LV_0100_20151001_009423	Bokor Juta seems to be in a trouble. Talk to Juta.
-QUEST_LV_0100_20151001_009424	Defeat the dead that has been revived
-QUEST_LV_0100_20151001_009425	Bokor Juta came here to look for Gemina Goddess and the place is full of deads. Defeat the deads who are disturbing the praying of Juta.
+QUEST_LV_0100_20151001_009424	Defeat the dead that have been revived.
+QUEST_LV_0100_20151001_009425	Bokor Juta came here to look for Gemina Goddess and the place is full of dead. Defeat the dead who are disturbing the praying of Juta.
 QUEST_LV_0100_20151001_009426	Report to Juta
-QUEST_LV_0100_20151001_009427	You've defeated all the deads as requested by Bokor Juta. Go back to Juta and talk to him.
-QUEST_LV_0100_20151001_009428	You've defeated all the deads as requested by Juta. Talk to Juta to ask if there's anything more you can help with.
+QUEST_LV_0100_20151001_009427	You've defeated all the dead as requested by Bokor Juta. Go back to Juta and talk to him.
+QUEST_LV_0100_20151001_009428	You've defeated all the dead as requested by Juta. Talk to Juta to ask if there's anything more you can help with.
 QUEST_LV_0100_20151001_009429	Destroy the coffin of the dead
 QUEST_LV_0100_20151001_009430	Bokor Juta wants you to eliminate the deads. Destroy the coffins at the room of the eternal sleep and Kauru Hall so they can't wake up again.
 QUEST_LV_0100_20151001_009431	You've destroyed all the coffins as requested by Juta. Return to Juta.
@@ -9468,7 +9468,7 @@ QUEST_LV_0100_20151001_009463	Talk to the spirit of the Believer
 QUEST_LV_0100_20151001_009464	As you cremated the dead bodies of the Believer, the spirit of the Believer appeared again. Talk to the spirit of the Believer that appeared.
 QUEST_LV_0100_20151001_009465	You've taken care of the corpses of Believers as requested by Gintas. Return to Gintas.
 QUEST_LV_0100_20151001_009466	Talk to Margiris
-QUEST_LV_0100_20151001_009467	You've obtained the token of the truth from Gintas. When you take it to Margiris, you would be able to enter the religious body.
+QUEST_LV_0100_20151001_009467	You've obtained the token of truth from Gintas. When you take it to Margiris, you will be able to enter the religious body.
 QUEST_LV_0100_20151001_009468	Go meet Margiris after you get acknowledged by the member of the religious body from Gintas
 QUEST_LV_0100_20151001_009469	You've met Margiris who is the leader of the religious body. Talk to him.
 QUEST_LV_0100_20151001_009470	Interrogate Kalrail
@@ -9493,10 +9493,10 @@ QUEST_LV_0100_20151001_009488	Sigis brought the spell doll. Talk to Sigis.
 QUEST_LV_0100_20151001_009489	Collect the traces of the evil magic
 QUEST_LV_0100_20151001_009490	Sigis told you that you should make the spell doll to realize the evil magic. Defeat the dead one and collect the traces of the evil magic.
 QUEST_LV_0100_20151001_009491	You've collected all the traces of the evil magic which Sigis requested from you. Talk to Sigis.
-QUEST_LV_0100_20151001_009492	Obtain %s from the resurrected deads
+QUEST_LV_0100_20151001_009492	Obtain %s from the resurrected dead
 QUEST_LV_0100_20151001_009493	You've collected all the documents that were scattered at the burial chamber of Kalrail. Talk to the spirit of Kalrail.
 QUEST_LV_0100_20151001_009494	Burn the list of the ones who possess gardens
-QUEST_LV_0100_20151001_009495	The spirit of Kalrail asked you to burn the list of the ones who possess gardens. You would need a bonfire to burn the list. Light up the bonfire and burn the list.
+QUEST_LV_0100_20151001_009495	The spirit of Kalrail asked you to burn the list of the ones who possess gardens. You will need a bonfire to burn the list. Light up the bonfire and burn the list.
 QUEST_LV_0100_20151001_009496	Talk to Druid Leja
 QUEST_LV_0100_20151001_009497	You can see someone injured in the forest. Talk to her and obtain some information.
 QUEST_LV_0100_20151001_009498	Collect the herbs which Druid Leja asked you to collect
@@ -9527,7 +9527,7 @@ QUEST_LV_0100_20151001_009522	{memo X}The mysterious girl disappeared to the gig
 QUEST_LV_0100_20151001_009523	Talk to the villager 
 QUEST_LV_0100_20151001_009524	Ask the villager if there's anything you can help with
 QUEST_LV_0100_20151001_009525	{memo X}Obtain the juice of the gigantic fruit from the Pharets
-QUEST_LV_0100_20151001_009526	{memo X}The villager is worried about the drinking water because of the polluted river and the fruits that grew from the river water. Pharets use the juice they obtained from the gigantic fruits for their drinking water and it seems that they know the way to elimiante the poison from the fruits. The villager asked you to obtain the fruit juice from Pharets. 
+QUEST_LV_0100_20151001_009526	{memo X}The villager is worried about the drinking water because of the polluted river and the fruits that grew from the river water. Pharets use the juice they obtained from the gigantic fruits for their drinking water and it seems that they know the way to eliminate the poison from the fruits. The villager asked you to obtain the fruit juice from Pharets. 
 QUEST_LV_0100_20151001_009527	Pass the gigantic fruit juice to the villager
 QUEST_LV_0100_20151001_009528	{memo X}You've obtained enough fruit juice from the Pharets. Pass it to the villager.
 QUEST_LV_0100_20151001_009529	{memo X}Obtain %s from Pharets
@@ -9548,7 +9548,7 @@ QUEST_LV_0100_20151001_009543	Talk to the grandchild of the elder
 QUEST_LV_0100_20151001_009544	{memo X}The grandchild of the elder seems to have some words to tell you after he went out to check whether the Pharets have become more gentle since the collapse of demonic totem. Talk to the grandchild of the elder.
 QUEST_LV_0100_20151001_009545	Talk to Divdirbys Withus
 QUEST_LV_0100_20151001_009546	{memo X}The grandchild of the elder told you that although the demonic totem has been destroyed, the Pharets were still very violent. Talk to Divdirbys, Withus if there's any way to make them calm.
-QUEST_LV_0100_20151001_009547	Divdirbys, Withus was actually enagaged in research to create a sculpture which would oppose the effects of the demonic totem. Talk to Withus.
+QUEST_LV_0100_20151001_009547	Divdirbys, Withus was actually engaged in research to create a sculpture which would oppose the effects of the demonic totem. Talk to Withus.
 QUEST_LV_0100_20151001_009548	Set the sculpture of peace
 QUEST_LV_0100_20151001_009549	{memo X}Divdirbys, Withus created the sculpture of peace after a long period of his research. He told you the Pharets will be kind again when you set the sculpture of peace near Pharets.
 QUEST_LV_0100_20151001_009550	{memo X}As you set the sculpture of peace, the Pharets became more violent. Tell this to Withus.
@@ -9842,7 +9842,7 @@ QUEST_LV_0100_20151016_009837	{memo X}
 QUEST_LV_0100_20151016_009838	
 QUEST_LV_0100_20151016_009839	{memo X}
 QUEST_LV_0100_20151016_009840	{memo X}
- ±◊∞… ∏‘¿∫ ∆‰∏¥¿∫ ¥ŸΩ≈ Ωƒ∑Æ¿ª »…ƒ°∑Ø ø¿¡ˆ æ ¿ª ∞…ø‰?{nl}¿œ¥‹ ø¿ø∞µ» ∫”¿∫ π∞¿ª ∂∞¥Ÿ¡÷ººø‰.{nl}ø¿ø∞µ» ∫”¿∫ π∞¿∫ ∏∂¿ª ±∏ºÆø° ¿÷¥¬ ø¿∑°µ» øÏπ∞ø°º≠ ∂„ ºˆ ¿÷æÓø‰.	
+ Í∑∏Í±∏ Î®πÏùÄ ÌéòÎ¶øÏùÄ Îã§Ïã† ÏãùÎüâÏùÑ ÌõîÏπòÎü¨ Ïò§ÏßÄ ÏïäÏùÑ Í±∏Ïöî?{nl}ÏùºÎã® Ïò§ÏóºÎêú Î∂âÏùÄ Î¨ºÏùÑ Îñ†Îã§Ï£ºÏÑ∏Ïöî.{nl}Ïò§ÏóºÎêú Î∂âÏùÄ Î¨ºÏùÄ ÎßàÏùÑ Íµ¨ÏÑùÏóê ÏûàÎäî Ïò§ÎûòÎêú Ïö∞Î¨ºÏóêÏÑú Îú∞ Ïàò ÏûàÏñ¥Ïöî.	
 QUEST_LV_0100_20151016_009841	
 QUEST_LV_0100_20151016_009842	
 QUEST_LV_0100_20151016_009843	{memo X}
@@ -9874,7 +9874,7 @@ QUEST_LV_0100_20151016_009868	{memo X}
 QUEST_LV_0100_20151016_009869	{memo X}
 QUEST_LV_0100_20151016_009870	
 QUEST_LV_0100_20151016_009871	{memo X}
-æ∆∏∂ ∆‰∏¥ ∫Œ¡∑∞˙ ¿⁄ø¨Ω∫∑¥∞‘ ¥Î»≠µµ ∞°¥…«“∞Ã¥œ¥Ÿ. {nl}∆‰∏¥ ∫Œ¡∑∞˙ ¥Î»≠«ÿº≠ ∆‰∏¥¿Ã ∏∂¡∑ ∆Ìø° µø¡∂«œ∞Ì ¿÷¥¬ ¿Ã¿Ø∏¶ æÀæ∆∫¡ ¡÷ººø‰.	
+ÏïÑÎßà ÌéòÎ¶ø Î∂ÄÏ°±Í≥º ÏûêÏó∞Ïä§ÎüΩÍ≤å ÎåÄÌôîÎèÑ Í∞ÄÎä•Ìï†Í≤ÅÎãàÎã§. {nl}ÌéòÎ¶ø Î∂ÄÏ°±Í≥º ÎåÄÌôîÌï¥ÏÑú ÌéòÎ¶øÏù¥ ÎßàÏ°± Ìé∏Ïóê ÎèôÏ°∞ÌïòÍ≥† ÏûàÎäî Ïù¥Ïú†Î•º ÏïåÏïÑÎ¥ê Ï£ºÏÑ∏Ïöî.	
 QUEST_LV_0100_20151016_009872	
 QUEST_LV_0100_20151016_009873	
 QUEST_LV_0100_20151016_009874	{memo X}
@@ -9883,7 +9883,7 @@ QUEST_LV_0100_20151016_009876	{memo X}
 QUEST_LV_0100_20151016_009877	{memo X}
 QUEST_LV_0100_20151016_009878	{memo X}
 QUEST_LV_0100_20151016_009879	{memo X}
-«œ¡ˆ∏∏ ¥Á¿Â ∆‰∏¥¿ª æÓ∂ª∞‘ «“ ºˆ∞° æ¯¿∏¥œ ¬—æ∆≥ª±‚∂Ûµµ «ÿæﬂ∞⁄æÓø‰.{nl}¿˙ø°∞‘ ∆‰∏¥µÈ¿Ã Ω»æÓ«œ¥¬ ¡ˆµ∂«— «‚¿Ã ¿÷æÓø‰.{nl}∏¥⁄∫“¿ª ««øˆµŒ∞Ì ¡ˆµ∂«— «‚¿ª ≈¬øÏ∏È ∆‰∏¥µÈ¿Ã ≥øªı∏¶ ∏√∞Ì µµ∏¡∞•∞Ã¥œ¥Ÿ.{nl}ªÁ∂˜«—≈◊µµ ¡∂±›.. ∞Ìæ‡«— ≥øªı¡ˆ∏∏ ¬¸∞Ì ∫Œ≈πµÂ∏Æ∞⁄Ω¿¥œ¥Ÿ..	
+ÌïòÏßÄÎßå ÎãπÏû• ÌéòÎ¶øÏùÑ Ïñ¥ÎñªÍ≤å Ìï† ÏàòÍ∞Ä ÏóÜÏúºÎãà Ï´ìÏïÑÎÇ¥Í∏∞ÎùºÎèÑ Ìï¥ÏïºÍ≤†Ïñ¥Ïöî.{nl}Ï†ÄÏóêÍ≤å ÌéòÎ¶øÎì§Ïù¥ Ïã´Ïñ¥ÌïòÎäî ÏßÄÎèÖÌïú Ìñ•Ïù¥ ÏûàÏñ¥Ïöî.{nl}Î™®Îã•Î∂àÏùÑ ÌîºÏõåÎëêÍ≥† ÏßÄÎèÖÌïú Ìñ•ÏùÑ ÌÉúÏö∞Î©¥ ÌéòÎ¶øÎì§Ïù¥ ÎÉÑÏÉàÎ•º Îß°Í≥† ÎèÑÎßùÍ∞àÍ≤ÅÎãàÎã§.{nl}ÏÇ¨ÎûåÌïúÌÖåÎèÑ Ï°∞Í∏à.. Í≥†ÏïΩÌïú ÎÉÑÏÉàÏßÄÎßå Ï∞∏Í≥† Î∂ÄÌÉÅÎìúÎ¶¨Í≤†ÏäµÎãàÎã§..	
 QUEST_LV_0100_20151016_009880	{memo X}
 QUEST_LV_0100_20151016_009881	{memo X}
 QUEST_LV_0100_20151016_009882	

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -791,7 +791,7 @@ SKILL_20150317_000790	$Attack an enemy with magic from a far distance.
 SKILL_20150317_000791	$Attack an enemy from a short distance(Warrior's Two-handed Sword only)
 SKILL_20150317_000792	$Attack an enemy magic from a far distance.(Two-handed Staff)
 SKILL_20150317_000793	$Dagger Pierce
-SKILL_20150317_000794	$Attack an enemy from a short distance. Knock the target back when it is struck a certain number of times.
+SKILL_20150317_000794	$Attack an enemy from a short distance. The target gets knocked back when it is struck a certain number of times.
 SKILL_20150317_000795	Dream Song
 SKILL_20150317_000796	Shadow Umbrella
 SKILL_20150317_000797	$In development


### PR DESCRIPTION
Updated a ton of skills. Grammar, some name changes, wording, etc..

Still hung up on Sterea Trofh - makes no sense. Should it be Stereotrope or Stereotroph? The attack looks like waves of distortion around the enemy. 

Also the Prominence skill. In the kor version it is 홍염 or HONG-YEONG, however it is spelled out as 
프로미넌스, peuromineonseu, or just Prominence. 홍염 translates to 'red flames' apparently, so maybe this is just 'Fire'? Need some explanation.. 

Also suggest changing 'Splash' to 'Splash Damage' or 'Splash Radius', I haven't determined which is actually increasing, but Splash isn't explanatory enough

Updated some words to be consistent in spelling. Defence -> defense. Whatever there was more occurrences of became the used spelling. 
