### PR TITLE
2nd iCBT: Minor fixes

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2700,7 +2700,7 @@ ETC_20150317_002699	Total Price
 ETC_20150317_002700	Quantity
 ETC_20150317_002701	Your selling price must be at least 0 Silver.
 ETC_20150317_002702	Your selling quantity must be higher than 0.
-ETC_20150317_002703	Your item has been successfully added on the Market.
+ETC_20150317_002703	Your item has been successfully added to the Market.
 ETC_20150317_002704	You have successfully purchased an item from the Market. {nl} Please check if you've received the item.
 ETC_20150317_002705	There are too many search results. Use more detailed search queries to narrow down your search.
 ETC_20150317_002706	Are you sure you want to cancel the item registration?
@@ -9628,8 +9628,8 @@ ETC_20150323_009628	Demon Prison
 ETC_20150323_009629	Limestone Cave
 ETC_20150323_009630	Demon Prison District 1
 ETC_20150323_009631	Demon Prison District 2
-ETC_20150323_009632	Demon Prison District 3
-ETC_20150323_009633	Demon Prison District 4
+ETC_20150323_009632	Demon Prison District 4
+ETC_20150323_009633	Demon Prison District 3
 ETC_20150323_009634	Demon Prison District 5
 ETC_20150323_009635	Bracken Forest
 ETC_20150323_009636	Tenants Farm
@@ -10351,10 +10351,10 @@ ETC_20150323_010352	{memo X}The Fortress of the Great Land59_2
 ETC_20150323_010353	{memo X}The Fortress of the Great Land59_3
 ETC_20150323_010354	{memo X}The Fortress of the Great Land59_1
 ETC_20150323_010355	Gate Entrance x
-ETC_20150323_010356	Demons Prison District 3
-ETC_20150323_010357	Demons Prison District 5
-ETC_20150323_010358	Demons Prison District 2
-ETC_20150323_010359	Demons Prison District 4
+ETC_20150323_010356	Demon Prison District 3
+ETC_20150323_010357	Demon Prison District 5
+ETC_20150323_010358	Demon Prison District 2
+ETC_20150323_010359	Demon Prison District 4
 ETC_20150323_010360	{memo X}Small, growing crevice
 ETC_20150323_010361	{memo X}Leader Horaceus??
 ETC_20150323_010362	{memo X}Food Drier??
@@ -11541,7 +11541,7 @@ ETC_20150428_011542	Conditions met.
 ETC_20150428_011543	Only one anvil can be placed at a time.
 ETC_20150428_011544	Only one bonfire can be placed at a time.
 ETC_20150428_011545	There is already a bonfire placed nearby.
-ETC_20150428_011546	Its buffs will disappear when you register it in the market. Are you sure you want to register it?
+ETC_20150428_011546	The buff disappears when you add it to the Market. Are you sure you want to add it?
 ETC_20150428_011547	This skill cannot be used in combat.
 ETC_20150428_011548	You are too far from the seller.
 ETC_20150428_011549	The seller's skill item is insufficient.
@@ -11565,7 +11565,7 @@ ETC_20150428_011566	Hire Helper
 ETC_20150428_011567	Would you like to hire a Helper?{nl}Consumes iCoin per minute{nl} {img medal 32 32}
 ETC_20150428_011568	{@st43} Helper Contract{/}
 ETC_20150428_011569	Helper Contract
-ETC_20150428_011570	Summoned Panto Guide
+ETC_20150428_011570	Summoned Panto Pathfinder
 ETC_20150428_011571	{memo X}Usable only in Crystal Mine 2F.
 ETC_20150428_011572	The Panto Archer has fallen to the brainwashing curse! {nl} Defeat it!
 ETC_20150428_011573	{memo X}Gained confidence from defeating monster.{nl} Use the Demon Transfer Scroll!
@@ -15497,7 +15497,7 @@ ETC_20151001_015498	Biteregina has been defeated.{nl}Move on to the next locatio
 ETC_20151001_015499	Defeat Chapparition!
 ETC_20151001_015500	Chapparition has been defeated.{nl}Move on to the next location!
 ETC_20151001_015501	Destroy all the Panto Totems!
-ETC_20151001_015502	Gloomy Panto Guide
+ETC_20151001_015502	Gloomy Panto Pathfinder
 ETC_20151001_015503	Gloomy Green Apparition
 ETC_20151001_015504	The Panto Totem has been destroyed.{nl}Move on to the next location!
 ETC_20151001_015505	Defeat Clymen!
@@ -16944,7 +16944,7 @@ ETC_20151102_016945	Retrieve the sacred objects destroyed by the Demons
 ETC_20151102_016946	Deliver an item that can overload the device to Edmundas
 ETC_20151102_016947	Find the experiment journal written by an unknown wizard
 ETC_20151102_016948	Deactivate the Gigantic Bracken Spore Breeding device
-ETC_20151102_016949	Increases the backstab damage by 400% when attacking from behind {nl} evasion {img red_down_arrow 16 16} decreased by 188
+ETC_20151102_016949	Increases Backstab damage by 4x when attacking an enemy from behind{nl}Evasion {img red_down_arrow 16 16}188
 ETC_20151102_016950	Player's Max Level
 ETC_20151102_016951	OptDesc/ - Thrust Skill Lv +1
 ETC_20151102_016952	OptDesc/ - Bash Skill Lv +1

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -6785,7 +6785,7 @@ ITEM_20150918_006784	A dangerous bomb that will explode soon after being thrown.
 ITEM_20150918_006785	Bomb with a high power output. It is extremely loud.
 ITEM_20150918_006786	A propaganda to encourage the surrender sprayed by Kingdom Army when the rebellion, 600 years ago
 ITEM_20150918_006787	Research on the petrification frost requested by the Knights of Kaliss.
-ITEM_20150918_006788	A lengthy advertisement noting the Kingdom's honor and pride
+ITEM_20150918_006788	A lengthy advertisement noting the kingdom's honor and pride
 ITEM_20150918_006789	A mark containing Blut's power. He seems to have distributed them among his underling demons.
 ITEM_20150918_006790	An orb that Kupole Arune used to interrogate demons. Hauberk's aid is needed.
 ITEM_20150918_006791	A crystal blessed with spatial powers by Goddess Vakarine. It has been modified by Zydrone, so that humans can use it.
@@ -6793,7 +6793,7 @@ ITEM_20150918_006792	Hauberk's soul divided itself in order to escape.
 ITEM_20150918_006793	A spectrum sphere created by Kupole Daiva to keep watch on demons. It can be used to find the hiding Hauberk.
 ITEM_20150918_006794	A rune containing the power of Goddess Vakarine.{nl}It absorbs the souls of demons.
 ITEM_20150918_006795	A trinket left by adventurers who entered the Demon Prison. It seems they were killed by demons.
-ITEM_20150918_006796	A token fragment dropped from the Lada Seal. Evidence that Dionysus spread riots after he lost his ego.
+ITEM_20150918_006796	A token fragment dropped from the Rada Seal. Evidence that Dionysus spread riots after he lost his ego.
 ITEM_20150918_006797	A claw found stuck in a demon. It looks like it was attacked by Dionysus.
 ITEM_20150918_006798	Kupole Sigita says that other demons will take this tooth as a warning.
 ITEM_20150918_006799	Workers used to use this while constructing the Fortress of the Earth.  You can easily cause it to explode with fire.
@@ -7524,7 +7524,7 @@ ITEM_20151022_007523	Blue Orb: Crystal Spider
 ITEM_20151022_007524	Blue Orb: Vubbe Shaman
 ITEM_20151022_007525	Blue Orb: Vubbe Fighter
 ITEM_20151022_007526	Blue Orb: Zignuts
-ITEM_20151022_007527	Blue Orb: Panto Guide
+ITEM_20151022_007527	Blue Orb: Panto Pathfinder
 ITEM_20151022_007528	Blue Orb: Grummer
 ITEM_20151022_007529	Blue Orb: Mali
 ITEM_20151022_007530	Blue Orb: Leafly
@@ -7902,7 +7902,7 @@ ITEM_20151022_007901	Red Orb: Crystal Spider
 ITEM_20151022_007902	Red Orb: Vubbe Shaman
 ITEM_20151022_007903	Red Orb: Vubbe Fighter
 ITEM_20151022_007904	Red Orb: Zignuts
-ITEM_20151022_007905	
+ITEM_20151022_007905	Red Orb: Panto Pathfinder
 ITEM_20151022_007906	Red Orb: Grummer
 ITEM_20151022_007907	Red Orb: Mali
 ITEM_20151022_007908	Red Orb: Leafly
@@ -8257,12 +8257,12 @@ ITEM_20151022_008256	Red Orb: Corrupt Deadborn Scap Archer
 ITEM_20151022_008257	Red Orb: Corrupt Deadborn Scap
 ITEM_20151022_008258	Guiding Owl's Will
 ITEM_20151022_008259	Contains the power of the owl statue.
-ITEM_20151022_008260	Carolis Altar Crystal
-ITEM_20151022_008261	Carolis Altar Crystal Fragment
-ITEM_20151022_008262	Carolis Altar Fragment
-ITEM_20151022_008263	Fragment of the main Carolis Altar
-ITEM_20151022_008264	Crystalized essence of the Carolis Fountain
-ITEM_20151022_008265	Essence of the Carolis Fountain materialized into a crystal.
+ITEM_20151022_008260	Karolis Altar Crystal
+ITEM_20151022_008261	Karolis Altar Crystal Fragment
+ITEM_20151022_008262	Karolis Altar Fragment
+ITEM_20151022_008263	Fragment of the main Karolis Altar
+ITEM_20151022_008264	Crystalized essence of the Karolis Fountain
+ITEM_20151022_008265	Essence of the Karolis Fountain materialized into a crystal.
 ITEM_20151022_008266	Letas Holy Branch
 ITEM_20151022_008267	A branch taken from the apparition of essence of the Letas Brook as a mystical tree.
 ITEM_20151022_008268	Romuva of Suppression

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -7907,7 +7907,7 @@ QUEST_LV_0100_20150804_007902	$Historian Rexipher says that the symbols are cove
 QUEST_LV_0100_20150804_007903	$Historian Rexipher disappeared with the symbols of the ordeal. Talk to Liaison Officer Bale at King's Plateau to ask about his whereabouts.
 QUEST_LV_0100_20150804_007904	$You must somehow find Rexipher since he has all the symbols of the ordeal. Ask him again.
 QUEST_LV_0100_20150804_007905	When you were about to remove the seal of the barrier, monsters suddenly appeared. Defeat the monsters!
-QUEST_LV_0100_20150908_007906	Check the map by pressing M
+QUEST_LV_0100_20150908_007906	$Check the map by pressing the M key
 QUEST_LV_0100_20150908_007907	$Avoid the Large Kepa's attacks by using jump!
 QUEST_LV_0100_20150908_007908	$Find the location of the treasure by right-clicking on the treasure map!
 QUEST_LV_0100_20150908_007909	$A Yonazolem has appeared at the marked spot with the locked treasure chest!{nl}Defeat the Yonazolem to find clues to open the chest!
@@ -7976,7 +7976,7 @@ QUEST_LV_0100_20150908_007971	$Defeat the Golem that suddenly appeared!
 QUEST_LV_0100_20150908_007972	{memo X}
 QUEST_LV_0100_20150908_007973	$You can feel a great vibration!
 QUEST_LV_0100_20150908_007974	$Defeat the Chafer!
-QUEST_LV_0100_20150908_007975	$You can check your skills by pressing the 'F3' key
+QUEST_LV_0100_20150908_007975	$You can check your skills by pressing the F3 key
 QUEST_LV_0100_20150908_007976	$A Biteregina has appeared after you removed the hive!{nl}Defeat the Biteregina!
 QUEST_LV_0100_20150908_007977	$The 1st floor of Tenet Chapel has been sealed by Gesti's powers.{nl}Find the way to go up to the first floor through the basement!
 QUEST_LV_0100_20150908_007978	$Restoring the Monument
@@ -8016,7 +8016,7 @@ QUEST_LV_0100_20150908_008011	$Defeat the monsters around the source of corrupti
 QUEST_LV_0100_20150908_008012	$Merregina has appeared!
 QUEST_LV_0100_20150908_008013	$Opening the chest with the key
 QUEST_LV_0100_20150908_008014	$Talk to Knight Commander Uska after going back to Klaipeda
-QUEST_LV_0100_20150908_008015	$Check your status by pressing F1 key
+QUEST_LV_0100_20150908_008015	$Check your status by pressing the F1 key
 QUEST_LV_0100_20150908_008016	$You've read the first tombstone of Lydia Schaffen{nl}Read the remaining tombstones!
 QUEST_LV_0100_20150908_008017	{memo X}
 QUEST_LV_0100_20150908_008018	$Defeat Chapparitions that are disturbing when you are checking the tombstone{nl}Check what was written on the last tombstone of Lydia Schaffen

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -3877,7 +3877,7 @@ SKILL_20150414_003876	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Train your ski
 SKILL_20150414_003877	{memo X}Reflect attack amounting to target's Physical attack.{nl}Reflect damage +#{SkillAtkAdd}#{nl}Ranged projectile, cannot defend magic
 SKILL_20150414_003878	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use your trained fists to attack the enemy in succession.
 SKILL_20150414_003879	{memo X}{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Continuously attack with tip of hand.
-SKILL_20150414_003880	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use hand knife to destroy the shield.
+SKILL_20150414_003880	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use your hand as a knife to release a strong strike on your target to break its defense.
 SKILL_20150414_003881	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Punch enemy from a close range. Enemy loses SP and receives continuous damage.
 SKILL_20150414_003882	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Gather force then shoot forward. Enemy is pushed away and received damage.
 SKILL_20150414_003883	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use tip of finger to throw coin and attack enemy.
@@ -4512,8 +4512,8 @@ SKILL_20150714_004511	$Increases the damage dealt on an enemy with [Full Draw] b
 SKILL_20150714_004512	$Increases the damage dealt on an enemy with [Oblique Shot] by 1% per attribute level.
 SKILL_20150714_004513	$Increases the damage dealt on an enemy with [Heavy Shot] by 1% per attribute level.
 SKILL_20150714_004514	$Increases the damage dealt on an enemy with [Twin Arrows] by 1% per attribute level.
-SKILL_20150714_004515	$Increases the Critical Chance of [Multi Shot] by 1% per attribute level.
-SKILL_20150714_004516	$Increases the Critical Rate of [Kneeling Shot] by 2% per attribute level.
+SKILL_20150714_004515	$Increases the critical chance of [Multi Shot] by 1% per attribute level.
+SKILL_20150714_004516	$Increases the critical rate during [Kneeling Shot] by 2% per attribute level.
 SKILL_20150714_004517	{memo X}$While [Swift Step] is active, enemies that are hit by [Oblique Shot] will be affected by [Slow] with a 5% chance per attribute level.
 SKILL_20150714_004518	{memo X}$Increases your Critical Rate by 10% per attribute level while [Swift Step] is active.
 SKILL_20150714_004519	{memo X}$Decreases the enemy's physical defense threaded with [Full Draw] by 2% per attribute level.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -5060,7 +5060,7 @@ SKILL_20150918_005059	$Shield Shoving
 SKILL_20150918_005060	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Interrupt an enemy's action using your shield. The enemy is turned around, and can't take any actions temporarily.
 SKILL_20150918_005061	Attack #{SkillAtkAdd}#{nl}Attribute Attack #{CaptionRatio}#%{nl}duration 1.5 seconds
 SKILL_20150918_005062	$Shield Bash
-SKILL_20150918_005063	{#DD5500}{ol}[Phyiscal] - [Slash]{/}{/}{nl}Attack with your shield. The attacked enemy will have its stat points jumbled temporarily.
+SKILL_20150918_005063	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Attack with your shield. The attacked enemy will have its stat points jumbled temporarily.
 SKILL_20150918_005064	$Attack: #{SkillAtkAdd}#{nl}Attribute Damage: #{CaptionRatio}#%{nl}Duration: #{CaptionRatio2}# seconds
 SKILL_20150918_005065	$High Kick
 SKILL_20150918_005066	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Perform a high kick on the enemy. The enemy will receive additional damage from Strike attacks temporarily.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -3877,7 +3877,7 @@ SKILL_20150414_003876	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Train your ski
 SKILL_20150414_003877	{memo X}Reflect attack amounting to target's Physical attack.{nl}Reflect damage +#{SkillAtkAdd}#{nl}Ranged projectile, cannot defend magic
 SKILL_20150414_003878	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use your trained fists to attack the enemy in succession.
 SKILL_20150414_003879	{memo X}{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Continuously attack with tip of hand.
-SKILL_20150414_003880	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use your hand as a knife to release a strong strike on your target to break its defense.
+SKILL_20150414_003880	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Break your target's armor with a strong strike using your hand as a knife.
 SKILL_20150414_003881	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Punch enemy from a close range. Enemy loses SP and receives continuous damage.
 SKILL_20150414_003882	{memo X}{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Gather force then shoot forward. Enemy is pushed away and received damage.
 SKILL_20150414_003883	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use tip of finger to throw coin and attack enemy.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -3726,7 +3726,7 @@ SKILL_20150414_003725	Summons a servant. The servant will grant beneficial effec
 SKILL_20150414_003726	{memo X}Servant HP #{CaptionRatio}#
 SKILL_20150414_003727	{memo X}Control time and temporarily increase attack speed of yourself or 1 ally in front.
 SKILL_20150414_003728	{memo X}Control time and make the monster appear again where it was killed.
-SKILL_20150414_003729	Stop time of monsters within target area. Enemies do not receive damage when time is stopped.
+SKILL_20150414_003729	Stops time of monsters within the targeted area. Enemies do not receive damage when time is stopped.
 SKILL_20150414_003730	Controls time to decrease the movement speed of enemies.
 SKILL_20150414_003731	{memo X}Control time and increase movement speed of yourself or 1 ally in front.
 SKILL_20150414_003732	Control time in an area, temporarily changing it back to its previous state.
@@ -3734,7 +3734,7 @@ SKILL_20150414_003733	{#993399}{ol}[Magic]{/}{/}{nl}Collect an enemy's corpse.
 SKILL_20150414_003734	{memo X}Attack #{SkillAtkAdd}#{nl}Collect corpse of each type
 SKILL_20150414_003735	{memo X}Make Shogos molded after the card inserted in Necronomicon. Necronomicon can equip only Animal, Plant, and Mutant type cards.
 SKILL_20150414_003736	{memo X}Use #{CaptionRatio}# each of {nl}Plant, Beast, Mutant corpse
-SKILL_20150414_003737	{#993399}{ol}[Magic]{/}{/}{nl}Throw corpse parts to target area and attack nearby enemies.
+SKILL_20150414_003737	{#993399}{ol}[Magic]{/}{/}{nl}Throw corpse parts on a targeted area to attack nearby enemies.
 SKILL_20150414_003738	{memo X}Attack #{SkillAtkAdd}#{nl}Splash #{SkillSR}#{nl}Use #{CaptionRatio}# each of{nl}Plant, Beast. Mutant monster corpse
 SKILL_20150414_003739	{#993399}{ol}[Magic]{/}{/}{nl}Encircle yourself with corpse parts that will damage nearby enemies.
 SKILL_20150414_003740	{memo X}Attack #{SkillAtkAdd}#{nl}Duration 15 seconds{nl}Use #{CaptionRatio}# Mutant corpse
@@ -5032,27 +5032,27 @@ SKILL_20150804_005031	{memo X}$Attack 300% + #{SkillAtkAdd}#{nl}Attribute Damage
 SKILL_20150804_005032	${#DD5500}{ol}[Physical] - [Poison] - [Pierce]{/}{/}{nl}Launches a contagious poisonous arrow. Poison spreads through the target whenever it gets attacked. 
 SKILL_20150804_005033	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl} Launches an arrow that explodes on enemy impact in a cross.
 SKILL_20150804_005034	$Attack: 250% + #{SkillAtkAdd}#{nl}Attribute Damage: #{CaptionRatio}#%{nl}AoE Attack Ratio: #{SkillSR}#
-SKILL_20150804_005035	$Reflect #{CaptionRatio}#% of the target's physical attack{nl}Maximum Duration #{CaptionTime}# sec{nl}Range projectile, Magic defense not possible
+SKILL_20150804_005035	$Reflects #{CaptionRatio}#% of the target's physical attack{nl}Maximum Duration #{CaptionTime}# sec{nl}Range projectile, Magic defense not possible
 SKILL_20150804_005036	$Cartar Stroke: Remove Knockback
 SKILL_20150804_005037	{memo X}Pushing power of [Cartar Stroke] becomes 0. (You will not be pushed if this attribute is ON.)
 SKILL_20150804_005038	$Increases your fire, ice and lightning properties by 5 and from Lv2 it increases by 1 per attribute level. 
 SKILL_20150804_005039	$Increases the reflection of [Iron Skin] by 5% per attribute level.
-SKILL_20150807_005040	While [Aggressor] is active, the character's added Critical Attack is proportional to the physical attack. Increases an addtional amount by 5% per attribute level.
-SKILL_20150918_005041	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Throw shield to attack. Shield drops on target area and you physical defense decreases as much as the epuipment . Shield may be picked up or automatically added to inventory after time limit. Decreased physical defense will be back to normal when the shield is back in inventory.
+SKILL_20150807_005040	While [Aggressor] is active, the character's added critical attack is proportional to the physical attack. Increases an addtional amount by 5% per attribute level.
+SKILL_20150918_005041	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Attack an enemy by throwing your shield. Your shield drops on the targeted area, and your physical defense decreases based on the value of the equipment. The shield may be picked up or it'll automatically return to your inventory after a certain time. The decreased physical defense will return back to normal once your shield is back in the inventory.
 SKILL_20150918_005042	$Umbo Thrust
-SKILL_20150918_005043	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use the spike on the shield to strike the enemy. Enemy may temporarily lose armor effects.
+SKILL_20150918_005043	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use the spike on the shield to strike an enemy. You may temporarily lose a small effect of your armor.
 SKILL_20150918_005044	$Sky Liner
-SKILL_20150918_005045	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Slash the enemy sideways. {nl}Inflict additional damage to enemies affected by [Bleeding].
+SKILL_20150918_005045	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Slash the enemy sideways.{nl}Inflicts additional damage on enemies affected by [Bleeding].
 SKILL_20150918_005046	$Crosscut
-SKILL_20150918_005047	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Charge towards the enemy and cut a cross on their body, inflicting [Bleeding].
+SKILL_20150918_005047	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Afflicts [Bleeding] on enemies by charging towards to cut a cross on their body.
 SKILL_20150918_005048	$Vertical Slash
 SKILL_20150918_005049	{memo X}{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Decreases the defense for medium, big enemies for a while by smaking down.
-SKILL_20150918_005050	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Throw your spear to damage an enemy. The spear will stick into the ground where it was thrown, and your physical attack will be decreased based on the equipment's upgrade count until you pick it up. Automatically returns to you after a time limit.
+SKILL_20150918_005050	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Attack an enemy by throwing your spear. Your spear will stick into the ground where it was thrown, and your physical attack will be decreased based on the equipment's upgrade count until you pick it up. It automatically returns to you after a certain time.
 SKILL_20150918_005051	$Attack per Stack: +#{CaptionRatio}#{nl}Maximum Stacks: #{CaptionRatio2}#{nl}Duration: #{CaptionTime}# seconds
 SKILL_20150918_005052	$Helm Chopper
 SKILL_20150918_005053	${#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Strike the enemy's head, causing it to be stunned.
 SKILL_20150918_005054	$Seism
-SKILL_20150918_005055	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Earthshake causes enemies to be unable to attack. Enemies have a chance to be stunned.
+SKILL_20150918_005055	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Earthshake causes enemies to be unable to attack. The enemy has a chance to be stunned.
 SKILL_20150918_005056	$Cleave
 SKILL_20150918_005057	{memo X}{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Use centrifugal force and continuously attack enemies by turning body. Make an additional damage to the enemy stunned.
 SKILL_20150918_005058	${#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Use your shield and sword to successively attack enemies.
@@ -5060,7 +5060,7 @@ SKILL_20150918_005059	$Shield Shoving
 SKILL_20150918_005060	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Interrupt an enemy's action using your shield. The enemy is turned around, and can't take any actions temporarily.
 SKILL_20150918_005061	Attack #{SkillAtkAdd}#{nl}Attribute Attack #{CaptionRatio}#%{nl}duration 1.5 seconds
 SKILL_20150918_005062	$Shield Bash
-SKILL_20150918_005063	{#DD5500}{ol}[Phyiscal] - [Slash]{/}{/}{nl}Attack with the shield. The stat points of attacked enemy will mix temporarily.
+SKILL_20150918_005063	{#DD5500}{ol}[Phyiscal] - [Slash]{/}{/}{nl}Attack with your shield. The attacked enemy will have its stat points jumbled temporarily.
 SKILL_20150918_005064	$Attack: #{SkillAtkAdd}#{nl}Attribute Damage: #{CaptionRatio}#%{nl}Duration: #{CaptionRatio2}# seconds
 SKILL_20150918_005065	$High Kick
 SKILL_20150918_005066	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Perform a high kick on the enemy. The enemy will receive additional damage from Strike attacks temporarily.

--- a/UI.tsv
+++ b/UI.tsv
@@ -73,7 +73,7 @@ UI_20150317_000072	Carriage Menu
 UI_20150317_000073	{ol}{s22}Disembark{/}
 UI_20150317_000074	Casting
 UI_20150317_000075	{@st43}Game Settings{/}
-UI_20150317_000076	{@st64}Use your arrow keys to select a cell!
+UI_20150317_000076	{@st64}Use the arrow keys to select a cell!
 UI_20150317_000077	{@st43}Advancement Information {/}
 UI_20150317_000078	{@st43}Select Class
 UI_20150317_000079	Psychokinesist


### PR DESCRIPTION
Fixed minor typos, errors and inconsistencies.

@imcgames I have questions about the 관음장 skill of Monk class.

 "대상을 손날로 강하게 내려쳐 방어구를 파괴합니다." - It says that it breaks/destroys the armor of a target. But there is an attribute 관음장: 방어구파괴 that says "스킬 [관음장]에 피격 된 적은 40% 확률로 7초동안 [아머브레이크] 상태에 빠집니다." - This attribute afflicts [Armor Break] state on enemies hit by 관음장 for 7 seconds at 40% chance.

Some players have told me and tested that 관음장 does not break/destroy armor of target without 관음장: 방어구파괴, even though the description of 관음장 says it does. What does 관음장 do without attribute? Is the description in Korean not up-to-date? Does it only deal damage to an enemy without the attribute?

Thanks to:
- https://forum.treeofsavior.com/t/archer-feedback-including-some-class-changes/119782
- https://forum.treeofsavior.com/t/i-can-not-craft-karacha-dagger/120699
- https://forum.treeofsavior.com/t/the-market-ui-needs-serious-work-list-of-problems/120580
- https://forum.treeofsavior.com/t/programming-bug-part-for-text-and-stuff/117456/3
- https://forum.treeofsavior.com/t/early-monk-feedback/119498/36
