### PR TITLE
Sissel Bracelet, additional effect minor fix

### DIFF
--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -5863,7 +5863,7 @@ ITEM_20150729_005862	This item has been crafted with various poisons since its o
 ITEM_20150729_005863	Originally from demons who passed the recipe down to the Vubbes, this recipe was released by human warriors who stole it from the Vubbes.
 ITEM_20150729_005864	- Plant Collection Effect{nl}, when defeat Plant types - Herb items can be droped when the Plant Collection Effect overlapped 15 times.
 ITEM_20150729_005865	The new monsters appeared since Medzio Diena, the name was made according to the a scholar woh devoted to find ways.
-ITEM_20150729_005866	 - Frenzy effect for 5 seconds when you avoid an enemy's attack {nl}  - Increases physical attack by 235, movement speed by 110 and decreases physical defense by 88 for 30 seconds when stacking the Frenzy effect 8 times
+ITEM_20150729_005866	 - [Frenzy Effect] for 5 seconds when an enemy avoids your attack{nl}  - Increases physical attack by 235, movement speed by 10 and reduces physical defense by 88 for 30 seconds when stacking the Frenzy effect 8 times
 ITEM_20150729_005867	{memo X}Adds 2814 EXP and 2166 Class EXP. {nl}There is a chance of receiving additional EXP. {nl}Right-click to use. 
 ITEM_20150729_005868	Lv3 EXP Card (Deletion)
 ITEM_20150729_005869	Kubas Card


### PR DESCRIPTION
Fixed mistranslation of the Frenzy effect from the Sissel Bracelet item.

Thanks to: 
- https://forum.treeofsavior.com/t/sissel-bracelet-mistranlation/121725/2
