### PR TITLE
Minor fixes.

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -4472,7 +4472,7 @@ ETC_20150317_004471	I'm still good...
 ETC_20150317_004472	The third argument UnHideNPC EX>
 ETC_20150317_004473	Parasitic Griba
 ETC_20150317_004474	Guards of Vacenin
-ETC_20150317_004475	Statue of Test
+ETC_20150317_004475	Goddess Statue of Test
 ETC_20150317_004476	Sequoia of Test
 ETC_20150317_004477	Deadborn of Test
 ETC_20150317_004478	Hiding Soul

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -27,7 +27,7 @@ ETC_20150317_000026	$Banshee
 ETC_20150317_000027	$The souls of those who ventured to the underworld now appear as demons.
 ETC_20150317_000028	$Red Banshee
 ETC_20150317_000029	$Evil Spirit
-ETC_20150317_000030	$A soul that did not receive the guidance of the Goddess. It was born through demonic control.
+ETC_20150317_000030	$A soul that did not receive the guidance of the goddess. It was born through demonic control.
 ETC_20150317_000031	$Large Banshee
 ETC_20150317_000032	$Beehive
 ETC_20150317_000033	$Blue Beehive
@@ -458,9 +458,9 @@ ETC_20150317_000457	Animals living in the Royal Mausoleum have been deformed in 
 ETC_20150317_000458	Karas
 ETC_20150317_000459	It is a magic creature whose name comes from the wishes of a golem species.
 ETC_20150317_000460	Echad
-ETC_20150317_000461	A magical creature created to protect the Royal Mausoleum. Despite being weak, it is strong enough to resist the Goddess' powers.
+ETC_20150317_000461	A magical creature created to protect the Royal Mausoleum. Despite being weak, it is strong enough to resist the goddess' powers.
 ETC_20150317_000462	Shtayim
-ETC_20150317_000463	Despite its appearance, this magical creation has received the blessing of the Goddess. Can deal critical damage to demons.
+ETC_20150317_000463	Despite its appearance, this magical creation has received the blessing of the goddess. Can deal critical damage to demons.
 ETC_20150317_000464	Tombsinker
 ETC_20150317_000465	Many creatures have been placed in the Royal Mausoleum, including the Tombsinker, to guard against intruding demons.
 ETC_20150317_000466	Graztas
@@ -613,7 +613,7 @@ ETC_20150317_000612	Tama is a monster originating from the spores of some plants
 ETC_20150317_000613	Kepari
 ETC_20150317_000614	Kepari are not related with the Kepa, and are instead akin to animals.
 ETC_20150317_000615	Kodomor
-ETC_20150317_000616	Since the disappearance of the Goddesses, one of the most bizarre change is that these water-dwelling creatures are now active on land.
+ETC_20150317_000616	Since the disappearance of the goddesses, one of the most bizarre change is that these water-dwelling creatures are now active on land.
 ETC_20150317_000617	Kowak
 ETC_20150317_000618	It still tends to gravitate toward rotten flesh.
 ETC_20150317_000619	Explosion Trap
@@ -2378,7 +2378,7 @@ ETC_20150317_002377	Second space
 ETC_20150317_002378	Third space
 ETC_20150317_002379	Fourth space
 ETC_20150317_002380	Firewood
-ETC_20150317_002381	Please lead to the Goddess.
+ETC_20150317_002381	Please lead to the goddess.
 ETC_20150317_002382	{memo X}Absorbed the energy of the guardian
 ETC_20150317_002383	{memo X}Moving.
 ETC_20150317_002384	{memo X}Do not move.
@@ -3060,7 +3060,7 @@ ETC_20150317_003059	Quest ClassName is not in ArgStr1.
 ETC_20150317_003060	Troubadour
 ETC_20150317_003061	Death awaits you, if you don't win!
 ETC_20150317_003062	For Klaipeda!
-ETC_20150317_003063	The blessing of the Goddess is with us!
+ETC_20150317_003063	The blessing of the goddess is with us!
 ETC_20150317_003064	{/}{#ffFFFF} Hit Me of {/}
 ETC_20150317_003065	Mejuda larvae has detected danger and is now self destructing!
 ETC_20150317_003066	Avoid me!
@@ -3071,11 +3071,11 @@ ETC_20150317_003070	Just kill me instead!
 ETC_20150317_003071	I want to be free..
 ETC_20150317_003072	Thank you...
 ETC_20150317_003073	I owe it to you! Thanks...
-ETC_20150317_003074	Are you leading me to the Goddess?
+ETC_20150317_003074	Are you leading me to the goddess?
 ETC_20150317_003075	I'm so afraid...
 ETC_20150317_003076	Where is this place?
 ETC_20150317_003077	What happened to me?
-ETC_20150317_003078	The Goddess is calling from there...
+ETC_20150317_003078	The goddess is calling from there...
 ETC_20150317_003079	$You led the soul to the Owl Sculpture!
 ETC_20150317_003080	Angry Soul
 ETC_20150317_003081	Revived Corpse
@@ -3202,7 +3202,7 @@ ETC_20150317_003201	{memo X}Fight back the Vubbes and install a bomb in the secr
 ETC_20150317_003202	{memo X}Monsters are trying to get rid of the seal! Get rid of them!
 ETC_20150317_003203	Vubbe Archer Soldier
 ETC_20150317_003204	Vubbe Soldier
-ETC_20150317_003205	You need to go to the Goddess quickly
+ETC_20150317_003205	You need to go to the goddess quickly
 ETC_20150317_003206	Why are there so many monsters suddenly?
 ETC_20150317_003207	Help!
 ETC_20150317_003208	I can't get out!
@@ -3400,7 +3400,7 @@ ETC_20150317_003399	The password does not match
 ETC_20150317_003400	Activate device
 ETC_20150317_003401	NA
 ETC_20150317_003402	Get rid of the monsters around the device
-ETC_20150317_003403	Remember the efforts of the Goddess to keep the world in order. And remember sufferings and hardships she has gone through amongst humans for that distant goal. Besides me, no one in thy past nor future era will know the full account of the hard works and efforts made for the world.
+ETC_20150317_003403	Remember the efforts of the goddess to keep the world in order. And remember sufferings and hardships she has gone through amongst humans for that distant goal. Besides me, no one in thy past nor future era will know the full account of the hard works and efforts made for the world.
 ETC_20150317_003404	$Collected firewood
 ETC_20150317_003405	Taking it out from the Molding Pot
 ETC_20150317_003406	Looks like a pillar that Sculptor Hilda would like
@@ -3509,7 +3509,7 @@ ETC_20150317_003508	Looks like we're going to have to go back quickly
 ETC_20150317_003509	The town seems safer than here
 ETC_20150317_003510	Thank you for the news
 ETC_20150317_003511	Looks like we're going to have to go back home quickly
-ETC_20150317_003512	Thanks to the Goddess
+ETC_20150317_003512	Thanks to the goddess
 ETC_20150317_003513	Returned the refugees to town!
 ETC_20150317_003514	Go first. I will follow in a little while.
 ETC_20150317_003515	Vubbe Invader
@@ -3867,7 +3867,7 @@ ETC_20150317_003866	Quest enrolled in the Session object QuestMapPointViewTerms
 ETC_20150317_003867	Quest enrolled in the Session object QuestMonViewTerms
 ETC_20150317_003868	Already used
 ETC_20150317_003869	Blessing of the Goddess {nl} Increases Skill Point by 1
-ETC_20150317_003870	You have already been blessed by the Goddess
+ETC_20150317_003870	You have already been blessed by the goddess
 ETC_20150317_003871	Unable to move to the warp area, as it doesn't exist
 ETC_20150317_003872	Through the NPC
 ETC_20150317_003873	Moving to
@@ -4420,7 +4420,7 @@ ETC_20150317_004419	I am not gonna let you mess this up!
 ETC_20150317_004420	Thanks for your help...
 ETC_20150317_004421	Guards of Vacenin
 ETC_20150317_004422	Captured Souls
-ETC_20150317_004423	Please lead me to the Goddess!
+ETC_20150317_004423	Please lead me to the goddess!
 ETC_20150317_004424	Wake up!
 ETC_20150317_004425	We didn't know that the demon had returned!
 ETC_20150317_004426	Why do you not help us?
@@ -4776,7 +4776,7 @@ ETC_20150317_004775	There is no PC
 ETC_20150317_004776	I drink a visible pollen stimulants
 ETC_20150317_004777	Matsum appeared from the thorn flowers!
 ETC_20150317_004778	Matsum: Meshumu: 50 / Matsum: Meshumu: 50 / Matsum: Meshumu: 50 / Matsum_Big: Meshumuma: 51
-ETC_20150317_004779	Regarding the five Goddesses
+ETC_20150317_004779	Regarding the five goddesses
 ETC_20150317_004780	About Goddess Ausrine
 ETC_20150317_004781	About Goddess Laima
 ETC_20150317_004782	About Goddess Gabija
@@ -4798,8 +4798,8 @@ ETC_20150317_004797	{memo X}Great eyes have whispered you to the right person is
 ETC_20150317_004798	Part of the fragmentation barrier is insufficient!
 ETC_20150317_004799	Junior Spirit
 ETC_20150317_004800	The work was fully collected!
-ETC_20150317_004801	Saule Goddess. please protect me
-ETC_20150317_004802	Saule Goddess. Please lend me your power to overcome my crisis
+ETC_20150317_004801	Goddess Saule. Please protect me.
+ETC_20150317_004802	Goddess Saule. Please lend me your power to overcome my crisis
 ETC_20150317_004803	that the miracle happens...
 ETC_20150317_004804	Enhancing the Thorn Flower Powder Stimulant
 ETC_20150317_004805	Drank the stimulant
@@ -5012,7 +5012,7 @@ ETC_20150317_005011	I can't see anything.
 ETC_20150317_005012	I can't move!
 ETC_20150317_005013	I want to see my mother.
 ETC_20150317_005014	Why do I have to die?!
-ETC_20150317_005015	O' Goddess, help me...
+ETC_20150317_005015	Take me, goddess...
 ETC_20150317_005016	Anyone there? Help me!
 ETC_20150317_005017	Applying Spirit Liberation potion...
 ETC_20150317_005018	{memo X}Making fire
@@ -5119,7 +5119,7 @@ ETC_20150317_005118	Argh!
 ETC_20150317_005119	Retreat to the fortress!
 ETC_20150317_005120	{memo X}Fort of the Land Portal
 ETC_20150317_005121	Assist the guards and defeat the stone whales!
-ETC_20150317_005122	Kingdom Army Guard
+ETC_20150317_005122	Royal Army Guard
 ETC_20150317_005123	Thank you for the supplies.
 ETC_20150317_005124	What's the fuss?
 ETC_20150317_005125	What is that?
@@ -5165,7 +5165,7 @@ ETC_20150317_005164	Corrupted Pond 1
 ETC_20150317_005165	The effect of the bomb slows down your movement {nl} when you approach the nearby Upents!
 ETC_20150317_005166	So you are still alive..
 ETC_20150317_005167	You're finished.{nl}Die in silence!
-ETC_20150317_005168	Goddess Shaule
+ETC_20150317_005168	Goddess Saule
 ETC_20150317_005169	Binding Magic Circle
 ETC_20150317_005170	Temple Border
 ETC_20150317_005171	Goddess Saule
@@ -5222,7 +5222,7 @@ ETC_20150317_005221	Throneweaver has appeared!
 ETC_20150317_005222	Bait in place
 ETC_20150317_005223	Help me!
 ETC_20150317_005224	Skilled Mechanic
-ETC_20150317_005225	Where did the Goddess go..
+ETC_20150317_005225	Where did the goddess go..
 ETC_20150317_005226	Give us peace and salvation..
 ETC_20150317_005227	Please listen to our prayers..
 ETC_20150317_005228	For peace and happiness..
@@ -6299,7 +6299,7 @@ ETC_20150317_006299	Schwarzer Reiter
 ETC_20150317_006300	Fletcher
 ETC_20150317_006301	Pied Piper
 ETC_20150317_006302	Appraiser
-ETC_20150317_006303	$Clerics heal and protect allies through the blessings{nl}of the Goddess, while knocking down their enemies {nl}with powerful blows.
+ETC_20150317_006303	$Clerics heal and protect allies through the blessings{nl}of the goddess, while knocking down their enemies {nl}with powerful blows.
 ETC_20150317_006304	Priest
 ETC_20150317_006305	Priests are clerics who give blessings and resurrect the dead with their holy powers.
 ETC_20150317_006306	Krivis
@@ -6313,11 +6313,11 @@ ETC_20150317_006313	Dievdirby
 ETC_20150317_006314	Dievdirbys carve and place holy statues which protect allies or attack enemies.
 ETC_20150317_006315	Oracle
 ETC_20150317_006316	Monk
-ETC_20150317_006317	Monks are clerics who train in martial arts through the blessing of the Goddess.
+ETC_20150317_006317	Monks are clerics who train in martial arts through the blessing of the goddess.
 ETC_20150317_006318	Pardoner
-ETC_20150317_006319	Pardoners are clerics who don't deny increasing their wealth through the Goddess's blessing.
+ETC_20150317_006319	Pardoners are clerics who don't deny increasing their wealth through the goddess's blessing.
 ETC_20150317_006320	Paladin 
-ETC_20150317_006321	Paladins use their holy power to protect allies and vanquish enemies through the blessings of the Goddess.
+ETC_20150317_006321	Paladins use their holy power to protect allies and vanquish enemies through the blessings of the goddess.
 ETC_20150317_006322	Chaplain
 ETC_20150317_006323	Shepherd
 ETC_20150317_006324	GM
@@ -8098,7 +8098,7 @@ ETC_20150317_008098	N/A
 ETC_20150317_008099	N/A
 ETC_20150317_008100	N/A
 ETC_20150317_008101	%s captured a Hanaming
-ETC_20150317_008102	Did you attack a Paladin!/You are not afraid of Goddess!/You have met your match today!
+ETC_20150317_008102	Did you attack a Paladin!/You are not afraid of goddess!/You have met your match today!
 ETC_20150317_008103	Owow~~
 ETC_20150317_008104	Name#Hot Panto Warrior#Level#50
 ETC_20150317_008105	Name#Hot Panto Spearman#Level#50
@@ -8184,7 +8184,7 @@ ETC_20150317_008184	Fidelmia
 ETC_20150317_008185	The girl in charge of the mercenary guild's request desk. {nl}Attacked by monsters during escape, she was saved by the captain of the mercenary guild.{nl}She soon joined the mercenaries and is now a proud mercenary herself.
 ETC_20150317_008186	Saint Ignatius
 ETC_20150317_008187	The First Bishop of the St. Ignatius Cathedral, he reformed the church himself by cleansing its false past.{nl}After his death, he continues to be remembered, with the St. Ignatius Cathedral bearing his name.
-ETC_20150317_008188	As the Goddess who brings the break of dawn, she is called many names.{nl}The Goddess of Dawn. The Daughter of God. The Representative of all Goddesses.{nl}Carrying out divine will, she looked after a tree. After she was kidnapped by the Demon Gods, the tree lost control and devoured the capital of the human world.
+ETC_20150317_008188	As the goddess who brings the break of dawn, she is called many names.{nl}The Goddess of Dawn. The Daughter of God. The representative of all goddesses.{nl}Carrying out the divine will, she looked after a tree. After she was kidnapped by the Demon Gods, the tree lost control and devoured the capital of the human world.
 ETC_20150317_008189	The Goddess of Fate. She can see a thousand years into the future, and prepare accordingly to alter the course of destiny.{nl}She left the Revelators a revelation every 100 years. It is said collecting all the scattered revelations will grant one the power to confront fate.
 ETC_20150317_008190	Goddess of Earth
 ETC_20150317_008191	Dahlia
@@ -9876,7 +9876,7 @@ ETC_20150323_009877	Demon Lord Blut
 ETC_20150323_009878	Alchemy Pot
 ETC_20150323_009879	Large Broken Signboard
 ETC_20150323_009880	Sleeping Scorpio
-ETC_20150323_009881	Small pot
+ETC_20150323_009881	Small Pot
 ETC_20150323_009882	Small Goddess Statue
 ETC_20150323_009883	Great Cathedral Footstep
 ETC_20150323_009884	Great Cathedral Device 1
@@ -9902,7 +9902,7 @@ ETC_20150323_009903	{memo X}AnimNPC:Local:OPEN:0/Notice:NOTICE_Dm_!:The meats ar
 ETC_20150323_009904	{memo X}DoTimeAction:Retrieving:2:MAKING:None
 ETC_20150323_009905	According to rumors around Fedimian, when the pilgrims passed by the Pilgrim Path
 ETC_20150323_009906	According to the survivors, survivors of the Fallen City lost their belongings or their lives in the Altar Way while going to Fedimian.
-ETC_20150323_009907	Revelators are exploring the different fallen parts of the world to find assignments of the Goddess. What seems to be a sanctuary was found in the Altar Way. If you can find something restore and use it again, you will be a hero to those who travel this area. 
+ETC_20150323_009907	Revelators are exploring the different fallen parts of the world to find assignments of the goddess. What seems to be a sanctuary was found in the Altar Way. If you can find something restore and use it again, you will be a hero to those who travel this area. 
 ETC_20150323_009908	According to the scout's reports, there were spell devices found in the Forest of Prayer. They tried to activate it but there were too many monsters around so they had to run for their lives. Someone has to activate the spell device and check what powers it has.
 ETC_20150323_009909	Pass through Tenet Garden and move to the Entrance of Kateen Forest
 ETC_20150323_009910	Place the Sun Essence in Ramstis Ridge
@@ -10896,9 +10896,9 @@ ETC_20150414_010897	Understood.
 ETC_20150414_010898	Did you think you could do whatever you want?
 ETC_20150414_010899	Stop, Hauberk!
 ETC_20150414_010900	Wake up, Revelator!
-ETC_20150414_010901	Hurry, tell the Goddess about Hauberk's escape!
+ETC_20150414_010901	Hurry, tell the goddess about Hauberk's escape!
 ETC_20150414_010902	Come this way..
-ETC_20150414_010903	$Dionysus! The Goddess has been looking for you.
+ETC_20150414_010903	$Dionysus! The goddess has been looking for you.
 ETC_20150414_010904	Kupoles. {nl}Begin the ritual.
 ETC_20150414_010905	{memo X}Need the 3rd circle of Thaumaturge
 ETC_20150414_010906	{memo X}You've obtained 100 recipes
@@ -11143,7 +11143,7 @@ ETC_20150414_011144	{memo X}There are monsters guarding the seal.
 ETC_20150414_011145	We have fully absorbed the power of Blut.
 ETC_20150414_011146	Now let's attack Blut!
 ETC_20150414_011147	You were already fooled. Are you going to be fooled again?
-ETC_20150414_011148	Followers of the Goddesses act like Goddesses themselves.
+ETC_20150414_011148	Followers of the goddesses act like goddesses themselves.
 ETC_20150414_011149	I said I'd spare you..
 ETC_20150414_011150	Kupole
 ETC_20150414_011151	Obtained Elixir of King's voice
@@ -11779,8 +11779,8 @@ ETC_20150714_011780	You've been spotted while destroying the Pot of Silence!{nl}
 ETC_20150714_011781	Pot of Silence
 ETC_20150714_011782	Defend until the Contract of Flesh has finished burning!
 ETC_20150714_011783	Contract of Flesh
-ETC_20150714_011784	Thanks. Now, they can meet the Goddesses.
-ETC_20150714_011785	May the Goddesses bless you in the future.
+ETC_20150714_011784	Thanks. Now, they can meet the goddesses.
+ETC_20150714_011785	May the goddesses bless you in the future.
 ETC_20150714_011786	Defeat Master Genie and release the Contract of Spirit!
 ETC_20150714_011787	The Holy Sphere has been activated!
 ETC_20150714_011788	Defend against attacks from Naktis' servants until the transformation scroll is complete!
@@ -11851,7 +11851,7 @@ ETC_20150714_011852	Suppress the evil energy to weaken it.
 ETC_20150714_011853	Decrease Defense, Increase Movement Speed
 ETC_20150714_011854	Protect yourself from the Stone Frost in Roxona Market
 ETC_20150714_011855	FLASH61_SQ_02 Use Quest
-ETC_20150714_011856	Colorless and odorless stimulant. The Kingdom Army Soldiers don't seem to recognize it.
+ETC_20150714_011856	A colorless and odorless stimulant. The Royal Army soldiers don't seem to recognize it.
 ETC_20150714_011857	Immune to Stone Frost
 ETC_20150714_011858	You are immune to Stone Frost temporarily. When the immunity disappears however, you will be petrified by the effects of the Stone Frost.
 ETC_20150714_011859	Petrifying
@@ -12772,7 +12772,7 @@ ETC_20150714_012773	You don't have enough Long-Branched Tree Charcoal
 ETC_20150714_012774	$You have obtained the third rubbing.
 ETC_20150714_012775	You have obtained the petrified good
 ETC_20150714_012776	You have handed over the water bottle that is engraved with the password
-ETC_20150714_012777	The Goddesses are relieving my thirst
+ETC_20150714_012777	The goddesses are relieving my thirst
 ETC_20150714_012778	You've used the petrification dissolution but the petrified part didn't change
 ETC_20150714_012779	It seems to be unconscious
 ETC_20150714_012780	The soldier closed his eyes peacefully
@@ -13138,25 +13138,25 @@ ETC_20150714_013139	{memo X}(Temporary) Amanda 1
 ETC_20150714_013140	{memo X}(Temporary) Amanda 2
 ETC_20150714_013141	{memo X}(Temporary) Amanda 3
 ETC_20150714_013142	Demon Box
-ETC_20150714_013143	[Kingdom Army]{nl}  Guard
-ETC_20150714_013144	[Kingdom Army]{nl}   Retia
+ETC_20150714_013143	[Royal Army]{nl}  Guard
+ETC_20150714_013144	[Royal Army]{nl}   Retia
 ETC_20150714_013145	[Amanda Tomb Robbers]{nl}  Hubertas
-ETC_20150714_013146	[Kingdom Army]{nl}  Gofden
+ETC_20150714_013146	[Royal Army]{nl}  Gofden
 ETC_20150714_013147	[Knights of Kaliss]{nl}Cryomancer Kostas
 ETC_20150714_013148	[Amanda Tomb Robbers]{nl}   Rudolfas
-ETC_20150714_013149	Petrified Kingdom Army Advance Party
+ETC_20150714_013149	Petrified Royal Army Advance Party
 ETC_20150714_013150	Discarded Petrification Detector
 ETC_20150714_013151	Bella Grass
 ETC_20150714_013152	Amanda Tomb Robbers' Crate
 ETC_20150714_013153	[Knights of Kaliss]{nl}Chronomancer Sabina
-ETC_20150714_013154	[Kingdom Army]{nl} Nomabis
-ETC_20150714_013155	[Kingdom Army]{nl}  Rail
+ETC_20150714_013154	[Royal Army]{nl} Nomabis
+ETC_20150714_013155	[Royal Army]{nl}  Rail
 ETC_20150714_013156	Petrified Soldier
-ETC_20150714_013157	[Kingdom Army]{nl}  Rofdel
+ETC_20150714_013157	[Royal Army]{nl}  Rofdel
 ETC_20150714_013158	[Knights of Kaliss]{nl}  Assitant Chief Hans
 ETC_20150714_013159	[Amanda Tomb Robbers]{nl}  Stephonas
-ETC_20150714_013160	Kingdom Army Notice Board
-ETC_20150714_013161	The Propaganda of Kingdom Army
+ETC_20150714_013160	Royal Army Notice Board
+ETC_20150714_013161	Propaganda of Royal Army
 ETC_20150714_013162	[Knights of Kaliss]{nl}Wilhelmina Carriot
 ETC_20150714_013163	[Knights of Kaliss]{nl}  Knight
 ETC_20150714_013164	[Knights of Kaliss]{nl}  Bokor Edita
@@ -13204,7 +13204,7 @@ ETC_20150717_013205	As the magic stabilizing device activated, the monsters rush
 ETC_20150717_013206	Protect Grita while she is controlling the magic of the tower!
 ETC_20150717_013207	Defeat Grinender that blocked the stairs to the 5th floor!
 ETC_20150717_013208	{memo X}Well done. Grita.
-ETC_20150717_013209	Kingdom Army Guard Dellus
+ETC_20150717_013209	Royal Army Guard Dellus
 ETC_20150717_013210	{memo X}Weapon Box
 ETC_20150717_013211	Let's retrieve the base!
 ETC_20150717_013212	What?! It's the box.
@@ -13458,7 +13458,7 @@ ETC_20150717_013459	{memo X}Notice:NOTICE_Dm_!:You haven't obtained anything:5
 ETC_20150717_013460	Release the petrified victims at Vienti Fortress
 ETC_20150717_013461	{memo X}The past of Crystal Mine[Alchemist Advancement]
 ETC_20150717_013462	Pass the corridor by dispersing the monsters
-ETC_20150717_013463	{memo X}Search through the corpses of the Kingdom Army guards and collect usable equipment
+ETC_20150717_013463	{memo X}Search through the corpses of the Royal Army guards and collect usable equipment
 ETC_20150717_013464	Obtain diluting solution from the Item Merchant in Fedimian
 ETC_20150717_013465	$Lure InfroGalas Mages using the food boxes to collect sticky resin
 ETC_20150717_013466	{memo X}Move to a safe place
@@ -13601,7 +13601,7 @@ ETC_20150717_013602	{memo X}[Tools Merchant]{nl}     Anna
 ETC_20150717_013603	[Item Merchant]{nl}           Mirina
 ETC_20150717_013604	Spell Control Magic Circle.
 ETC_20150717_013605	The guard that fell behind
-ETC_20150717_013606	{memo X}The corpse of the Kingdom Army Guard
+ETC_20150717_013606	{memo X}The corpse of the Royal Army Guard
 ETC_20150717_013607	There is no regeneration of monsters
 ETC_20150717_013608	Inner Fortress District
 ETC_20150717_013609	Petrified Monster
@@ -14497,7 +14497,7 @@ ETC_20150918_014498	You need flowers to calm the altar-bound soul
 ETC_20150918_014499	The pilgrim's soul is attacking the Tree Root Crystal!
 ETC_20150918_014500	Move forward in order to open the chest
 ETC_20150918_014501	{memo X}The statue of the goddess won't react
-ETC_20150918_014502	Do you think I will be able to go to the Goddesses?
+ETC_20150918_014502	Do you think I will be able to go to the goddesses?
 ETC_20150918_014503	Thanks for comforting me...
 ETC_20150918_014504	Shut up! I will destroy you all!
 ETC_20150918_014505	I won't forgive them! Never!
@@ -15648,7 +15648,7 @@ ETC_20151016_015649	Demon Lord Zaura
 ETC_20151016_015650	{memo X}You foolish human..
 ETC_20151016_015651	{memo X}Don't think this is the end..
 ETC_20151016_015652	An unknown power is blocking it.
-ETC_20151016_015653	Face against Zaura to save the Goddesses!
+ETC_20151016_015653	Face against Zaura to save the goddess!
 ETC_20151016_015654	{memo X}You really want to die, don't you?
 ETC_20151016_015655	{memo X}You cannot get near the Goddesses!
 ETC_20151016_015656	{memo X}I will kill you here!
@@ -15872,7 +15872,7 @@ ETC_20151016_015873	Now, tell me.
 ETC_20151016_015874	I will never tell you!
 ETC_20151016_015875	Please don't!
 ETC_20151016_015876	What is the device that was destroyed by Ruklys!
-ETC_20151016_015877	Persuading to go back to the Goddess
+ETC_20151016_015877	Persuading to return to the goddess
 ETC_20151016_015878	I will follow you..
 ETC_20151016_015879	There aren't useful components
 ETC_20151016_015880	Destroying Demon Totems
@@ -16568,7 +16568,7 @@ ETC_20151102_016569	Perit appeared!
 ETC_20151102_016570	Perit Murloader, protector of Demon Totems has appeared!
 ETC_20151102_016571	Eliminate Perit Murloader and destroy the Demon Totem!
 ETC_20151102_016572	Ack.. You insolent human!!
-ETC_20151102_016573	Fight against Demon Lord Zaura who imprisoned Goddess Lada
+ETC_20151102_016573	Fight against Demon Lord Zaura who imprisoned Goddess Rada
 ETC_20151102_016574	Stand back.
 ETC_20151102_016575	No!!
 ETC_20151102_016576	Demon Lord Zaura disappeared with the girl! Eliminate the horde of Perits!
@@ -17200,7 +17200,7 @@ ETC_20151102_017201	OptDesc/ - Carve Goddess Zemyna Skill Lv +1
 ETC_20151102_017202	OptDesc/ - Carve Goddess Laima Skill Lv +1
 ETC_20151102_017203	OptDesc/ - Carve Skill Lv +1
 ETC_20151102_017204	OptDesc/ - Carve Owl Skill Lv +1
-ETC_20151102_017205	OptDesc/ - Carve Austras Koks Skill Lv +1
+ETC_20151102_017205	OptDesc/ - Carve World Tree Skill Lv +1
 ETC_20151102_017206	OptDesc/ - Carve Goddess Ausrine Skill Lv +1
 ETC_20151102_017207	OptDesc/ - Arcane Energy Skill Lv +1
 ETC_20151102_017208	OptDesc/ - Change Skill Lv +1
@@ -17298,7 +17298,7 @@ ETC_20151102_017299
 ETC_20151102_017300
 ETC_20151102_017301
 ETC_20151102_017302	Breaking out of Redemption Ward
-ETC_20151102_017303	The little powers captured by the Redemption Ward have returned to the Goddesses.
+ETC_20151102_017303	The little powers captured by the Redemption Ward have returned to Goddess Rada.
 ETC_20151102_017304
 ETC_20151102_017305
 ETC_20151102_017306

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -8609,7 +8609,7 @@ ETC_20150317_008609	Recipe - Gladiator Band
 ETC_20150317_008610	Recipe - Bracelet of Linne
 ETC_20150317_008611	Recipe - Pora
 ETC_20150317_008612	Recipe - Pore
-ETC_20150317_008613	Recipe - Cicel Bracelet
+ETC_20150317_008613	Recipe - Sissel Bracelet
 ETC_20150317_008614	Recipe - Zachariel Bangle
 ETC_20150317_008615	Recipe - Nesting Chick
 ETC_20150317_008616	Recipe for crafting a costume

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -16541,19 +16541,19 @@ ETC_20151102_016542	Let's get out of here, quick
 ETC_20151102_016543	Demons!
 ETC_20151102_016544	Thank you for saving us.
 ETC_20151102_016545	Edmundas
-ETC_20151102_016546	Ugh… my head…
+ETC_20151102_016546	Ugh... my head...
 ETC_20151102_016547	No! Please save my brother!
-ETC_20151102_016548	To foil my plans this easily…
+ETC_20151102_016548	To foil my plans this easily...
 ETC_20151102_016549	Your foolish and imprudent actions will have the siblings killed
 ETC_20151102_016550	Magic Stone of Pain
-ETC_20151102_016551	I'm… alright..
+ETC_20151102_016551	I'm... alright..
 ETC_20151102_016552	Roze, are you okay?
-ETC_20151102_016553	No… this can't be…
+ETC_20151102_016553	No... this can't be...
 ETC_20151102_016554	I won't let you interfere
 ETC_20151102_016555	Protect me until the mind control is completed
 ETC_20151102_016556	Step away.
 ETC_20151102_016557	Now, let's return to Lord Melchioras.
-ETC_20151102_016558	Wh…what is this..
+ETC_20151102_016558	Wh... what is this..
 ETC_20151102_016559	Quick! Run!!
 ETC_20151102_016560	Please help!
 ETC_20151102_016561	He...help!
@@ -16574,7 +16574,7 @@ ETC_20151102_016575	No!!
 ETC_20151102_016576	Demon Lord Zaura disappeared with the girl! Eliminate the horde of Perits!
 ETC_20151102_016577	The Kingdom Guards are being chased by the monsters! It's better to save them for now.
 ETC_20151102_016578	I'm sorry. Please leave
-ETC_20151102_016579	We came to investigate…
+ETC_20151102_016579	We came to investigate...
 ETC_20151102_016580	Namott
 ETC_20151102_016581	Namott Holy Water Effect: Demon monsters will not appear
 ETC_20151102_016582	Decreased Resistance against Ice Property 

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -15841,7 +15841,7 @@ ETC_20151016_015842	Ferret attacked the injured villager!
 ETC_20151016_015843	{memo X}Ferret is running away after smelling the terrible odor!
 ETC_20151016_015844	{memo X}There are no Ferrets around
 ETC_20151016_015845	Destroying the restraining device
-ETC_20151016_015846	The power that was trapped in the restraining device went back to Rada
+ETC_20151016_015846	The power that was trapped in the restraining device went back to Lada
 ETC_20151016_015847	The status of the device to absorb vitalities is strange!
 ETC_20151016_015848	The magic power is being overloaded
 ETC_20151016_015849	As you used the orb of the goddess, the suppressor was destroyed
@@ -16568,7 +16568,7 @@ ETC_20151102_016569	Perit appeared!
 ETC_20151102_016570	Perit Murloader, protector of Demon Totems has appeared!
 ETC_20151102_016571	Eliminate Perit Murloader and destroy the Demon Totem!
 ETC_20151102_016572	Ack.. You insolent human!!
-ETC_20151102_016573	Fight against Demon Lord Zaura who imprisoned Goddess Rada
+ETC_20151102_016573	Fight against Demon Lord Zaura who imprisoned Goddess Lada
 ETC_20151102_016574	Stand back.
 ETC_20151102_016575	No!!
 ETC_20151102_016576	Demon Lord Zaura disappeared with the girl! Eliminate the horde of Perits!
@@ -17298,7 +17298,7 @@ ETC_20151102_017299
 ETC_20151102_017300
 ETC_20151102_017301
 ETC_20151102_017302	Breaking out of Redemption Ward
-ETC_20151102_017303	The little powers captured by the Redemption Ward have returned to Goddess Rada.
+ETC_20151102_017303	The little powers captured by the Redemption Ward have returned to Goddess Lada.
 ETC_20151102_017304
 ETC_20151102_017305
 ETC_20151102_017306

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -7256,7 +7256,7 @@ ITEM_20151016_007255	The stolen food by Ferrets
 ITEM_20151016_007256	{memo X}Fruit juice extracted from of a gigantic fruit that a Ferret obtained. It is in the container made up of fruit peels.
 ITEM_20151016_007257	A sculpture of peace carved by Dievdirbys Widus. When you place it, the Ferrets around you will be calmed.
 ITEM_20151016_007258	A scent created by Druid Leja using the herb. When you spread the scent, the Ferrets nearby will become unconscious.
-ITEM_20151016_007259	The orb that was left by the Goddess Laima. You've received the message from Laima Goddess to rescue Goddess Rada.
+ITEM_20151016_007259	The orb that was left by the Goddess Laima. You've received the message from Goddess Laima to rescue Goddess Lada.
 ITEM_20151016_007260	Empty Scroll
 ITEM_20151016_007261	Nothing is written on this scroll. As requested by Benes, you should write the behaviors of Ferrets on it.
 ITEM_20151016_007262	Ferret Transformation Scroll

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -103,7 +103,7 @@ ITEM_20150317_000102	{memo X}$Prima Sword
 ITEM_20150317_000103	$Trinity Sword 
 ITEM_20150317_000104	$If you're unsatisfied with one type of Falchion, this is an alternative. However, you'll have to bear the extra cost for its crafting. 
 ITEM_20150317_000105	$Durandal 
-ITEM_20150317_000106	$Many adventurers name their best sword after this weapon. This was the name of the sword wielded by an ancient warrior chosen by a Goddess. 
+ITEM_20150317_000106	$Many adventurers name their best sword after this weapon. This was the name of the sword wielded by an ancient warrior chosen by a goddess. 
 ITEM_20150317_000107	$Velniup 
 ITEM_20150317_000108	$People will even go so far as to say that this weapon is overly cruel. 
 ITEM_20150317_000109	$Fortis 
@@ -115,7 +115,7 @@ ITEM_20150317_000114	{memo X}$By wielding this blade, one becomes the deathbring
 ITEM_20150317_000115	$Chapparition Sword 
 ITEM_20150317_000116	{memo X}$This serves as indirect evidence for the disputes between Demons. 
 ITEM_20150317_000117	$Bendras Sword 
-ITEM_20150317_000118	$A sword carrying the might of the Goddess that has smited many evils in the past. 
+ITEM_20150317_000118	$A sword carrying the might of the goddess that has smited many evils in the past. 
 ITEM_20150317_000119	$Illizia 
 ITEM_20150317_000120	$This blade severely threatens both the life of its foe and the owner's finances. Of course, most swordsmen ignore the latter effect. 
 ITEM_20150317_000121	$Scheduled for deletion 
@@ -492,7 +492,7 @@ ITEM_20150317_000491	$A very simple weapon for anyone to use without difficulty.
 ITEM_20150317_000492	$Wooden Club 
 ITEM_20150317_000493	$Even an ordinary wooden stick can become a holy item if wielded by a cleric. 
 ITEM_20150317_000494	$Dunkel Iron Club 
-ITEM_20150317_000495	$A weapon at least of this caliber is necessary to carry out the Goddess' punishment. 
+ITEM_20150317_000495	$A weapon at least of this caliber is necessary to carry out the goddess' punishment. 
 ITEM_20150317_000496	{memo X}$Low Mace 
 ITEM_20150317_000497	$This is the minimum requirement to prove that one is no longer an apprentice cleric. 
 ITEM_20150317_000498	$Morning Star 
@@ -587,7 +587,7 @@ ITEM_20150317_000586	{memo X}$No matter what monster you face, this weapon will 
 ITEM_20150317_000587	$Stunner 
 ITEM_20150317_000588	$Some clerics prefer to disorient their target through means other than preaching. 
 ITEM_20150317_000589	$Valia 
-ITEM_20150317_000590	$It is consecrated with the power of the Goddess during the crafting process. Elder demons can't stand the sight of this weapon. 
+ITEM_20150317_000590	$It is consecrated with the power of the goddess during the crafting process. Elder demons can't stand the sight of this weapon. 
 ITEM_20150317_000591	$Spearfish Rod 
 ITEM_20150317_000592	$May it produce barbed dicipline. 
 ITEM_20150317_000593	$Wooden Shield 
@@ -812,7 +812,7 @@ ITEM_20150317_000811	Users of this wand must be able to control their own darkne
 ITEM_20150317_000812	Levereuse 
 ITEM_20150317_000813	People with strong mind and self-realization can utilize Levereuse to its full potential during battle. 
 ITEM_20150317_000814	Kyrnus 
-ITEM_20150317_000815	{memo X}Prior to the Great Plant Cataclym, there was nobody who would use this weapon because it used Demonic powers. However, with the vanishing of the Goddesses, desperate people have begun using it. 
+ITEM_20150317_000815	{memo X}Prior to the Great Plant Cataclym, there was nobody who would use this weapon because it used Demonic powers. However, with the vanishing of the goddesses, desperate people have begun using it. 
 ITEM_20150317_000816	Knife 
 ITEM_20150317_000817	Sub-Weapon 
 ITEM_20150317_000818	It is a small knife used for various purposes such as battle, cooking, or camping. 
@@ -1334,7 +1334,7 @@ ITEM_20150317_001333	According to legend; after learning its secret recipe, Lydi
 ITEM_20150317_001334	Panto Talisman 
 ITEM_20150317_001335	It is said that a human wizard gave the recipe for this necklace to the Pantos a long time ago as a gift when the Pantos and humankind were not hostile to one another. 
 ITEM_20150317_001336	Pyrlight Pendant 
-ITEM_20150317_001337	Used to be awarded by the Pyromancer Master to beginners. This tradition ceased after the Goddesses disappeared. 
+ITEM_20150317_001337	Used to be awarded by the Pyromancer Master to beginners. This tradition ceased after the goddesses disappeared. 
 ITEM_20150317_001338	Cryolight Pendant 
 ITEM_20150317_001339	{memo X}Since their assumption of office prior to the Great Plant Cataclysm, the Cryomancer Master has stopped the tradition of awarding this pendant to people. Now this pendant must be either obtained or crafted by the users themselves. 
 ITEM_20150317_001340	Magic Talisman 
@@ -1389,7 +1389,7 @@ ITEM_20150317_001388	An increase in your mental strength is not because of an am
 ITEM_20150317_001389	Ring Bracelet 
 ITEM_20150317_001390	Accuracy is, in essence, the ability to exert precise control over your body. The Accuracy Bangle enables that kind of self-control. 
 ITEM_20150317_001391	Noble Bracelet 
-ITEM_20150317_001392	It is said that the blessings of the Goddess of the Lands, Zemyna, lie within this equipment. 
+ITEM_20150317_001392	It is said that the blessings of the Goddess of the Earth, Zemyna, lie within this equipment. 
 ITEM_20150317_001393	Iron Bangle 
 ITEM_20150317_001394	Although devoid of any magical effect, it will certainly increase your defense. 
 ITEM_20150317_001395	{memo X}Health Heavy Bangle 
@@ -1581,7 +1581,7 @@ ITEM_20150317_001580	If you face the real Teeny, it will be very different from 
 ITEM_20150317_001581	Wing Helmet 
 ITEM_20150317_001582	A helmet with a wing decoration. 
 ITEM_20150317_001583	Wing Decoration 
-ITEM_20150317_001584	Inspired by a Goddess' wing. 
+ITEM_20150317_001584	Inspired by a goddess' wing. 
 ITEM_20150317_001585	Nesting Egg 
 ITEM_20150317_001586	Nobody knows why the egg was nested on someone's head. 
 ITEM_20150317_001587	Nesting Chick 
@@ -2737,7 +2737,7 @@ ITEM_20150317_002736	Mithril Ore
 ITEM_20150317_002737	A shining, silvery ore. Since it contains magic power, it is used for crafting powerful equipment. 
 ITEM_20150317_002738	Orichalcum Ore 
 ITEM_20150317_002739	Ithildin Ore 
-ITEM_20150317_002740	During the Kingdom's founding period, it used to be a precious metal that could only be mined with the guidance of the Goddess. Nowadays, it is more common.
+ITEM_20150317_002740	During the Kingdom's founding period, it used to be a precious metal that could only be mined with the guidance of the goddess. Nowadays, it is more common.
 ITEM_20150317_002741	Annotation 
 ITEM_20150317_002742	Obtainable from Corylus. 
 ITEM_20150317_002743	Titanium 
@@ -5589,7 +5589,7 @@ ITEM_20150717_005588	Shot with hope to make a great damage every shoting.
 ITEM_20150717_005589	Please be a person to show what the real worth of this weapon.
 ITEM_20150717_005590	Unlike the different weapons of same names, this name is related with the weapon effect. It has a magic to get the opponent like a death nest.
 ITEM_20150717_005591	Beast can make a pain to whom is not this world.
-ITEM_20150717_005592	There are traces of it being used for other purposes. But even ordinary equipments can show Goddess' divinity. 
+ITEM_20150717_005592	There are traces of it being used for other purposes. But even ordinary equipments can show goddess' divinity. 
 ITEM_20150717_005593	Many priests, wizards and warriors use this personally as an advantage in battle. Although, this weapon is not officially supported by the army of the kingdom.
 ITEM_20150717_005594	It has a form to display the unique character of this town, but the material is not silver.
 ITEM_20150717_005595	Hit and Slash, don't worry about the damage of Lune.
@@ -5607,8 +5607,8 @@ ITEM_20150717_005606	A weapon that crafted to have a lot of magic and effort eve
 ITEM_20150717_005607	It is powerful against Mutant type monsters but no ones why.
 ITEM_20150717_005608	Don't think it is poor just regarding about form. It has a strong durability and has a good face to distinguish the other weapon.
 ITEM_20150717_005609	The Battle ways using this unique form of the shield has been upgraded by lots of Masters.
-ITEM_20150717_005610	In the fast, There were a lot of shield crafted by Fedimian. Since the God of Goddess, The lot of type shield have been crafted due to the dangerous world.
-ITEM_20150717_005611	Unlike the some of misunderstanding, This type is not origin from the Kingdom outside. Since The God of Goddess, It made an effect, surely the shield is origin from the some place of Kingdom.
+ITEM_20150717_005610	In the fast, There were a lot of shield crafted by Fedimian. Since the Medzio Diena, the lot of type shield have been crafted due to the dangerous world.
+ITEM_20150717_005611	Unlike the some of misunderstanding, This type is not origin from the kingdom outside. Since Medzio Diena, It made an effect, surely the shield is origin from the some place of the kingdom.
 ITEM_20150717_005612	This shield is specilized in riding battle, It can make a good performance at the Hamasi battle. After Taniel period which made a stablization Kingdom, It has been crafted constanly.
 ITEM_20150717_005613	This is the equipment that was crafted from the shield, which is used on mount battles, by focusing on its defensive rate instead of focusing on its mass. Unlike a cavalry shield, it may be too much for a foot soldier.
 ITEM_20150717_005614	The history of Tower Shield is even longer than the small shields. The soldiers who followed Zachariel during the war of the country were used to this kind of shields.
@@ -5664,7 +5664,7 @@ ITEM_20150717_005663	This is the by-product of the period when the wizards and t
 ITEM_20150717_005664	This is the equipment that has been changed a lot from the original equipment from the Kadumel Era. It generally possesses the improved qualities.
 ITEM_20150717_005665	For the amusement of the aristocrats, a kind of Metal Plate armor was needed so it was changed practically from then. It is being keep improved and developed after Medzio Diena.
 ITEM_20150717_005666	Under the stabilized royal regime, the Metal Plate armor has developed with various reasons even when there weren't any large scale wars going on. The requests of the aristocrats who didn't forget the importance of militairy training were accepted many times and as a result, it has the shape of nowadays.
-ITEM_20150717_005667	Not only the wars and the tastes of the aristocrats developed the history of the battlegear. The master craftmen in Fedimian have been creating many equipment and craft items by utilizing their unique experimental minds for a long time. Also this is the result of the support from the Goddesses who are trying to develop the cizilization of the humans.
+ITEM_20150717_005667	Not only the wars and the tastes of the aristocrats developed the history of the battlegear. The master craftmen in Fedimian have been creating many equipment and craft items by utilizing their unique experimental minds for a long time. Also this is the result of the support from the goddesses who are trying to develop the cizilization of the humans.
 ITEM_20150717_005668	According to an old saying, Jane, the disciple of Agailla Flurry, created this equipment. She resolved her limit by doing so, but there aren't any clear records remaining.
 ITEM_20150717_005669	After Medzio Diena, the equipment that were used for the hunting and the adventures are receiving the spotlight. As the number of violent monsters increases, the adventurous hunting which was unique before is becoming daily lives.
 ITEM_20150717_005670	Its appearance looks good since it was used for the designs of the court guards and its defensive rate is also great.
@@ -5674,11 +5674,11 @@ ITEM_20150717_005673	The pattern of the foot soldiers that was adopted from the 
 ITEM_20150717_005674	This equipment possesses the passion of the archmages to improve themselves to the next level.
 ITEM_20150717_005675	The previous Skirmisher equipment is being crafted with improved qualities as the monsters go rampant since Medzio Diena.
 ITEM_20150717_005676	This equipment was once adopted as the official equipment of the foot soldiers inside the castle of the capital. As the time passed by after that, this equipment was used constantly even in the periods when it wasn't adopted by the kingdom.
-ITEM_20150717_005677	According to folklore, the source of this recipe was leaked from the Library of the Goddesses.
+ITEM_20150717_005677	According to folklore, the source of this recipe was leaked from the Library of the goddesses.
 ITEM_20150717_005678	This is the equipment with the pattern that was mainly worn at the outer areas of the kingdom. It is believed to be used in the southern part of Orsha for about a hundred years.
 ITEM_20150717_005679	In the past, this equipment was given to commemorate all the people who received a knighthood.
 ITEM_20150717_005680	Since the pattern was adopted from the tribal society outside the kingdom, this equipment shows the improvements as the time passed by.
-ITEM_20150717_005681	Its name is said to be taken from a famous monster in the past which cannot be confirmed, unless you are using the Library of the Goddesses. 
+ITEM_20150717_005681	Its name is said to be taken from a famous monster in the past which cannot be confirmed, unless you are using the Library of the goddesses. 
 ITEM_20150717_005682	This equipment was adopted from the Gele Plateau area. The history has been long, so it is believed to be made from in the period of the first Paladin Master, but I am sure it was first crafted at some point of time in the later generations.
 ITEM_20150717_005683	Heavier and weaker than expected but its enchantment with power of mummies that are different from the undead helps the wearer.
 ITEM_20150717_005684	Beyo Boots
@@ -5689,34 +5689,34 @@ ITEM_20150717_005688	A strong point of mounted equipment by monsters is to borro
 ITEM_20150717_005689	Nepenthes is not an active monster. Then, the feature of this equipment is a reaction of the origin.
 ITEM_20150717_005690	Originally, Shnayim was a creation bearing Great King Zachariel's great plans and arrangements. As for now, it would be of more help this way.
 ITEM_20150717_005691	Rumor has it that Maven made this for any of his disciples. But in reality, none of his disciples were related to it. 
-ITEM_20150717_005692	There have been endless tries to enhance weapons with the Goddess' divinity. That's how much will of people this item contains. 
-ITEM_20150717_005693	There have been endless tries to enhance weapons with the Goddess' divinity. It was not very successful but it wasn't a failure either. 
-ITEM_20150717_005694	There have been endless tries to enhance weapons with the Goddess' divinity. The most preferred Goddess is Goddess Zemyna and so is this item. 
-ITEM_20150717_005695	Infused with the Goddess' divinity, this footwear does not distinguish between priests and those who seek the Goddess' power. It will support anyone in the world the same.
-ITEM_20150717_005696	The Goddess' power on an item differs on the type of material, even if the item use the same name. It reflects the ability and personality of the one who made it.
-ITEM_20150717_005697	It does not have necessarily powerful effect just because the equipment has the sacred power of various Goddesses. The equipment as name Thresh was made to seek the blessings of the three Goddesses, you will feel it's weak considering the name.
-ITEM_20150717_005698	It is one of the recipes that three Goddesses tried to save the blessing into on equipment. This way is still not finished, and it's hard to see the last since the Goddess have disappeared.
-ITEM_20150717_005699	The first devised who of this equipment has been kept secret until what was going to receive the blessing of any Goddess. But it is a little weak by considering the result of the confidentiality.
+ITEM_20150717_005692	There have been endless tries to enhance weapons with the goddess' divinity. That's how much will of people this item contains. 
+ITEM_20150717_005693	There have been endless tries to enhance weapons with the goddess' divinity. It was not very successful but it wasn't a failure either. 
+ITEM_20150717_005694	There have been endless tries to enhance weapons with the goddess' divinity. The most preferred goddess is Goddess Zemyna and so is this item. 
+ITEM_20150717_005695	Infused with the goddess' divinity, this footwear does not distinguish between priests and those who seek the goddess' power. It will support anyone in the world the same.
+ITEM_20150717_005696	The goddess' power on an item differs on the type of material, even if the item use the same name. It reflects the ability and personality of the one who made it.
+ITEM_20150717_005697	It does not have necessarily powerful effect just because the equipment has the sacred power of various goddesses. The equipment as name Thresh was made to seek the blessings of the three goddesses, you will feel it's weak considering the name.
+ITEM_20150717_005698	It is one of the recipes that three goddesses tried to save the blessing into on equipment. This way is still not finished, and it's hard to see the last since the goddesses have disappeared.
+ITEM_20150717_005699	The first devised who of this equipment has been kept secret until what was going to receive the blessing of any goddess. But it is a little weak by considering the result of the confidentiality.
 ITEM_20150717_005700	In order to praise Sixth generation king Melkiele what he came to the throne and death, the various equipments have been made.
 ITEM_20150717_005701	In order to praise the sixth generation king Melkiele what he came to the throne and death, the various equipments have been made. At that time, the personality change has been reflected, the style will disappear almost as years went, only the name is remained.
 ITEM_20150717_005702	Sixth generation king Melkiele is the first king that has extended the area of the kingdom was established in the era of Zachariel. He succeeded in absorbing a large number of tribal society in the kingdom of the region using a Wasen both sides tactics. In order to praise his achievement, the various equipments have been made.
-ITEM_20150717_005703	The freaks can appear in the community rely on the Goddess completely. Fortunately the merciful Goddess and high priests regard the name of this equipment as the just fun.
-ITEM_20150717_005704	The performace is good even though the name is strange. There are priests saying half jokingly that the Goddess's grace is evidence of fairness to all.
-ITEM_20150717_005705	Despite the unusual name, the user is high as the look and performance. The Goddess and priests will not have joy and sorrow in quick alternation on human emotional language.
+ITEM_20150717_005703	The freaks can appear in the community rely on the goddess completely. Fortunately the merciful goddess and high priests regard the name of this equipment as the just fun.
+ITEM_20150717_005704	The performace is good even though the name is strange. There are priests saying half jokingly that the goddess's grace is evidence of fairness to all.
+ITEM_20150717_005705	Despite the unusual name, the user is high as the look and performance. The goddess and priests will not have joy and sorrow in quick alternation on human emotional language.
 ITEM_20150717_005706	The name of Aston was designed from the fashionable the times during 10 years in the 600 years ago. Aston has times tried to establish a center for the royal family
 ITEM_20150717_005707	After Ruklys' civil war has ended, the local nobility who had exhausted the tyranny of king Kadumel showed the tendency that in order to ensure the autonomy in their respective regions. As a result of this tendency, the special products will increase in some areas, the recipe and product contain it were affected by the Aston thought.
 ITEM_20150717_005708	Although the Kingdom is stable by the King succeeds, but the Aston went out, The name and recipes are still delivered with the name.
 ITEM_20150717_005709	Mainly it refers to equipment made by a secret recipe of the family. Although there are many differences in the family, These names are mostly used for equipment have in common to meet the needs of them.
 ITEM_20150717_005710	It has a characteristic of advanced equipment according to the lifestyle of the nobility. The most visible part of the difference with other combat equipment is that it is suitable like hunt for entertainment not like a normal battle.
 ITEM_20150717_005711	When describing Devi type equipment, the Onething easily misleading of equipment that It's not only developed to meet the needs of the nobility. The majority of the nobles were generous the people involved with them and using this equipment. Including the large scale battle and hunt for entertainment.
-ITEM_20150717_005712	There is a story that the equipment belonging to Prima is following the forms of the old genesis kingdom. The problem in this case that the recipe one thousand years ago is still advanced and useful. So there is a guess that people tried to imitate the technial part of the Goddess's skill in the past.
+ITEM_20150717_005712	There is a story that the equipment belonging to Prima is following the forms of the old genesis kingdom. The problem in this case that the recipe one thousand years ago is still advanced and useful. So there is a guess that people tried to imitate the technial part of the goddess's skill in the past.
 ITEM_20150717_005713	Unlike the prejudice, they are not reproduced the form found in the ancient cemetery. The story that those who robbed upgraded it is more potent.
 ITEM_20150717_005714	The most common type of shoes. Many civilians wear it too. 
 ITEM_20150717_005715	Weapons crafted by applying the old wisdom and experience of miner.
 ITEM_20150717_005716	That person is briefly mentioned as the master of Lucid Winterspoon in the history. She wasn't well known since her disciple surpassed the abilities of her, but the device that was created from her was named after her.
 ITEM_20150717_005717	The people who keep the old promise in the province did not neglect to prepare for the coming attack. This equipment is a clear evidence.
 ITEM_20150717_005718	There is a legend that Ruklys received the Goddess Zemyna's grace, but someone does not bend that Goddess Zemyna did not give Ruklys any favor.
-ITEM_20150717_005719	There are people had asked that Goddess Zemyna really given the grace to this equipment through Ruklys to priests. As a result, they are only confirmed again that the grace of the Goddess is fair to all.
+ITEM_20150717_005719	There are people had asked that Goddess Zemyna really given the grace to this equipment through Ruklys to priests. As a result, they are only confirmed again that the grace of the goddess is fair to all.
 ITEM_20150717_005720	Once the traders were also selling and claimed that these arms are the same type of product like Ruklys equipped at final time. Of course, it is a story after the Kadumel.
 ITEM_20150717_005721	Square Master Yustina Legwyn has an exceptional ability to manufacture as well as repair. She is celebrating the fall family by putting the name of her family after she became famous due to the designed equipments.
 ITEM_20150717_005722	This equipment made by Square Master Yustina Legwyn according to the recipe was devised and disseminate. She leaves a handmade sign into some products. If lucky, you can also see the contents in honor of a brother and father who already died.
@@ -5732,9 +5732,9 @@ ITEM_20150717_005731	Life and death rely on the small differences in the battle.
 ITEM_20150717_005732	A guardian charm has been used in the kingdom a long time ago, there are many necklaces like this. Although there are people who believed that, it used beyond the foundation of the kingdom.
 ITEM_20150717_005733	In the past, the Magic Master of each field gave disciples who completed some process it for the present. The time of disappeared this tradition guessed that an Agailla Flurry, but it is unfair because many magics of kingdom made by her.
 ITEM_20150717_005734	Klaipeda is famous for the origin of crystals around a history of a thousand years.
-ITEM_20150717_005735	Something among the goods containing the magic crafted with the pure magic not the Goddess's blessing. This necklace is a typicial sample of them.
+ITEM_20150717_005735	Something among the goods containing the magic crafted with the pure magic not the goddess's blessing. This necklace is a typicial sample of them.
 ITEM_20150717_005736	It is mysterious that people don't completely know of the rune. However, placing a part of the mysterious into the necklace is possible.
-ITEM_20150717_005737	You can craft the necklace to hold better power into certain metal by concentrating the magic and the blessing of the Goddess.
+ITEM_20150717_005737	You can craft the necklace to hold better power into certain metal by concentrating the magic and the blessing of the goddess.
 ITEM_20150717_005738	Made by Maven, who wished to help his disciples as clerics. It helps you reach a higher level of faith after trials and ordeals. 
 ITEM_20150717_005739	Bokor's history is too long and only a few Master at that time know the ancient knowledge. The recipe and ceremony is not known to the  general populace.
 ITEM_20150717_005740	This necklace can summon the forgotten souls against disturbing of powerful partner when Bokor used. However, it has an ability to help its wearer even when it is not used for the ceremony.
@@ -5760,7 +5760,7 @@ ITEM_20150717_005759	Sometimes, disappeared skills and styles has been rediscove
 ITEM_20150717_005760	A lot of jewels used for consumer goods to hold the magic into this bracelet.
 ITEM_20150717_005761	Silver material containing the magic is used to display the surface's pattern.
 ITEM_20150717_005762	These types of pearls are mainly for decoration purposes as it is generally hard to hold the magic.
-ITEM_20150717_005763	Priests who communicated directly with Goddess also don't know lots of parts. However, known up to now can endow a lot of abilities.
+ITEM_20150717_005763	Priests who communicated directly with a goddess also don't know lots of parts. However, known up to now can endow a lot of abilities.
 ITEM_20150717_005764	The origin of this bracelet is connecting to Lydia Schaffen and Schaffenstar formed by her. However, there are no restrictions to use this bracelet for people who did not come from the Astral Tower.
 ITEM_20150717_005765	Goddess Jurate evicted demons living in the sea from her territory. As Merregina roams on land, its purpose as material is becoming known. 
 ITEM_20150717_005766	The study of strong demons and the creation of new magical weapons has become more important after Medzio Diena.
@@ -5851,7 +5851,7 @@ ITEM_20150729_005850	Minotaur Shield
 ITEM_20150729_005851	{memo X}The recipe for this shield was only discovered recently. It may not be possible to craft it after Medzio Diena.
 ITEM_20150729_005852	Since Medzio Diena, many recipes were found through the use of altenative ingredients from monsters.
 ITEM_20150729_005853	Crafters say that it has become easier to empower a wooden wand's attributes since Medzio Diena.
-ITEM_20150729_005854	Prior to Medzio Diena, there was nobody who would use this weapon because it uses demonic powers, However, with the vanishing of the Goddesses, desperate people have begun using it.
+ITEM_20150729_005854	Prior to Medzio Diena, there was nobody who would use this weapon because it uses demonic powers, However, with the vanishing of the goddesses, desperate people have begun using it.
 ITEM_20150729_005855	Rumor has it that supplies of leather increased after Medzio Diena.
 ITEM_20150729_005856	One of the benefits of Medzio Diena is that crafters have found ways to reuse monsters's remains for stronger armor.
 ITEM_20150729_005857	Since Medzio Diena, many equipment crafted from new material, like these pants, are replacing traditional ones.
@@ -5924,7 +5924,7 @@ ITEM_20150803_005923	Krausas Mace
 ITEM_20150803_005924	- Apply additional damage bonus to Effigy upon the 2nd attack
 ITEM_20150803_005925	A weapon invented to strengthen Bokor's power. The recipe was forgotten, but was eventually restored through effort.
 ITEM_20150803_005926	Restores 30 Stamina. {nl}Right-click to use. Cooldown of 30 seconds. 
-ITEM_20150803_005927	A collection of the conflict between the demon and the Goddess in Goddess Laima's revelation.{nl}Right-click to add it to the Collection window through the Magic Association NPC.
+ITEM_20150803_005927	A collection of the conflict between the demon and the goddess in Goddess Laima's revelation.{nl}Right-click to add it to the Collection window through the Magic Association NPC.
 ITEM_20150803_005928	A collection of one of the world's hidden secret in Goddess Laima's revelation.{nl}Right-click to add it to the Collection window through the Magic Association NPC.
 ITEM_20150803_005929	{memo X}Serum collected from the blood of the Vubbes. Requested for the officer by Vaidotas.
 ITEM_20150803_005930	{memo X}Material to help  with the research of the Wizard Master.
@@ -7256,7 +7256,7 @@ ITEM_20151016_007255	The stolen food by Ferrets
 ITEM_20151016_007256	{memo X}Fruit juice extracted from of a gigantic fruit that a Ferret obtained. It is in the container made up of fruit peels.
 ITEM_20151016_007257	A sculpture of peace carved by Dievdirbys Widus. When you place it, the Ferrets around you will be calmed.
 ITEM_20151016_007258	A scent created by Druid Leja using the herb. When you spread the scent, the Ferrets nearby will become unconscious.
-ITEM_20151016_007259	The orb that was left by the Goddess Laima. You've received the message from Laima Goddess to rescue the Goddess, Rada.
+ITEM_20151016_007259	The orb that was left by the Goddess Laima. You've received the message from Laima Goddess to rescue Goddess Rada.
 ITEM_20151016_007260	Empty Scroll
 ITEM_20151016_007261	Nothing is written on this scroll. As requested by Benes, you should write the behaviors of Ferrets on it.
 ITEM_20151016_007262	Ferret Transformation Scroll

--- a/ITEM.tsv
+++ b/ITEM.tsv
@@ -3860,7 +3860,7 @@ ITEM_20150317_003859	{memo X}Casts Ice Wall when used.
 ITEM_20150317_003860	{memo X}Sparkling Stone 
 ITEM_20150317_003861	{memo X}Inside it might contain a Silk Token! 
 ITEM_20150317_003862	Stolen Supplies 
-ITEM_20150317_003863	{memo X}Military supplies stolen from the Kingdom Army's guards by Dico Doguldan. 
+ITEM_20150317_003863	{memo X}Military supplies stolen from the Royal Army's guards by Dico Doguldan. 
 ITEM_20150317_003864	Petrified Cargo Rubbings 
 ITEM_20150317_003865	{memo X}Rubbing of the petrified book on Ruklys Street 
 ITEM_20150317_003866	{memo X}Knight Supplies 
@@ -3877,7 +3877,7 @@ ITEM_20150317_003876	{memo X}A dangerous bomb that will explode soon after being
 ITEM_20150317_003877	{memo X}Boulder Explosives 
 ITEM_20150317_003878	{memo X}Bomb with a high power output. It is extremely loud. 
 ITEM_20150317_003879	{memo X}Central Propaganda 
-ITEM_20150317_003880	{memo X}Advertisement fliers distributed by the Kingdom Army 
+ITEM_20150317_003880	{memo X}Advertisement fliers distributed by the Royal Army 
 ITEM_20150317_003881	Frosty Core 
 ITEM_20150317_003882	{memo X}Research on the petrification frost requested by the Kaliss Knightage 
 ITEM_20150317_003883	Recruitment Notice 
@@ -5331,8 +5331,8 @@ ITEM_20150714_005330	{memo X}A powerful bomb that can make a big fuss after a ce
 ITEM_20150714_005331	Sticky Fluids 
 ITEM_20150714_005332	Processed Bomb 
 ITEM_20150714_005333	Hardened Explosives 
-ITEM_20150714_005334	Kingdom Army Propaganda 
-ITEM_20150714_005335	{memo X}A propaganda to encourage the surrender sprayed by Kingdom Army when the rebellion, 600 years ago 
+ITEM_20150714_005334	Royal Army Propaganda 
+ITEM_20150714_005335	{memo X}A propaganda to encourage the surrender sprayed by Royal Army when the rebellion, 600 years ago 
 ITEM_20150714_005336	Part of a soul torn from Demon Lord Hauberk.
 ITEM_20150714_005337	{memo X}Hauberk's soul divided itself in order to escape. 
 ITEM_20150714_005338	{memo X}the ground of the fort built at the time, was hustle and explosives used. Complaints can be easily attaching to burst. 
@@ -5822,10 +5822,10 @@ ITEM_20150717_005821	Svitrigaila's Orb
 ITEM_20150717_005822	{memo X}Magic orb has been crafted with the soul essence and detonator using the core of intensive spirits' device by Svitrigaila. When using it to the intensive spirit' device,
 ITEM_20150717_005823	Ruklys Army Seal
 ITEM_20150717_005824	{memo X}Ruklys Parchment
-ITEM_20150717_005825	Kingdom Army Guard's Spear
-ITEM_20150717_005826	{memo X}Kingdom Army Guard's Used Spear
-ITEM_20150717_005827	Kingdom Army Guard's Breastplate
-ITEM_20150717_005828	{memo X}Kingdom Army Guard's Equipped Armor
+ITEM_20150717_005825	Royal Army Guard's Spear
+ITEM_20150717_005826	{memo X}Royal Army Guard's Used Spear
+ITEM_20150717_005827	Royal Army Guard's Breastplate
+ITEM_20150717_005828	{memo X}Royal Army Guard's Equipped Armor
 ITEM_20150717_005829	Bomb
 ITEM_20150717_005830	{memo X}Bomb crafted to protect the camp from monster's attack
 ITEM_20150729_005831	While initially unpopular during Medzio Diena, the resurgence of strongly armored monsters is proving its value.
@@ -5904,8 +5904,8 @@ ITEM_20150729_005903	Desmodus' Tail Pin
 ITEM_20150729_005904	Broken Legwyn Seal Fragment
 ITEM_20150729_005905	{memo X}Legwyn's seal. Only a part remains because it has been broken a long time ago.
 ITEM_20150729_005906	Great Pirate Vladslovas's Broken Necklace
-ITEM_20150729_005907	Kingdom Army's Torn Flag
-ITEM_20150729_005908	{memo X}A lost army flag from the Kingdom Army. It cannot be examined due to the severe damage.
+ITEM_20150729_005907	Royal Army's Torn Flag
+ITEM_20150729_005908	{memo X}A lost army flag from the Royal Army. It cannot be examined due to the severe damage.
 ITEM_20150729_005909	Orb Recorder of Past Memories
 ITEM_20150729_005910	A mysterious orb that is able to read the owner's past memories.
 ITEM_20150729_005911	Relics can strongly feel the regret
@@ -6776,14 +6776,14 @@ ITEM_20150918_006775	An unknown kingdom's military flag. The flag is too damaged
 ITEM_20150918_006776	A relic of one who died with such strong regret that you can still feel it. It is unknown what kind of person the owner was, or when and how that person died.
 ITEM_20150918_006777	The monster who was the sign of a weak armor. Movement speed increased slightly.
 ITEM_20150918_006778	The nuclear core of the petrification detector that Cryomaster Costas asked you to retrieve.
-ITEM_20150918_006779	Military supplies stolen from the Kingdom Army's guards by Dico Doguldan.
+ITEM_20150918_006779	Military supplies stolen from the Royal Army's guards by Dico Doguldan.
 ITEM_20150918_006780	Rubbing of the petrified book on Ruklys Street
 ITEM_20150918_006781	Supply covered with monster's odor. It smells terrible.
 ITEM_20150918_006782	A powerful bomb that can make a big fuss after a certain time.
 ITEM_20150918_006783	A sticky liquid that can attach even heavy items to anything.
 ITEM_20150918_006784	A dangerous bomb that will explode soon after being thrown.
 ITEM_20150918_006785	Bomb with a high power output. It is extremely loud.
-ITEM_20150918_006786	A propaganda to encourage the surrender sprayed by Kingdom Army when the rebellion, 600 years ago
+ITEM_20150918_006786	A propaganda to encourage the surrender sprayed by Royal Army when the rebellion, 600 years ago.
 ITEM_20150918_006787	Research on the petrification frost requested by the Knights of Kaliss.
 ITEM_20150918_006788	A lengthy advertisement noting the kingdom's honor and pride
 ITEM_20150918_006789	A mark containing Blut's power. He seems to have distributed them among his underling demons.
@@ -6937,8 +6937,8 @@ ITEM_20150918_006936	{memo X}A bomb discovered in the Outpost area. Seems like i
 ITEM_20150918_006937	{memo X}A box with tools to safely remove bombs
 ITEM_20150918_006938	{memo X}The seal of Ruklys army
 ITEM_20150918_006939	{memo X}Ruklys Parchment.
-ITEM_20150918_006940	Kingdom Army Guard's Used Spear.
-ITEM_20150918_006941	Kingdom Army Guard's Equipped Armor
+ITEM_20150918_006940	Royal Army Guard's Used Spear.
+ITEM_20150918_006941	Royal Army Guard's Equipped Armor
 ITEM_20150918_006942	{memo X}bomb crafted to protect the camp from monster's attack
 ITEM_20150918_006943	{memo X}The materials to make the certification
 ITEM_20150918_006944	Something helpful to safely pass the magic device.

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -2029,7 +2029,7 @@ QUEST_20150511_002032	$The picture of the essence is drawn on the old surface.
 QUEST_20150511_002033	$The Eternal Adventure
 QUEST_20150714_002034	$Well, you're a new face. Did Julian send you?
 QUEST_20150714_002035	{memo X}$Yeah. There's something weird about Goddess Laima. {nl}No one seems to know when she disappeared. To be honest nobody seems to really know whether or not she actually is a goddess.
-QUEST_20150714_002036	$She has never appeared before. {nl}Although I've read somewhere that she does appear every now and then…
+QUEST_20150714_002036	$She has never appeared before. {nl}Although I've read somewhere that she does appear every now and then...
 QUEST_20150714_002037	$Even though it would be bad for my business, I wish I could just live peacefully rather than live in fear of monster attacks coming at any moment.
 QUEST_20150714_002038	$Welcome! {nl}While I can do basic repairs, I don't have the materials to create anything. {nl}Take a look at what I have.
 QUEST_20150714_002039	$When all is said and done, I don't lie about my prices. Everything I sell is priced honestly and accordingly.
@@ -2040,7 +2040,7 @@ QUEST_20150714_002043	$Monk Lotze
 QUEST_20150714_002044	$I'll do whatever it takes to take back the monastery from the monsters.
 QUEST_20150714_002045	$I dislike those Hunters. {nl}Outsiders must not interfere with the affairs of the monastery.
 QUEST_20150714_002046	$Monk Zidas
-QUEST_20150714_002047	$It would do us good if everyone stopped being so stubborn. {nl}I am sure the Hunters will be a great help in retaking the monastery…
+QUEST_20150714_002047	$It would do us good if everyone stopped being so stubborn. {nl}I am sure the Hunters will be a great help in retaking the monastery...
 QUEST_20150714_002048	$I don't like how everyone is insisting their opinions to be right. {nl}It would be great if we helped each other.
 QUEST_20150714_002049	$Monk Ortega
 QUEST_20150714_002050	$I don't like those Hunters. {nl}Especially the one called Natasha. I don't know why she is bothering Potos...
@@ -2070,18 +2070,18 @@ QUEST_20150714_002073	$Even Lydia Schaffen, friend of Ruklys, turned to the side
 QUEST_20150714_002074	$Are you going to die with Ruklys who misled you with malicious tricks to create The Fortress of the Land to stand against the kingdom? {nl}Or live a new life by serving the king until the end by following the way of Premier Eminent who protected the kingdom from the rebellion?
 QUEST_20150714_002075	$The Records of Rebel Forces
 QUEST_20150714_002076	$As I was retreating from kingdom soldiers, I encountered many demons. {nl}It doesn't make sense. Where did they come from?
-QUEST_20150714_002077	{memo X}$There's no hope at all. Ah… my lovely Ridell. {nl}The kingdom soldiers did not keep their word. We're all going to die.
+QUEST_20150714_002077	{memo X}$There's no hope at all. Ah... my lovely Ridell. {nl}The kingdom soldiers did not keep their word. We're all going to die.
 QUEST_20150714_002078	$Those kingdom soldiers! Especially that Premier Eminent! They're no different from demons. {nl}Even the goddesses would not forgive them.
 QUEST_20150714_002079	$I don't want to die. {nl}We were just following the goddesses' words. {nl}Everyone is killing each other in the names of the goddesses. {nl}Who has deceived us? {nl}
 QUEST_20150714_002080	$Kingdom Military Recruit Propaganda
 QUEST_20150714_002081	$Kingdom Military needs competent people like you! {nl}Loyalty to the kingdom! To victory and a brighter future!
 QUEST_20150714_002082	$Swear loyalty to Kingdom Military and become a new person. {nl}The goddesses protect our armies.
-QUEST_20150714_002083	$Life and death… which one would you choose? {nl}The only way to survive is to swear loyalty to the kingdom!
+QUEST_20150714_002083	$Life and death... which one would you choose? {nl}The only way to survive is to swear loyalty to the kingdom!
 QUEST_20150714_002084	$Don't forget that we won 600 years ago. {nl}Join the military. You sins can be forgiven.
 QUEST_20150714_002085	$Please move with us if possible. {nl}There's been a number of monster sightings near here.
-QUEST_20150714_002086	$The supplies should be here soon… {nl}Are they going to be late again?
+QUEST_20150714_002086	$The supplies should be here soon... {nl}Are they going to be late again?
 QUEST_20150714_002087	$You will need various tools when traveling. {nl}It's better to buy them in advance.
-QUEST_20150714_002088	$Goddess Laima… Actually, I don't know her that well. No one does, except for her priests. {nl}I heard she's the goddess of fate and forecasts, but she has not once appeared before us.
+QUEST_20150714_002088	$Goddess Laima... Actually, I don't know her that well. No one does, except for her priests. {nl}I heard she's the goddess of fate and forecasts, but she has not once appeared before us.
 QUEST_20150714_002089	$I just remembered something while I was talking to you. {nl}Maybe Goddess Laima knew everything about the disaster beforehand.
 QUEST_20150714_002090	$I pray to Goddess Gabija everyday. It keeps the house warm. {nl}As you may already know, Goddess Gabija controls fire and since I'm a housewife, I am close to fire as well.
 QUEST_20150714_002091	$If you cleverly use the dry air that forms around areas of severe cold, you'd be able to freeze any object even in a desert. {nl}However, if you can't receive the blessing from the goddess, it won't be possible to make that kind of air.
@@ -2096,12 +2096,12 @@ QUEST_20150714_002099	$The Records about Disciple Hones
 QUEST_20150714_002100	{memo X}$Among my disciples, two of them followed me until my later years and will be my successors after my death.
 QUEST_20150714_002101	$Hones, who is one of them, is lacking in scholarly intelligence. However, I am sure his faithfulness and efforts will help him follow my teachings.
 QUEST_20150714_002102	$The Records of the Hidden Object
-QUEST_20150714_002103	{memo X}$…I don't know whether I should thank the goddesses for this discovery or not. My greed for knowledge can ruin the world.
+QUEST_20150714_002103	{memo X}$...I don't know whether I should thank the goddesses for this discovery or not. My greed for knowledge can ruin the world.
 QUEST_20150714_002104	{memo X}I can't sleep well for fear of my research results being spread by demon investigation. {nl}That's why I wish to pass the rest of the research to the one I can trust.
 QUEST_20150714_002105	$The Inheritance of the Master
 QUEST_20150714_002106	$As the priests and theologians know, Goddess Vibora is in charge of the library where all records of the world are stored. {nl}I was able to check several records in that fantastic library after the research and long studying I can't tell anyone about at the moment. {nl}
 QUEST_20150714_002107	From the many records of the goddess, I was only able to see a few. {nl}Nevertheless, the fact that I checked the existence of the records with the important facts was astonishing. {nl}
-QUEST_20150714_002108	$The record which I can use to find the whereabouts of all the goddesses… {nl}If one had such secret information, it would be possible to predict the goddesses' future locations by analyzing what they did in the past. {nl}Because of that, their future plans may be disturbed or put at risk. {nl}
+QUEST_20150714_002108	$The record which I can use to find the whereabouts of all the goddesses... {nl}If one had such secret information, it would be possible to predict the goddesses' future locations by analyzing what they did in the past. {nl}Because of that, their future plans may be disturbed or put at risk. {nl}
 QUEST_20150714_002109	$This is more dangerous because, if the demons find out the truth, their desire for the library will grow {nl}and, if they do acquire that knowledge, the world will be swallowed by evil. That's why - {nl}
 QUEST_20150714_002110	$(The rest is blurred and unreadable.)
 QUEST_20150714_002111	$Disciple Hones's Memo
@@ -2111,18 +2111,18 @@ QUEST_20150714_002114	$The Spatial Magic Gem of Offer is with the Templeshooter.
 QUEST_20150714_002115	$The Spatial Magic Gem of Promise can be found in Siaura Mine. {nl}Use the Soul Crystal on the monsters first to collect their Condensed Spite. {nl}With that, destroy the stones in Siaura Mine. {nl}Black Chasers will pursue from behind, avoid them and go to the end of the mine to find the magic gem.
 QUEST_20150714_002116	$When you find all three spatial magic gems, go to the fusion device again and place the magic gems there. {nl}The path to the master's research will then open at the Laudi Tower.
 QUEST_20150714_002117	$Spirit
-QUEST_20150714_002118	$Please… save us from this horrible contract… {nl}Remove us from this… Contract of Enunciation…
-QUEST_20150714_002119	$The Contract of Enunciation… {nl} we'll vanish if we speak… I have no regrets…
-QUEST_20150714_002120	$Eternal imprisonment… from the restraints of the contract… {nl}Break… the Pot of Silence…
-QUEST_20150714_002121	$The Pot of Silence is at Memum Corridor… {nl}I'm so… exhausted…
-QUEST_20150714_002122	$Where to start…
+QUEST_20150714_002118	$Please... save us from this horrible contract... {nl}Remove us from this... Contract of Enunciation...
+QUEST_20150714_002119	$The Contract of Enunciation... {nl} we'll vanish if we speak... I have no regrets...
+QUEST_20150714_002120	$Eternal imprisonment... from the restraints of the contract... {nl}Break... the Pot of Silence...
+QUEST_20150714_002121	$The Pot of Silence is at Memum Corridor... {nl}I'm so... exhausted...
+QUEST_20150714_002122	$Where to start...
 QUEST_20150714_002123	$I was a disciple of Agailla Flurry when I was alive. {nl}I didn't have any magical abilities so I couldn't use magic.
 QUEST_20150714_002124	$That's why I survived Helgasercle's wrath. {nl}He must've thought he didn't have to kill me since I wasn't able to use magic.
-QUEST_20150714_002125	$I am confident I am better when it comes to theories than other disciples… {nl}That's why I studied magic. And in my studies, I learned of the magic stone of interaction.
+QUEST_20150714_002125	$I am confident I am better when it comes to theories than other disciples... {nl}That's why I studied magic. And in my studies, I learned of the magic stone of interaction.
 QUEST_20150714_002126	$I came here when Helgasercle attacked the Mage Tower. {nl}I thought that if I could use the magic stone of interaction, I'd be able to use magic.
 QUEST_20150714_002127	$But, Archon drove me away from the Mage Tower. Due to this disturbance, the magic stone activated defensive magic, linking my and Archon's spirit to each other.
 QUEST_20150714_002128	$As a result, Archon was sealed and my body disappeared without a trace. {nl}We became shackled to each other.
-QUEST_20150714_002129	$I've been tied here for hundreds of years… {nl}Since I can't do anything with my astral body.
+QUEST_20150714_002129	$I've been tied here for hundreds of years... {nl}Since I can't do anything with my astral body.
 QUEST_20150714_002130	$The bigger problem is that Archon was released as well. {nl}I lost the body, but Archon, who is a demon, is still alive.
 QUEST_20150714_002131	$Memorial Stone
 QUEST_20150714_002132	$By avoiding the eyes of Helgasercle, I was able to come here to continue my research. {nl}I needed to find a way. A way to reduce the power of demons and increase that magical power.
@@ -2152,9 +2152,9 @@ QUEST_20150714_002155	$The facts that we've discovered so far are thus: {nl}{nl}
 QUEST_20150714_002156	$This movement was made very naturally. {nl}If that hadn't been the case, then there must have been conflicts, and more fables would have been created as a result.
 QUEST_20150714_002157	$I believe the goddesses erased all memory and records of that time completely. {nl}However, we can't deny the possibility that another reason may exist due to the fact that this legend still remains despite the authority of the great goddesses.
 QUEST_20150714_002158	$And this is a very cautious prediction, but the creatures that we call demons may exist underground. {nl}Though that theory is hard to accept when we think about all the facts that are recorded in history and the present.
-QUEST_20150714_002159	$I can smell many Avietes. I heard they're effective… Could you share them with us?
+QUEST_20150714_002159	$I can smell many Avietes. I heard they're effective... Could you share them with us?
 QUEST_20150714_002160	$Thank you. I will give you as many as you need. {nl}You will be successful.
-QUEST_20150714_002161	$I wanted to eat it…
+QUEST_20150714_002161	$I wanted to eat it...
 QUEST_20150714_002162	$You're not collecting Avietes?
 QUEST_20150714_002163	$I'll give them to you. {nl}You will be successful.
 QUEST_20150714_002164	$Our hope will definitely come true.
@@ -2188,7 +2188,7 @@ QUEST_20150714_002191	$Can you lay the villagers' spirits to rest in peace?
 QUEST_20150714_002192	$The Basics of Ignition
 QUEST_20150714_002193	$Ignition differs by elements, but with the blessing from the goddess, there may be cases where we can ignore that. {nl}To do so, we should try hard to achieve the scholarly knowledge and the faithfulness to the goddesses.
 QUEST_20150714_002194	$1. Dried environment{nl}2. Something that can be ridden on. {nl}3. Enough mana. {nl}4. The blessing of the goddesses.
-QUEST_20150714_002195	$Flurry… turned into a handful of ashes by illuminating a great light. {nl}Did that demon do something? {nl}I had no idea, being a mere probationary wizard.
+QUEST_20150714_002195	$Flurry... turned into a handful of ashes by illuminating a great light. {nl}Did that demon do something? {nl}I had no idea, being a mere probationary wizard.
 QUEST_20150714_002196	{memo X}$[Caution]{nl}- It is the last stage of the experiment. Be cautious when handling it -
 QUEST_20150714_002197	{memo X}1. Do not overreact Schilt Essences into a sample of Petrification Detector. {nl}2. Do not keep the Schilt Amplifier activated for a long time. {nl}3. Even if you become immune to petrification using the Schilt Amplifier, it will only be temporary, so do not stay in the lab room for too long.
 QUEST_20150714_002198	{memo X}$[Usage Limit]{nl}- Due to a recent incident, we sealed the isolated lab room. {nl}Only people permitted by the chief can enter the room via the portal.
@@ -2209,14 +2209,14 @@ QUEST_20150714_002212	$Please go to Viltis Forest after persuading the senior mo
 QUEST_20150714_002213	$Thanks! {nl}I ran away without noticing my bag was ripped by the thorns.
 QUEST_20150714_002214	We ran away from Laukyme Swamp. {nl}When you find the pages of the documents from Ershike Path to Dumvala Crossroads, please bring them to me.
 QUEST_20150714_002215	$No. That cannot be done. {nl}I don't have anything more to say about the expulsion until I retake the monastery and save the director.
-QUEST_20150714_002216	$What? You're going with the hunters? {nl}Well, I don't approve but I guess I can't do anything about it since Marko told you that he'd go with them… {nl}Okay.
+QUEST_20150714_002216	$What? You're going with the hunters? {nl}Well, I don't approve but I guess I can't do anything about it since Marko told you that he'd go with them... {nl}Okay.
 QUEST_20150714_002217	$Are you going to retake the monastery with the hunters?{nl}That's good news, but I guess that means Marko changed his mind, huh?
-QUEST_20150714_002218	$I'm worried about the chief of the monastery who should be at the prayer room. {nl}I don't know if the hunters can be trusted…
-QUEST_20150714_002219	$I don't know if it's going to be okay. {nl}It's feels like the outsiders are swinging us around… {nl}Well, I know Marko is clever so we should trust him.
+QUEST_20150714_002218	$I'm worried about the chief of the monastery who should be at the prayer room. {nl}I don't know if the hunters can be trusted...
+QUEST_20150714_002219	$I don't know if it's going to be okay. {nl}It's feels like the outsiders are swinging us around... {nl}Well, I know Marko is clever so we should trust him.
 QUEST_20150714_002220	$At any rate, we will trust Marko's orders. {nl}It's good that we've reliable reinforcements now.
 QUEST_20150714_002221	$Also, it's important to retake the monastery as soon as possible. {nl}The chief of the monastery's safety is critical.
 QUEST_20150714_002222	$Unknown traveler. Falls down under the nameless poison. {nl}Now stop the journey and rest in peace in the goddesses.
-QUEST_20150714_002223	$Biblam the Farmer. He who took care of his neighbors more than himself… {nl}rests here.
+QUEST_20150714_002223	$Biblam the Farmer. He who took care of his neighbors more than himself... {nl}rests here.
 QUEST_20150714_002224	$I'm going to go to the arms of you who I longed for for a long time. {nl}With your bow and with your dagger. {nl}From, {nl}Siana.
 QUEST_20150714_002225	$The young tailor, Godan, who was born in Fedimian, {nl}rests in Tilda Monastery.
 QUEST_20150714_002226	$Mighty goddess. {nl}I am finally free. {nl} - Tenant Farmer Tila
@@ -2232,15 +2232,15 @@ QUEST_20150714_002235	$I'll block the monsters that are rushing in here. {nl}You
 QUEST_20150714_002236	$Thanks. {nl}I saw the Moheim brothers enter the monastery a while ago. {nl}Looking after the important objects is also their responsibility, so you better ask them.
 QUEST_20150714_002237	$I'm sorry I bothered you. {nl}The boxes are lined up inside the reception room.
 QUEST_20150714_002238	$So you've come. {nl}Please give me the Crystal Ball.
-QUEST_20150714_002239	$Damn! Until the bitter end… {nl}You two! Follow that guy! {nl}The rest of you! Help me!
+QUEST_20150714_002239	$Damn! Until the bitter end... {nl}You two! Follow that guy! {nl}The rest of you! Help me!
 QUEST_20150714_002240	$The hunter who is caring for his colleagues
-QUEST_20150714_002241	$Hey…! Get a hold of yourself!
-QUEST_20150714_002242	$Thanks. I have far too many things to do… {nl}I have to sort out the green cover pages, but I can't find any. {nl}Please look for them around the furniture inside the monastery.
+QUEST_20150714_002241	$Hey...! Get a hold of yourself!
+QUEST_20150714_002242	$Thanks. I have far too many things to do... {nl}I have to sort out the green cover pages, but I can't find any. {nl}Please look for them around the furniture inside the monastery.
 QUEST_20150714_002243	$For what reason did you visit this cursed city? {nl}Go back if you have none.
 QUEST_20150714_002244	$So you are the famous Revelator. {nl}I've definitely heard about you before.
 QUEST_20150714_002245	$I shall temporarily permit your entrance. {nl}The Knights of Kaliss are looking for competent people like you.
 QUEST_20150714_002246	$However, all the authority here belongs to our kingdom army. {nl}I hope you behave well.
-QUEST_20150714_002247	$Saltistter? What are you talking about? {nl}Such nonsense you speak…
+QUEST_20150714_002247	$Saltistter? What are you talking about? {nl}Such nonsense you speak...
 QUEST_20150715_002248	{memo X}$The Gambler of Klaipeda
 QUEST_20150715_002249	{memo X}$Modestas admitted defeat and said he'd pay him pay back. As he was leaving the place with wagon in tow, the old alchemist broke into a strange smile that caught Modestas' attention.
 QUEST_20150717_002250	$Please enter the name of your companion.
@@ -2249,11 +2249,11 @@ QUEST_20150717_002252	What do you think? They make a pretty good friend, right? 
 QUEST_20150717_002253	Item Merchant 
 QUEST_20150717_002254	$I am sorry, but I can't come forward myself. {nl}It's just, if I use magic, the demons will sense it.
 QUEST_20150717_002255	$I will correct the disrupted magic of this tower.{nl} I will have to use magic at first so monsters will rush in. Please protect me.
-QUEST_20150717_002256	$I hope Goddess Gabija is safe… Let's hurry.
-QUEST_20150717_002257	$I don't have a good feeling about it. That vibration…{nl}Let's move quickly for now.
+QUEST_20150717_002256	$I hope Goddess Gabija is safe... Let's hurry.
+QUEST_20150717_002257	$I don't have a good feeling about it. That vibration...{nl}Let's move quickly for now.
 QUEST_20150717_002258	$We can help Goddess Gabija if we have the Jewel of Prominence.
 QUEST_20150717_002259	The goddess has reached her limit.{nl}We should give her the Jewel of Prominence as quickly as possible.
-QUEST_20150717_002260	$That vibration… It's serious.
+QUEST_20150717_002260	$That vibration... It's serious.
 QUEST_20150717_002261	Let's quickly go to Magic Control Room.{nl}I will be able to control the magic of the tower.
 QUEST_20150717_002262	It's fortunate that the Magic Control Room is near.{nl}Let's go quickly.
 QUEST_20150717_002263	$My other disciple, Laius, is clever and a fast learner but has an insatiable greed for knowledge. I am worried that he may fail the task. {nl}A scholar should always try to learn, but obsessing about it will make one walk the wrong path.
@@ -2261,7 +2261,7 @@ QUEST_20150717_002264	{memo X}$Among my disciples, two of them followed me until
 QUEST_20150717_002265	Suspicious Tombstone
 QUEST_20150717_002266	{memo X}$When small things are gathered one by one, they will one day become a great power.
 QUEST_20150717_002267	Suspicious Stone Pole
-QUEST_20150717_002268	The one Gabija is waiting for… has he come yet?
+QUEST_20150717_002268	The one Gabija is waiting for... has he come yet?
 QUEST_20150717_002269	[Caution]{nl}- It is the last stage of the experiment. Be cautious when handling it -{nl}
 QUEST_20150717_002270	$1. Do not overreact Schilt Essences into a sample of Petrification Detector. {nl}2. Do not keep the Schilt Amplifier activated for a long time. {nl}3. Even if you become immune to petrification using the Schilt Amplifier, it will only be temporary, so do not stay in the lab room for too long.
 QUEST_20150717_002271	$[Usage Limit]{nl}- Due to a recent incident, we sealed the isolated lab room. {nl}Only people permitted by the chief can enter the room via the portal.
@@ -2270,19 +2270,19 @@ QUEST_20150717_002273	The flame crystals are formed here.{nl}Be careful, because
 QUEST_20150717_002275	$Story of Fire
 QUEST_20150717_002276	$I saw a bizarre sight at the goddess' whereabouts at the top of the tower. The bird beside Gabija, by her grace, lit up and engulfed itself in flames.{nl}
 QUEST_20150717_002277	The serenely burning fire. The wings consumed by flames. Nothing else in this world has left me more in awe than that sight.{nl}
-QUEST_20150729_002281	{memo X}Hmm… Have the party members fully gathered yet?
-QUEST_20150729_002282	{memo X}$Welcome to the Commissioner's Office. {nl}Unfortunately… I don't have any appropriate requests for you yet.{nl}
+QUEST_20150729_002281	{memo X}Hmm... Have the party members fully gathered yet?
+QUEST_20150729_002282	{memo X}$Welcome to the Commissioner's Office. {nl}Unfortunately... I don't have any appropriate requests for you yet.{nl}
 QUEST_20150729_002283	{memo X}I will give you an appropriate quest when you return with reliable comrades.{nl}If there are such requests.{nl}
 QUEST_20150729_002284	$There is a good request that just came in.{nl}Would you like to take it?
 QUEST_20150729_002285	Anyway, that is very strange.{nl}If it was Goddess Laima's will, not just anyone could undo her seal.
-QUEST_20150729_002286	$Whether this revelation will become a new beacon of hope or a start of a new disaster, is indeed {nl}difficult to judge… We are thinking of continuing our investigation.
+QUEST_20150729_002286	$Whether this revelation will become a new beacon of hope or a start of a new disaster, is indeed {nl}difficult to judge... We are thinking of continuing our investigation.
 QUEST_20150729_002287	)}My son volunteered to join the army.{nl}So I have been offering my prayers to the greatest Goddess Ausrine.{nl}
 QUEST_20150729_002288	)}Monsters have been multiplying to the point where people cannot safely live in the forest anymore.{nl}At least Klaipeda is still safe.{nl}
 QUEST_20150729_002289	Maybe the Goddess Ausrine gave us her protection.{nl}Isn't she the goddess who leads all other goddesses?
-QUEST_20150729_002290	)}I am glad my son dreams of becoming a soldier…{nl}But the monsters keep increasing in number, and I'm worried he will be injured.
+QUEST_20150729_002290	)}I am glad my son dreams of becoming a soldier...{nl}But the monsters keep increasing in number, and I'm worried he will be injured.
 QUEST_20150729_002291	I told him about the revelation that I found at the Crystal Mine.
 QUEST_20150729_002292	$The morning dawns after the night, does it not? Goddess Ausrine is the one who brings us the morning. {nl}Not only that, when we die, we go to her as well.
-QUEST_20150729_002293	{memo X}$Eternal life…{nl}Through the Goddess Ausrine's power, my life extends for every Owl Statue I sculpt.{nl}If this old body of mine can give her strength and help the world then I am determined to carry on forever. 
+QUEST_20150729_002293	{memo X}$Eternal life...{nl}Through the Goddess Ausrine's power, my life extends for every Owl Statue I sculpt.{nl}If this old body of mine can give her strength and help the world then I am determined to carry on forever. 
 QUEST_20150729_002294	{memo X}$Are you interested in everlasting life?{nl}Since necromancers deal with the dead, they can sense life forces, and, depending on their ability, manipulate it. {nl}If you are as good as I am, absorbing that life force to extend your own is possible.
 QUEST_20150729_002295	{memo X}$Are you curious as to how I obtained eternal life?{nl}If stilled time is eternal, then you can consider it life everlasting.{nl}By stopping time I maintain a body that is neither aging nor dying.{nl}Whether or not quiescence can be described as eternal, I do not have an answer.
 QUEST_20150729_002296	Unless during a specific window of time, recklessly touching the terminal would only bring trouble. It could release the curse.
@@ -2321,7 +2321,7 @@ QUEST_20150729_002328	The orchard owner took out a large amount of coins, more t
 QUEST_20150729_002329	Disregarding the amount Aiste had shown him, the orchard owner said, {nl}'Well, even so, I would be ashamed for not giving you my due, so please just take it.' {nl}After saying this, the orchard owner stuffed his coins into Aiste's bag and left. {nl}By the time Aiste could muster up the energy to call the orchard owner, he was too far away.{nl}{nl}
 QUEST_20150729_002330	She hesitated for a moment but then set her mind on the beggar. {nl}After a bit of walking, Aiste arrived at where they met. The old beggar spotted her first and hurried over to her. {nl}He showed her the silver coins he was clenching onto and said, 'Look! I found your lost silver.' {nl}Aiste received the beggar's silver and then showed the beggar her bag and said, {nl}'Look, I found your silver coins too.'{nl}{nl}
 QUEST_20150729_002331	After that, Aiste also held out her bag and said, {nl}'This is a gift as thanks for looking for my silver. I was given this through Goddess Zemyna's grace.' {nl}Aiste then left before the Old Beggar could figure out how to reply.{nl}{nl}
-QUEST_20150729_002332	$Over the jingling sound of gold, the old woman muttered. {nl}'If these two pieces of gold could ever marry, the baby gold would make me rich… but there's no life in these things…' {nl}Modestas heard those words, and decided to comment. {nl}'That gold won't make you rich by itself, so just put it into something worthwhile. {nl}Do you really think muttering at baby gold will do something?'{nl}
+QUEST_20150729_002332	$Over the jingling sound of gold, the old woman muttered. {nl}'If these two pieces of gold could ever marry, the baby gold would make me rich... but there's no life in these things...' {nl}Modestas heard those words, and decided to comment. {nl}'That gold won't make you rich by itself, so just put it into something worthwhile. {nl}Do you really think muttering at baby gold will do something?'{nl}
 QUEST_20150729_002333	The old woman spoke plainly, 'Why not? If this way bears fruit, it'll be safe and secure.' {nl}'That's ridiculous. You should do what I do and gamble.' {nl}The woman was incensed.{nl}
 QUEST_20150729_002334	'So, you think your betting ways are better?' {nl}'Why wouldn't I? There are moments where I could win or lose, but your way won't make any gold at all.' {nl}With Modestas' words, the old woman paused in thought. Finally, she said, {nl}'Then let's have a bet.'{nl}
 QUEST_20150729_002335	The disturbing aura around her grew as soon as the offer reached Modestas' ears. He couldn't outright refuse. {nl}'What kind of bet?' {nl}'We'll see whether your way or my way will make us richer.' {nl}'And if I lose?'{nl}
@@ -2329,13 +2329,13 @@ QUEST_20150729_002336	'Don't worry about that. You will win, and you will lose -
 QUEST_20150729_002337	'No. No matter how unlucky it may seem, you will win your first gamble. {nl}And then, no matter how favorable life may seem, you will fail the next.'{nl}
 QUEST_20150729_002338	Modestas was still confused by these strange words. {nl}'So, you're saying I'll win on every odd bet, and lose on every even one?' {nl}'Yes. It will be so. You will win coin, and then you won't. Is that not fair? {nl}One coin will be enough to succeed, no matter how many bets you make. That is my offer.' {nl}'You think I'll switch between winning and losing, huh?{nl}
 QUEST_20150729_002339	With her hand to her chin, the old woman gave a puzzling response. {nl}'Three times each, should be enough. Return to me after you make six gambles. {nl}Naturally, if you don't have more coin after your sixth bet, I will win.'{nl}
-QUEST_20150729_002340	Modestas seemed to tremble. 'How much should I earn, then?' {nl}'You start with one gold piece,' she replied, 'and when you return, show me all your gold pieces but that one. {nl}If you stretch that single piece to anything more, then you win. As for the time… you have one week.' {nl}'So, what do you get when I lose?' Modestas reminded her.{nl}
-QUEST_20150729_002341	'Well…' the old woman lingered, 'If you win, everyone will know about my gold - {nl}and you'll have the power of winning and losing. On the other hand…' {nl}''On the other hand…'?' Modestas said, tensely.{nl}
+QUEST_20150729_002340	Modestas seemed to tremble. 'How much should I earn, then?' {nl}'You start with one gold piece,' she replied, 'and when you return, show me all your gold pieces but that one. {nl}If you stretch that single piece to anything more, then you win. As for the time... you have one week.' {nl}'So, what do you get when I lose?' Modestas reminded her.{nl}
+QUEST_20150729_002341	'Well...' the old woman lingered, 'If you win, everyone will know about my gold - {nl}and you'll have the power of winning and losing. On the other hand...' {nl}''On the other hand...'?' Modestas said, tensely.{nl}
 QUEST_20150729_002342	'When I win, then after this, the friends you know will disappear every time you lose a bet.' {nl}Modestas was unnerved by the conditions set. He did not immediately object, but thought of the victory, {nl}and soon accepted. Modestas was, most of all, the kind of person who never backed down.{nl}
 QUEST_20150729_002343	$'Are you not busy? You seemed in a hurry on your horse before you passed by for a talk. You should stop worrying about me and go.' {nl} Sigfried, hearing Modestas' words, replied, {nl} 'I was busy, but I still have time to walk with you for another 10 minutes or so. This horse might not seem like much, but when it comes down to it he can go pretty fast.' {nl}
-QUEST_20150729_002344	$Seeing Sigfried not budge, Modestas tried again to persuade him, {nl} 'Wouldn't it be better to be early as opposed to be on time?' {nl} {nl} Hearing this, Sigfried became adamant, {nl} 'Do you not believe what I just said or are you willfully ignoring it all?' {nl} A disconcerted Modestas said, {nl} 'No, I didn't mean it like that……' {nl}
+QUEST_20150729_002344	$Seeing Sigfried not budge, Modestas tried again to persuade him, {nl} 'Wouldn't it be better to be early as opposed to be on time?' {nl} {nl} Hearing this, Sigfried became adamant, {nl} 'Do you not believe what I just said or are you willfully ignoring it all?' {nl} A disconcerted Modestas said, {nl} 'No, I didn't mean it like that......' {nl}
 QUEST_20150729_002345	$However, before Modestas could say any more, Sigfried said, 'If you don't believe me, why don't we have a bet?' {nl} {nl} Naturally, the words, 'Sure. What do you want to wager?' rose up in Modestas' throat.
-QUEST_20150729_002346	Considering Modestas' habit, to simply not immediately accept a gamble took superhuman willpower from him. {nl} 'What…  what kind of bet?' {nl} 'We were going to bet on whether my horse is fast or not.' {nl} Modestas desperately fought his inner gambler.
+QUEST_20150729_002346	Considering Modestas' habit, to simply not immediately accept a gamble took superhuman willpower from him. {nl} 'What...  what kind of bet?' {nl} 'We were going to bet on whether my horse is fast or not.' {nl} Modestas desperately fought his inner gambler.
 QUEST_20150729_002347	$As soon as the bet started, Sigfried tried every method possible to command his horse to move. Despite his efforts it didn't move a single hoof at all.{nl}At the end, Sigfried repeatedly cursed its strange behavior. Realizing he'd be late to his appointment without a horse, he threw the reins to Modestas and sprinted away.{nl}
 QUEST_20150729_002348	As Sigfried disappeared, Modestas felt uncomfortable.
 QUEST_20150729_002349	$'You, the young man with the horse, can you come over and help us for a bit?' {nl} Modestas had no idea what these soldiers needed help for, but since he could no longer ignore them, he decided to head over. {nl} Once Modestas arrived, one of the soldiers said, {nl} 'You came at just the right time. We would like you to referee a small gamble we're about to make here.' {nl}
@@ -2356,7 +2356,7 @@ QUEST_20150729_002363	Modestas, after saying he'll be back if he loses the bet, 
 QUEST_20150729_002364	$And right before his eyes, the lead nugget prize let out a sparkle and in a moment clearly became gold. {nl} The old Alchemist now snickered, 'Now you owe me one gold nugget, be sure to bring it.' {nl} Modestas protested, but as much as he looked, what the old Alchemist now held was clearly no longer lead. {nl}
 QUEST_20150729_002365	$'This time, no matter what, I have to wage a bet against the world's richest, well maybe not the richest, but a wealthy man at the very least.'{nl}As soon as he uttered these words, his surroundings shook like an earthquake and a heavy, deep voice declared.{nl}'I am the richest in this region.'{nl}
 QUEST_20150729_002366	$Modestas scanned his surroundings but failed to find anyone. So he asked,{nl}'Who are you?'{nl}The heavy deep voice answered his question.{nl}'I am where you stand. In your tongue, I am called the mountain.'{nl}Modestas in disbelief, couldn't help but talk back.{nl}
-QUEST_20150729_002367	$'You are… the mountain?'{nl}'That is correct. I am the mountain, and just as you are looking for, the richest around here.'{nl}'You are the mountain? Well, no, even if you are the mountain, how can you claim to be the richest?'{nl}'I own much land for my sierra stretches far. Further in me I contain large valuable lodes.'{nl}
+QUEST_20150729_002367	$'You are... the mountain?'{nl}'That is correct. I am the mountain, and just as you are looking for, the richest around here.'{nl}'You are the mountain? Well, no, even if you are the mountain, how can you claim to be the richest?'{nl}'I own much land for my sierra stretches far. Further in me I contain large valuable lodes.'{nl}
 QUEST_20150729_002368	$Even if the mountain's veins contained nothing but rocks, he thought he could end up owning a large quarry to dig out valuable stones. Instead, the mountain had paid an inadequate reward.{nl}When Modestas pointed it out, the mountain disagreed.{nl}'All you own are two horses and a wagon.'
 QUEST_20150729_002369	$Surely one must wage things of equal value. This boulder is worth as much as you own.'{nl}With that said, the mountain returned to his former self, never to deal with Modestas nor anyone else ever again. {nl}Modestas, in his desperate situation, had wasted his crucial chance to just win one big boulder.{nl}Despite his bad luck, he consoled himself knowing at least he had horses and a wagon to transport the boulder.{nl}
 QUEST_20150729_002370	$In front of Modestas, who had been worrying, appeared a familiar figure. It was none other than the one who had started the bet, the suspicious old woman.{nl}The old woman asked Modestas.{nl}'How is it? Is it going well?'{nl}
@@ -2377,8 +2377,8 @@ QUEST_20150729_002384	$In the end, Goddess Ausrine, in exchange for giving incom
 QUEST_20150730_002385	$Voodoo Doll
 QUEST_20150730_002386	{memo X}$The Gravekeeper's Magic Doll has shut down the barrier!
 QUEST_20150803_002387	$You need the key that fits the box
-QUEST_20150803_002388	$Another headache… I have a headache. Just go back and don't worry about me. {nl}Ah, the beautiful flowers are coming…
-QUEST_20150803_002389	$Eternal life… {nl}I continue to live by the authority of Goddess Ausrine.{nl}
+QUEST_20150803_002388	$Another headache... I have a headache. Just go back and don't worry about me. {nl}Ah, the beautiful flowers are coming...
+QUEST_20150803_002389	$Eternal life... {nl}I continue to live by the authority of Goddess Ausrine.{nl}
 QUEST_20150803_002390	$The death moves away from me whenever I set Owl Sculptures that guide the spirits.{nl}Even if an old person like me could be helpful to the goddess and the world, I should live an eternal life.
 QUEST_20150803_002391	{memo X}$Are you interested in eternal life?{nl}We necromancers control the dead so it's easy to figure out.{nl}
 QUEST_20150803_002392	$Absorbing another's vitality and extending one's own life is possible for me.{nl}But, it's not possible for humans.
@@ -2411,7 +2411,7 @@ QUEST_20150918_002418	I heard that some Revelator saved the Mage Tower. {nl}Fedi
 QUEST_20150918_002419	The expectations on the Revelator from all the people of Fedimian is increasing. {nl}News has spread that a certain Revelator defeated the Demon Lord holding the Great Cathedral.{nl}Anyway, you don't necessarily have to buy something so feel free to look around.
 QUEST_20150918_002420	It looks like something is in that grass.
 QUEST_20150918_002421	{memo X}What was she looking for even when she was dying? {nl}There's definitely a tragic story behind all this.
-QUEST_20150918_002422	Then something snapped. {nl}A fellow clergyman, I can't remember who, had murdered Dion in his sleep with a mace and I… {nl}Everyone… {nl}No one can remember why they wanted to become priest in the past anymore.
+QUEST_20150918_002422	Then something snapped. {nl}A fellow clergyman, I can't remember who, had murdered Dion in his sleep with a mace and I... {nl}Everyone... {nl}No one can remember why they wanted to become priest in the past anymore.
 QUEST_20150918_002423	Each Goddess Statue is known to have different abilities depending on which goddess it depicts. {nl}For example, the statue of Goddess Zemyna gives a blessing that enhances any ability you want.
 QUEST_20150918_002424	$But the statue of Goddess Ausrine in Klaipeda is a bit strange. {nl}It moves you to a desired area even though such a thing is Goddess Vakarine's power.
 QUEST_20150918_002425	Go down quickly. It's dangerous. {nl}This place is empty.
@@ -2451,7 +2451,7 @@ QUEST_20151001_002458	There's a request that is being progressed.{nl}Come see me
 QUEST_20151001_002459	The request can be accepted by the party leader.
 QUEST_20151001_002460	Thorny Vines Forest Dungeon
 QUEST_20151001_002461	Thorny Vines Forest (Recommended Lv : 175){nl}Only you and your party members can enter together.{nl}Do you want to enter?
-QUEST_20151001_002462	It was a disaster… Many people were either injured or killed. {nl}Gentle creatures grew fierce and many new monsters emerged.{nl}
+QUEST_20151001_002462	It was a disaster... Many people were either injured or killed. {nl}Gentle creatures grew fierce and many new monsters emerged.{nl}
 QUEST_20151001_002463	The best weapons and armors are the ones that you get used to over a long period of time. In order to do so, you must start by buying good items.
 QUEST_20151001_002464	The things I sell are good both in price and quality.
 QUEST_20151001_002465	A lot of people seem to be coming thanks to Sir Uska's recruitment notice.{nl}Take a look around at your own pace without feeling anxious.
@@ -2462,7 +2462,7 @@ QUEST_20151001_002469	I heard the monsters are moving in herds outside Klaipeda.
 QUEST_20151001_002470	My device will soon be functional. By the end of the day, you too will be able to enter the Mage Tower.
 QUEST_20151001_002471	The thief who foolishly entered this tower to rob it was burned alive. {nl}At the very least, the monuments he left will serve as a warning to other trespassers. {nl}- Agailla Flurry
 QUEST_20151001_002472	General Ruklys has fallen in battle, and the Fortress of the Land has been taken. {nl}Some people say he was killed by Lydia Schaffen's arrow while others say by the royal magicians' magic, but it is certain that he passed away. {nl}It is indeed sad news.	
-QUEST_20151001_002473	There's no hope at all. Ah… my lovely Ridell. {nl}The kingdom soldiers did not keep their words. We're all going to die.{nl}	
+QUEST_20151001_002473	There's no hope at all. Ah... my lovely Ridell. {nl}The kingdom soldiers did not keep their words. We're all going to die.{nl}	
 QUEST_20151001_002474	Even if the world collapses, the people will remain.{nl}If you have the desire to win with trustworthy companions.	
 QUEST_20151001_002475	This too is my ordeal and duty which Laima foresaw... {nl}I will tell you Laima's message.{nl}	
 QUEST_20151001_002476	$If I'm paid well, there's no reason I would stop a person who wants to learn my techniques.{nl}Rather, I would even welcome that person. That doesn't mean they should follow my every move, though.
@@ -2527,7 +2527,7 @@ QUEST_20151001_002534	What was the thing she was looking for until the end?{nl}I
 QUEST_20151001_002535	Tree Root Crystals are slowly killing me.{nl}It feels as if I am drowning.{nl}
 QUEST_20151001_002536	I have lost all desires. Am I dying? {nl}Eating and even breathing feels meaningless to me.{nl}
 QUEST_20151001_002537	This surely isn't a teaching of Maven. {nl}Greed? Laziness? How can we call killing each other a lesson? {nl}I even envy Dion for dying first.{nl}
-QUEST_20151001_002538	If only I had a little more time… {nl}The data I've collected near Dykyne Fork… I can't leave them…
+QUEST_20151001_002538	If only I had a little more time... {nl}The data I've collected near Dykyne Fork... I can't leave them...
 QUEST_20151001_002539	The archer gives an arrow as a present, but the enemy take it as death.{nl}I think the world is like that now.
 QUEST_20151001_002540	$I will stay here with the Believers. {nl}I will somehow prevent the Thorn Forest from expanding any more.{nl}
 QUEST_20151001_002541	Don't tell them about me for a while.{nl}Humans need a place to rely on...{nl}When they find out the powerlessness of the goddesses, this world will be filled with chaos and sighs.{nl}
@@ -2538,7 +2538,7 @@ QUEST_20151001_002545	Even when the goddesses are not around, the Oracles still 
 QUEST_20151001_002546	$Medzio Diena was not nature's will.{nl}After all, nature is governed by the goddesses, and they would never do harm to us all.
 QUEST_20151001_002547	I offer this Goddess Statue, which I have put all my heart and soul into, to the goddess of great honor and light.
 QUEST_20151001_002548	Among my disciples, two of them followed me until my latter years and they will also be my successors after my death. {nl}
-QUEST_20151001_002549	…I am thinking whether I should thank the goddesses for this discovery or worry that my craving for knowledge could ruin the world.{nl}
+QUEST_20151001_002549	...I am thinking whether I should thank the goddesses for this discovery or worry that my craving for knowledge could ruin the world.{nl}
 QUEST_20151001_002550	I can't sleep well due to the fear of my research results being spread by interrogations from the demons. {nl}That's why I wish to pass the rest of the research to the one I can trust.
 QUEST_20151001_002551	Are you interested in the eternal life?{nl}We, Necromancers control the dead, so it's easy when you think about that.{nl}
 QUEST_20151001_002552	If he asks about the weather, then tell him that it will be sunny.{nl}Okay then, I will be counting on you as I wait.
@@ -2624,8 +2624,8 @@ QUEST_20151001_002631	Beyond Pilgrim's Way is the Great Cathedral, which was bui
 QUEST_20151001_002632	Among them, the Paladin Master was a hero who saved many lives in the capital. {nl}Currently, he has gone to Srautas Gorge to fight a great evil...
 QUEST_20151001_002633	Many people made bets with Modestas to find out who the statue of the goddess is, but Modesta has never lost before he died.
 QUEST_20151001_002634	$By the end of my life I hope to see Fedimian completely restored.{nl}If there's one thing I can do, I can make 1,000 pots in dedication to this wish.
-QUEST_20151001_002635	$I hope I can make it big off of the excavation site at Zachariel's Royal Mausoleum…
-QUEST_20151001_002636	$I beg to the goddess. {nl}I hope the day when my oath to the Watchers is realized never comes…
+QUEST_20151001_002635	$I hope I can make it big off of the excavation site at Zachariel's Royal Mausoleum...
+QUEST_20151001_002636	$I beg to the goddess. {nl}I hope the day when my oath to the Watchers is realized never comes...
 QUEST_20151001_002637	$When I close my eyes at last, I hope my many disciples will protect me at my side.
 QUEST_20151001_002638	Now is the moment that we become one with our blades. My last wish is to die beside the one I love.
 QUEST_20151001_002639	Why have you returned?{nl}
@@ -2648,7 +2648,7 @@ QUEST_20151001_002655	Although I founded the kingdom,{nl}I wish to speak to you 
 QUEST_20151001_002656	You are the Savior of this kingdom.{nl}I can feel that you will save this world and become the one who the goddesses would rely upon.{nl}
 QUEST_20151001_002657	After spending a thousand years of worshiping the providence of the goddess,{nl}I shall now show you the great will that was left to you in the revelation.
 QUEST_20151001_002658	The soldiers will die if I don't make it. {nl}I have to be strong. 
-QUEST_20151001_002659	…Only after three years since Ruklys learned from my teachings…
+QUEST_20151001_002659	...Only after three years since Ruklys learned from my teachings...
 QUEST_20151001_002660	If the demons cross the dimensional crack and join hands together with their brethren at the Demon Prison...,{nl}the world will be in for another kind of threat.
 QUEST_20151001_002661	I've told sister Vakarine to promise me that she'd prepare for the worst.{nl}But the uprising of the demons that broke through might be hindering her.
 QUEST_20151001_002662	Bishop Aurelius, who was ordained at a young age, soon took ill and lost his life.{nl}

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -1760,7 +1760,7 @@ QUEST_20150401_001761	The crystal is empty because the seal was released.
 QUEST_20150401_001762	Sealing the spell.
 QUEST_20150401_001763	$The powerful spell can be suppressed using a fragment of the Spell Suppressing Crystal. 
 QUEST_20150401_001764	Demon Lord Naktis
-QUEST_20150401_001765	$You have been running around hard in my land. {nl}Sorry, kid, but my name calls for the curse.
+QUEST_20150401_001765	$You have been running around hard in my land. {nl}Sorry kid, but my name calls for the curse.
 QUEST_20150401_001766	{memo X}What is this...? {nl}What are you doing with my soul?!
 QUEST_20150401_001768	Reconstruction of Blessings
 QUEST_20150406_001769	{memo X}$You think so too, huh? {nl}Please collect some leather. You can get some from the monsters. 

--- a/QUEST.tsv
+++ b/QUEST.tsv
@@ -12,9 +12,9 @@ QUEST_20150317_000011	$Please select a class.
 QUEST_20150317_000012	$Bokor Master
 QUEST_20150317_000013	$So you are curious about this stone slate. {nl}If you wish, I shall show you the will of its creator.
 QUEST_20150317_000014	$Goddess Laima
-QUEST_20150317_000015	$By the time you get this message, much time will have passed. {nl}I am the Goddess of Fate and Wisdom, Laima.
+QUEST_20150317_000015	$By the time you get this message, much time will have passed. {nl}I am Laima, the goddess of fate and wisdom.
 QUEST_20150317_000016	$600 years ago while creating this revelation, I foresaw a great deal of death and suffering. {nl}If you're seeing this, then I'm afraid what I foresaw has come to pass.
-QUEST_20150317_000017	$The demons have started the first of cataclysms, and the Goddesses have vanished. {nl}I knew all of this would occur and did everything I could to prevent this fate, but my power was not enough.
+QUEST_20150317_000017	$The demons have started the first of cataclysms, and the goddesses have vanished. {nl}I knew all of this would occur and did everything I could to prevent this fate, but my power was not enough.
 QUEST_20150317_000018	$Instead, I wandered through far-seeing dreams for an answer. {nl}You were at the end of them... a Savior.
 QUEST_20150317_000019	$Unfortunately, the demons could not stay still, knowing that I possess strength in clairvoyance. {nl}I was forced to hide until the time of your appearance.
 QUEST_20150317_000020	$I decided to divide my being and remain within many revelations. {nl} Revelations that I continued to create secretly over a millennium.
@@ -23,7 +23,7 @@ QUEST_20150317_000022	$This divine task may be a heavy burden, but it is somethi
 QUEST_20150317_000023	$Nevertheless, only we can save this world.
 QUEST_20150317_000024	$I've passed the next revelation to the first Paladin. {nl}He will be waiting for you at the highest flower garden.
 QUEST_20150317_000025	{memo X}The dark aura is indeed unpleasant... {nl}But if this message is truly from the Goddess Laima, then I am simply in awe.
-QUEST_20150317_000026	{memo X}Well, you should hurry and go find Sir Uska. {nl}He will tell you where to go next. {nl}May the Goddess bless your fate...
+QUEST_20150317_000026	{memo X}Well, you should hurry and go find Sir Uska. {nl}He will tell you where to go next. {nl}May the goddess bless your fate...
 QUEST_20150317_000027	$Please select the preferred Smart Gen.
 QUEST_20150317_000028	$William
 QUEST_20150317_000029	{memo X}The fee's 100 silver. {nl}It's cheaper than cutting through monster central.
@@ -55,16 +55,16 @@ QUEST_20150317_000054	$I long for a time when our team is no longer needed... {n
 QUEST_20150317_000055	$I don't know where to start. {nl}Have you heard anything?
 QUEST_20150317_000056	$By royal orders, we've come to this forest to investigate some strange events. {nl}Witnesses have reported something with a big face and bony fingers. {nl}What in the world could that be?
 QUEST_20150317_000057	$In the past, pilgrims traveled through this forest. {nl}But now due to the presence of monsters, only soldiers gather here.
-QUEST_20150317_000058	$Up until four years ago, the Goddesses often blessed us with signs of their presence. {nl}But now, even our combined prayers don't bring so much as a tremor. {nl}Have they truly abandoned us?
+QUEST_20150317_000058	$Up until four years ago, the goddesses often blessed us with signs of their presence. {nl}But now, even our combined prayers don't bring so much as a tremor. {nl}Have they truly abandoned us?
 QUEST_20150317_000059	$Vacenin personally goes to each region to deal with things. {nl}He gets uncomfortable when he stays in the city.
 QUEST_20150317_000060	$Do you plan on staying or enlisting? {nl}If you're interested, I'll gladly recommend you to the head commanders.
 QUEST_20150317_000061	$Don't let your guard down. Monsters can appear any time, anywhere.
 QUEST_20150317_000062	$Where in the world did Goddess Zemyna go...
 QUEST_20150317_000063	$What in the world do you call this?
-QUEST_20150317_000064	$I think the Goddess of Earth, Zemyna, would grieve more than anyone else.
+QUEST_20150317_000064	$I think Zemyna, the goddess of the earth would grieve more than anyone else.
 QUEST_20150317_000065	$The Pokubu have always been here, but sometimes unfamiliar monsters are spotted as well.
-QUEST_20150317_000066	$I've thought about it. There's no doubt that the Goddesses have abandoned us all. {nl}If that weren't so, then there wouldn't be so many monsters.
-QUEST_20150317_000067	$They say there's a man blessed with the Goddess' strength living in the forest.
+QUEST_20150317_000066	$I've thought about it. There's no doubt that the goddesses have abandoned us all. {nl}If that weren't so, then there wouldn't be so many monsters.
+QUEST_20150317_000067	$They say there's a man blessed with the goddess' strength living in the forest.
 QUEST_20150317_000068	$I want to go home.
 QUEST_20150317_000069	$The number of monsters here doesn't seem to change no matter how many of them we kill.
 QUEST_20150317_000070	{memo X}Did Julian send you off, Revelator?
@@ -77,19 +77,19 @@ QUEST_20150317_000076	$Henryka
 QUEST_20150317_000077	$Hello! {nl}Welcome to the Klaipeda branch of the Mage Society. {nl}We specialize in studying the strange phenomena that occur when special items are combined.
 QUEST_20150317_000078	$There's nothing to see here but steam and Vubbes. {nl}Wait, what's that thing with the big face that's approaching?!
 QUEST_20150317_000079	$The land needs our attention as well. {nl}The world still isn't ruined... right?
-QUEST_20150317_000080	$If we continue to have courtesy, then we still know the way of a righteous life. {nl}We should all consider whether or not this mess is our fault because we relied on the Goddess for everything.
+QUEST_20150317_000080	$If we continue to have courtesy, then we still know the way of a righteous life. {nl}We should all consider whether or not this mess is our fault because we relied on the goddess for everything.
 QUEST_20150317_000081	$Bulletin Board
 QUEST_20150317_000082	$Welcome to the mining town of Klaipeda!
 QUEST_20150317_000083	$Indifferent Widow
-QUEST_20150317_000084	$I'm not sure I understand it completely, but what I'm sure of is that the Goddesses didn't disappear all at once.
+QUEST_20150317_000084	$I'm not sure I understand it completely, but what I'm sure of is that the goddesses didn't disappear all at once.
 QUEST_20150317_000085	$The first to disappear was the Goddess Gabija. {nl}I heard it was a very long time ago. {nl}One by one, starting with Gabija, they stopped replying.
-QUEST_20150317_000086	$The Goddess Vakarine left us shortly before Medzio Diena. {nl}Both Zemyna and Ausrine disappeared soon after. {nl}It's already been four years since.
+QUEST_20150317_000086	$Goddess Vakarine left us shortly before Medzio Diena. {nl}Both Zemyna and Ausrine disappeared soon after. {nl}It's already been four years since.
 QUEST_20150317_000087	{memo X}That's right. The strangest one of all was the Goddess Laima. {nl}No one's really sure when she disappeared.
 QUEST_20150317_000088	{memo X}Besides, isn't Laima the Goddess of Fate and Wisdom? {nl}She probably knew all about it.
 QUEST_20150317_000089	$Resting Soldier
 QUEST_20150317_000090	$I used to be an adventurer like you. Then I took an arrow in the knee...
 QUEST_20150317_000091	$It doesn't matter. Come and face me, you monsters!
-QUEST_20150317_000092	$A Goddess appeared in my dream just now... {nl}It was so enchanting...
+QUEST_20150317_000092	$A goddess appeared in my dream just now... {nl}It was so enchanting...
 QUEST_20150317_000093	$Still, I have a duty to defend the kingdom. That's why I'm here.
 QUEST_20150317_000094	$Uska is an old friend of mine.
 QUEST_20150317_000095	$We did our tests to become knights together. Uska got to where he is now with my sincere support. {nl}Oh, those were some crazy days... It'd be nice to see him again.
@@ -100,9 +100,9 @@ QUEST_20150317_000099	$Everything that flies out of his mouth is a lie. Don't tr
 QUEST_20150317_000100	$Siauliai Guard
 QUEST_20150317_000101	{memo X}There are monsters beyond this point. Be careful.
 QUEST_20150317_000102	$These woods aren't exactly peaceful, but it's better than other places. {nl}There are forests that have nothing but souls roaming about.
-QUEST_20150317_000103	$This is what people who have seen a Goddess in their dreams are being called.
-QUEST_20150317_000104	$I thought the Revelators' visions were madness at first. {nl}The Goddesses have been gone for a long time after all.
-QUEST_20150317_000105	$Isn't it true that the Goddesses haven't been responding to our prayers ever since Medzio Diena four years ago?
+QUEST_20150317_000103	$This is what people who have seen a goddess in their dreams are being called.
+QUEST_20150317_000104	$I thought the Revelators' visions were madness at first. {nl}The goddesses have been gone for a long time after all.
+QUEST_20150317_000105	$Isn't it true that the goddesses haven't been responding to our prayers ever since Medzio Diena four years ago?
 QUEST_20150317_000106	$You can find Class Masters all around the kingdom. {nl}Why don't you visit them and learn what you can?
 QUEST_20150317_000107	$You don't know about Medzio Diena? You must have come from really far away. {nl}Four years ago, things went out of control in the capital.
 QUEST_20150317_000108	${memo X}It was a disaster... Many people were either injured or killed. {nl}Once gentle creatures grew fierce and many new monsters emerged.
@@ -126,11 +126,11 @@ QUEST_20150317_000125	{memo X}It looks like you can see into the upper forest fr
 QUEST_20150317_000126	$You don't have the required quest item. Are you sure you want to continue?
 QUEST_20150317_000127	$Klaipeda Girl
 QUEST_20150317_000128	$My neighbor used to be a monster hunter. {nl}He's retired now though. It has gotten ferociously dangerous.
-QUEST_20150317_000129	{memo X}It would be nice if all these Revelators being here meant that the Goddesses are back.
-QUEST_20150317_000130	$It might be silly to hope for the Goddess' return, but it's better than nothing.
+QUEST_20150317_000129	{memo X}It would be nice if all these Revelators being here meant that the goddesses are back.
+QUEST_20150317_000130	$It might be silly to hope for the goddess' return, but it's better than nothing.
 QUEST_20150317_000131	$Klaipeda Lady
-QUEST_20150317_000132	$We can still grow from the land, and have a warm hearth at our homes to rest at. {nl}I will always believe the Goddess is somewhere in the world.
-QUEST_20150317_000133	$Keep faith. {nl}The Goddess may still send a Savior to us.
+QUEST_20150317_000132	$We can still grow from the land, and have a warm hearth at our homes to rest at. {nl}I will always believe the goddess is somewhere in the world.
+QUEST_20150317_000133	$Keep faith. {nl}The goddess may still send a Savior to us.
 QUEST_20150317_000134	$Hoplite Master
 QUEST_20150317_000135	$If the sword is a symbol of power, then the spear is that of pure destruction. {nl}Power or destruction - what would you reach for on the battlefield?
 QUEST_20150317_000136	$Machine Worker
@@ -140,7 +140,7 @@ QUEST_20150317_000139	$My old man did this thing where he checked around corners
 QUEST_20150317_000140	$Retired Hunter
 QUEST_20150317_000141	$I remember this battle in a deep canyon where soldiers fought a huge monster. {nl}Seeing the giant thing fall was amazing, but what was more amazing was the spoils.
 QUEST_20150317_000142	$Old Potter
-QUEST_20150317_000143	$I put a prayer on my earthenware, one by one. {nl}That way, the pots will one day be filled with the Goddess' blessings.
+QUEST_20150317_000143	$I put a prayer on my earthenware, one by one. {nl}That way, the pots will one day be filled with the goddess' blessings.
 QUEST_20150317_000144	{memo X}Swordsmen should have Strength, but you can also have Dexterity and Constitution. {nl}You'll need to think about what to start with.
 QUEST_20150317_000145	$Wizards work with Intelligence, but shouldn't forget Spirit for more spell-casting. {nl}You'll have to choose between being balanced or specializing.
 QUEST_20150317_000146	{memo X}Archers should have Strength, but Dexterity will prevent problems with movement. {nl}You'll need to think about what to start with.
@@ -177,10 +177,10 @@ QUEST_20150317_000176	$Temporary Operator
 QUEST_20150317_000177	$Please change this character's status.
 QUEST_20150317_000178	$NPC HIDE/UNHIDE Setting!
 QUEST_20150317_000179	$Follower Algis
-QUEST_20150317_000180	$The moment that the Goddess foretold to the first Paladin has finally arrived. {nl}Come. Ask me anything.
+QUEST_20150317_000180	$The moment that the goddess foretold to the first Paladin has finally arrived. {nl}Come. Ask me anything.
 QUEST_20150317_000181	$A long, long time ago, there were nomads who suffered from a cursed plague. {nl}The honorable first Paladin removed the curse with a Holy Relic.
 QUEST_20150317_000182	$The Watchers are the descendants of those nomads. {nl}However, the Holy Relic was not meant for healing those people.
-QUEST_20150317_000183	$One day, the Goddess requested the first Paladin to safeguard a divine revelation. {nl}The cursed nomads appeared just as the paladin mulled on how to keep it secret.
+QUEST_20150317_000183	$One day, the goddess requested the first Paladin to safeguard a divine revelation. {nl}The cursed nomads appeared just as the paladin mulled on how to keep it secret.
 QUEST_20150317_000184	$They and the first Paladin made three pledges before breaking the curse.
 QUEST_20150317_000185	$To build the Tenet Church together. {nl}To conceal the Holy Relic within these grounds and worship its holiness. {nl}To gather and fight together when danger come close to this location.
 QUEST_20150317_000186	$All this, was to protect the revelation hidden in the sanctum of the Tenet Church.
@@ -231,7 +231,7 @@ QUEST_20150317_000230	{memo X}Up until now, I've only seen the cursed figures of
 QUEST_20150317_000231	{memo X}Will lifting this city's curse bring back the dead? {nl}I doubt it, but our lords have put great effort into retaking this area. {nl}They've done all they could for that purpose.
 QUEST_20150317_000232	$Graverobber Stephonas
 QUEST_20150317_000233	{memo X}We're different from those other grave-robbing hooligans. {nl}They've no pride or business sense! {nl}If you help us now, we'll return the favor someday soon.
-QUEST_20150317_000234	$Kingdom Army Rofdel
+QUEST_20150317_000234	$Royal Army Guard Rofdel
 QUEST_20150317_000235	{memo X}You can see all sorts of things happening from this watchtower even if it's as if time in the city has stopped. {nl}The dust usually gets in the way, but you can see all the way to Ruklys' paths when it rains.
 QUEST_20150317_000236	{memo X}We've worked for centuries to revive these ruins. {nl}With your help, we might be able to learn about that day and finally succeed.
 QUEST_20150317_000237	$Bokor Edita
@@ -243,7 +243,7 @@ QUEST_20150317_000242	$Our family's different from those other grave-robbing ani
 QUEST_20150317_000243	{memo X}Are the soldiers already dead? {nl}I've never seen a frost stone as strange as this before. {nl}It's like everyone in the city is trying to hide something by reliving that day.
 QUEST_20150317_000244	$High Speed Movement
 QUEST_20150317_000245	$Torn Letter
-QUEST_20150317_000246	$To my beloved Brother in Fedimian...
+QUEST_20150317_000246	$To my beloved brother in Fedimian...
 QUEST_20150317_000247	$Gesti has sensed it. Stay calm. It is not yet time.
 QUEST_20150317_000248	$Off-duty Supply Trooper
 QUEST_20150317_000249	$I have no idea what the royal household is doing. {nl}I even heard that the nobles have already fled the town.
@@ -254,7 +254,7 @@ QUEST_20150317_000253	$Gesti's demons keep attacking relentlessly. {nl}Their dar
 QUEST_20150317_000254	$The Panto were once docile, but now they charge and attack on sight.
 QUEST_20150317_000255	$There is a tree here that the Panto worship. {nl}If this is happening, that tree has almost certainly been corrupted by a dark power.
 QUEST_20150317_000256	$Please protect the Romuvan barrier at the top of the valley. {nl}We will take care of the rest when our brothers arrive here.
-QUEST_20150317_000257	{memo X}May the Goddess bless you.
+QUEST_20150317_000257	{memo X}May the goddess bless you.
 QUEST_20150317_000258	{memo X}I want to get some action. {nl}I haven't seen a fight in a long while.
 QUEST_20150317_000259	$We're still preparing. {nl}Please wait a little longer.
 QUEST_20150317_000260	$Antares
@@ -285,8 +285,8 @@ QUEST_20150317_000284	$Auctioneer
 QUEST_20150317_000285	$It ain't easy to get the good stuff. {nl}Merchants have been rethinking their routes thanks to the monsters around Klaipeda.
 QUEST_20150317_000286	$The auction has started! {nl}We went through a lot of trouble to bring you these listed items. {nl}Let's start the bidding!
 QUEST_20150317_000287	$These are the West Siauliai Woods. {nl}We should give a certain amount away when the villagers tend to the memorials, right?
-QUEST_20150317_000288	$So the Thaumaturge Master sent you. {nl}One question, first. The center of Fedimian holds a statue designed after which Goddess?
-QUEST_20150317_000289	$Here's the quiz, so listen up! {nl}What is the name of the group that Lydia Schaffen formed to retrieve the Goddess' revelation?
+QUEST_20150317_000288	$So the Thaumaturge Master sent you. {nl}One question, first. The center of Fedimian holds a statue designed after which goddess?
+QUEST_20150317_000289	$Here's the quiz, so listen up! {nl}What is the name of the group that Lydia Schaffen formed to retrieve the goddess' revelation?
 QUEST_20150317_000290	$Did you read any books in the Crystal Mine's 1st Lot, 2nd Floor? {nl}What's the name of the prisoner who wasn't able to escape after sealing Mirtis by caving in the Crystal Mine?
 QUEST_20150317_000291	{memo X}Take it. I don't need it any more... Ugh... {nl}After I finish this booze, I'll go look for my brother again... Heh...
 QUEST_20150317_000292	{memo X}What? My brother's dead? {nl}What nonsense are you talking 'bout, huh? Get outta here! *sniff*
@@ -302,15 +302,15 @@ QUEST_20150317_000301	$You got that wrong. {nl}Why don't you try again?
 QUEST_20150317_000302	$The place upstairs is the divine place where the gigantic Goddess Statue, the symbol of Fedimian, is located. {nl}All believers, tidy yourself and worship quietly.
 QUEST_20150317_000303	{memo X}Fedimian wasn't always like this... {nl}It was once a beautiful and vibrant city. {nl}Fortunately, the divine district, where the central Goddess Statue is located, is still okay.
 QUEST_20150317_000304	{memo X}Fedimian was originally divided into two districts, the commerce district and the divine district. {nl}But an incident four years ago left the commerce district completely destroyed and Fedimian soon changed for the worse...
-QUEST_20150317_000305	{memo X}Mercifully, the divine district still stands today thanks to the blessing of the Goddess.
+QUEST_20150317_000305	{memo X}Mercifully, the divine district still stands today thanks to the blessing of the goddess.
 QUEST_20150317_000306	{memo X}I am just an ordinary old man in Fedimian. {nl}If you want to know more, then bring me some potato dumplings...
 QUEST_20150317_000307	{memo X}The food at Fedimian is awful. {nl}Before I die, is it going to be possible to try all delicious food in the world?
-QUEST_20150317_000308	$This is the Holy District of Fedimian. {nl}May you receive the full blessings of the Goddesses.
+QUEST_20150317_000308	$This is the Holy District of Fedimian. {nl}May you receive the full blessings of the goddesses.
 QUEST_20150317_000309	$Right now, the Market District is closed for reconstruction. {nl}Please do not enter that district.
 QUEST_20150317_000310	$The Fedimian Holy District welcomes you.
 QUEST_20150317_000311	$Thank you so much for your efforts. We are going to investigate here one more time. {nl}Cheer up!
 QUEST_20150317_000312	$Finished already? {nl}Amazing! You'd expect nothing less from a Revelator!
-QUEST_20150317_000313	$It is said that if one receives too much good, he begins to believe it's his right. {nl}Maybe, we relied too much on the Goddess.
+QUEST_20150317_000313	$It is said that if one receives too much good, he begins to believe it's his right. {nl}Maybe, we relied too much on the goddess.
 QUEST_20150317_000314	$Soldier Pitt
 QUEST_20150317_000315	$Are you the Revelator? {nl}It is such an honor to meet you!
 QUEST_20150317_000316	$Soldier Bran
@@ -325,14 +325,14 @@ QUEST_20150317_000324	$Do you need anything?
 QUEST_20150317_000325	$What you see here is not everything I have for sale. Hehe...
 QUEST_20150317_000326	$Instructor Nicker
 QUEST_20150317_000327	$If one soldier breaks a rule, then it may endanger the entire military. {nl}That's why we have to be very strict.
-QUEST_20150317_000328	$I guess I'll admit it now. You, the Revelator, pursue the dream of the Goddess. {nl}It's not going to be easy, but I believe you'll do well.
+QUEST_20150317_000328	$I guess I'll admit it now. You, the Revelator, pursue the dream of the goddess. {nl}It's not going to be easy, but I believe you'll do well.
 QUEST_20150317_000329	$Are you the Revelator? Good work, {nl}but I'm not quite sure I can trust you.
 QUEST_20150317_000330	$Private Personnel
 QUEST_20150317_000331	$To survive in this chaotic world, you'll sometimes need to use some dirty tricks. {nl}You shouldn't feel bad about it.
 QUEST_20150317_000332	$If you want to get a job done quick, then do it yourself. {nl}That's why I became a soldier.
 QUEST_20150317_000333	$I've heard many stories of heroes who fought for justice in my childhood, {nl}but I've always thought of them as just stories...{nl}Now I think heroes may exist.
 QUEST_20150317_000334	$York
-QUEST_20150317_000335	$The Goddess may have abandoned us, but we feel safe with the Revelator here with us.
+QUEST_20150317_000335	$The goddess may have abandoned us, but we feel safe with the Revelator here with us.
 QUEST_20150317_000336	$I want to go back to my hometown... {nl}I can't wait for supplies any longer. {nl}There's also no end in sight for this situation. *sigh*
 QUEST_20150317_000337	$There are moments that I just want to go out without the uniform and the boots. {nl}I only do this for my family's safety.
 QUEST_20150317_000338	$I am not a poet myself so I can't say it for sure... but you seem different. {nl}Anyway, I hope I can hear about you even if you are far away.
@@ -382,12 +382,12 @@ QUEST_20150317_000381	$You feel something suspicious inside.
 QUEST_20150317_000382	$Worried Wife
 QUEST_20150317_000383	{memo X}Have you ever had your fortune told? It is quite accurate, isn't it? {nl}Goddess Laima knows everything. Fate, Foresight, and Luck. {nl}I think she may have known beforehand about all these disasters coming.
 QUEST_20150317_000384	{memo X}I pray to Goddess Gabija everyday. It keeps the house warm. {nl}As you may already know, Goddess Gabija controls fire and since I'm a housewife, I am close to fire as well.
-QUEST_20150317_000385	$My husband always prays to Goddess Zemyna. {nl}If you want a good potato harvest, you shouldn't get on her bad side. {nl}Goddess Zemyna is the Goddess of Earth. She oversees farms and agriculture.
+QUEST_20150317_000385	$My husband always prays to Goddess Zemyna. {nl}If you want a good potato harvest, you shouldn't get on her bad side. {nl}Goddess Zemyna is the goddess of the earth. She oversees farms and agriculture.
 QUEST_20150317_000386	$Speaking of which. {nl}About the plants overgrowing ever since Medzio Diena four years ago...
-QUEST_20150317_000387	$I wonder what Goddess Zemyna will think of it. {nl}Everything will be revealed when the Goddess returns but... {nl}Oh, what blasphemous words I speak.
+QUEST_20150317_000387	$I wonder what Goddess Zemyna will think of it. {nl}Everything will be revealed when the goddess returns but... {nl}Oh, what blasphemous words I speak.
 QUEST_20150317_000388	$Have you ever seen the stars glittering red in the night sky? {nl}That's the very symbol of Goddess Vakarine. {nl}She leads the evening star and wakes Goddess Ausrine the following day.
 QUEST_20150317_000389	$She also oversees energy and rest, so she is the guardian of travelers like you. {nl}Shout Goddess Vakarine's name three times when your legs hurt and you'll feel much better.
-QUEST_20150317_000390	$What are you doing here? {nl}Did the Goddess also tell you to go to Klaipeda in your dreams?
+QUEST_20150317_000390	$What are you doing here? {nl}Did the goddess also tell you to go to Klaipeda in your dreams?
 QUEST_20150317_000391	$Still following me after all that? {nl}Fine, struggle all you want.
 QUEST_20150317_000392	{memo X}There is a Maze Tower near Fedimian known to have been built by Archmage Agailla Flurry. {nl}The tower has never been revealed and no entrance can be found.
 QUEST_20150317_000393	{memo X}Well, that's why some say it's just a made up story... {nl}But recently there have been people claiming to have come from there.
@@ -395,7 +395,7 @@ QUEST_20150317_000394	{memo X}The size of Goddess Zemyna's Statue will amaze you
 QUEST_20150317_000395	$Welcome. I heard you were coming from Uska. {nl}Don't just stand there. I wish to have a word with you.
 QUEST_20150317_000396	$So, you're the one who got the revelation from the Crystal Mine, right? {nl}If it's alright with you, I'd like to hear the details.
 QUEST_20150317_000397	$Amazing. {nl}We also follow the first Paladin's will and came here to guard this place. {nl}Same goes for the Watchers here.
-QUEST_20150317_000398	{memo X}The first Paladin was told many things by the Goddess. {nl}Threats of Gesti, things to abide by, and that a Savior would come.
+QUEST_20150317_000398	{memo X}The first Paladin was told many things by the goddess. {nl}Threats of Gesti, things to abide by, and that a Savior would come.
 QUEST_20150317_000399	{memo X}Anyway, I will go back to battle so please help the guards and my followers. {nl}I'll meet you again in Jade-Filled Cliff.
 QUEST_20150317_000400	$Disciple of the Elderly
 QUEST_20150317_000401	{memo X}Helping reconstruct Fedimian may be more meaningful than pottery. {nl}But people need something to soothe their hearts.
@@ -409,12 +409,12 @@ QUEST_20150317_000408	$Help the herbalists before you get into training. {nl}I n
 QUEST_20150317_000409	$My father told me Klaipeda is also becoming a difficult place to live.
 QUEST_20150317_000410	$There are many people who want to buy things but it's not easy to get what they want. {nl}We have enough food supplies for now but it won't last long.
 QUEST_20150317_000411	$I heard the town men can't make their way back because of the monsters. {nl}We have food but it will run out soon...
-QUEST_20150317_000412	$How will we live if this continues to go on? {nl}Where have all the Goddesses?
+QUEST_20150317_000412	$How will we live if this continues to go on? {nl}Where have all the goddesses gone?
 QUEST_20150317_000413	$It's a good idea to sell the various items you get from killing monsters, {nl}but using them to craft new items isn't such a bad idea either.
 QUEST_20150317_000414	$Although we need to be self-sufficient, things like recipes are better bought from the merchants. {Nl}You need to know how to make it before you actually craft one yourself.
 QUEST_20150317_000415	$Be sure to kill any sparkling monsters you encounter. You might get some great items as trophies. {nl}And what about buying me some drinks for the good information I just gave you?
 QUEST_20150317_000416	$If you have any questions, head over to the Pyromancer Master's Laboratory. {nl}Thankfully, you can read a lot of books there for free.
-QUEST_20150317_000417	{memo X}Each Goddess Statue is known to have different abilities depending on which Goddess it depicts. {nl}Strangely, though that Statue is not of Goddess Vakarine, it can still send you to your desired location.
+QUEST_20150317_000417	{memo X}Each Goddess Statue is known to have different abilities depending on which goddess it depicts. {nl}Strangely, though that Statue is not of Goddess Vakarine, it can still send you to your desired location.
 QUEST_20150317_000418	$Adventurer Varkis' Spirit
 QUEST_20150317_000419	{memo X}If only I had a little more time... {nl}The data I've collected near the Dykyne crossroad... I can't leave it...
 QUEST_20150317_000420	$Now I can leave without any regrets. {nl}Goodbye. Be careful of that man...
@@ -435,7 +435,7 @@ QUEST_20150317_000434	{memo X}Stop!
 QUEST_20150317_000435	{memo X}That's terrible. {nl}You'd be dead before you could be of any help on the battlefield.
 QUEST_20150317_000436	$If I meet the sculptor again, {nl}I'll ask him to decorate it with purple and green feathers!
 QUEST_20150317_000437	$Don't you think it would look great? {nl}Purple and green... Hehe.
-QUEST_20150317_000438	$The sculptor created us. And we received the Goddess' revelation. Yep! He made us. {nl}We follow the sculptor's will to comfort the souls.
+QUEST_20150317_000438	$The sculptor created us. And we received the goddess' revelation. Yep! He made us. {nl}We follow the sculptor's will to comfort the souls.
 QUEST_20150317_000439	$The souls are great. They're like fireflies or beetles. {nl}It's wonderful just watching it. Like where the sculptor is.
 QUEST_20150317_000440	$We can no longer be approve of Sequoia's actions. {nl}We owls will be destroyed if we leave him be. {nl}Who then will lead all the souls?
 QUEST_20150317_000441	$I have been watching the abyssal darkness of this holy forest: things like the hatred and greed of humans.
@@ -450,21 +450,21 @@ QUEST_20150317_000449	$Isn't it cute? {nl}I was nervous when I first saw it, but
 QUEST_20150317_000450	$It's not easy working in the woods, but it's better than the dried and weathered valley. {nl}I heard the wind there is hot. I don't want to go there.
 QUEST_20150317_000451	$We always lack soldiers, but thankfully not eager, young men.
 QUEST_20150317_000452	$Then what's the problem? {nl}We make soldiers, not coffins. {nl}You need strength to join the war, mere passion will just lead to defeat.
-QUEST_20150317_000453	$The Goddess is also indifferent... {nl}I still have a many things I want to do... But I was killed by the monster... {nl}Many others have also died, their belongings scattered around the forest.
+QUEST_20150317_000453	$The goddess is also indifferent... {nl}I still have a many things I want to do... But I was killed by the monster... {nl}Many others have also died, their belongings scattered around the forest.
 QUEST_20150317_000454	$I don't have much memory of when I was alive. {nl}The monsters raided when the Owl Statue was about to guide me and then I was left alone. {nl}I hope there won't be other souls like me any more.
-QUEST_20150317_000455	$You are the chosen one. {nl}Do not forget that. {nl}The revelation is prepared for you. {nl}You need to get the revelation and carry on the will of Goddess.
-QUEST_20150317_000456	$May the blessings of Goddess be with you in your journey.
+QUEST_20150317_000455	$You are the chosen one. {nl}Do not forget that. {nl}The revelation is prepared for you. {nl}You need to get the revelation and carry on the will of goddess.
+QUEST_20150317_000456	$May the blessings of goddess be with you in your journey.
 QUEST_20150317_000457	{memo X}You can get stamina by destroying Tree Root Crystals. {nl}It grows back after you destroy it. Weird, huh?
 QUEST_20150317_000458	{memo X}When the Divine Beast raged in the capital, I was born.
 QUEST_20150317_000459	$We are willing to accept additional requests but... {nl}If something like this were to happen without notice then... Phew...
 QUEST_20150317_000460	$Isn't Vacenin really nice? {nl}I really want to enlist in his unit but I can't find the right opportunity.
 QUEST_20150317_000461	$Well... It is better to meet people when they're alive than dead, you know?
 QUEST_20150317_000462	$I was waiting for the Owl Statue to guide me. {nl}But I saw a strong monster swallow a soul, so I hid. {nl}I barely saved myself but you must kill that monster to save the captured soul.
-QUEST_20150317_000463	$I don't know about the other owls, but I still have hope. {nl}The Goddess will not abandon us. {nl}Looking at the revelations left in the world, I'm sure she has plans for us. {nl}Please gather the scattered revelations.
+QUEST_20150317_000463	$I don't know about the other owls, but I still have hope. {nl}The goddess will not abandon us. {nl}Looking at the revelations left in the world, I'm sure she has plans for us. {nl}Please gather the scattered revelations.
 QUEST_20150317_000464	$Bramble's subordinates are still going wild. {nl}More people will die if this goes on. {nl}Please help the humans fighting against monsters.
-QUEST_20150317_000465	{memo X}Well... Why am I still here? {nl}Maybe it's not yet my time to leave. {nl}No one knows, not the Owl Statue nor other souls. {nl}Unless it was the Goddess who can see the future. No one knows their fate anyway, right?
+QUEST_20150317_000465	{memo X}Well... Why am I still here? {nl}Maybe it's not yet my time to leave. {nl}No one knows, not the Owl Statue nor other souls. {nl}Unless it was the goddess who can see the future. No one knows their fate anyway, right?
 QUEST_20150317_000466	{memo X}Have you not met other Revelators yet?
-QUEST_20150317_000467	{memo X}I don't know much about the Dream of Goddess or the revelation... {nl}But one thing for sure is that there are a lot of people like you.
+QUEST_20150317_000467	{memo X}I don't know much about the Dream of goddess or the revelation... {nl}But one thing for sure is that there are a lot of people like you.
 QUEST_20150317_000468	$I named it Spion. {nl}Why I named it that is... Well... Doesn't it sound cool?
 QUEST_20150317_000469	$That guy who's playing with a furry friend is Pitt, my long time friend. {nl}We've been friends since we were young and emotional. We really wanted to be heroes.
 QUEST_20150317_000470	$And while listening to stories about Vacenin, we just entered the army. {nl}But isn't it cool? One day, I will enter Vacenin's troops and be a hero.
@@ -499,7 +499,7 @@ QUEST_20150317_000498	$Aide de Camp Selina
 QUEST_20150317_000499	$The number of days where squads like us have to stay self-sufficient is growing. {nl}We sometimes joke about plowing a farm for ourselves, {nl}but nowadays we're actually considering it.
 QUEST_20150317_000500	$Beholder
 QUEST_20150317_000501	$If it isn't you, the one who made me release Goddess Saule. {nl}Why are you putting your life on the line?
-QUEST_20150317_000502	$There's no need for all these troubles. {nl}You should follow the others' example and immerse yourself in peace. {nl}And pray that the Goddess will grant you your wishes.
+QUEST_20150317_000502	$There's no need for all these troubles. {nl}You should follow the others' example and immerse yourself in peace. {nl}And pray that the goddess will grant you your wishes.
 QUEST_20150317_000503	$I warned you, but you just wouldn't listen.
 QUEST_20150317_000504	$You shall pay the price for your choice.
 QUEST_20150317_000505	$I have underestimated you.
@@ -516,7 +516,7 @@ QUEST_20150317_000515	$The guardian of the next revelation will be one who unite
 QUEST_20150317_000516	{memo X}The mausoleum is in the valley area. {nl}I will open the portal for you.
 QUEST_20150317_000517	$Trapped Soul of Soldier
 QUEST_20150317_000518	$Please help.
-QUEST_20150317_000519	$Take me to the Goddess.
+QUEST_20150317_000519	$Take me to the goddess.
 QUEST_20150317_000520	$It's so painful
 QUEST_20150317_000521	$It seems to be asleep.
 QUEST_20150317_000522	$Enraged Owl Statue
@@ -536,7 +536,7 @@ QUEST_20150317_000535	{memo X}It seems that the function stopped working.
 QUEST_20150317_000536	{memo X}Yes... this is the best weather to drink some rum in.
 QUEST_20150317_000537	{memo X}I'm the pirate who lost his ship last! {nl}Hmm... I like the sound of that.
 QUEST_20150317_000538	{memo X}Prove your competence to me.
-QUEST_20150317_000539	{memo X}Even if the Goddesses are not around, {nl}the Oracle can still deliver the Goddess' message to people.
+QUEST_20150317_000539	{memo X}Even if the goddesses are not around, {nl}the Oracle can still deliver the goddess' message to people.
 QUEST_20150317_000540	{memo X}Haha, thank you. {nl}Remember, it must be the tree in the central square.
 QUEST_20150317_000541	$Blaster Luina
 QUEST_20150317_000542	$The Hogmas are breaking in through an entrance they found. {nl}We were asked to destroy that entrance to block their invasions.
@@ -552,7 +552,7 @@ QUEST_20150317_000551	$When I was a kid, I heard that the demons were sealed in 
 QUEST_20150317_000552	$I'm not sure if the mine should be operating at a dangerous time like this. {nl}Even if mining is our livelihood, our lives are still more important.
 QUEST_20150317_000553	$I used to be a miner myself. {nl}I didn't see many monsters back then, but I heard it's very different nowadays.
 QUEST_20150317_000554	$They say there are many holy relics hidden in the Tenet Church. {nl}Some of them are said to transport people to a place where no one can go... {nl}Amazing, isn't it?
-QUEST_20150317_000555	{memo X}One day, I will find out. {nl}Even if that entails my meeting the Goddess.
+QUEST_20150317_000555	{memo X}One day, I will find out. {nl}Even if that entails my meeting the goddess.
 QUEST_20150317_000556	{memo X}I don't know what to do if you are like that...
 QUEST_20150317_000557	$Crystal Mine 2F is closed until further notice due to safety reasons. {nl} - Klaipeda Mines Union
 QUEST_20150317_000558	$Business Guide
@@ -579,7 +579,7 @@ QUEST_20150317_000578	$I feel a bit safer here.
 QUEST_20150317_000579	{memo X}That's a relief. {nl}Can you go back to town?
 QUEST_20150317_000580	$Oh, it's a good thing you made it here.
 QUEST_20150317_000581	$I'm so relieved.
-QUEST_20150317_000582	Thank you! Thank you so much! {nl}I'm sure the Goddess sent you to save us!
+QUEST_20150317_000582	Thank you! Thank you so much! {nl}I'm sure the goddess sent you to save us!
 QUEST_20150317_000583	$Thank you.
 QUEST_20150317_000584	{memo X}There is a lot of stuff still missing here. {nl}The monsters probably took it all.
 QUEST_20150317_000585	{memo X}It would seem the other monsters have what remains.
@@ -607,7 +607,7 @@ QUEST_20150317_000606	$The eternal kingdom shines bright. {nl}Zachariel succeede
 QUEST_20150317_000607	$This kingdom is the only one in the land. It does not need a name.
 QUEST_20150317_000608	$The Story of Millenary
 QUEST_20150317_000609	$The Millenary Festival for the Founding of the Kingdom just started.
-QUEST_20150317_000610	$Everyone's drinking honey alcohol, dancing the Goddess Dance of Faith, and laughing their hearts out.
+QUEST_20150317_000610	$Everyone's drinking honey mead, dancing to the goddesses, and laughing their hearts out.
 QUEST_20150317_000611	$Festival Zensho
 QUEST_20150317_000612	$When Zachariel established the Kingdom, he built the capital city around a tree called the Divine Tree.
 QUEST_20150317_000613	$The Emperor, together with priests, blessed this Divine Tree every year.
@@ -641,20 +641,20 @@ QUEST_20150317_000640	$Guardian of Zachariel Mausoleum
 QUEST_20150317_000641	$Aside from the guardians who watch over Zachariel's Mausoleum, {nl}there are stone statues guarding the Mausoleum.
 QUEST_20150317_000642	$Activated with flowing mana, {nl}the guardian statues move as if they were alive. Some can even talk.
 QUEST_20150317_000643	$Maven's Opinion
-QUEST_20150317_000644	$The easiest way to tell Clerics and Wizards apart is to see how they use the grace of the Goddess. {nl}They can turn the grace of the Goddess to different forms.
+QUEST_20150317_000644	$The easiest way to tell Clerics and Wizards apart is to see how they use the grace of the goddess. {nl}They can turn the grace of the goddess to different forms.
 QUEST_20150317_000645	$And that power of changing grace is called mana.
 QUEST_20150317_000646	$Goddess Gabija of Fire
 QUEST_20150317_000647	{memo X}Pyromancers use the blessings of Gabija, the Goddess of Fire, as their main force.
 QUEST_20150317_000648	{memo X}It differs on the type of element, and depends on the grace of Goddess Gabija, {nl}but some elements may ignore oxidation.
 QUEST_20150317_000649	{memo X}For this, you will need great academic standards as well as faith in Goddess Gabija.
 QUEST_20150317_000650	$Will of All Things
-QUEST_20150317_000651	$The base forms of all things are Water, Earth, Wind, and Fire, {nl}and these are controlled by the Goddess.
+QUEST_20150317_000651	$The base forms of all things are Water, Earth, Wind, and Fire, {nl}and these are controlled by the goddess.
 QUEST_20150317_000652	$Elementary Fire Magic
 QUEST_20150317_000653	{memo X}1. Dried environment{nl}2. Something combustible. {nl}3. Enough mana. {nl}4. The blessing of Goddess Gabija.
 QUEST_20150317_000654	$Agailla Flurry's Diary
 QUEST_20150317_000655	$Lord Helgasercle is still going after my tower, {nl}and I can't find a successor to continue my mission.
 QUEST_20150317_000656	$My life feels like that of a waning fire. {nl}Even so, I shall light up the last bit of my life to find one.
-QUEST_20150317_000657	$Because of Helgasercle, a great chaos will come down on this world. {nl}It's a desperate gamble to leave the tower to a Goddess who should be taking care of the world's flame.
+QUEST_20150317_000657	$Because of Helgasercle, a great chaos will come down on this world. {nl}It's a desperate gamble to leave the tower to a goddess who should be taking care of the world's flame.
 QUEST_20150317_000658	$But my mission must not fall under the hands of the demons, {nl}so I am counting on the future Goddess Laima foretold.
 QUEST_20150317_000659	$It was such a long journey. {nl}We'll know whether or not it was the right life or decision when the time comes.
 QUEST_20150317_000660	$The Diary of Jane, the Wizard Apprentice
@@ -662,7 +662,7 @@ QUEST_20150317_000661	$I came to Agailla Flurry's room to pick up cleaning mater
 QUEST_20150317_000662	$The ambiance terrified me, so I hid behind a wall and watched. {nl}Then suddenly, a scary demon rushed in.
 QUEST_20150317_000663	{memo X}Flurry... turned into a handful of ashes by illuminating a great light. {nl}Did that demon do something? {nl}I had no idea, even as a wizard apprentice.
 QUEST_20150317_000664	$The demon somehow disappeared behind the flaming woman... {nl}There was nothing I could do, so I ran away.
-QUEST_20150317_000665	$After a few days, my seniors told me that Gabija would be the new owner of the tower. {nl}When the Goddesses disappeared from the world, I was told to keep quiet.
+QUEST_20150317_000665	$After a few days, my seniors told me that Gabija would be the new owner of the tower. {nl}When the goddesses disappeared from the world, I was told to keep quiet.
 QUEST_20150317_000666	$Are things really going to be okay? {nl}Well... those people were never wrong about anything before so I guess it will be.
 QUEST_20150317_000667	$Chronomancer Ron
 QUEST_20150317_000668	$Archmage Agailla Flurry, owner of the Mage Tower, {nl}made many contributions to magic.
@@ -671,12 +671,12 @@ QUEST_20150317_000670	$The most prominent example of which was Chronomancy - tim
 QUEST_20150317_000671	$There were many others in the past who lived longer than you might expect, {nl}but Agailla Flurry is the first to have lived a long life by her own design.
 QUEST_20150317_000672	$The Pedigree of Magic
 QUEST_20150317_000673	$Magic, at the beginning, began from the investigation of mana {nl}and the review of basic elements.
-QUEST_20150317_000674	$After that, the basic senses, religious belief of the Goddesses, {nl}and mathematical approaches were mixed to find areas for expansion.
+QUEST_20150317_000674	$After that, the basic senses, religious belief of the goddesses, {nl}and mathematical approaches were mixed to find areas for expansion.
 QUEST_20150317_000675	$The research twisted previous notions of time and space, {nl}which were beyond the changes of the body, {nl}and the rules of physics and the elements progressed significantly.
 QUEST_20150317_000676	$The Report of the High Barrier Magic
 QUEST_20150317_000677	$The barrier in this tower could not have possibly been created by the Demon Lord alone.
 QUEST_20150317_000678	$It acts like a tight-knit net. {nl}Someone with a normal level of divine power cannot escape from it.
-QUEST_20150317_000679	$For what reason was this barrier created?{nl}Is it related to the fact that the Goddess who controls the flames of this world is staying here?
+QUEST_20150317_000679	$For what reason was this barrier created?{nl}Is it related to the fact that the goddess who controls the flames of this world is staying here?
 QUEST_20150317_000680	$Agailla Flurry called Gabija to this tower, so this barrier is not meant to lock Gabija in. {nl}To find out the reason for this, we first have to understand the composition of the barrier.
 QUEST_20150317_000681	$After a long investigation, we've found that this barrier was {nl}was not only created with the power of Helgasercle, but rather blended with mana of different wavelengths.
 QUEST_20150317_000682	$We've also found that mana was composed by aligning the foundation stones in a certain position.
@@ -684,7 +684,7 @@ QUEST_20150317_000683	$We were able to retrieve some of those foundation stones 
 QUEST_20150317_000684	$The mana provided to use barrier magic wasn't voluntary. {nl}We theorize that the levels of the Demon Lords were divided and sealed into the foundation stones and aligned into a position.
 QUEST_20150317_000685	$The key to unlock this barrier is in the foundation. {nl}We'll continue to search for the answer after we block Helgasercle's invasion.
 QUEST_20150317_000686	$The Understanding of Mana
-QUEST_20150317_000687	$Unlike priests who control the blessing of the Goddess directly, {nl}the wizard is defined as a person who releases various magic information or the blessing of the Goddess.
+QUEST_20150317_000687	$Unlike priests who control the blessing of the goddess directly, {nl}the wizard is defined as a person who releases various magic information or the blessing of the goddess.
 QUEST_20150317_000688	$Okay so, what is mana? {nl}We can say the true quality of mana is the life force on this land. {nl}The life force of nature. It doesn't just imply the length of lives.
 QUEST_20150317_000689	$The life force is a form of energy that composes this world and it spreads like branches to various places in the world. {nl}If you could find the source of that energy, you may obtain astonishing power.
 QUEST_20150317_000690	$The Diary of Antares' Investigation
@@ -699,7 +699,7 @@ QUEST_20150317_000698	{memo X}I hope Fedimian is restored to its previous state 
 QUEST_20150317_000699	$Girl's Clay Tablet
 QUEST_20150317_000700	$I hope you find your lost brother at the Goddess' Ancient Garden.
 QUEST_20150317_000701	$Commander Willis' Clay Tablet
-QUEST_20150317_000702	$I pray to the Goddess that I can continue my work as an administration officer in the city. {nl}I don't like work as a dispatched worker.
+QUEST_20150317_000702	$I pray to the goddess that I can continue my work as an administration officer in the city. {nl}I don't like work as a dispatched worker.
 QUEST_20150317_000703	$Klaipeda Farmer's Clay Tablet
 QUEST_20150317_000704	$I want to take back my farm and experience the challenge of potato farming again.
 QUEST_20150317_000705	$Soldier's Clay Tablet
@@ -708,7 +708,7 @@ QUEST_20150317_000707	$I hope we can recapture Kateen Forest. {nl}I hope we neve
 QUEST_20150317_000708	$Ranger Master's Clay Tablet
 QUEST_20150317_000709	{memo X}I don't like Fiona and wonder why she's the Hunter Master. {nl}But, if we need her to defeat Evoniphon, I'm fine with allying with her.
 QUEST_20150317_000710	$Coben's Clay Tablet
-QUEST_20150317_000711	$I pray to the Goddess that I find my lost brother again. {nl}We could open another bar and spend all day there listening to his heroic stories.
+QUEST_20150317_000711	$I pray to the goddess that I find my lost brother again. {nl}We could open another bar and spend all day there listening to his heroic stories.
 QUEST_20150317_000712	$Kevin's Clay Tablet
 QUEST_20150317_000713	{memo X}I hope I can make it big out of the excavation site of Zachariel's royal tomb...
 QUEST_20150317_000714	$Uska's Clay Tablet
@@ -716,14 +716,14 @@ QUEST_20150317_000715	$Goddess. {nl}As the commander that leads the knights, I h
 QUEST_20150317_000716	$Wizard Master's Clay Tablet
 QUEST_20150317_000717	$I will become a Wizard Master some day. {nl}And then I will become a great wizard like Agailla Flurry.
 QUEST_20150317_000718	$Clay Tablet with a wish in it
-QUEST_20150317_000719	$It is all due to the blessing of the Goddess that we {nl}were able to avoid Medzio Diena in Andale Village. {nl}I hope our village is happy and flourishes from now on.
+QUEST_20150317_000719	$It is all due to the blessing of the goddess that we {nl}were able to avoid Medzio Diena in Andale Village. {nl}I hope our village is happy and flourishes from now on.
 QUEST_20150317_000720	$Titas' Clay Tablet
-QUEST_20150317_000721	$I hope the Revelators I've met find the Goddesses. {nl}I don't understand why I couldn't become a Revelator myself though.
+QUEST_20150317_000721	$I hope the Revelators I've met find the goddesses. {nl}I don't understand why I couldn't become a Revelator myself though.
 QUEST_20150317_000722	$Paladin Master's Clay Tablet
-QUEST_20150317_000723	{memo X}I beg to the Goddess. {nl}I hope the day where the Watchers collect my pledge never comes...
+QUEST_20150317_000723	{memo X}I beg to the goddess. {nl}I hope the day where the Watchers collect my pledge never comes...
 QUEST_20150317_000724	$Cyrenia Odell's Clay Tablet
 QUEST_20150317_000725	$I hope I can solve the secret of the Royal Mausoleum of Zachariel.
-QUEST_20150317_000726	$While I am dispatched, I pray to the Goddess that I never get cursed by petrification.
+QUEST_20150317_000726	$While I am dispatched, I pray to the goddess that I never get cursed by petrification.
 QUEST_20150317_000727	$Pilgrim's Clay Tablet
 QUEST_20150317_000728	$I am going to the Great Cathedral to pledge my marriage with him. {nl}I hope the Pilgrim Path is safe.
 QUEST_20150317_000729	$Wizard's Clay Tablet
@@ -737,7 +737,7 @@ QUEST_20150317_000736	$I hope Sequoia protects the owl well.
 QUEST_20150317_000737	$Tesla's Third Fragment
 QUEST_20150317_000738	{memo X}When I die, I hope my disciples will stand by me.
 QUEST_20150317_000739	$Tesla's Fourth Fragment
-QUEST_20150317_000740	$Maven. He was such a good friend. I hope he rests in peace beside the Goddess...
+QUEST_20150317_000740	$Maven. He was such a good friend. I hope he rests in peace beside the goddess...
 QUEST_20150317_000741	$Maven's Fragment
 QUEST_20150317_000742	$I hope my disciples wish for a great dream without any problems.
 QUEST_20150317_000743	$Ruklys' Fragment
@@ -751,7 +751,7 @@ QUEST_20150317_000750	$I don't care about wishes. I will strive for myself.
 QUEST_20150317_000751	$King Kadumel's Fragment
 QUEST_20150317_000752	$Kalezimas. How sweet the word is!
 QUEST_20150317_000753	$Rimgaudas's Fragment
-QUEST_20150317_000754	$My work will be done once the Tenet Church is completed. {nl}May the Goddess guide us until the end.
+QUEST_20150317_000754	$My work will be done once the Tenet Church is completed. {nl}May the goddess guide us until the end.
 QUEST_20150317_000755	$Lucid Winterspoon's Fragment
 QUEST_20150317_000756	$May my plan be successful and earn me the title of Chronomancer Master.
 QUEST_20150317_000757	$Encyclopedia of Masters Chapter 1
@@ -788,7 +788,7 @@ QUEST_20150317_000787	$Young men nowadays are so restless. {nl}They try to do ev
 QUEST_20150317_000788	$Whether it be making weapons, making potions, or even cooking, they try to do it while standing. {nl}You must calm yourself and sit in a comfortable position.
 QUEST_20150317_000789	$Sit down and prepare all the tools and materials you need. {nl}Remember that creation comes after preparations.
 QUEST_20150317_000790	$Goddess Austeja
-QUEST_20150317_000791	{memo X}Thank you again in the name of the Goddess. {nl}Now I will follow the stars in search of Goddess Ausrine.
+QUEST_20150317_000791	{memo X}Thank you again in the name of the goddess. {nl}Now I will follow the stars in search of Goddess Ausrine.
 QUEST_20150317_000792	$It may be better for me to just guard the seal. {nl}But I believe finding all my lost sisters will be the solution to all of this.
 QUEST_20150317_000793	$I wish you well... {nl}And may you and this land be blessed. 
 QUEST_20150317_000794	{memo X}Right. I think so too. {nl}The monsters are definitely preying on our honey. {nl}But it is better to have evidence on hand, so bring a piece of beehive {nl}from Saltus Bee Farm.
@@ -801,9 +801,9 @@ QUEST_20150317_000800	$Please save them and the Spring Light Woods.
 QUEST_20150317_000801	{memo X}Investigation Unit
 QUEST_20150317_000802	{memo X}Why have so many more monsters appeared?
 QUEST_20150317_000803	{memo X}The monsters have ruined the entire harvest.
-QUEST_20150317_000804	$As you may already know, our kingdom has five major Goddesses and other Goddesses who assist them. {nl}But nobody knows where all of them are now.
+QUEST_20150317_000804	$As you may already know, our kingdom has five major goddesses and other goddesses who assist them. {nl}But nobody knows where all of them are now.
 QUEST_20150317_000805	$Flower Shop Lady
-QUEST_20150317_000806	$People don't buy flowers anymore. {nl}The only flowers they buy are the ones to offer for the Goddesses' return. {nl}It's really depressing in many ways.
+QUEST_20150317_000806	$People don't buy flowers anymore. {nl}The only flowers they buy are the ones to offer for the goddesses' return. {nl}It's really depressing in many ways.
 QUEST_20150317_000807	$I hope Klaipeda becomes lively like it used to be... {nl}With the fragrance of flowers in the air and people dancing in spring to worship Goddess Zemyna, {nl}the Goddess of the Earth...
 QUEST_20150317_000808	$Warning
 QUEST_20150317_000809	$Beware of Leaf Bugs! They are different from Beetles. {nl}It is hard to fight them when they come in flocks so be careful. 
@@ -812,8 +812,8 @@ QUEST_20150317_000811	$Please worship the Goddess Statue with a pious mind. You 
 QUEST_20150317_000812	$The Statue of Goddess Zemyna lies at the end of this road.
 QUEST_20150317_000813	$Warning! Hanaming-infested area. {nl}Do not be fooled by their cute appearance. {nl}They attack in groups and...{nl}(Red marks are covering the rest.)
 QUEST_20150317_000814	$Caution! What happens to you beyond this point is your responsibility! {nl}Golems are rumored to appear in this area. Do not go any further.
-QUEST_20150317_000815	$P.S. It is better to run away than to pray to the Goddess when you encounter Golems.
-QUEST_20150317_000816	$The Goddesses have disappeared. {nl}But if we fight bravely against the demons, perhaps the Goddesses will return someday. {nl} - Laimonas
+QUEST_20150317_000815	$P.S. It is better to run away than to pray to the goddess when you encounter Golems.
+QUEST_20150317_000816	$The goddesses have disappeared. {nl}But if we fight bravely against the demons, perhaps the goddesses will return someday. {nl} - Laimonas
 QUEST_20150317_000817	$Attention to those who come to Klaipeda after having a dream about the revelation. {nl}Knight Commander Uska is waiting for you in the Central Plaza.
 QUEST_20150317_000818	$Welcome to Klaipeda Shopping Center. {nl}You can shop for a variety of accessories, tools, equipment, and other items.
 QUEST_20150317_000819	$Use the stairs on the right to go to the Klaipeda Central Plaza.
@@ -825,8 +825,8 @@ QUEST_20150317_000824	$Good job. {nl}I have done my task. {nl}It is my time now.
 QUEST_20150317_000825	$Go forward. {nl}The Sculptor is waiting for you. {nl}I was glad to have guided you.
 QUEST_20150317_000826	$Ah...
 QUEST_20150317_000827	$Danger! The vacant lot below these crossroads {nl}has regularly seen dangerous monsters. Entrance is forbidden! {nl} - The Fedimian Market
-QUEST_20150317_000828	$People are now praying less and less to the Goddesses. {nl}They're losing hope...
-QUEST_20150317_000829	$How could I have forgotten you... {nl}Please do not roam around this cursed land {nl}and go to the arms of the Goddess.
+QUEST_20150317_000828	$People are now praying less and less to the goddesses. {nl}They're losing hope...
+QUEST_20150317_000829	$How could I have forgotten you... {nl}Please do not roam around this cursed land {nl}and go to the arms of the goddess.
 QUEST_20150317_000830	$Holiday Notice
 QUEST_20150317_000831	$I have been enlisted to the army to save the kingdom. {nl}Therefore, the restaurant will be closed in the meantime. {nl} - Owner of Klaipeda's Specialty Restaurant, Vulinya
 QUEST_20150317_000832	$Don't blow out the candles. {nl}They guide the souls so they don't lose their way.
@@ -856,14 +856,14 @@ QUEST_20150317_000855	{memo X}...Only after three years since Ruklys learned fro
 QUEST_20150317_000856	$...two years after the war, my first disciple ended up dead...
 QUEST_20150317_000857	$...year after Lydia Schaffen left the Great Cathedral...
 QUEST_20150317_000858	$...One of the three disciples, Agailla Flurry...
-QUEST_20150317_000859	$It has been an old tradition of this town to make pots with wishes inside and offer it to the Goddess. {nl}Wouldn't this disaster end when the Goddess returns?
+QUEST_20150317_000859	$It has been an old tradition of this town to make pots with wishes inside and offer it to the goddess. {nl}Wouldn't this disaster end when the goddess returns?
 QUEST_20150317_000860	$The writing on the platform as I recall went like this... {nl}Remember the holy number with your two eyes. {nl}The light of the candles drives away the evil dark.
 QUEST_20150317_000861	$Remember the number written on the candle holder. {nl}And light that many candles to solve it.
 QUEST_20150317_000862	$The relics have fallen into the demon hands because of my weakness. {nl}But they shouldn't have reached Naktis yet.
 QUEST_20150317_000863	{memo X}The other relics and keys are also in danger, so you better move quickly.
 QUEST_20150317_000864	$Writings on the Altar
-QUEST_20150317_000865	$Everlasting Goddess. {nl}May we praise your infinite mercy.
-QUEST_20150317_000866	$Life withers and the soul has nowhere to go. {nl}Only the Goddess can save us.
+QUEST_20150317_000865	$Everlasting goddess. {nl}May we praise your infinite mercy.
+QUEST_20150317_000866	$Life withers and the soul has nowhere to go. {nl}Only the goddess can save us.
 QUEST_20150317_000867	{memo X}I have sent the bishop there.
 QUEST_20150317_000868	{memo X}Monsters! Run!
 QUEST_20150317_000869	$Maven's Device
@@ -885,10 +885,10 @@ QUEST_20150317_000884	$It is now up to the humans to fulfill that prophecy. {nl}
 QUEST_20150317_000885	$I plan to leave the end of this story in the next revelation. {nl}Find my revelation in the Mage Tower.
 QUEST_20150317_000886	$Laima
 QUEST_20150317_000887	$There are still more keys left to find. {nl}It's a relief that they are all secretly guarded by Maven's plan.
-QUEST_20150317_000888	{memo X}What once housed the Goddesses is now filled with demons. {nl}Maven, the first bishop, would be very sad about this.
+QUEST_20150317_000888	{memo X}What once housed the goddesses is now filled with demons. {nl}Maven, the first bishop, would be very sad about this.
 QUEST_20150317_000889	$Insert the Relics that match each altar. {nl}Then you will be able to get Maven's first key.
 QUEST_20150317_000890	$First, prepare. {nl}The Wood Goblins will be attacking soon.
-QUEST_20150317_000891	{memo X}The Cathedral used to be where we worshipped the Goddess. {nl}Now it's turned to a nest of demons...
+QUEST_20150317_000891	{memo X}The Cathedral used to be where we worshipped the goddess. {nl}Now it's turned to a nest of demons...
 QUEST_20150317_000892	{memo X}It's the key. Go to the Veiniky Altar. {nl}Maven's device can be found there.
 QUEST_20150317_000893	{memo X}Naktis' subordinates have become disoriented.
 QUEST_20150317_000894	{memo X}I presume this is the key that releases the device at the Veiniky Altar.
@@ -964,7 +964,7 @@ QUEST_20150317_000963	$The main industry of Siauliai is mining, and its specialt
 QUEST_20150317_000964	$Currently only the 1st Mine Lot is being worked on, but the mines used to have two lots.
 QUEST_20150317_000965	$But the 2nd Mine Lot was closed by the declaration of the bishop to seal away demons. {nl}The alchemist also resides in the village for this reason.
 QUEST_20150317_000966	$Summa Theologica
-QUEST_20150317_000967	$Everything about the Statue of Goddess Vakarine is beautiful, {nl}but its most beautiful part is the fact that its special powers {nl}can be used to take you to the world of the Goddesses.
+QUEST_20150317_000967	$Everything about the Statue of Goddess Vakarine is beautiful, {nl}but its most beautiful part is the fact that its special powers {nl}can be used to take you to the world of the goddesses.
 QUEST_20150317_000968	$Legend of Cunningham
 QUEST_20150317_000969	$It is a story old enough to be lost from all memory.
 QUEST_20150317_000970	$During his compulsory labor in the mines, Cunningham met a strange girl that was around seven years old. {nl}The girl kept speaking of a great danger, but knew little about it herself.
@@ -978,10 +978,10 @@ QUEST_20150317_000977	$The men of that family had a weird sickness. {nl}Their sk
 QUEST_20150317_000978	$The skin cracked like the surface of dry earth, with blood and pus flowing out. {nl}They were in pain for a very long time and were unable to sleep. {nl}They were constantly in a state of nervous breakdown.
 QUEST_20150317_000979	$Kingdom Travelogue
 QUEST_20150317_000980	{memo X}Rhombuspaving Dale is a masterpiece of the Goddess of Wonder and Nature. {nl}The lime stairs encompassing the southern land is filled with spring water and glows fantastically.
-QUEST_20150317_000981	$The color of the spring is sometimes sapphire and other times, jade green. {nl}Looking at their profound and mysterious colors makes you wonder if this is the work of the Goddess.
+QUEST_20150317_000981	$The color of the spring is sometimes sapphire and other times, jade green. {nl}Looking at their profound and mysterious colors makes you wonder if this is the work of the goddess.
 QUEST_20150317_000982	$My Confession
-QUEST_20150317_000983	{memo X}The many deaths of demons could not fill the emptiness in my heart. {nl}Once the Goddess' great mission for me is over, I will be left with a long life full of boring moments.
-QUEST_20150317_000984	$In that case, I shall try to interpret the Goddess' revelation for the rest of my remaining life. {nl}If that goes against her will, the Goddess should punish me right away.
+QUEST_20150317_000983	{memo X}The many deaths of demons could not fill the emptiness in my heart. {nl}Once the goddess' great mission for me is over, I will be left with a long life full of boring moments.
+QUEST_20150317_000984	$In that case, I shall try to interpret the goddess' revelation for the rest of my remaining life. {nl}If that goes against her will, the goddess should punish me right away.
 QUEST_20150317_000985	$But it will give me the chance to look back at my life. {nl}And in the long run, it could help a Revelator who shows up in the future.
 QUEST_20150317_000986	$Reading Desk
 QUEST_20150317_000987	$There are some books on the shelves below the reading desk. {nl}Which book shall we read?
@@ -1085,7 +1085,7 @@ QUEST_20150317_001084	Thanks to this behavior, the people of Fedimian fared bett
 QUEST_20150317_001085	Because of this, no few words are said about the cautiousness of the Fedimian people.
 QUEST_20150317_001086	At Fedimian, if someone dropped money on the ground, it will be gone forever. In a world where money is mostly silver coin, only the creditors would know exactly how much money has been lost in this manner.
 QUEST_20150317_001087	Why money disappears into the ground at Fedimian remains unknown. {nl}Some people believe the Goddess Zemyna absorbs money that makes contact with her area. {nl}But most commoners believe this was done to reduce the demand of silver coins from creditors.
-QUEST_20150317_001088	By believing that the Goddess herself takes the silver, the people found it fruitless trying to dig up silver on her grounds. {nl}The fact that you can offer silver coin at Fedimian as tribute to her reinforces this idea.
+QUEST_20150317_001088	By believing that the goddess herself takes the silver, the people found it fruitless trying to dig up silver on her grounds. {nl}The fact that you can offer silver coin at Fedimian as tribute to her reinforces this idea.
 QUEST_20150317_001089	In any case, the fact that one could lose money by dropping it on Fedimian soil has made Fedimians very careful in handling their money.
 QUEST_20150317_001090	However, as much as one tries to be careful, mistakes still happen. {nl}More so with the case of young girls. {nl}One day, it happened to a girl named Aiste.
 QUEST_20150317_001091	Normally, when one drops silver coins on the ground, it would scatter about on the road, and then disappear without a trace. {nl}Fedimians usually curse their own carelessness and move on, but Aiste was different: she wondered why and how it happens.
@@ -1105,17 +1105,17 @@ QUEST_20150317_001104	It is for this reason that he lives on the outskirts of Fe
 QUEST_20150317_001105	{memo X}The silversmith, after hearing Aiste's story, stated, {nl}'Even for children it is foolish to be so careless. How could you not know that all money that falls on Fedimian soil disappears, never to be found again?'
 QUEST_20150317_001106	{memo X}Aiste was surprised by what the silversmith said and grew sad. {nl}After a while she asked, {nl}'Then why is it that such a cruel thing happens?'
 QUEST_20150317_001107	{memo X}Even the silversmith did not know the true answer, so he improvised, {nl}'The Goddess Zemyna must be taking them.'
-QUEST_20150317_001108	{memo X}Hearing those words, Aiste replied, {nl}'Then I will just have to go ask the Goddess.' {nl}The silversmith was astounded and replied, {nl}'While you're at it, why don't you ask the Goddess to return my silverware?'
+QUEST_20150317_001108	{memo X}Hearing those words, Aiste replied, {nl}'Then I will just have to go ask the Goddess.' {nl}The silversmith was astounded and replied, {nl}'While you're at it, why don't you ask the goddess to return my silverware?'
 QUEST_20150317_001109	The silversmith did not take to heart his own words, but Aiste did. {nl}She immediately set out to do what was said. The silversmith felt sorry for Aiste, {nl}but did not have the courage to call her back as she faded into the distance.
-QUEST_20150317_001110	{memo X}An exhausted Aiste soon arrived at Zemyna's Goddess Statue. {Nl}She prostrated herself before it and prayed to the Goddess Statue represented, her head completely down. {nl}'Oh, Goddess. Please return my lost silver coins.' {nl}Soon, while offering her prayers, Aiste could no longer hold in her sadness and she finally wept.
+QUEST_20150317_001110	{memo X}An exhausted Aiste soon arrived at Zemyna's Goddess Statue. {Nl}She prostrated herself before it and prayed to the Goddess Statue represented, her head completely down. {nl}'Oh, goddess. Please return my lost silver coins.' {nl}Soon, while offering her prayers, Aiste could no longer hold in her sadness and she finally wept.
 QUEST_20150317_001111	{memo X}How long did she pray crying? {nl}Suddenly, Aiste heard a voice addressed to her. {nl}'My child, have come to take back what you have lost?'
 QUEST_20150317_001112	Aiste knew in her heart that it was the Goddess Zemyna that was addressing her. {nl}She stopped crying, cleared her voice and replied so.
 QUEST_20150317_001113	{memo X}The Goddess' voice was heard again. {nl}'Aiste, what your asking from me is not in a method I approve of. Where I reign there is no harvest nor fruits to those who do not work.'
 QUEST_20150317_001114	{memo X}'But I worked very hard today!'
 QUEST_20150317_001115	{memo X}'I know. So instead, I will give you and the others a chance. Look under your feet.'
-QUEST_20150317_001116	The Goddess's voice faded with those words, and Aiste found silver coins under her feet. {nl}She looked to where she had left her coins and found that the tears she shed had transformed into coins.{nl}Aiste was very happy, and made sure to pick up all the silver before leaving.
+QUEST_20150317_001116	The goddess's voice faded with those words, and Aiste found silver coins under her feet. {nl}She looked to where she had left her coins and found that the tears she shed had transformed into coins.{nl}Aiste was very happy, and made sure to pick up all the silver before leaving.
 QUEST_20150317_001117	{memo X}After a number of steps, Aiste thought about the silversmith, {nl}and, again, went to his house and knocked on his door. {nl}As if the silversmith was waiting for her return, he opened the door immediately and said. {nl}'I'm sorry. I regret sending you away like that. I'll give you some silver. {nl}This time, be careful not to drop any and get home safely.'
-QUEST_20150317_001118	{memo X}As the silversmith held out his silver coins, Aiste shook her head and said,{nl}'No thank you, the Goddess returned all my coins. On top of that she gave me even more. {nl}I remembered you saying you had also lost silver, so I came to give you my extra coins. You don't need to give me yours.'
+QUEST_20150317_001118	{memo X}As the silversmith held out his silver coins, Aiste shook her head and said,{nl}'No thank you, the goddess returned all my coins. On top of that she gave me even more. {nl}I remembered you saying you had also lost silver, so I came to give you my extra coins. You don't need to give me yours.'
 QUEST_20150317_001119	{memo X}At first, the silversmith was skeptical about the coins being returned, {nl}so he was surprised when Aiste showed him genuine coins. After thinking for a while, the silversmith said, {nl}'Then how about this. You give me what you want while you accept what I was about to give you. {nl}Isn't that fair? On top of that I'll give you a pouch to carry your extra silver.'
 QUEST_20150317_001120	Aiste obliged and gave her extra coins to the silversmith. {nl}After this, the silversmith gave Aiste a bag of coins.
 QUEST_20150317_001121	{memo X}After leaving the silversmith's house, {nl}Aiste suddenly remembered that the old beggar must still be looking for her lost coins and worried about him. {nl}On her way to the beggar, she met the orchard owner again. {nl}Upon seeing Aiste, the orchard owner was overjoyed. {nl}'I was looking for you. I'm sorry for sending you off earlier. As an apology, I'll give you your salary again. {nl}Please be careful not to lose it this time.'
@@ -1128,14 +1128,14 @@ QUEST_20150317_001127	{memo X}After that, Aiste also held out her bag and said, 
 QUEST_20150317_001128	The beggar looked towards Aiste's distant shadow, and opened the present she gave him, {nl}curious to what was inside. Inside, he was surprised to find dozens of silver coins. {nl}Now he understood why Aiste was able to depart much more quickly than she arrived - she had lightened her load by giving him the excess.
 QUEST_20150317_001129	For a beggar who had been stingy over a single silver coin, the fact Aiste could simply give away several tens of times that amount moved him. {nl}The fact that Aiste, who had went off and solved the mystery of Fedimian, came back and gave him what she really didn't owe, made the beggar thankful.
 QUEST_20150317_001130	The more he thought, the less the beggar was able to hold back his tears. {nl}As he cried, he noticed something odd - every shining teardrop that touched the ground transformed to silver coins.
-QUEST_20150317_001131	The beggar could not believe his eyes, but quickly remembered Aiste words about a blessing from the Goddess. {nl}After a while, the beggar stopped crying, and went to pick up the coins and put them in the bag Aiste gave him.
-QUEST_20150317_001132	A few days later, the beggar went to the statue that Aiste prayed to. There, he took out one coin from the bag to keep, and offered the rest to the Goddess Statue. {nl}He then prayed to the Goddess whole-heartedly and left. As the money he offered disappeared, the beggar again to shed tears, but that's another story.
+QUEST_20150317_001131	The beggar could not believe his eyes, but quickly remembered Aiste words about a blessing from the goddess. {nl}After a while, the beggar stopped crying, and went to pick up the coins and put them in the bag Aiste gave him.
+QUEST_20150317_001132	A few days later, the beggar went to the statue that Aiste prayed to. There, he took out one coin from the bag to keep, and offered the rest to the Goddess Statue. {nl}He then prayed to the goddess whole-heartedly and left. As the money he offered disappeared, the beggar again to shed tears, but that's another story.
 QUEST_20150317_001133	After a few days, an odd rumor spread across Fedimian. {nl}The rumor claimed that silver no longer disappeared into Fedimian soil. {nl}The rumor did not sit well at first with older, experienced people, but some tested the rumor with a paltry amount of silver, {nl}and it turned out to be true. Everyone agreed that finally, the mysterious phenomenon of Fedimian has come to an end.
 QUEST_20150317_001134	After some time, word of this occurrence reached the king. Curious as to why this happened, the king ordered an investigation. {nl}The hidden truth was brought to light, and Aiste's story was known.
-QUEST_20150317_001135	The king praised the people that caused the miracle with their charitable hearts. {nl}Additionally, to honor the grace of the Goddess, he decided to spend the national treasury to build a large statue dedicated to her.
+QUEST_20150317_001135	The king praised the people that caused the miracle with their charitable hearts. {nl}Additionally, to honor the grace of the goddess, he decided to spend the national treasury to build a large statue dedicated to her.
 QUEST_20150317_001136	On the day the statue was finally completed, {nl}something miraculous happened as the King and Aiste went together to make the first offering. {nl}From the circumference of the statue sprouted coins - all the silver coins that had been lost by Fedimians up until that time.
 QUEST_20150317_001137	After heated debate, the Fedimian people decided to not to hoard their lost silver coins. {nl}Instead, they asked the king to collect all the coins and distribute them among the poor of the Kingdom. {nl}The king readily agreed, and gave the order to record this beautiful event into the history of the Kingdom.
-QUEST_20150317_001138	Even now, nobody knows when and how the mysterious phenomenon of Fedimian started, {nl}but everybody knows when, how, and who helped unravel the mystery. {nl}It was through the kindness of Aiste and the people who helped her, as well as through the grace of the Goddess, that the mystery came to an end.
+QUEST_20150317_001138	Even now, nobody knows when and how the mysterious phenomenon of Fedimian started, {nl}but everybody knows when, how, and who helped unravel the mystery. {nl}It was through the kindness of Aiste and the people who helped her, as well as through the grace of the goddess, that the mystery came to an end.
 QUEST_20150317_001139	The Gambler of Klaipeda
 QUEST_20150317_001140	{memo X}The Gambler of Klaipeda {nl}~A Short Story~
 QUEST_20150317_001141	In the town of Klaipeda, there once lived a man by the name of Modestas. {nl}He was a good, honest man - but had one major flaw that his friends and family all worried about, his wife especially so. {nl}Modestas was not lazy nor very clever nor not too foolish. {nl}He did not drink or repeatedly get into fights. {nl}The man had one flaw, and it was that he loved to gamble.
@@ -1169,17 +1169,17 @@ QUEST_20150317_001168	For Modestas, who had always been elated upon winning bets
 QUEST_20150317_001169	Knowing he had just deceived his long-time gambling friend, Sigfried, and also missed an opportunity to earn a lot of money, Modestas felt conflicted, and walked slowly alongside the horse he had just won. {nl} While walking, Modestas remembered the earlier warnings of his unconditional bet results. He realized that now, with his upcoming defeat, he is doomed to not earn any more silver than he started with.
 QUEST_20150317_001170	While walking along the road, Modestas encountered a group of soldiers. {nl} Upon looking closer, the soldiers seemed to be arguing about what to buy at a store. {nl} Modestas decided not to interfere and pass them, but the soldiers noticed him and called. {nl}
 QUEST_20150317_001171	{memo X}'You, the young man with the horse, can you come over and help us for a bit?' {nl} Modestas had no idea what these soldiers needed help for, but since he could no longer ignore them, he decided to head over. {nl} Once Modestas arrived, one of the soldiers said, {nl} 'You came at just the right time. We would like you to referee a small gamble we're about to make here.' {nl}
-QUEST_20150317_001172	Modestas was surprised when he heard the word, 'bet', but was relieved to know he was only being asked to referee. After all, nothing could possibly happen if he was just refereeing. {nl} Modestas learned that the soldiers were fighting over which Goddess was the best. {nl}
-QUEST_20150317_001173	{memo X}What started as a small banter turned into a big argument, which finally grew to become a big money bet. The soldiers had already gathered their money and only had to decide the winner. Unfortunately, every Goddess got equal votes and a winner couldn't be decided.{nl} Thus, the soldiers decided to settle the bet by calling the first person who passed by, asking him who he thought the best Goddess is, and deciding the winner from there. The soldiers agreed that the first passer-by would symbolize the will of whatever Goddess he supported. {nl}
-QUEST_20150317_001174	The soldiers did not tell Modestas who voted for which Goddess, for fear of his decision being affected by the expressions of each individual soldier. {nl} The soldiers did tell him however, how much they have each wagered. Just by seeing the gold nuggets, he could easily figure that there was a large amount of money in this bet. {nl}
-QUEST_20150317_001175	{memo X}Since a big jackpot was on the line, the soldiers waited with bated breath for Modestas' answer. {nl}Knowing there was no right answer to the question, Modestas simply said aloud the name of his own favorite Goddess. {nl} When he did, the soldiers reacted strangely. {nl} There was supposed to be an ecstatic winner and disappointed losers, but nobody seemed joyful nor disappointed. Instead, everyone had a bewildered look on their faces. {nl}
-QUEST_20150317_001176	{memo X}Modestas, perplexed by their reaction, asked for an explanation to which one of the soldiers answered, {nl}'We originally had votes for four Goddesses but your choice isn't any of them, so now we have five Goddesses.' {nl}The soldiers then resumed their squabble about how to decide the winner. {nl}
+QUEST_20150317_001172	Modestas was surprised when he heard the word, 'bet', but was relieved to know he was only being asked to referee. After all, nothing could possibly happen if he was just refereeing. {nl} Modestas learned that the soldiers were fighting over which goddess was the best. {nl}
+QUEST_20150317_001173	{memo X}What started as a small banter turned into a big argument, which finally grew to become a big money bet. The soldiers had already gathered their money and only had to decide the winner. Unfortunately, every goddess got equal votes and a winner couldn't be decided.{nl} Thus, the soldiers decided to settle the bet by calling the first person who passed by, asking him who he thought the best goddess is, and deciding the winner from there. The soldiers agreed that the first passer-by would symbolize the will of whatever goddess he supported. {nl}
+QUEST_20150317_001174	The soldiers did not tell Modestas who voted for which goddess, for fear of his decision being affected by the expressions of each individual soldier. {nl} The soldiers did tell him however, how much they have each wagered. Just by seeing the gold nuggets, he could easily figure that there was a large amount of money in this bet. {nl}
+QUEST_20150317_001175	{memo X}Since a big jackpot was on the line, the soldiers waited with bated breath for Modestas' answer. {nl}Knowing there was no right answer to the question, Modestas simply said aloud the name of his own favorite goddess. {nl} When he did, the soldiers reacted strangely. {nl} There was supposed to be an ecstatic winner and disappointed losers, but nobody seemed joyful nor disappointed. Instead, everyone had a bewildered look on their faces. {nl}
+QUEST_20150317_001176	{memo X}Modestas, perplexed by their reaction, asked for an explanation to which one of the soldiers answered, {nl}'We originally had votes for four goddesses but your choice isn't any of them, so now we have five goddesses.' {nl}The soldiers then resumed their squabble about how to decide the winner. {nl}
 QUEST_20150317_001177	{memo X}The mood began to deteriorate so Modestas wanted to leave. {nl}When he was about to take off, the soldiers blocked his path and accused him. {nl}'It's your fault the argument heated up even more. You're not thinking of just leaving are you?'{nl}Intimidated by the irritated soldiers, Modestas dared not to escape. {nl}
 QUEST_20150317_001178	In Modestas' mind, he concluded that the quarrelling soldiers didn't have him referee, but simply added him into the bet. In reality however, he had no real claim, so he wasn't in the bet just yet. {nl}
 QUEST_20150317_001179	{memo X}Knowing Modestas, he could not simply sit on the sidelines watching a big bet grow. Eventually, he became enticed to join. Modestas, caught in the heat of the moment and ending up participating, finally remembered it was his turn to lose.{nl}But it was too late.{nl}
 QUEST_20150317_001180	In addition, because the other soldiers had already bet deeply, Modestas had to bet the only gold bullion he had. {nl}
-QUEST_20150317_001181	{memo X}If you think about it, even if it was his turn to lose, all it took for him to lose was one more vote for any of the Goddesses he didn't choose. With the odds of the next person walking by supporting his Goddess being against him, the probability of winning was low anyway.{nl} {nl} However, the victor was chosen unexpectedly. An officer found the soldiers slacking, disciplined them and was about to lead them away. {nl}The soldiers, obeying the superior's command, were about to march off when they shrewdly asked him which Goddess he favored. {nl}
-QUEST_20150317_001182	The officer inadvertently said the name of a Goddess, and some of the soldiers began cheering. {nl} The officer, not knowing what's going on, simply ordered his soldiers to move on. In any case, Modestas certainly lost. {nl}
+QUEST_20150317_001181	{memo X}If you think about it, even if it was his turn to lose, all it took for him to lose was one more vote for any of the goddesses he didn't choose. With the odds of the next person walking by supporting his goddess being against him, the probability of winning was low anyway.{nl} {nl} However, the victor was chosen unexpectedly. An officer found the soldiers slacking, disciplined them and was about to lead them away. {nl}The soldiers, obeying the superior's command, were about to march off when they shrewdly asked him which goddess he favored. {nl}
+QUEST_20150317_001182	The officer inadvertently said the name of a goddess, and some of the soldiers began cheering. {nl} The officer, not knowing what's going on, simply ordered his soldiers to move on. In any case, Modestas certainly lost. {nl}
 QUEST_20150317_001183	Having now lost the gold bullion given to him by the strange old woman, Modestas was now at a loss. {nl} To originally intend to referee, only to end up losing all the gold he had, and knowing exactly the reason why, Modestas felt heartbroken, dumbfounded, yet understanding. A unique feeling. {nl}
 QUEST_20150317_001184	Although Modestas had just lost money by entering a bet started by others, it was the first time he's done so in his life. Modestas spent some time thinking of how to better his situation and {nl} suddenly got an idea, knowing he was certain to win his next bet. {nl}
 QUEST_20150317_001185	If he could call back the soldiers from earlier and bet his horse, he could certainly earn his gold back and possibly more. {nl} Knowing this, Modestas got on his horse, and sped in the direction the soldiers left towards. {nl} {nl} With speed, Modestas soon spotted a stationary wagon. Modestas lowered his speed to check out the wagon parked on the side of the road. {nl}
@@ -1221,17 +1221,17 @@ QUEST_20150317_001221	The officer and solders had sturdy rope, so they were able
 QUEST_20150317_001222	To Modestas, a promise was a promise, so he immediately handed over the gold the soldiers returned to him to the Alchemist. {nl} The Alchemist, surprised by how Modestas could do this with no complaints or dissatisfaction, took the gold and conversed with him.
 QUEST_20150317_001223	Not wanting to be left out of the conversation between Modestas and the Alchemist, the soldiers couldn't continue working, joined in, and learned about the Alchemist's past with Modestas. {nl} The Alchemist apologized to Modestas for turning his lead into gold, and promised to gather all the support he could for Modestas at Klaipeda. He then left. {nl}
 QUEST_20150317_001224	Soon after, Modestas and the soldiers reached Klaipeda. They set the stone down at the large open space at the center of town. {nl}
-QUEST_20150317_001225	{memo X}When the boulder was set in its proper place with the help of the soldiers, the Alchemist who had left returned with another person. The Alchemist had brought with him a famous Dievdirbys.{nl}To the Dievdirbys, the Alchemist suggested, {nl}'Why don't you sculpt a statue of a Goddess using this boulder, on this central site of Klaipeda? If this boulder is changed into a statue of a Goddess, then nobody in Klaipeda will be able to deny its significance. I think that will fulfill your promise to the old woman.'{nl}
+QUEST_20150317_001225	{memo X}When the boulder was set in its proper place with the help of the soldiers, the Alchemist who had left returned with another person. The Alchemist had brought with him a famous Dievdirbys.{nl}To the Dievdirbys, the Alchemist suggested, {nl}'Why don't you sculpt a statue of a goddess using this boulder, on this central site of Klaipeda? If this boulder is changed into a statue of a goddess, then nobody in Klaipeda will be able to deny its significance. I think that will fulfill your promise to the old woman.'{nl}
 QUEST_20150317_001226	Everyone who were there on the spot favored the idea. {nl} The Alchemist took the gold he obtained from Modestas and paid it to the Dievdirbys as commission, and went to get permission from the Knight Leader and Bishop of Klaipeda.{nl}
-QUEST_20150317_001227	As news spread, everyone in Klaipeda was pleased to know a Goddess Statue was planned for their city. {nl} However, one last problem remained aside from winning their favor. And that question was, which Goddess should the statue commemorate? {nl} The soldiers who gave help transporting the boulder were especially passionate about this issue, and began quarrelling again. {nl}
-QUEST_20150317_001228	The one who answered this question was none other than Modestas. {nl} Without any real intent, Modestas argued that the Goddesses in power have guided him via divine providence to build a statue at Klaipeda that day. {nl}
-QUEST_20150317_001229	{memo X}That the old woman appeared before him, that the many bets occurred, that the mountain erupted a stone for material was the divine providence of the Goddesses, argued Modestas, persuading everyone. {nl} Thus, the people decided to follow the words of Modestas, and Modestas relayed to the Dievdirbys the order to create the statue. {nl} When the statue was finally finished, the citizens of Klaipeda gathered, curious to know the identity of the Goddess who had been raised in the center of their beloved city.{nl}
-QUEST_20150317_001230	However, to their bewilderment, not a single soul could recognize the Goddess whom the completed statue commemorated.{nl}
+QUEST_20150317_001227	As news spread, everyone in Klaipeda was pleased to know a Goddess Statue was planned for their city. {nl} However, one last problem remained aside from winning their favor. And that question was, which goddess should the statue commemorate? {nl} The soldiers who gave help transporting the boulder were especially passionate about this issue, and began quarrelling again. {nl}
+QUEST_20150317_001228	The one who answered this question was none other than Modestas. {nl} Without any real intent, Modestas argued that the goddesses in power have guided him via divine providence to build a statue at Klaipeda that day. {nl}
+QUEST_20150317_001229	{memo X}That the old woman appeared before him, that the many bets occurred, that the mountain erupted a stone for material was the divine providence of the goddesses, argued Modestas, persuading everyone. {nl} Thus, the people decided to follow the words of Modestas, and Modestas relayed to the Dievdirbys the order to create the statue. {nl} When the statue was finally finished, the citizens of Klaipeda gathered, curious to know the identity of the goddess who had been raised in the center of their beloved city.{nl}
+QUEST_20150317_001230	However, to their bewilderment, not a single soul could recognize the goddess whom the completed statue commemorated.{nl}
 QUEST_20150317_001231	{memo X}The Dievdirbys who had sculpted the statue had already vanished deep into the Kateen Forest, so the citizens of Klaipeda repeatedly questioned Modestas for her name. {nl} Despite the numerous questions nobody received an answer from Modestas. {nl}At any rate, this is the story of how the Goddess Statue of Klaipeda came to be. Even now that statue stands in the center of Klaipeda.{nl}
-QUEST_20150317_001232	And so, some people believed Modestas, having undertaken the Goddesses' intervention, was an honest man who did not gamble. In reality, Modestas didn't stop making gambles until his death. {nl}
-QUEST_20150317_001233	{memo X}Since that time, whenever Modestas took on a wager, he always bet the same thing. The answer to the question of who the Statue of Klaipeda honored.{nl}To uncover the name of the Goddess, numerous people challenged Modestas to a bet.{nl} {nl} But no matter the impossible odds, Modestas never lost a bet. Therefore nobody was able to win the answer from Modestas for years and time flew by.{nl}
-QUEST_20150317_001234	Though Modestas died an undefeated, invincible gambler, by then he had never bet anything other than the Goddess' identity, living purely off the profits gained from such bets through the end of his life. {nl}
-QUEST_20150317_001235	{memo X}In the end, this unknown Goddess, in exchange for giving income to a certain gambler from Klaipeda, created an interesting, mysterious, yet beautiful statue for the city of Klaipeda, and a tale to last for times to come.{nl} {nl}
+QUEST_20150317_001232	And so, some people believed Modestas, having undertaken the goddesses' intervention, was an honest man who did not gamble. In reality, Modestas didn't stop making gambles until his death. {nl}
+QUEST_20150317_001233	{memo X}Since that time, whenever Modestas took on a wager, he always bet the same thing. The answer to the question of who the Statue of Klaipeda honored.{nl}To uncover the name of the goddess, numerous people challenged Modestas to a bet.{nl} {nl} But no matter the impossible odds, Modestas never lost a bet. Therefore nobody was able to win the answer from Modestas for years and time flew by.{nl}
+QUEST_20150317_001234	Though Modestas died an undefeated, invincible gambler, by then he had never bet anything other than the goddess' identity, living purely off the profits gained from such bets through the end of his life. {nl}
+QUEST_20150317_001235	{memo X}In the end, this unknown goddess, in exchange for giving income to a certain gambler from Klaipeda, created an interesting, mysterious, yet beautiful statue for the city of Klaipeda, and a tale to last for times to come.{nl} {nl}
 QUEST_20150317_001236	$Talk To Knight Titas
 QUEST_20150317_001237	$Talk to the Scout
 QUEST_20150317_001238	$Road to Klaipeda
@@ -1429,10 +1429,10 @@ QUEST_20150323_001429	{memo X}Please be sure to find the scripture! {nl}One of t
 QUEST_20150323_001430	All pilgrims should offer different amounts.
 QUEST_20150323_001431	This is not a reasonable amount.
 QUEST_20150323_001432	Worship the Goddess Statue to receive blessings or move on to another area.
-QUEST_20150323_001433	$What a nasty curse. {nl}Let's see which is stronger. Naktis' curse or the Goddess' purifier.
+QUEST_20150323_001433	$What a nasty curse. {nl}Let's see which is stronger. Naktis' curse or the goddess' purifier.
 QUEST_20150323_001434	$Of course I have the purifier. {nl}But I'm not giving it to you unless you offer me money.
 QUEST_20150323_001435	{memo X}It could be the one who stole the gypsum carving of the Goddess Statue, so get rid of the monsters there. {nl}If my hunch is right, then Naktis must be behind it. {nl} It might be far away, but I just heard that.
-QUEST_20150323_001436	{memo X}Naktis is looking for a clue to enter the Cathedral. {nl}If I'm right, not only has the Forest of Prayer been affected, but all of the Pilgrim Path. {nl}Revelator, if you reach the Cathedral, please defeat Naktis. {nl}You must stop the Goddess' revelation from falling into demon hands.
+QUEST_20150323_001436	{memo X}Naktis is looking for a clue to enter the Cathedral. {nl}If I'm right, not only has the Forest of Prayer been affected, but all of the Pilgrim Path. {nl}Revelator, if you reach the Cathedral, please defeat Naktis. {nl}You must stop the goddess' revelation from falling into demon hands.
 QUEST_20150323_001437	This place is dying. {nl}All the Tree Root Crystals have mutated.
 QUEST_20150323_001438	Some Tree Root Crystals are useless unless burned. {nl}Some even fume at the core.
 QUEST_20150323_001439	We must do whatever it takes to turn it back but... {nl}It's all so tiring now...
@@ -1450,7 +1450,7 @@ QUEST_20150323_001450	I can hear snickering somewhere. {nl}It could be the sound
 QUEST_20150323_001451	The trapped spirit gave you a scripture and disappeared.
 QUEST_20150323_001452	You endured Witas' curse thanks to the medicine.
 QUEST_20150323_001453	{memo X}If you ever see the Devout Tree, please bring it back to life. {nl}I've heard that tree can block the power of the curse.
-QUEST_20150323_001454	I believe that the evil will eventually fall and the Goddess will be victorious. {nl}The mark of victory is right in front of me.
+QUEST_20150323_001454	I believe that the evil will eventually fall and the goddess will be victorious. {nl}The mark of victory is right in front of me.
 QUEST_20150323_001455	Anyway, I will go to the battlefield first, so please help the Watchers and my followers. {nl}I will see you at Nefritas Cliff.
 QUEST_20150323_001456	This isn't over yet. {nl}I'll be watching you from Kvailas Forest.
 QUEST_20150323_001457	Catacomb 1st Floor internal warp
@@ -1468,15 +1468,15 @@ QUEST_20150323_001468	They warn against the five deadly sins of mankind. {nl}Pil
 QUEST_20150323_001469	The Starving Demon's Way is for Gluttony. {nl}Throw away your obsession for food and start your pilgrimage with reverence. 
 QUEST_20150323_001470	The Pilgrim Path is for Sloth. {nl}You mustn't be indolent during the long journey to Cathedral.
 QUEST_20150323_001471	The Altar Way is for Wrath. {nl}Excessive rage impoverishes the soul.
-QUEST_20150323_001472	The Forest of Prayer is for Deceit. {nl}You cannot reach the Goddess with a deceitful heart.
+QUEST_20150323_001472	The Forest of Prayer is for Deceit. {nl}You cannot reach the goddess with a deceitful heart.
 QUEST_20150323_001473	The Apsimesti Crossroads is for Envy. {nl}Compose yourself so that you won't fall into bewilderment.
 QUEST_20150323_001474	Tree of Faith
-QUEST_20150323_001475	The Tree of Faith. {nl}Like the power of the Goddess, its branches block evil curses. 
+QUEST_20150323_001475	The Tree of Faith. {nl}Like the power of the goddess, its branches block evil curses. 
 QUEST_20150323_001476	Pilgrims who pass by this road, {nl}If ever the pond is corrupted, pour sap from the Tree of Brothers.
 QUEST_20150323_001477	Tree of Brothers Notice
-QUEST_20150323_001478	First Tree of the Brothers. {nl}Guard the Tree of Faith with the name of the Goddess.
-QUEST_20150323_001479	Second Tree of the Brothers. {nl}Purify the evil force with the power of the Goddess.
-QUEST_20150323_001480	Third Tree of the Brothers. {nl}Live a full life with the grace of the Goddess.
+QUEST_20150323_001478	First Tree of the Brothers. {nl}Guard the Tree of Faith with the name of the goddess.
+QUEST_20150323_001479	Second Tree of the Brothers. {nl}Purify the evil force with the power of the goddess.
+QUEST_20150323_001480	Third Tree of the Brothers. {nl}Live a full life with the grace of the goddess.
 QUEST_20150323_001481	{memo X}Spoiled already? Here, take this.
 QUEST_20150323_001482	Magic circle is shaking.
 QUEST_20150323_001483	Baron Allerno
@@ -1587,7 +1587,7 @@ QUEST_20150323_001587	{memo X}Guards are working hard to protect the farm. {nl}H
 QUEST_20150323_001588	{memo X}$I thank you again in the name of fate. {nl}From here on, I will follow the stars to find Goddess Ausrine.
 QUEST_20150323_001589	$Thanks to you, the seal of Uskis Arable Land is now stable. {nl}However, many other Revelators have lost their consciousness to the evil energy at the Spring Light Woods.
 QUEST_20150323_001590	$This most glorious Great Cathedral was built 660 years ago under the guide of Archbishop Silvestro Maven.
-QUEST_20150323_001591	$I can still hear it. {nl}The priests' prayers filling the kingdom. {nl}The endless march of pilgrims coming for the grace of the Goddess.
+QUEST_20150323_001591	$I can still hear it. {nl}The priests' prayers filling the kingdom. {nl}The endless march of pilgrims coming for the grace of the goddess.
 QUEST_20150323_001592	$It was like that until four years ago. {nl}Before the curse surrounded the Great Cathedral on Medzio Diena...
 QUEST_20150323_001593	Candlestick
 QUEST_20150323_001594	No candlesticks are lit. 
@@ -1600,21 +1600,21 @@ QUEST_20150323_001600	Bishop Ilam
 QUEST_20150323_001601	{memo X}$Bishop Aurelius, who was ordained at a young age, soon took ill and lost his life.
 QUEST_20150323_001602	{memo X}$His last request was for the Divine Mission for Maven to be fulfilled even after his death and the Church accepted.
 QUEST_20150323_001603	Nature of the Curse
-QUEST_20150323_001604	$Gluttony, Wrath, Sloth, etc. {nl}The nature of all curses that affect mankind is obsession. {nl}It's like the spirit of the dead staying behind and not going to the Goddess. 
+QUEST_20150323_001604	$Gluttony, Wrath, Sloth, etc. {nl}The nature of all curses that affect mankind is obsession. {nl}It's like the spirit of the dead staying behind and not going to the goddess. 
 QUEST_20150323_001605	$The difference is that it is the will of the dead that keeps the spirit behind {nl}while curses are forced upon by others onto you.
-QUEST_20150323_001606	$Naturally, priests learning the teachings of the Goddess are not permitted to use it unless it's for experiments.
+QUEST_20150323_001606	$Naturally, priests learning the teachings of the goddess are not permitted to use it unless it's for experiments.
 QUEST_20150323_001607	My Mission 1
 QUEST_20150323_001608	$Even if the Revelator gets the revelation in his hands, {nl}it's useless if it can't be protected.
 QUEST_20150323_001609	$The purpose of my secret is not only to protect the revelation from evil but also to prevent the greed of weak Revelators.
 QUEST_20150323_001610	$May you wander in the everlasting fog of the unknown if you recklessly approach without realizing my intentions.
 QUEST_20150323_001611	My Mission 2
 QUEST_20150323_001612	$Those who challenge the Holy Mission won't just try to gently unravel the secret. {nl}Because of that, I had to plan many secrets and take measures against such barbaric actions.
-QUEST_20150323_001613	$To obey my secret. {nl}That is the only way to earn the legacy of the Goddess.
+QUEST_20150323_001613	$To obey my secret. {nl}That is the only way to earn the legacy of the goddess.
 QUEST_20150323_001614	$Sign Commemorating the Completion of the Cathedral
-QUEST_20150323_001615	$The Goddess of this land shall build a church. {nl}The forces of evil can never invade this sanctuary. {nl} - Est. Year 434, Silvestro Maven
+QUEST_20150323_001615	$The goddess of this land shall build a church. {nl}The forces of evil can never invade this sanctuary. {nl} - Est. Year 434, Silvestro Maven
 QUEST_20150323_001616	$Memo Someone Left Behind
 QUEST_20150323_001617	$The highest steeple of the church also fell on Medzio Diena. {nl}The grief and sorrow of the evacuation march was indescribable.
-QUEST_20150323_001618	$On the day we prayed to the Goddess that we would return, everyone cried tears of outrage. {nl}Our church will never succumb to the evil curse.
+QUEST_20150323_001618	$On the day we prayed to the goddess that we would return, everyone cried tears of outrage. {nl}Our church will never succumb to the evil curse.
 QUEST_20150323_001619	$(There are many books left on the shelf. Which one shall we read?)
 QUEST_20150323_001620	Dusty Book
 QUEST_20150323_001621	$(There is a dusty book with a memo on the chair. Which one shall we read?)
@@ -1627,9 +1627,9 @@ QUEST_20150323_001627	$Of course, you'll need to use the transformation scroll b
 QUEST_20150323_001628	$The secret supposedly unveils upon application of a holy force, {nl}but the trap will activate regardless if it detects an evil force.
 QUEST_20150323_001629	$The plan is to get the key after exhausting that trap using Naktis' subordinates.
 QUEST_20150323_001630	$Naktis' subordinates will be punished for prying on Maven's secret. {nl}Use that opportunity to get the key.
-QUEST_20150323_001631	$Even if the Goddess condemns me for this... I will hold my head high,{nl} because it was for the protection of the revelation.
+QUEST_20150323_001631	$Even if the goddess condemns me for this... I will hold my head high,{nl} because it was for the protection of the revelation.
 QUEST_20150323_001632	$Did you find the last key?
-QUEST_20150323_001633	$This sanctuary is a treasure house of knowledge. {nl}You need to master the fundamentals of everything to protect the kingdom and revelation in the name of the Goddess. 
+QUEST_20150323_001633	$This sanctuary is a treasure house of knowledge. {nl}You need to master the fundamentals of everything to protect the kingdom and revelation in the name of the goddess. 
 QUEST_20150323_001634	$Studying the demons is no exception.
 QUEST_20150323_001635	$The Monarch of Curses, Naktis... {nl}He has not shown himself yet but I'm sure he's somewhere inside the sanctuary.
 QUEST_20150323_001636	$Perhaps he's waiting for us to get all the keys.
@@ -1673,8 +1673,8 @@ QUEST_20150323_001673	{memo X}It's a task of getting rid of the Lauzinutes acros
 QUEST_20150323_001674	{memo X}$Good. My men need to defend this area. {nl}It was spotted in the upper area. I'll mark the map for you. {nl}You might have to go through some underground tunnels. 
 QUEST_20150323_001675	Underground Tunnel
 QUEST_20150323_001676	(I can't seem to go the opposite way.)
-QUEST_20150323_001677	$Is Vietos Gorge a masterpiece of the Goddess or a marvel of nature? {nl}The limestone stairway in the southern area is shining with spring water and looks fantastic.
-QUEST_20150323_001678	{memo X}$You shouldn't trust anyone here. Not the Goddess and not even yourself.
+QUEST_20150323_001677	$Is Vietos Gorge a masterpiece of the goddess or a marvel of nature? {nl}The limestone stairway in the southern area is shining with spring water and looks fantastic.
+QUEST_20150323_001678	{memo X}$You shouldn't trust anyone here. Not the goddess and not even yourself.
 QUEST_20150323_001679	{memo X}$Hauberk, the Goddess has no intentions of fighting against you. {nl}Cease your hostility.
 QUEST_20150323_001680	$Valtrus...
 QUEST_20150323_001681	Go back there!
@@ -1821,7 +1821,7 @@ QUEST_20150414_001824	{memo X}$Someone's Memo
 QUEST_20150414_001825	{memo X}$This place is insane. {nl}The only way to get rid of this cursed Tree Root Crystal is to burn the place down. {nl}It should all be burned.
 QUEST_20150414_001826	$The Baron's greed had him send his men into this area. {nl}None of them made it back.
 QUEST_20150414_001827	$I watched everything through the eyes of this wizard. {nl}Even the screams of Vakarine and her Kupoles. 
-QUEST_20150414_001828	$That depends on whether or not you have the will to save the Goddess. {nl}We can take time later to talk about it. 
+QUEST_20150414_001828	$That depends on whether or not you have the will to save the goddess. {nl}We can take time later to talk about it. 
 QUEST_20150414_001829	$Isn't there a more effective way to block the monsters?
 QUEST_20150414_001830	$Freshly cultivating the farm isn't easy though at least there are less monsters than before.
 QUEST_20150414_001831	{memo X}$They were once gentle monsters that suddenly grew vicious. {nl}Have you heard of anything else like that? 
@@ -1839,7 +1839,7 @@ QUEST_20150414_001842	$It's a bit dubious, a monster hiding in a dead end like t
 QUEST_20150414_001843	Crops from here will be brought to Klaipeda. {nl}I heard the farm has been corrupted with an evil energy.
 QUEST_20150414_001844	$The farm's cultivation just started so I'm the only one who received farmland. {nl}I wonder when they'll cultivate the whole area like this. 
 QUEST_20150414_001845	$You defeated the Gorgon? {nl}Wow, Revelators must be some sort of superhuman.
-QUEST_20150414_001846	$One wrong move and we could've been wiped out. {nl}It feels like the Goddess has returned and is keeping us safe. 
+QUEST_20150414_001846	$One wrong move and we could've been wiped out. {nl}It feels like the goddess has returned and is keeping us safe. 
 QUEST_20150414_001847	I could have fought more but my colleagues ran away. {nl}I can take those monsters anytime...
 QUEST_20150414_001848	Next time, I'll fight at the front line. {nl}I'm sure I can take it down. 
 QUEST_20150414_001849	$It would have been dangerous if you weren't around. {nl}Such a big monster near Klaipeda...
@@ -1850,10 +1850,10 @@ QUEST_20150414_001853	$I saw your fight as I ran away and it was spectacular. {n
 QUEST_20150414_001854	$I really envy you. {nl}I could be a good soldier too if I had your abilities. 
 QUEST_20150414_001855	I feel sick... Ugh...
 QUEST_20150414_001856	I still feel sick but it's getting better. {nl}Thank you very much. 
-QUEST_20150414_001857	$You brought the medicine for us? {nl}Thank you. The Goddess will surely bless you. 
+QUEST_20150414_001857	$You brought the medicine for us? {nl}Thank you. The goddess will surely bless you. 
 QUEST_20150414_001858	Hm... Is the antidote ready yet...?
 QUEST_20150414_001859	Save me...
-QUEST_20150414_001860	$If it weren't for you, I'd be meeting the Goddess right now. {nl}Thank you very much.
+QUEST_20150414_001860	$If it weren't for you, I'd be meeting the goddess right now. {nl}Thank you very much.
 QUEST_20150414_001861	$I lost consciousness on something weird that I then knew was poison. {nl}That pain... I don't ever want to think about it again. 
 QUEST_20150414_001862	Help... I feel like dying...
 QUEST_20150414_001863	$Thank you for saving us. {nl}I was sure we were dead.
@@ -1862,10 +1862,10 @@ QUEST_20150414_001865	$My stomach's burning...
 QUEST_20150414_001866	{memo X}$Go back. {nl}Humans shouldn't enter this place.
 QUEST_20150414_001867	{memo X}$We cannot protect you. Go back.
 QUEST_20150414_001868	{memo X}$Nuaele's subordinates are all gone. {nl}Go find Aladona. She'll take you to Nuaele's territory. 
-QUEST_20150414_001869	{memo X}$Aside from the corruption breach, our biggest problem was Nuaele. {nl}Now we can focus on the corruption breach. {nl}Go to Prison District 3. The Goddess awaits your support.
+QUEST_20150414_001869	{memo X}$Aside from the corruption breach, our biggest problem was Nuaele. {nl}Now we can focus on the corruption breach. {nl}Go to Prison District 3. The goddess awaits your support.
 QUEST_20150414_001870	$Be prepared. We are establishing a new base.
 QUEST_20150414_001871	$We will make a home here, a world where both demons and humans meet.
-QUEST_20150414_001872	$We shall break the wings of the Goddess and destroy all the barriers.
+QUEST_20150414_001872	$We shall break the wings of the goddess and destroy all the barriers.
 QUEST_20150414_001873	$Let us expand our forces starting from here.
 QUEST_20150414_001874	$This will be our land.
 QUEST_20150414_001875	$Come find me if you have anything to ask.
@@ -1877,13 +1877,13 @@ QUEST_20150414_001880	$If the grapes keep turning out this way, I'm leaving Shat
 QUEST_20150414_001881	$I thought the poison would burn my body. {nl}Thank you very much for saving me.
 QUEST_20150414_001882	Warehouse Keeper Rita
 QUEST_20150414_001883	$Welcome! {nl}How can I help you?
-QUEST_20150414_001884	$You shouldn't trust anyone here. Not the Goddess and not even yourself.
-QUEST_20150414_001885	$Demon Lord Hauberk, the Goddess does not wish to fight you. {nl}Cease your hostile actions at once.
+QUEST_20150414_001884	$You shouldn't trust anyone here. Not the goddess and not even yourself.
+QUEST_20150414_001885	$Demon Lord Hauberk, the goddess does not wish to fight you. {nl}Cease your hostile actions at once.
 QUEST_20150414_001886	$Prepare to make the Key of the Night Star. {nl}Hurry, we don't have much time. I'll be sending the Revelator soon.
 QUEST_20150414_001887	My soul is mine, only mine!
 QUEST_20150414_001888	{memo X}$I was able to gather my soul thanks to you. {nl}But this... Isn't this the reverting chain that shredded my soul?
 QUEST_20150414_001889	$Right. Now I understand... {nl}The plan was to close the dimensional crack with the power of my soul?
-QUEST_20150414_001890	$Give me the power, Revelator. {nl}It is power that only the Goddess should take care of.
+QUEST_20150414_001890	$Give me the power, Revelator. {nl}It is power that only the goddess should take care of.
 QUEST_20150414_001891	$Receptionist Brandon
 QUEST_20150428_001892	The information to share with you is not getting gathered.
 QUEST_20150428_001893	{memo X}$It's better to use the cable car than heading straight into the monsters.
@@ -1895,7 +1895,7 @@ QUEST_20150428_001898	Torn Letter
 QUEST_20150428_001899	Ripped Diary
 QUEST_20150428_001900	Last Record
 QUEST_20150428_001901	$Abandoned Diary
-QUEST_20150428_001902	$The Goddess left many things to the first Paladin: {nl}The threat of the Demon Queen, Gesti, and the mission to protect. {nl}She also mentioned that the Savior would come.
+QUEST_20150428_001902	$The goddess left many things to the first Paladin: {nl}The threat of the Demon Queen, Gesti, and the mission to protect. {nl}She also mentioned that the Savior would come.
 QUEST_20150428_001903	{memo X}$The royal tomb that was mentioned in the revelation is located too far away from you. {nl}I'll open the portal for you.
 QUEST_20150428_001904	$You can feel the fading existence around.
 QUEST_20150428_001905	$Beings that were once invisible are starting to appear...
@@ -1919,7 +1919,7 @@ QUEST_20150428_001922	{memo X}$How stingy. I'll have to be stingy as well then.
 QUEST_20150428_001923	Blackened Clue
 QUEST_20150428_001924	{memo X}$This place is insane. {nl}The only way to get rid of this cursed Tree Root Crystal is to burn the place down. {nl}It should all be burned.
 QUEST_20150428_001925	$The Diary that was Written in Anger
-QUEST_20150428_001926	{memo X}$I'll never forgive the monsters that killed my family. {nl}Though my body returns to the ground, my soul still burns with anger. {nl}Oh, Goddess. Only the cold blood of the monsters can cool my rage.
+QUEST_20150428_001926	{memo X}$I'll never forgive the monsters that killed my family. {nl}Though my body returns to the ground, my soul still burns with anger. {nl}Oh, goddess. Only the cold blood of the monsters can cool my rage.
 QUEST_20150428_001927	Wrinkled Letter
 QUEST_20150428_001928	$Maven's teaching is ruined by the curse. {nl}Sinful Naktis. May the curse come upon you as well!
 QUEST_20150428_001929	{memo X}$Savior, {nl}I shall show you the great will that you've been left.
@@ -1946,8 +1946,8 @@ QUEST_20150428_001949	$As the wind sways, as the leaves fall down. {nl}If fallin
 QUEST_20150428_001950	$He rests here after fighting against the herd of evil with the first Paladin.
 QUEST_20150428_001951	$Born as a son of a Watcher. Completed the construction of the Tenet Church. He rests here.
 QUEST_20150428_001952	$Mother, please don't cry. {nl}I am finally free of the curse.
-QUEST_20150428_001953	$Finally, you sleep like you are at your mother's house. {nl}You don't have to worry about the pain any more. {nl}You don't have to wait for the salvation from the Goddess.
-QUEST_20150428_001954	$In the touch of the Goddess. Beside the mother. {nl}Sleeping. Having a sleep. {nl}Me, who is not beside, getting lean and hardened like a winter tree.
+QUEST_20150428_001953	$Finally, you sleep like you are at your mother's house. {nl}You don't have to worry about the pain any more. {nl}You don't have to wait for the salvation from the goddess.
+QUEST_20150428_001954	$In the touch of the goddess. Beside the mother. {nl}Sleeping. Having a sleep. {nl}Me, who is not beside, getting lean and hardened like a winter tree.
 QUEST_20150428_001955	$The sons of the Watchers rest here.
 QUEST_20150428_001956	$The Grass of King Zachariel
 QUEST_20150428_001957	$The king told those who engraved the letters and the symbols onto the hard woods {nl}to abstain from sin, but they lost their memories as the king ordered. {nl}I did it because I was afraid that the demons and the people with malicious intent may steal my artifacts. {nl}However, I don't want to repeat that for my people.
@@ -1978,19 +1978,19 @@ QUEST_20150428_001981	{memo X}$Help the druids that were dispatched to the farm 
 QUEST_20150428_001982	{memo X}$Dina Bee Farm is in danger of monster attacks. {nl}They can't even work so they desperately need help.
 QUEST_20150511_001983	$It's better to use the cable car than to fight through the monsters.
 QUEST_20150511_001984	$Just don't believe everything he says. {nl}He was known for being quite the show-off back at home.
-QUEST_20150511_001985	$It would be nice if all these Revelators being here meant that the Goddesses are back.
+QUEST_20150511_001985	$It would be nice if all these Revelators being here meant that the goddesses are back.
 QUEST_20150511_001986	$Strength is the most important stat for swordsmen. {nl}You could also train yourself to be agile and possess strong stamina. {nl}You should take a moment to decide on what to prioritize from now on.
 QUEST_20150511_001987	$Strength is the most important stat for archers. {nl}But, of course you can't ignore agile movement. {nl}You should take a moment to decide on what to prioritize from now on.
 QUEST_20150511_001988	$Intelligence is the most important stat for clerics. {nl}But sometimes you may need more strength or a stronger spirit. {nl}You should take a moment to decide what to prioritize from now on.
 QUEST_20150511_001989	$Helping reconstruct Fedimian may be more meaningful than pottery. {nl}But people need something to soothe their hearts.
 QUEST_20150511_001990	$If I had the journal, I could continue my adventure, but I wasn't chosen... {nl}But for you things might be different...
-QUEST_20150511_001991	{memo X}$If you cleverly use the dry air that forms around areas of severe cold, you'd be able to freeze any object even in a desert. {nl}However, if you can't receive the blessing from the Goddess, it won't be possible to make that kind of air.
+QUEST_20150511_001991	{memo X}$If you cleverly use the dry air that forms around areas of severe cold, you'd be able to freeze any object even in a desert. {nl}However, if you can't receive the blessing from the goddess, it won't be possible to make that kind of air.
 QUEST_20150511_001992	$I'll report the damages. {nl}Chasing a Sparnas, a gigantic bird-type creature, will be hard. Despite being large, they are rather agile. {nl}It usually goes after the supplies, but I can't imagine nor find out why. I'm guessing someone's playing a trick.
 QUEST_20150511_001993	$Grain pocket was discovered in the ashes of the supplies. {nl}They smell so bad and old they can't be used for food at all. {nl}Please check the supplies for anything missing.
 QUEST_20150511_001994	$Defeat all the monsters nearby. {nl}The vicious energy in the thorn forest is constantly creating new monsters. {nl}But you should first defeat most of them before you face Ironbaum. {nl}Even a small factor could ruin the big task. {nl}Also, you could try threatening the monsters so they can't do what they want to do.
 QUEST_20150511_001995	$(Everything is scribbled so poorly that they can't be distinguished from letters or drawings.)
 QUEST_20150511_001996	$The facility that belonged to the workers who worked on the Mausoleum of Zachariel suddenly shut down. {nl}It's not like they left because finishing it was hopeless, but they just vanished all at once. {nl}Maybe it is related to the irregularly big size of the tomb and its complicated composition {nl}even after considering the fact that it was the grave to commemorate the greatest king in history.
-QUEST_20150511_001997	$King Zachariel had made many arrangements for future generations. {nl}We and the Jonas family were one of them. {nl}But the meaning of the arrangements is only known by the Goddess. {nl}At least we know that the will of the king that we are protecting and the secret of the tomb indicates one person.
+QUEST_20150511_001997	$King Zachariel had made many arrangements for future generations. {nl}We and the Jonas family were one of them. {nl}But the meaning of the arrangements is only known by the goddess. {nl}At least we know that the will of the king that we are protecting and the secret of the tomb indicates one person.
 QUEST_20150511_001998	$Trees become bigger as years pass. {nl}There are only Woodmen here but when you think of the large trees or the trees that stand in the old capital city... {nl}You can't help but think of the existence of even larger trees. {nl}After the disaster occurred, many plants turned into monsters so we can't ever rule out that possibility.
 QUEST_20150511_001999	{memo X}$(There are barely legible words written here.) {nl}Euros could not hold his breath any longer so he ended up inhaling the spores and died. {nl}Mushworts hunt people with the cruelest method I've ever seen. {nl}They walk around our gathering places and shake out mushrooms that release spores.
 QUEST_20150511_002000	$We never know when they'll release spores. If we don't stop them, the entire camp could be annihilated. {nl}I have no way to keep safe from the spores. I can't stop coughing...
@@ -1999,28 +1999,28 @@ QUEST_20150511_002002	$The Mausoleum of Zachariel has never allowed anyone entry
 QUEST_20150511_002003	$For the first step: recharge the magical essence I gave to you. Look for where magic is condensed at Pavydo Mixed Forest. {nl}You won't be able to use the magical essence right away, however, since it has also absorbed some malign energy. {nl}For that, you'll need to collect Operor saliva and purify it at the altar of purification at the Wasteland of Renistu.
 QUEST_20150511_002004	$Name: High Raven{nl}Sex: Male{nl}Occupation: Merchant{nl}List of items: luxurious goods, weapons {nl}{nl}In accordance with kingdom laws, you may enter.
 QUEST_20150511_002005	$If you're seeing this you either didn't pay me in full or did something I told you not to do. {nl}I have cursed this letter. {nl}I've no idea what's gonna happen to you from now on, but know that my curse is absolute.
-QUEST_20150511_002006	$The one who fell while researching. {nl}Return to the Goddess by becoming a part of the canyon. {nl}The saddened mind breaks the gold stones of the canyon and the poured alcohol soaks into the ground on behalf of the tears.
-QUEST_20150511_002007	$Eventually, Ruklys had failed. {nl}He was destroyed and broken by those who were jealous of him. {nl}He left the Goddess in my hands. {nl}
+QUEST_20150511_002006	$The one who fell while researching. {nl}Return to the goddess by becoming a part of the canyon. {nl}The saddened mind breaks the gold stones of the canyon and the poured alcohol soaks into the ground on behalf of the tears.
+QUEST_20150511_002007	$Eventually, Ruklys had failed. {nl}He was destroyed and broken by those who were jealous of him. {nl}He left the goddess in my hands. {nl}
 QUEST_20150511_002008	$Every object possess the inner strength of its possessor. {nl}And to add to the magical interpretations on that, they could also transform the shapes of their possessors. {nl}Objects belonging to demons could do it with relative ease. (The same applies to the sacred areas, but don't even dare doing that in those places.)
-QUEST_20150511_002009	$But that's still just a theory despite the efforts of many frontiers. {nl}The possessor's inner strength and interpretations can never be fully understood if it were not for the possessor himself. {nl}That's why we hope for the blessing from the Goddess or the wisdom from the possessor for the knowledge we lack.
+QUEST_20150511_002009	$But that's still just a theory despite the efforts of many frontiers. {nl}The possessor's inner strength and interpretations can never be fully understood if it were not for the possessor himself. {nl}That's why we hope for the blessing from the goddess or the wisdom from the possessor for the knowledge we lack.
 QUEST_20150511_002010	$I shall name you Revelator, my representative sent out to seek help from others. {nl}We can't be deceived any more. {nl}We have to protest against the violence behind the mask that claims to protect us.
 QUEST_20150511_002011	$We believe your help is the main factor to our success so that our efforts will not have been in vain.
 QUEST_20150511_002012	$We've finally arrived in front of the Zachariel's Mausoleum. {nl}He was the first king of this kingdom and used an enormous number of people to build it. {nl}I believe only this place can answer the question I've had in my mind for a long time.
 QUEST_20150511_002013	$What was he trying to protect with this gigantic Royal Mausoleum? {nl}The answer must be inside, but the bleak atmosphere the inside exudes makes me hesitate to go in.
 QUEST_20150511_002014	$There's something inside the dark tomb.{nl}As I advanced inside, the large stone statues all turned to look down at me and then chased me out. {nl}I guess the great king in the past is still the great king in the present. {nl}I better investigate from the pillar outside of the Royal Mausoleum.
-QUEST_20150511_002015	$With the help from a young, kind historian, I was able to find a big clue. {nl}Yes. The best place to hide a tree is in a forest. {nl}Ruko Plateau and the King's Plateau... I'm so close I can almost touch it. {nl}I'm confident the Goddess sent him to me. May the blessing of the Goddess always be with us!
+QUEST_20150511_002015	$With the help from a young, kind historian, I was able to find a big clue. {nl}Yes. The best place to hide a tree is in a forest. {nl}Ruko Plateau and the King's Plateau... I'm so close I can almost touch it. {nl}I'm confident the goddess sent him to me. May the blessing of the goddess always be with us!
 QUEST_20150511_002016	$Some pillars unlock the tomb and some altars lock it. {nl}The magical energy that surrounds the tomb moves by the key. {nl}But none can be that key. {nl}We are not chosen.
-QUEST_20150511_002017	$The curse disturbs the rules of the universe that are being controlled by the Goddess through human greed. {nl}These rules in the human world get influenced by the personalities of each person, their abilities and their potential power. {nl}The cases when these abilities get released depend on the conditions above.
-QUEST_20150511_002018	$According to the old writing left on the Great Cathedral, that is using a small part of the Goddess' abilities secretly. {nl}Some people say that after seducing the weak minds of people, the demons used them for the source of the curse. {nl}May the Goddess bless!
+QUEST_20150511_002017	$The curse disturbs the rules of the universe that are being controlled by the goddess through human greed. {nl}These rules in the human world get influenced by the personalities of each person, their abilities and their potential power. {nl}The cases when these abilities get released depend on the conditions above.
+QUEST_20150511_002018	$According to the old writing left on the Great Cathedral, that is using a small part of the goddess' abilities secretly. {nl}Some people say that after seducing the weak minds of people, the demons used them for the source of the curse. {nl}May the goddess bless you!
 QUEST_20150511_002019	$There are two ways to release the curse: {nl}Remove the curse using a greater power or eliminate its caster. {nl}
-QUEST_20150511_002020	$Removing the curse using a greater power: {nl}This way depends on whether the power that overwhelms the curse comes from good or evil and from darkness or light.{nl}{nl}The most important factor for eliminating the caster: {nl}Even after eliminating the caster, the curse may not be removed due to other factors.{nl}{nl}I have no doubt that the power of the Goddess is stronger.
+QUEST_20150511_002020	$Removing the curse using a greater power: {nl}This way depends on whether the power that overwhelms the curse comes from good or evil and from darkness or light.{nl}{nl}The most important factor for eliminating the caster: {nl}Even after eliminating the caster, the curse may not be removed due to other factors.{nl}{nl}I have no doubt that the power of the goddess is stronger.
 QUEST_20150511_002021	$There are mainly two ways to spread the curse. {nl}First, using equipment and uttering simple words. It sounds easy but it is, in fact, the hardest way. {nl}Therefore, from the example of the Pilgrim Path, we mainly use the cursed ones as the mediums to spread the curse.
 QUEST_20150511_002022	$When a caster makes a curse, the caster has a tremendous influence on the mind of the victim. Their ego usually can't endure the feeling of guilt this causes. {nl}It seems the magic that was used on the cursed city of Ruklys is of a higher level than the one used on Naktis. We need to look into it more.
 QUEST_20150511_002023	$Varkis' Complete Research Materials
 QUEST_20150511_002024	$The First Research Material{nl}-{nl}We've finally arrived in front of the Great King Zachariel's Royal Mausoleum. {nl}He was the first king of this kingdom and used an enormous number of people to build it.{nl}I believe only this place can answer the question I've had in my mind for a long time.
 QUEST_20150511_002025	$What was he trying to protect with this gigantic tomb? {nl}The answer must be inside, but the bleak atmosphere the inside exudes makes me hesitate to go in.
 QUEST_20150511_002026	$The Second Research Material{nl}-{nl}There's something inside the dark tomb.{nl}As I advanced inside, the large stone statues all turned to look down at me and then chased me out. {nl}I guess the great king in the past is still the great king in the present. {nl}I better investigate from the pillar outside of the Royal Mausoleum.
-QUEST_20150511_002027	$The Third Research Material{nl}-{nl}With the help from the young, kind historian, I was able to find a big clue. {nl}Yes. The best place to hide a tree is in a forest. {nl}Ruko Plateau and the King's Plateau... I'm so close I can almost touch it. {nl}I'm confident the Goddess sent him to me. May the blessing of the Goddess always be with us!
+QUEST_20150511_002027	$The Third Research Material{nl}-{nl}With the help from the young, kind historian, I was able to find a big clue. {nl}Yes. The best place to hide a tree is in a forest. {nl}Ruko Plateau and the King's Plateau... I'm so close I can almost touch it. {nl}I'm confident the goddess sent him to me. May the blessing of the goddess always be with us!
 QUEST_20150511_002028	$The Fourth Research Material{nl}-{nl}Some pillars unlock the Royal Mausoleum and some altars lock it. {nl}The magical energy that surrounds the tomb moves by the key. {nl}But none can be that key. {nl}We are not chosen.
 QUEST_20150511_002029	$A wish would come true if we make a pot and put the wish in it. {nl}I understand that it's tradition, but for now, restoring Fedimian back to its former glory is more important than that.
 QUEST_20150511_002030	$I cannot guarantee the safety of other Holy Relics or the keys so you best hurry.
@@ -2028,13 +2028,13 @@ QUEST_20150511_002031	{memo X}$I'm just listening! I'm not going to do what you 
 QUEST_20150511_002032	$The picture of the essence is drawn on the old surface.
 QUEST_20150511_002033	$The Eternal Adventure
 QUEST_20150714_002034	$Well, you're a new face. Did Julian send you?
-QUEST_20150714_002035	{memo X}$Yeah. There's something weird about Goddess Laima. {nl}No one seems to know when she disappeared. To be honest nobody seems to really know whether or not she actually is a Goddess.
+QUEST_20150714_002035	{memo X}$Yeah. There's something weird about Goddess Laima. {nl}No one seems to know when she disappeared. To be honest nobody seems to really know whether or not she actually is a goddess.
 QUEST_20150714_002036	$She has never appeared before. {nl}Although I've read somewhere that she does appear every now and then…
 QUEST_20150714_002037	$Even though it would be bad for my business, I wish I could just live peacefully rather than live in fear of monster attacks coming at any moment.
 QUEST_20150714_002038	$Welcome! {nl}While I can do basic repairs, I don't have the materials to create anything. {nl}Take a look at what I have.
 QUEST_20150714_002039	$When all is said and done, I don't lie about my prices. Everything I sell is priced honestly and accordingly.
 QUEST_20150714_002040	$Fire is a grace sent to us by Goddess Gabija. {nl} You won't become a great Pyromancer if you don't acknowledge that.
-QUEST_20150714_002041	$The Goddesses may be all gone but my powers are still doing fine. {nl} I'm sure it's proof that Goddess Gabija is at least safe somewhere.
+QUEST_20150714_002041	$The goddesses may be all gone but my powers are still doing fine. {nl} I'm sure it's proof that Goddess Gabija is at least safe somewhere.
 QUEST_20150714_002042	$Killing enemies one by one from a distance is the beauty of the bow and arrow. {nl}It doesn't matter how many shots you have to take, the shots that actually hit {nl}are the ones that count.
 QUEST_20150714_002043	$Monk Lotze
 QUEST_20150714_002044	$I'll do whatever it takes to take back the monastery from the monsters.
@@ -2045,7 +2045,7 @@ QUEST_20150714_002048	$I don't like how everyone is insisting their opinions to 
 QUEST_20150714_002049	$Monk Ortega
 QUEST_20150714_002050	$I don't like those Hunters. {nl}Especially the one called Natasha. I don't know why she is bothering Potos...
 QUEST_20150714_002051	$I'll make my preparations to retake the monastery from here. {nl}I could ask for the Hunters to lend me their power but... they're so cold-hearted.
-QUEST_20150714_002052	$According to the priests, Laima is the Goddess of Destiny and Forecasts. {nl}If Laima really exists, wouldn't she know the world would turn out like this?
+QUEST_20150714_002052	$According to the priests, Laima is the goddess of fate and forecasts. {nl}If Laima really exists, wouldn't she know the world would turn out like this?
 QUEST_20150714_002053	$It's been a year since the civil war broke out. Prices in town have risen dramatically. {nl}Commander Ruklys has sent for aid, to restore the town's dwindling supplies.
 QUEST_20150714_002054	$It's been a while since we've had any good news. There's talk about King Kadumel going after the general.
 QUEST_20150714_002055	$The guard posts have been reinforced in response to the king's forces movements in the country.
@@ -2071,22 +2071,22 @@ QUEST_20150714_002074	$Are you going to die with Ruklys who misled you with mali
 QUEST_20150714_002075	$The Records of Rebel Forces
 QUEST_20150714_002076	$As I was retreating from kingdom soldiers, I encountered many demons. {nl}It doesn't make sense. Where did they come from?
 QUEST_20150714_002077	{memo X}$There's no hope at all. Ah… my lovely Ridell. {nl}The kingdom soldiers did not keep their word. We're all going to die.
-QUEST_20150714_002078	$Those kingdom soldiers! Especially that Premier Eminent! They're no different from demons. {nl}Even the Goddesses would not forgive them.
-QUEST_20150714_002079	$I don't want to die. {nl}We were just following the Goddesses' words. {nl}Everyone is killing each other in the names of the Goddesses. {nl}Who has deceived us? {nl}
+QUEST_20150714_002078	$Those kingdom soldiers! Especially that Premier Eminent! They're no different from demons. {nl}Even the goddesses would not forgive them.
+QUEST_20150714_002079	$I don't want to die. {nl}We were just following the goddesses' words. {nl}Everyone is killing each other in the names of the goddesses. {nl}Who has deceived us? {nl}
 QUEST_20150714_002080	$Kingdom Military Recruit Propaganda
 QUEST_20150714_002081	$Kingdom Military needs competent people like you! {nl}Loyalty to the kingdom! To victory and a brighter future!
-QUEST_20150714_002082	$Swear loyalty to Kingdom Military and become a new person. {nl}The Goddesses protect our armies.
+QUEST_20150714_002082	$Swear loyalty to Kingdom Military and become a new person. {nl}The goddesses protect our armies.
 QUEST_20150714_002083	$Life and death… which one would you choose? {nl}The only way to survive is to swear loyalty to the kingdom!
 QUEST_20150714_002084	$Don't forget that we won 600 years ago. {nl}Join the military. You sins can be forgiven.
 QUEST_20150714_002085	$Please move with us if possible. {nl}There's been a number of monster sightings near here.
 QUEST_20150714_002086	$The supplies should be here soon… {nl}Are they going to be late again?
 QUEST_20150714_002087	$You will need various tools when traveling. {nl}It's better to buy them in advance.
-QUEST_20150714_002088	$Goddess Laima… Actually, I don't know her that well. No one does, except for her priests. {nl}I heard she's the Goddess of Destiny and Forecasts, but she has not once appeared before us.
+QUEST_20150714_002088	$Goddess Laima… Actually, I don't know her that well. No one does, except for her priests. {nl}I heard she's the goddess of fate and forecasts, but she has not once appeared before us.
 QUEST_20150714_002089	$I just remembered something while I was talking to you. {nl}Maybe Goddess Laima knew everything about the disaster beforehand.
 QUEST_20150714_002090	$I pray to Goddess Gabija everyday. It keeps the house warm. {nl}As you may already know, Goddess Gabija controls fire and since I'm a housewife, I am close to fire as well.
-QUEST_20150714_002091	$If you cleverly use the dry air that forms around areas of severe cold, you'd be able to freeze any object even in a desert. {nl}However, if you can't receive the blessing from the Goddess, it won't be possible to make that kind of air.
+QUEST_20150714_002091	$If you cleverly use the dry air that forms around areas of severe cold, you'd be able to freeze any object even in a desert. {nl}However, if you can't receive the blessing from the goddess, it won't be possible to make that kind of air.
 QUEST_20150714_002092	$The Records of the Master Himself
-QUEST_20150714_002093	$I've studied magic for a long time as a sorcerer. {nl}From the process, the advancement of sorcery can't be explained without relating with demons, and since they've fought against the Goddesses, the field has been widened to the study of the Goddesses as well.
+QUEST_20150714_002093	$I've studied magic for a long time as a sorcerer. {nl}From the process, the advancement of sorcery can't be explained without relating with demons, and since they've fought against the goddesses, the field has been widened to the study of the goddesses as well.
 QUEST_20150714_002094	$While I was doing that, I learned of the field of accumulation. {nl}It's an empty field. The theory of the beginning and the end is a fantastic library at the boundary of transcendency, all for one purpose.
 QUEST_20150714_002095	$The Records about Disciple Laius
 QUEST_20150714_002096	{memo X}$My other disciple, Laius, is clever and a fast learner but has an insatiable greed for knowledge. I am worried that he may fail the task. {nl}A scholar should always try to learn, but obsessing about it will make one walk the wrong path.
@@ -2096,12 +2096,12 @@ QUEST_20150714_002099	$The Records about Disciple Hones
 QUEST_20150714_002100	{memo X}$Among my disciples, two of them followed me until my later years and will be my successors after my death.
 QUEST_20150714_002101	$Hones, who is one of them, is lacking in scholarly intelligence. However, I am sure his faithfulness and efforts will help him follow my teachings.
 QUEST_20150714_002102	$The Records of the Hidden Object
-QUEST_20150714_002103	{memo X}$…I don't know whether I should thank the Goddesses for this discovery or not. My greed for knowledge can ruin the world.
+QUEST_20150714_002103	{memo X}$…I don't know whether I should thank the goddesses for this discovery or not. My greed for knowledge can ruin the world.
 QUEST_20150714_002104	{memo X}I can't sleep well for fear of my research results being spread by demon investigation. {nl}That's why I wish to pass the rest of the research to the one I can trust.
 QUEST_20150714_002105	$The Inheritance of the Master
 QUEST_20150714_002106	$As the priests and theologians know, Goddess Vibora is in charge of the library where all records of the world are stored. {nl}I was able to check several records in that fantastic library after the research and long studying I can't tell anyone about at the moment. {nl}
-QUEST_20150714_002107	From the many records of the Goddess, I was only able to see a few. {nl}Nevertheless, the fact that I checked the existence of the records with the important facts was astonishing. {nl}
-QUEST_20150714_002108	$The record which I can use to find the whereabouts of all the Goddesses… {nl}If one had such secret information, it would be possible to predict the Goddesses' future locations by analyzing what they did in the past. {nl}Because of that, their future plans may be disturbed or put at risk. {nl}
+QUEST_20150714_002107	From the many records of the goddess, I was only able to see a few. {nl}Nevertheless, the fact that I checked the existence of the records with the important facts was astonishing. {nl}
+QUEST_20150714_002108	$The record which I can use to find the whereabouts of all the goddesses… {nl}If one had such secret information, it would be possible to predict the goddesses' future locations by analyzing what they did in the past. {nl}Because of that, their future plans may be disturbed or put at risk. {nl}
 QUEST_20150714_002109	$This is more dangerous because, if the demons find out the truth, their desire for the library will grow {nl}and, if they do acquire that knowledge, the world will be swallowed by evil. That's why - {nl}
 QUEST_20150714_002110	$(The rest is blurred and unreadable.)
 QUEST_20150714_002111	$Disciple Hones's Memo
@@ -2146,11 +2146,11 @@ QUEST_20150714_002149	{memo X}$King Kadumel finally dies.
 QUEST_20150714_002150	$Instead of the Mage Tower, the Tower of Fire would be a more fitting name for Flurry's tower.
 QUEST_20150714_002151	$This is a very secluded area so monsters usually prey around here. {nl}Be careful around here.
 QUEST_20150714_002152	$The Research Records of Demetrius
-QUEST_20150714_002153	$In ancient times, humans lived with the Goddesses. {nl}When I first heard of this piece of folklore, I thought it was made up out of respect for the Goddesses. {nl}I started to investigate what historic background caused such reverence as well as why this myth was created.
+QUEST_20150714_002153	$In ancient times, humans lived with the goddesses. {nl}When I first heard of this piece of folklore, I thought it was made up out of respect for the goddesses. {nl}I started to investigate what historic background caused such reverence as well as why this myth was created.
 QUEST_20150714_002154	$I increased the extent of my research. {nl}I travelled to many regions of the kingdom and collected similar cases. {nl}And I started to believe that this story was part of a bigger truth rather than just a small truth covered in fabrication.
-QUEST_20150714_002155	$The facts that we've discovered so far are thus: {nl}{nl}In the beginning, or a period not that far from the beginning, all humans used to live with the Goddesses underground. {nl}I suppose the Goddesses used to be more directly involved with humans. {nl}I have no idea why but soon, the humans left that place and scattered across the land.
+QUEST_20150714_002155	$The facts that we've discovered so far are thus: {nl}{nl}In the beginning, or a period not that far from the beginning, all humans used to live with the goddesses underground. {nl}I suppose the goddesses used to be more directly involved with humans. {nl}I have no idea why but soon, the humans left that place and scattered across the land.
 QUEST_20150714_002156	$This movement was made very naturally. {nl}If that hadn't been the case, then there must have been conflicts, and more fables would have been created as a result.
-QUEST_20150714_002157	$I believe the Goddesses erased all memory and records of that time completely. {nl}However, we can't deny the possibility that another reason may exist due to the fact that this legend still remains despite the authority of the great Goddesses.
+QUEST_20150714_002157	$I believe the goddesses erased all memory and records of that time completely. {nl}However, we can't deny the possibility that another reason may exist due to the fact that this legend still remains despite the authority of the great goddesses.
 QUEST_20150714_002158	$And this is a very cautious prediction, but the creatures that we call demons may exist underground. {nl}Though that theory is hard to accept when we think about all the facts that are recorded in history and the present.
 QUEST_20150714_002159	$I can smell many Avietes. I heard they're effective… Could you share them with us?
 QUEST_20150714_002160	$Thank you. I will give you as many as you need. {nl}You will be successful.
@@ -2168,7 +2168,7 @@ QUEST_20150714_002171	$I am busy right now. We better do it later.
 QUEST_20150714_002172	$Ah, you're the one Adrijus sent. {nl}I've obtained the diluting solution he ordered. {nl}Be careful not to break the glass.
 QUEST_20150714_002173	$One glass of diluting solution will be enough.
 QUEST_20150714_002174	$Epitaph of Juan
-QUEST_20150714_002175	$I lie here without yet creating thirteen thousand pieces of armor. {nl}I hope to finish them alongside the Goddesses.
+QUEST_20150714_002175	$I lie here without yet creating thirteen thousand pieces of armor. {nl}I hope to finish them alongside the goddesses.
 QUEST_20150714_002176	$I can hear a whisper in my head.
 QUEST_20150714_002177	$Please install the device I gave you in the 2nd district of Crystal Mine.
 QUEST_20150714_002178	$The location is Sidabro Rest Place in Vejo Ravine. {nl}I hope he's still alive.
@@ -2186,8 +2186,8 @@ QUEST_20150714_002189	$I can feel the regrets of the spirits.
 QUEST_20150714_002190	$The seal is not yet ready? {nl}It pains me so that you are the only one I can trust.
 QUEST_20150714_002191	$Can you lay the villagers' spirits to rest in peace?
 QUEST_20150714_002192	$The Basics of Ignition
-QUEST_20150714_002193	$Ignition differs by elements, but with the blessing from the Goddess, there may be cases where we can ignore that. {nl}To do so, we should try hard to achieve the scholarly knowledge and the faithfulness to the Goddesses.
-QUEST_20150714_002194	$1. Dried environment{nl}2. Something that can be ridden on. {nl}3. Enough mana. {nl}4. The blessing of the Goddesses.
+QUEST_20150714_002193	$Ignition differs by elements, but with the blessing from the goddess, there may be cases where we can ignore that. {nl}To do so, we should try hard to achieve the scholarly knowledge and the faithfulness to the goddesses.
+QUEST_20150714_002194	$1. Dried environment{nl}2. Something that can be ridden on. {nl}3. Enough mana. {nl}4. The blessing of the goddesses.
 QUEST_20150714_002195	$Flurry… turned into a handful of ashes by illuminating a great light. {nl}Did that demon do something? {nl}I had no idea, being a mere probationary wizard.
 QUEST_20150714_002196	{memo X}$[Caution]{nl}- It is the last stage of the experiment. Be cautious when handling it -
 QUEST_20150714_002197	{memo X}1. Do not overreact Schilt Essences into a sample of Petrification Detector. {nl}2. Do not keep the Schilt Amplifier activated for a long time. {nl}3. Even if you become immune to petrification using the Schilt Amplifier, it will only be temporary, so do not stay in the lab room for too long.
@@ -2197,7 +2197,7 @@ QUEST_20150714_002200	$Petrification in Progress
 QUEST_20150714_002201	$My body is becoming stiff.
 QUEST_20150714_002202	$We can move faster.
 QUEST_20150714_002203	$We tried our best to impede them until your arrival. {nl}But as you can see, we're at our limit.
-QUEST_20150714_002204	$I've received your letter. {nl}Now is the chance the Goddesses gave to you since Legwyn is dead. {nl}It's great to hear that the lads of Legwyn family trust you.
+QUEST_20150714_002204	$I've received your letter. {nl}Now is the chance the goddesses gave to you since Legwyn is dead. {nl}It's great to hear that the lads of Legwyn family trust you.
 QUEST_20150714_002205	$I've changed the name on this certificate for you so return the rest of documents to me. {nl}I guarantee either his assets or his land document. {nl}Please pay me the deposit as you did last time.
 QUEST_20150714_002206	$Anyone under the Legwyn name can't be left alive. Even the servants. {nl}Please also get rid of the daughter of Legwyn who is the Squire Master.
 QUEST_20150714_002207	$Mysterious Man
@@ -2215,11 +2215,11 @@ QUEST_20150714_002218	$I'm worried about the chief of the monastery who should b
 QUEST_20150714_002219	$I don't know if it's going to be okay. {nl}It's feels like the outsiders are swinging us around… {nl}Well, I know Marko is clever so we should trust him.
 QUEST_20150714_002220	$At any rate, we will trust Marko's orders. {nl}It's good that we've reliable reinforcements now.
 QUEST_20150714_002221	$Also, it's important to retake the monastery as soon as possible. {nl}The chief of the monastery's safety is critical.
-QUEST_20150714_002222	$Unknown traveler. Falls down under the nameless poison. {nl}Now stop the journey and rest in peace in the Goddesses.
+QUEST_20150714_002222	$Unknown traveler. Falls down under the nameless poison. {nl}Now stop the journey and rest in peace in the goddesses.
 QUEST_20150714_002223	$Biblam the Farmer. He who took care of his neighbors more than himself… {nl}rests here.
 QUEST_20150714_002224	$I'm going to go to the arms of you who I longed for for a long time. {nl}With your bow and with your dagger. {nl}From, {nl}Siana.
 QUEST_20150714_002225	$The young tailor, Godan, who was born in Fedimian, {nl}rests in Tilda Monastery.
-QUEST_20150714_002226	$Mighty Goddess. {nl}I am finally free. {nl} - Tenant Farmer Tila
+QUEST_20150714_002226	$Mighty goddess. {nl}I am finally free. {nl} - Tenant Farmer Tila
 QUEST_20150714_002227	$Thank you. {nl}If their number could be reduced by even a bit, I'd feel more relaxed.
 QUEST_20150714_002228	$Thanks. {nl}If you see any bubble that spurts out air, it means that there are spiny water chestnuts. {nl}Please bring me the roots of those.
 QUEST_20150714_002229	$Really? {nl}If you can help me, I'll do anything I can.
@@ -2252,7 +2252,7 @@ QUEST_20150717_002255	$I will correct the disrupted magic of this tower.{nl} I w
 QUEST_20150717_002256	$I hope Goddess Gabija is safe… Let's hurry.
 QUEST_20150717_002257	$I don't have a good feeling about it. That vibration…{nl}Let's move quickly for now.
 QUEST_20150717_002258	$We can help Goddess Gabija if we have the Jewel of Prominence.
-QUEST_20150717_002259	The Goddess has reached her limit.{nl}We should give her the Jewel of Prominence as quickly as possible.
+QUEST_20150717_002259	The goddess has reached her limit.{nl}We should give her the Jewel of Prominence as quickly as possible.
 QUEST_20150717_002260	$That vibration… It's serious.
 QUEST_20150717_002261	Let's quickly go to Magic Control Room.{nl}I will be able to control the magic of the tower.
 QUEST_20150717_002262	It's fortunate that the Magic Control Room is near.{nl}Let's go quickly.
@@ -2268,7 +2268,7 @@ QUEST_20150717_002271	$[Usage Limit]{nl}- Due to a recent incident, we sealed th
 QUEST_20150717_002272	$[Method of Usage]{nl}1. Use the Schilt Essences on the portal generator. {nl}2. One person can enter after a certain number of Essences are used. {nl}3. When more than one person enters simultaneously, please notify and ask the chief.
 QUEST_20150717_002273	The flame crystals are formed here.{nl}Be careful, because you might get burned.
 QUEST_20150717_002275	$Story of Fire
-QUEST_20150717_002276	$I saw a bizarre sight at the Goddess' whereabouts at the top of the tower. The bird beside Gabija, by her grace, lit up and engulfed itself in flames.{nl}
+QUEST_20150717_002276	$I saw a bizarre sight at the goddess' whereabouts at the top of the tower. The bird beside Gabija, by her grace, lit up and engulfed itself in flames.{nl}
 QUEST_20150717_002277	The serenely burning fire. The wings consumed by flames. Nothing else in this world has left me more in awe than that sight.{nl}
 QUEST_20150729_002281	{memo X}Hmm… Have the party members fully gathered yet?
 QUEST_20150729_002282	{memo X}$Welcome to the Commissioner's Office. {nl}Unfortunately… I don't have any appropriate requests for you yet.{nl}
@@ -2278,7 +2278,7 @@ QUEST_20150729_002285	Anyway, that is very strange.{nl}If it was Goddess Laima's
 QUEST_20150729_002286	$Whether this revelation will become a new beacon of hope or a start of a new disaster, is indeed {nl}difficult to judge… We are thinking of continuing our investigation.
 QUEST_20150729_002287	)}My son volunteered to join the army.{nl}So I have been offering my prayers to the greatest Goddess Ausrine.{nl}
 QUEST_20150729_002288	)}Monsters have been multiplying to the point where people cannot safely live in the forest anymore.{nl}At least Klaipeda is still safe.{nl}
-QUEST_20150729_002289	Maybe the Goddess Ausrine gave us her protection.{nl}Isn't she the Goddess who leads all other Goddesses?
+QUEST_20150729_002289	Maybe the Goddess Ausrine gave us her protection.{nl}Isn't she the goddess who leads all other goddesses?
 QUEST_20150729_002290	)}I am glad my son dreams of becoming a soldier…{nl}But the monsters keep increasing in number, and I'm worried he will be injured.
 QUEST_20150729_002291	I told him about the revelation that I found at the Crystal Mine.
 QUEST_20150729_002292	$The morning dawns after the night, does it not? Goddess Ausrine is the one who brings us the morning. {nl}Not only that, when we die, we go to her as well.
@@ -2307,17 +2307,17 @@ QUEST_20150729_002314	He was soon overtaken by guilt and said, {nl}'If you reall
 QUEST_20150729_002315	The silversmith, after hearing Aiste's story, stated, {nl}'Even for children it is foolish to be so careless. How could you not know that all money that falls on Fedimian soil disappears, never to be found again?'{nl}{nl}
 QUEST_20150729_002316	Aiste was surprised by what the silversmith said and grew sad. {nl}After a while she asked, {nl}'Then why is it that such a cruel thing happens?'{nl}{nl}
 QUEST_20150729_002317	Even the silversmith did not know the true answer, so he improvised, {nl}'The Goddess Zemyna must be taking them.'{nl}{nl}
-QUEST_20150729_002318	Hearing those words, Aiste replied, {nl}'Then I will just have to go ask the Goddess.' {nl}The silversmith was astounded and replied, {nl}'While you're at it, why don't you ask the Goddess to return my silverware?'{nl}{nl}
-QUEST_20150729_002319	An exhausted Aiste soon arrived at the Statue of Goddess Zemyna. {nl}She prostrated herself before it and prayed to the Goddess Statue represented, her head completely down. {nl}'Oh, Goddess. Please return my lost silver coins.' {nl}Soon, while offering her prayers, Aiste could no longer hold in her sadness and she finally wept.{nl}{nl}
+QUEST_20150729_002318	Hearing those words, Aiste replied, {nl}'Then I will just have to go ask the goddess.' {nl}The silversmith was astounded and replied, {nl}'While you're at it, why don't you ask the goddess to return my silverware?'{nl}{nl}
+QUEST_20150729_002319	An exhausted Aiste soon arrived at the Statue of Goddess Zemyna. {nl}She prostrated herself before it and prayed to the Goddess Statue represented, her head completely down. {nl}'Oh, goddess. Please return my lost silver coins.' {nl}Soon, while offering her prayers, Aiste could no longer hold in her sadness and she finally wept.{nl}{nl}
 QUEST_20150729_002320	How long did she pray crying? {nl}Suddenly, Aiste heard a voice addressed to her. {nl}'My child, have come to take back what you have lost?'{nl}{nl}
-QUEST_20150729_002321	The Goddess' voice was heard again. {nl}'Aiste, what your asking from me is not in a method I approve of. Where I reign there is no harvest nor fruits to those who do not work.'{nl}{nl}
+QUEST_20150729_002321	The goddess' voice was heard again. {nl}'Aiste, what your asking from me is not in a method I approve of. Where I reign there is no harvest nor fruits to those who do not work.'{nl}{nl}
 QUEST_20150729_002322	'But I worked very hard today!'{nl}{nl}
 QUEST_20150729_002323	'I know. So instead, I will give you and the others a chance. Look under your feet.'{nl}{nl}
 QUEST_20150729_002324	After a number of steps, Aiste thought about the silversmith, {nl}and, again, went to his house and knocked on his door. {nl}As if the silversmith was waiting for her return, he opened the door immediately and said. {nl}'I'm sorry. I regret sending you away like that. I'll give you some silver. {nl}This time, be careful not to drop any and get home safely.'{nl}{nl}
-QUEST_20150729_002325	As the silversmith held out his silver coins, Aiste shook her head and said,{nl}'No thank you, the Goddess returned all my coins. On top of that she gave me even more. {nl}I remembered you saying you had also lost silver, so I came to give you my extra coins. You don't need to give me yours.'{nl}{nl}
+QUEST_20150729_002325	As the silversmith held out his silver coins, Aiste shook her head and said,{nl}'No thank you, the goddess returned all my coins. On top of that she gave me even more. {nl}I remembered you saying you had also lost silver, so I came to give you my extra coins. You don't need to give me yours.'{nl}{nl}
 QUEST_20150729_002326	At first, the silversmith was skeptical about the coins being returned, {nl}so he was surprised when Aiste showed him genuine coins. After thinking for a while, the silversmith said, {nl}'Then how about this. You give me what you want while you accept what I was about to give you. {nl}Isn't that fair? On top of that I'll give you a pouch to carry your extra silver.'{nl}{nl}
 QUEST_20150729_002327	After leaving the silversmith's house, {nl}Aiste suddenly remembered that the old beggar must still be looking for her lost coins and worried about him. {nl}On her way to the beggar, she met the orchard owner again. {nl}Upon seeing Aiste, the orchard owner was overjoyed. {nl}'I was looking for you. I'm sorry for sending you off earlier. As an apology, I'll give you your salary again. {nl}Please be careful not to lose it this time.'{nl}{nl}
-QUEST_20150729_002328	The orchard owner took out a large amount of coins, more than what Aiste's salary was, and handed it to her. {nl}However, Aiste shook her head and said, {nl}'The Goddess Zemyna already returned my money to me. The silversmith also helped me, so now I actually have too much. {nl}Here, take a look.'{nl}{nl}
+QUEST_20150729_002328	The orchard owner took out a large amount of coins, more than what Aiste's salary was, and handed it to her. {nl}However, Aiste shook her head and said, {nl}'Goddess Zemyna already returned my money to me. The silversmith also helped me, so now I actually have too much. {nl}Here, take a look.'{nl}{nl}
 QUEST_20150729_002329	Disregarding the amount Aiste had shown him, the orchard owner said, {nl}'Well, even so, I would be ashamed for not giving you my due, so please just take it.' {nl}After saying this, the orchard owner stuffed his coins into Aiste's bag and left. {nl}By the time Aiste could muster up the energy to call the orchard owner, he was too far away.{nl}{nl}
 QUEST_20150729_002330	She hesitated for a moment but then set her mind on the beggar. {nl}After a bit of walking, Aiste arrived at where they met. The old beggar spotted her first and hurried over to her. {nl}He showed her the silver coins he was clenching onto and said, 'Look! I found your lost silver.' {nl}Aiste received the beggar's silver and then showed the beggar her bag and said, {nl}'Look, I found your silver coins too.'{nl}{nl}
 QUEST_20150729_002331	After that, Aiste also held out her bag and said, {nl}'This is a gift as thanks for looking for my silver. I was given this through Goddess Zemyna's grace.' {nl}Aiste then left before the Old Beggar could figure out how to reply.{nl}{nl}
@@ -2339,16 +2339,16 @@ QUEST_20150729_002346	Considering Modestas' habit, to simply not immediately acc
 QUEST_20150729_002347	$As soon as the bet started, Sigfried tried every method possible to command his horse to move. Despite his efforts it didn't move a single hoof at all.{nl}At the end, Sigfried repeatedly cursed its strange behavior. Realizing he'd be late to his appointment without a horse, he threw the reins to Modestas and sprinted away.{nl}
 QUEST_20150729_002348	As Sigfried disappeared, Modestas felt uncomfortable.
 QUEST_20150729_002349	$'You, the young man with the horse, can you come over and help us for a bit?' {nl} Modestas had no idea what these soldiers needed help for, but since he could no longer ignore them, he decided to head over. {nl} Once Modestas arrived, one of the soldiers said, {nl} 'You came at just the right time. We would like you to referee a small gamble we're about to make here.' {nl}
-QUEST_20150729_002350	$What started as a small banter turned into a big argument, which finally grew to become a big money bet. The soldiers had already gathered their money and only had to decide the winner. Unfortunately, every Goddess got equal votes and a winner couldn't be decided.{nl}
-QUEST_20150729_002351	$Thus, the soldiers decided to settle the bet by calling the first person who passed by, asking him who he thought the best Goddess is, and deciding the winner from there. The soldiers agreed that the first passer-by would symbolize the will of whatever Goddess he supported. {nl}
-QUEST_20150729_002352	$Since a big jackpot was on the line, the soldiers waited with bated breath for Modestas' answer. {nl}Knowing there was no right answer to the question, Modestas simply said aloud the name of his favorite Goddess. {nl}
+QUEST_20150729_002350	$What started as a small banter turned into a big argument, which finally grew to become a big money bet. The soldiers had already gathered their money and only had to decide the winner. Unfortunately, every goddess got equal votes and a winner couldn't be decided.{nl}
+QUEST_20150729_002351	$Thus, the soldiers decided to settle the bet by calling the first person who passed by, asking him who he thought the best goddess is, and deciding the winner from there. The soldiers agreed that the first passer-by would symbolize the will of whatever goddess he supported. {nl}
+QUEST_20150729_002352	$Since a big jackpot was on the line, the soldiers waited with bated breath for Modestas' answer. {nl}Knowing there was no right answer to the question, Modestas simply said aloud the name of his favorite goddess. {nl}
 QUEST_20150729_002353	When he did, the soldiers reacted strangely. {nl} There was supposed to be an ecstatic winner and disappointed losers, but nobody seemed joyful nor disappointed. Instead, everyone had a bewildered look on their faces. {nl}
-QUEST_20150729_002354	$Modestas, perplexed by their reaction, asked for an explanation to which one of the soldiers answered, {nl}'We originally had votes for four Goddesses but your choice isn't any of them, so now we have five Goddesses.' {nl}Then the soldiers resumed their squabble about how to decide the winner. {nl}
+QUEST_20150729_002354	$Modestas, perplexed by their reaction, asked for an explanation to which one of the soldiers answered, {nl}'We originally had votes for four goddesses but your choice isn't any of them, so now we have five goddesses.' {nl}Then the soldiers resumed their squabble about how to decide the winner. {nl}
 QUEST_20150729_002355	$The mood began to deteriorate so Modestas wanted to leave them. {nl}When he was about to take off, the soldiers blocked his path and accused him.{nl}'It's your fault the argument heated up even more. You're not thinking of just leaving are you?'{nl}Intimidated by the irritated soldiers, Modestas dared not to escape. {nl}
 QUEST_20150729_002356	$Knowing Modestas, he could not simply sit on the sidelines watching a big bet grow. Eventually, he became enticed to join.
 QUEST_20150729_002357	$Modestas, caught in the heat of the moment and ending up participating in the soldier's bet, finally remembered it was his turn to lose.{nl}But it was too late.{nl}
-QUEST_20150729_002358	$If you think about it, even if it was his turn to lose, all it took for him to lose was one more vote for any of the Goddesses he didn't choose. With the odds of the next person walking by supporting his Goddess being against him, the probability of winning was low anyway.{nl}
-QUEST_20150729_002359	$However, the victor was chosen unexpectedly. A commanding officer found the soldiers slacking, disciplined them and was about to lead them away. {nl}The soldiers, obeying the superior's command, were about to march off when they shrewdly asked him which Goddess he favored. {nl}
+QUEST_20150729_002358	$If you think about it, even if it was his turn to lose, all it took for him to lose was one more vote for any of the goddesses he didn't choose. With the odds of the next person walking by supporting his goddess being against him, the probability of winning was low anyway.{nl}
+QUEST_20150729_002359	$However, the victor was chosen unexpectedly. A commanding officer found the soldiers slacking, disciplined them and was about to lead them away. {nl}The soldiers, obeying the superior's command, were about to march off when they shrewdly asked him which goddess he favored. {nl}
 QUEST_20150729_002360	$Someone approached Modestas who had been lying down hurt and helped him get back on his feet. He turned out to be one of the people standing on the side, the wagon owner. {nl}The man who helped Modestas uttered with relief, {nl}'I am glad you're not too hurt. Your horse also didn't hurt himself tripping over that pit.'{nl}Modestas noticed a well-hidden pit where he pointed. {nl}The wagon owner continued.{nl}
 QUEST_20150729_002361	'My horse became injured here and can no longer pull my wagon. It's just an empty wagon, but at any rate, it won't be going anywhere for a while. That's why I have a proposition. Won't you sell me your horse? I believe with a healthy horse pulling the wagon, even my injured horse can help pull it in some way.'{nl}
 QUEST_20150729_002362	It was an unexpected suggestion, but Modestas had to ride the horse to quickly find and catch up to the soldiers. He immediately refused the offer.{nl}The wagon owner tried to explain there was no way his injured horse can pull the wagon alone but Modestas was not persuaded. After his repeated refusal, the wagon owner offered a new suggestion.{nl}'Then let's do this. What if you buy my wagon? I will sell it for cheap. Since my injured horse can't pull the wagon, it will be better off in your hands.'{nl}
@@ -2364,22 +2364,22 @@ QUEST_20150729_002371	Modestas confessed he was far from making profits, instead
 QUEST_20150729_002372	'Since you are unsure how to transport this boulder you suddenly won, how about this? Normally, I wouldn't change the initial conditions, but as an amusement I will give you a suggestion. Why don't you use your last bet to see whether or not I can lift this boulder up into your wagon? Even if you lose, at least you can have this heavy boulder loaded on your wagon.'{nl}
 QUEST_20150729_002373	$Modestas who had nothing to lose, nodded his head to accept her proposal. But before he could consent to the bet, the old woman continued. {nl}'But I can't just give you such a favorable idea for free. Therefore I will add one more condition.'{nl}
 QUEST_20150729_002374	When Modestas asked about the condition, the old woman answered.{nl}'You are to take the boulder, which I will load onto the wagon, to Klaipeda. Then, turn it into an object of value which everyone will recognize and esteem. If you are successful then the punishment for losing the bet against me will become void. Your friends will not disappear. Since you already lost the bet against me, although this is difficult, I will still give you one more chance. How about it?'{nl}Like always Modestas had no choice.
-QUEST_20150729_002375	When the boulder was set in its proper place with the help of the soldiers, the Alchemist who had left returned with another person. The Alchemist had brought with him a famous Dievdirbys sculptor.{nl}To the famous Dievdirbys, the Alchemist suggested, {nl}'Why don't you sculpt a statue of a Goddess using this boulder, on this central site of Klaipeda? If this boulder is changed into a statue of a Goddess, then nobody in Klaipeda will be able to deny its significance. I think that will fulfill your promise to the old woman.'{nl}
-QUEST_20150729_002376	$That the old woman appeared before him, that the many bets occurred, that the mountain erupted a stone for material was the divine providence of the Goddesses, argued Modestas, persuading everyone. {nl}
+QUEST_20150729_002375	When the boulder was set in its proper place with the help of the soldiers, the Alchemist who had left returned with another person. The Alchemist had brought with him a famous Dievdirbys sculptor.{nl}To the famous Dievdirbys, the Alchemist suggested, {nl}'Why don't you sculpt a statue of a goddess using this boulder, on this central site of Klaipeda? If this boulder is changed into a statue of a goddess, then nobody in Klaipeda will be able to deny its significance. I think that will fulfill your promise to the old woman.'{nl}
+QUEST_20150729_002376	$That the old woman appeared before him, that the many bets occurred, that the mountain erupted a stone for material was the divine providence of the goddesses, argued Modestas, persuading everyone. {nl}
 QUEST_20150729_002377	Thus, the people decided to follow the words of Modestas, and Modestas relayed to the Dievdirbys the order to create the statue. {nl}
-QUEST_20150729_002378	When the statue was finally finished, the citizens of Klaipeda gathered, curious to know the identity of the Goddess who had been raised in the center of their beloved city.{nl}
+QUEST_20150729_002378	When the statue was finally finished, the citizens of Klaipeda gathered, curious to know the identity of the goddess who had been raised in the center of their beloved city.{nl}
 QUEST_20150729_002379	The Dievdirbys who had sculpted the statue had already vanished deep into the Kateen Forest, so the citizens of Klaipeda repeatedly questioned Modestas for her name. {nl}
 QUEST_20150729_002380	Despite the numerous questions nobody received an answer from Modestas. {nl}At any rate, this is the story of how the Goddess Statue of Klaipeda came to be. Even now that statue stands in the center of Klaipeda.{nl}
-QUEST_20150729_002381	$Since that time, whenever Modestas took on a wager, he always bet the same thing. The answer to the question of who the Statue of Klaipeda honored.{nl}To uncover the name of the Goddess, numerous people challenged Modestas to a bet.{nl}
+QUEST_20150729_002381	$Since that time, whenever Modestas took on a wager, he always bet the same thing. The answer to the question of who the Statue of Klaipeda honored.{nl}To uncover the name of the goddess, numerous people challenged Modestas to a bet.{nl}
 QUEST_20150729_002382	But no matter the impossible odds, Modestas never lost a bet. Therefore nobody was able to win the answer from Modestas for years and time flew by.{nl}
-QUEST_20150729_002383	$And, as he lay dying, Modestas revealed the secret to the Goddess Statue in his will. When all became clear, the one who orchestrated all of this was none other than the one whom all other Goddesses stem from, Goddess Ausrine.{nl}
+QUEST_20150729_002383	$And, as he lay dying, Modestas revealed the secret to the Goddess Statue in his will. When all became clear, the one who orchestrated all of this was none other than the one whom all other goddesses stem from, Goddess Ausrine.{nl}
 QUEST_20150729_002384	$In the end, Goddess Ausrine, in exchange for giving income and an interesting life full of mystery to a certain gambler from Klaipeda, gave the city of Klaipeda a beautiful Goddess Statue, and a tale to last for times to come.{nl} {nl}
 QUEST_20150730_002385	$Voodoo Doll
 QUEST_20150730_002386	{memo X}$The Gravekeeper's Magic Doll has shut down the barrier!
 QUEST_20150803_002387	$You need the key that fits the box
 QUEST_20150803_002388	$Another headache… I have a headache. Just go back and don't worry about me. {nl}Ah, the beautiful flowers are coming…
 QUEST_20150803_002389	$Eternal life… {nl}I continue to live by the authority of Goddess Ausrine.{nl}
-QUEST_20150803_002390	$The death moves away from me whenever I set Owl Sculptures that guide the spirits.{nl}Even if an old person like me could be helpful to the Goddess and the world, I should live an eternal life.
+QUEST_20150803_002390	$The death moves away from me whenever I set Owl Sculptures that guide the spirits.{nl}Even if an old person like me could be helpful to the goddess and the world, I should live an eternal life.
 QUEST_20150803_002391	{memo X}$Are you interested in eternal life?{nl}We necromancers control the dead so it's easy to figure out.{nl}
 QUEST_20150803_002392	$Absorbing another's vitality and extending one's own life is possible for me.{nl}But, it's not possible for humans.
 QUEST_20150803_002393	$Are you curious as to how I obtained eternal life?{nl}If stilled time is eternal, then you can consider it life everlasting.{nl}
@@ -2396,7 +2396,7 @@ QUEST_20150918_002403	There are no missions for today.
 QUEST_20150918_002404	$There are only missions that seem difficult to you.{nl} Please come again another time.
 QUEST_20150918_002405	Historic Site Ruins
 QUEST_20150918_002406	Historic Site Ruins (Recommended Lv : 90){nl}Only you and your party members can enter together.{nl}Are you sure you want to enter?
-QUEST_20150918_002407	Right. Goddess Laima is the strangest of them all.{nl}No one knows when she disappeared. To be honest, I don't know if she really is a Goddess.{nl}
+QUEST_20150918_002407	Right. Goddess Laima is the strangest of them all.{nl}No one knows when she disappeared. To be honest, I don't know if she really is a goddess.{nl}
 QUEST_20150918_002408	Even if they say the world is doomed, our soldiers will guard this place until the end. {nl}However, we won't be responsible for you getting into trouble, so be careful.
 QUEST_20150918_002409	${memo Uska is a knight}Welcome. Sir Uska is waiting for you in the central square of Klaipeda. {nl}Well, is there anything that you are unsure of?
 QUEST_20150918_002410	{memo X}$But this is also my ordeal and mission that Laima has seen. {nl}I will tell you Laima's message.{nl}
@@ -2406,13 +2406,13 @@ QUEST_20150918_002413	Fedimian used to be crowded with pilgrims in the past. {nl
 QUEST_20150918_002414	The red-haired wizard found the Revelator to save the Mage Tower {nl}even when there were other masters. He did save the Mage Tower so that was great but.. {nl}Anyway, browsing's free so have a look around.
 QUEST_20150918_002415	$Now isn't this amazing? The Revelator who protected the Great Cathedral.{nl}We decided to not increase our prices, even though we are in tough times. Take your time.
 QUEST_20150918_002416	$Have you heard the rumor? Regarding the Mage Tower? {nl}A Revelator defeated the Demon Lord. {nl}If father was around, I would have given you some discounts to celebrate.
-QUEST_20150918_002417	$The people of Fedimian live by the teachings of Maven.{nl}But the Demon Lord dirtied it. The Revelators sure punished him for the Goddess. {nl}Now, what do you want me to check?{nl}
+QUEST_20150918_002417	$The people of Fedimian live by the teachings of Maven.{nl}But the Demon Lord dirtied it. The Revelators sure punished him for the goddess. {nl}Now, what do you want me to check?{nl}
 QUEST_20150918_002418	I heard that some Revelator saved the Mage Tower. {nl}Fedimian should be safe now, right? {nl}Anyway, you might find some helpful items so look around. {nl}
 QUEST_20150918_002419	The expectations on the Revelator from all the people of Fedimian is increasing. {nl}News has spread that a certain Revelator defeated the Demon Lord holding the Great Cathedral.{nl}Anyway, you don't necessarily have to buy something so feel free to look around.
 QUEST_20150918_002420	It looks like something is in that grass.
 QUEST_20150918_002421	{memo X}What was she looking for even when she was dying? {nl}There's definitely a tragic story behind all this.
 QUEST_20150918_002422	Then something snapped. {nl}A fellow clergyman, I can't remember who, had murdered Dion in his sleep with a mace and I… {nl}Everyone… {nl}No one can remember why they wanted to become priest in the past anymore.
-QUEST_20150918_002423	Each Goddess Statue is known to have different abilities depending on which Goddess it depicts. {nl}For example, the statue of Goddess Zemyna gives a blessing that enhances any ability you want.
+QUEST_20150918_002423	Each Goddess Statue is known to have different abilities depending on which goddess it depicts. {nl}For example, the statue of Goddess Zemyna gives a blessing that enhances any ability you want.
 QUEST_20150918_002424	$But the statue of Goddess Ausrine in Klaipeda is a bit strange. {nl}It moves you to a desired area even though such a thing is Goddess Vakarine's power.
 QUEST_20150918_002425	Go down quickly. It's dangerous. {nl}This place is empty.
 QUEST_20150918_002426	I cannot feel any magic.
@@ -2439,10 +2439,10 @@ QUEST_20150918_002446	Huh? How did you get up here?
 QUEST_20151001_002447	Amazing.{nl}This must have been created hundreds of years ago..{nl}It seems to speak of you.{nl}
 QUEST_20151001_002448	I don't feel any evil energy nor malicious intent in this.{nl}If so, this revelation must truly have come from the Goddess Laima...{nl}
 QUEST_20151001_002449	I'm surprised about this talk of a 'Savior'.{nl}
-QUEST_20151001_002450	Amongst the many Revelators, the one who can save the world and the Goddesses...{nl}The revelation says you are that Savior.{nl}
+QUEST_20151001_002450	Amongst the many Revelators, the one who can save the world and the goddesses...{nl}The revelation says you are that Savior.{nl}
 QUEST_20151001_002451	You better keep quiet about this.{nl}Unless you want the demons looking for you.{nl}
 QUEST_20151001_002452	I don't want to talk anymore about Saviors and such.{nl}Now, you should hurry back to Uska.{nl}
-QUEST_20151001_002453	He will tell you where to go.{nl}May the Goddess bless you in the future.
+QUEST_20151001_002453	He will tell you where to go.{nl}May the goddess bless you in the future.
 QUEST_20151001_002454	Receptionist Liam
 QUEST_20151001_002455	What kind of request are you looking for?
 QUEST_20151001_002456	Please be with someone you can trust.
@@ -2467,18 +2467,18 @@ QUEST_20151001_002474	Even if the world collapses, the people will remain.{nl}If
 QUEST_20151001_002475	This too is my ordeal and duty which Laima foresaw... {nl}I will tell you Laima's message.{nl}	
 QUEST_20151001_002476	$If I'm paid well, there's no reason I would stop a person who wants to learn my techniques.{nl}Rather, I would even welcome that person. That doesn't mean they should follow my every move, though.
 QUEST_20151001_002477	Some Revelator drove out the demons in the Crystal Mine. {nl}That's just splendid news. {nl}Take your time and look around.
-QUEST_20151001_002478	Have you heard the rumors about the Tenet Church?{nl}The Revelator may come see the Goddess.{nl}I can also benefit from it in terms of my business.
+QUEST_20151001_002478	Have you heard the rumors about the Tenet Church?{nl}The Revelator may come see the goddess.{nl}I can also benefit from it in terms of my business.
 QUEST_20151001_002479	I am so happy to hear such good news after you came here.{nl}I was very depressed about how the world would turn out. Ah, take your time to look around.
 QUEST_20151001_002480	I heard the Crystal Mine may open again because of some Revelator.{nl}It doesn't cost you anything to look around, so take your time.
 QUEST_20151001_002481	Have you heard what happened at the Crystal Mine?{nl}I heard one Revelator defeated the scary Demon Lord and I think it's so great.{nl}Please do not refuse and take your time to look around.
-QUEST_20151001_002482	I was hoping that the Goddess was at the Tenet Church, but I guess she wasn't.{nl}But, I am sure the Revelators will find her.{nl}So I've decided not to raise the prices although we are having difficult times these days. Please check.
+QUEST_20151001_002482	I was hoping that the goddess was at the Tenet Church, but I guess she wasn't.{nl}But, I am sure the Revelators will find her.{nl}So I've decided not to raise the prices although we are having difficult times these days. Please check.
 QUEST_20151001_002483	It is so good to hear that the Crystal Mine is opening again soon. {nl}I'd thought the world would've collapsed soon. {nl}Let's see, which equipment do you want me to take a look at?
 QUEST_20151001_002484	The Revelator who saved the Tenet Church... I'd like to fix your equipment for free,{nl}but that is going to be hard due to the current circumstances.
 QUEST_20151001_002485	It is great that the Revelator retook the Crystal Mine back from the hands of the demons.{nl}We feel embarrassed since it should have been retaken by us.
 QUEST_20151001_002486	The Paladin Master could ask for our help...{nl}We would have caught the Demon King if he had done so.
 QUEST_20151001_002487	I don't care who saved the Crystal Mine.{nl}Wasn't he a Cryomancer? I just hope he isn't a Pyromancer.
-QUEST_20151001_002488	You saved the Tenet Church... But the Goddess wasn't there, right?{nl}That's unfortunate. Everyone wished deeply to see the Goddesses.
-QUEST_20151001_002489	About the Crystal Mine, I don't know who the Revelator is, but he has done us a great deed.{nl}Should we just look for the Goddesses now?{nl}
+QUEST_20151001_002488	You saved the Tenet Church... But the goddess wasn't there, right?{nl}That's unfortunate. Everyone wished deeply to see the goddesses.
+QUEST_20151001_002489	About the Crystal Mine, I don't know who the Revelator is, but he has done us a great deed.{nl}Should we just look for the goddesses now?{nl}
 QUEST_20151001_002490	I thought the Tenet Church would not be influenced by Medzio Diena, but it turned into a demons' den.{nl}But, it is still has hope. We just have to start again. 
 QUEST_20151001_002491	I feel embarrassed that the Revelator has done something which the Masters couldn't do.{nl}Please don't misunderstand. It is not an inferiority complex.
 QUEST_20151001_002492	I've heard about the Tenet Church. Isn't it great? {nl}The expectations of you are getting bigger at Klaipeda. You realize this, right?
@@ -2488,10 +2488,10 @@ QUEST_20151001_002495	I want to research further about the sacred power which th
 QUEST_20151001_002496	The Vubbes rushed out from the Crystal Mine because of the Demon Lord. {nl}But, I don't know why they took the villagers. Do you know anything about it?
 QUEST_20151001_002497	I can't believe it. Is the Cunningham legend at the Crystal Mine for real?{nl}If that's so, where is she?
 QUEST_20151001_002498	When I first saw the Revelator, I thought it was a trick by the demons...{nl}But, since he retook the Tenet Church, I think he may save the world.
-QUEST_20151001_002499	I've heard about what happened at the Crystal Mine.{nl}I am sure the Revelators are the ones sent by the Goddesses.
+QUEST_20151001_002499	I've heard about what happened at the Crystal Mine.{nl}I am sure the Revelators are the ones sent by the goddesses.
 QUEST_20151001_002500	We are happy to hear that the Tenet Church was taken back from the hands of the demons.{nl}But, we still have a long way to go. We feel ashamed that we couldn't actively participate.
-QUEST_20151001_002501	The Goddesses always win.{nl}The defeat of the Demon Lord, Mirtis by the Revelator is evidence.
-QUEST_20151001_002502	Even though the Goddesses aren't here, we have no doubts that we are going to win.{nl}The Revelator who protected the Tenet Church confirms that.
+QUEST_20151001_002501	The goddesses always win.{nl}The defeat of the Demon Lord, Mirtis by the Revelator is evidence.
+QUEST_20151001_002502	Even though the goddesses aren't here, we have no doubts that we are going to win.{nl}The Revelator who protected the Tenet Church confirms that.
 QUEST_20151001_002503	Everyone thought that the legend of Cunningham was just a story.{nl}But, since the Demon Lord at the Crystal Mine really appeared, who was that girl anyways...
 QUEST_20151001_002504	I've known the Paladin Master for a long time.{nl}He must have had some worries... You have done something great.
 QUEST_20151001_002505	The Crystal Mine is the start of the ordeal.{nl}But, that is the sacred duty which you are responsible for.{nl}
@@ -2507,14 +2507,14 @@ QUEST_20151001_002514	I have heard about the Revelator who drove out the demons 
 QUEST_20151001_002515	Everyone is just busy trying to survive after Medzio Diena so they don't have time to think about going to the great cathedral.{nl}But everyone relies on the Great Cathedral. {nl}The Revelator completed a huge task.
 QUEST_20151001_002516	I don't know who the Revelator is, but I could have saved Mage Tower better than the Revelator. {nl}Of course, my fees would have be met.
 QUEST_20151001_002517	Even a person like me who goes after money, I know how important the Great Cathedral is.{nl}But, one thing that keeps my attention... The necklaces of the wise man, Maven. {nl}They are not in the hands of the demons right?
-QUEST_20151001_002518	I came here by passing through rough winds and waves while you've came here by going through Thorny Vines Forest.{nl} You must be joking that you haven't found the Goddesses. Seriously, how did you do that?
+QUEST_20151001_002518	I came here by passing through rough winds and waves while you've came here by going through Thorny Vines Forest.{nl} You must be joking that you haven't found the goddesses. Seriously, how did you do that?
 QUEST_20151001_002519	If Mage Tower collapses, Fedimian won't be safe.{nl}The Demon Lord, Helgasercle... the end of the obsession ends in such vain. 
-QUEST_20151001_002520	Ever since the Revelators who dreamt of the Goddesses appeared, the hands of the demons released them one by one.{nl}The same goes to the Great Cathedral. {nl}The proof that the Goddesses didn't abandon us is them.
+QUEST_20151001_002520	Ever since the Revelators who dreamt of the goddesses appeared, the hands of the demons released them one by one.{nl}The same goes to the Great Cathedral. {nl}The proof that the Goddesses didn't abandon us is them.
 QUEST_20151001_002521	Leaving the kingdom
 QUEST_20151001_002522	A gigantic tree rose up from deep underground the capital city.{nl}The size of the tree was big enough that it couldn't even be compared against any mountain.{nl}As a result, many cities were destroyed and many people lost their beloved ones.{nl}
 QUEST_20151001_002523	But, the disaster did not end there.{nl}The evil energy started to surround the grounds and the monsters started to become feral. {nl}The demons started to attack.{nl}It was like an incurable disease, we didn't see any sign of recovery.
-QUEST_20151001_002524	Still, the Goddesses were no where to be found.{nl}The Goddesses who we trusted disappeared without a trace and responded to nobody's prayers.{nl}People became mad and depressed, and soon only resignations were left behind.{nl}We started to prevent the chaos as much as we could, but as we did so, more misunderstandings were created. {nl}Death was always close-by and we gradually became dreary. {nl}
-QUEST_20151001_002525	We are becoming dreary to all the sadness and the pains.{nl}As if lifeless, we give up on everything and try not to do anything.{nl}It is like we are seeing the end of the history of the kingdom...{nl}We are just keep repeating the names of the Goddesses.{nl}
+QUEST_20151001_002524	Still, the goddesses were no where to be found.{nl}The goddesses who we trusted disappeared without a trace and responded to nobody's prayers.{nl}People became mad and depressed, and soon only resignations were left behind.{nl}We started to prevent the chaos as much as we could, but as we did so, more misunderstandings were created. {nl}Death was always close-by and we gradually became dreary. {nl}
+QUEST_20151001_002525	We are becoming dreary to all the sadness and the pains.{nl}As if lifeless, we give up on everything and try not to do anything.{nl}It is like we are seeing the end of the history of the kingdom...{nl}We are just keep repeating the names of the goddesses.{nl}
 QUEST_20151001_002526	I will end my writing here and leave the kingdom.{nl}I don't like my feeling of helplessness and the depressions.{nl}I am going to leave to a place where I can dream for hope again...
 QUEST_20151001_002527	Savior...{nl}Laima told us that she had dreamt about the collapse of the world.{nl}And among many Revelators, one Savior would save everyone.{nl}
 QUEST_20151001_002528	However, I cannot fully trust Laima's foresight.{nl}
@@ -2522,7 +2522,7 @@ QUEST_20151001_002529	For the Savior that would appear some day...{nl}I should h
 QUEST_20151001_002530	I thought the reason why I had to follow the revelation on behalf of Agailla Flurry,{nl}was related to her death and the ill-fated relationship with Helgasercle.{nl}
 QUEST_20151001_002531	But, everything was accomplished as foretold by Laima.{nl}After Medzio Diena, I had to endure the long fight with my weak power.{nl}
 QUEST_20151001_002532	Thanks for rescuing me, Savior.{nl}I should've listened to Laima sooner... and I regret the days in the past.
-QUEST_20151001_002533	Perhaps I shall soon lose my breath. {nl}Pilgrims, may the blessings of the Goddess be with you!
+QUEST_20151001_002533	Perhaps I shall soon lose my breath. {nl}Pilgrims, may the blessings of the goddess be with you!
 QUEST_20151001_002534	What was the thing she was looking for until the end?{nl}I am sure it has a sad story behind it.
 QUEST_20151001_002535	Tree Root Crystals are slowly killing me.{nl}It feels as if I am drowning.{nl}
 QUEST_20151001_002536	I have lost all desires. Am I dying? {nl}Eating and even breathing feels meaningless to me.{nl}
@@ -2530,15 +2530,15 @@ QUEST_20151001_002537	This surely isn't a teaching of Maven. {nl}Greed? Laziness
 QUEST_20151001_002538	If only I had a little more time… {nl}The data I've collected near Dykyne Fork… I can't leave them…
 QUEST_20151001_002539	The archer gives an arrow as a present, but the enemy take it as death.{nl}I think the world is like that now.
 QUEST_20151001_002540	$I will stay here with the Believers. {nl}I will somehow prevent the Thorn Forest from expanding any more.{nl}
-QUEST_20151001_002541	Don't tell them about me for a while.{nl}Humans need a place to rely on...{nl}When they find out the powerlessness of the Goddesses, this world will be filled with chaos and sighs.{nl}
-QUEST_20151001_002542	The guardian of the Royal Mausoleum where the next revelation awaits is quite far from here.{nl}So I will open a portal for you as a shortcut.{nl}In the name of Saule, the Goddess of the Sun, I will pray for your safety.
+QUEST_20151001_002541	Don't tell them about me for a while.{nl}Humans need a place to rely on...{nl}When they find out the powerlessness of the goddesses, this world will be filled with chaos and sighs.{nl}
+QUEST_20151001_002542	The guardian of the Royal Mausoleum where the next revelation awaits is quite far from here.{nl}So I will open a portal for you as a shortcut.{nl}In the name of Saule, the goddess of the sun, I will pray for your safety.
 QUEST_20151001_002543	$Speaking of eternal life.. look at Tesla. {nl}One would think that there is no aging in eternal life, don't you agree?
 QUEST_20151001_002544	(There are barely legible words written here.) {nl}...Juros could not hold his breath any longer so he ended up inhaling the spores and died. {nl}Mushworts hunt people with the cruelest method I've ever seen. {nl}They walk around our gathering places and shake out mushrooms that release spores.{nl}
-QUEST_20151001_002545	Even when the Goddesses are not around, the Oracles still deliver the Goddesses' message to people. {nl}Surely that is proof that the Goddesses still exist.
-QUEST_20151001_002546	$Medzio Diena was not nature's will.{nl}After all, nature is governed by the Goddesses, and they would never do harm to us all.
-QUEST_20151001_002547	I offer this Goddess Statue, which I have put all my heart and soul into, to the Goddess of great honor and light.
+QUEST_20151001_002545	Even when the goddesses are not around, the Oracles still deliver the goddesses' message to people. {nl}Surely that is proof that the goddesses still exist.
+QUEST_20151001_002546	$Medzio Diena was not nature's will.{nl}After all, nature is governed by the goddesses, and they would never do harm to us all.
+QUEST_20151001_002547	I offer this Goddess Statue, which I have put all my heart and soul into, to the goddess of great honor and light.
 QUEST_20151001_002548	Among my disciples, two of them followed me until my latter years and they will also be my successors after my death. {nl}
-QUEST_20151001_002549	…I am thinking whether I should thank the Goddesses for this discovery or worry that my craving for knowledge could ruin the world.{nl}
+QUEST_20151001_002549	…I am thinking whether I should thank the goddesses for this discovery or worry that my craving for knowledge could ruin the world.{nl}
 QUEST_20151001_002550	I can't sleep well due to the fear of my research results being spread by interrogations from the demons. {nl}That's why I wish to pass the rest of the research to the one I can trust.
 QUEST_20151001_002551	Are you interested in the eternal life?{nl}We, Necromancers control the dead, so it's easy when you think about that.{nl}
 QUEST_20151001_002552	If he asks about the weather, then tell him that it will be sunny.{nl}Okay then, I will be counting on you as I wait.
@@ -2550,13 +2550,13 @@ QUEST_20151001_002557	So you are the one sent by the Monk Master.{nl}We've recei
 QUEST_20151001_002558	Is that so... I must hurry then.
 QUEST_20151001_002559	Unfortunately, we don't have any goods to sell at the moment.
 QUEST_20151001_002560	Be careful on your way back.
-QUEST_20151001_002561	I'll never forgive the monsters that killed my family. {nl}Though my body returns to the ground, my soul still burns with anger. {nl}Oh, Goddess. Only the cold blood of the monsters can cool my rage.
+QUEST_20151001_002561	I'll never forgive the monsters that killed my family. {nl}Though my body returns to the ground, my soul still burns with anger. {nl}Oh, goddess. Only the cold blood of the monsters can cool my rage.
 QUEST_20151001_002562	King Kadumel finally dies.
-QUEST_20151001_002563	The checks of mutual power between the demons and the Goddesses had been stable for a long time.{nl}So long as they didn't cross each other's territories.{nl}
+QUEST_20151001_002563	The checks of mutual power between the demons and the goddesses had been stable for a long time.{nl}So long as they didn't cross each other's territories.{nl}
 QUEST_20151001_002564	But, the demons broke through first.{nl}And from the Stone Frosts... even the spirits became stones.
-QUEST_20151001_002565	As the demons started casting their petrification curse on this region, the Goddesses tried to save the humans.{nl}However, the demons advised the Goddesses that doing so would violate the rules that they mutually agreed to...
-QUEST_20151001_002566	Excuse me for a bit. It is a horrible memory...{nl}They brought the catastrophe. A strong catastrophe which made Goddesses to give up rescuing this place.
-QUEST_20151001_002567	The Goddesses already gave up rescuing once as they couldn't do anything on Medzio Diena.{nl}But, we can't just give up.
+QUEST_20151001_002565	As the demons started casting their petrification curse on this region, the goddesses tried to save the humans.{nl}However, the demons advised the goddesses that doing so would violate the rules that they mutually agreed to...
+QUEST_20151001_002566	Excuse me for a bit. It is a horrible memory...{nl}They brought the catastrophe. A strong catastrophe which made goddesses to give up rescuing this place.
+QUEST_20151001_002567	The goddesses already gave up rescuing once as they couldn't do anything on Medzio Diena.{nl}But, we can't just give up.
 QUEST_20151001_002568	$Savior.{nl}As you can see, I cannot do anything myself at the moment.{nl}As you have heard, after Medzio Diena my powers have become weak...{nl}
 QUEST_20151001_002569	{memo X}In this prison, a new disaster is about to happen.{nl}The demons are keep coming over from the dimensional crack and they are trying to take this prison as their new camp.{nl}
 QUEST_20151001_002570	I don't have any power left to close the dimensional crack.{nl}But, I think there is still a way.{nl}
@@ -2596,9 +2596,9 @@ QUEST_20151001_002603	{memo X}You need a certificate in order to go to the next 
 QUEST_20151001_002604	Wait! Can you hear anything?
 QUEST_20151001_002605	Stop thinking that this is a bad method. It's the best method that I can think of to help you at the moment.
 QUEST_20151001_002606	Ruklys' Squad Member Spirit
-QUEST_20151001_002607	I want to go beside the Goddesses.
+QUEST_20151001_002607	I want to go beside the goddesses.
 QUEST_20151001_002608	Premier Eminent
-QUEST_20151001_002609	{memo X}The revelation of the Goddesses which we were looking for is near.
+QUEST_20151001_002609	{memo X}The revelation of the goddesses which we were looking for is near.
 QUEST_20151001_002610	{memo X}So you activated the magic circle again!
 QUEST_20151001_002611	{memo X}Even if I die, I will block you from obtaining the revelation!
 QUEST_20151001_002612	{memo X}My loyal subordinate, Mandara! Kill that arrogant Revelator!
@@ -2616,16 +2616,16 @@ QUEST_20151001_002623	We can't just let go of your intrusion into the Fortress o
 QUEST_20151001_002624	We appreciate for your help, but we can't just ignore the royal order.
 QUEST_20151001_002625	Please get out of the Fortress of the Land.
 QUEST_20151001_002626	Ruklys' Army Spirit
-QUEST_20151001_002627	{memo X}Take him to the Goddess.
+QUEST_20151001_002627	{memo X}Take him to the goddess.
 QUEST_20151001_002628	The resistance has been weakened. Let's use the token of the restraint.
 QUEST_20151001_002629	Premier Eminent is giving some orders to the demons.
 QUEST_20151001_002630	I will be stationing one of our guards here in case you're planning to run away.
 QUEST_20151001_002631	Beyond Pilgrim's Way is the Great Cathedral, which was built by Maven. {nl}Ruklys, Lydia Schaffen, and Agailla Flurry were all his disciples.{nl}
 QUEST_20151001_002632	Among them, the Paladin Master was a hero who saved many lives in the capital. {nl}Currently, he has gone to Srautas Gorge to fight a great evil...
-QUEST_20151001_002633	Many people made bets with Modestas to find out who the statue of the Goddess is, but Modesta has never lost before he died.
+QUEST_20151001_002633	Many people made bets with Modestas to find out who the statue of the goddess is, but Modesta has never lost before he died.
 QUEST_20151001_002634	$By the end of my life I hope to see Fedimian completely restored.{nl}If there's one thing I can do, I can make 1,000 pots in dedication to this wish.
 QUEST_20151001_002635	$I hope I can make it big off of the excavation site at Zachariel's Royal Mausoleum…
-QUEST_20151001_002636	$I beg to the Goddess. {nl}I hope the day when my oath to the Watchers is realized never comes…
+QUEST_20151001_002636	$I beg to the goddess. {nl}I hope the day when my oath to the Watchers is realized never comes…
 QUEST_20151001_002637	$When I close my eyes at last, I hope my many disciples will protect me at my side.
 QUEST_20151001_002638	Now is the moment that we become one with our blades. My last wish is to die beside the one I love.
 QUEST_20151001_002639	Why have you returned?{nl}
@@ -2635,18 +2635,18 @@ QUEST_20151001_002642	And Alina... I am not sure.{nl}She ran to the lower side s
 QUEST_20151001_002643	You've passed the object and the story of Grazina.
 QUEST_20151001_002644	Please find Alina...
 QUEST_20151001_002645	2nd page of the Roxona Conflict
-QUEST_20151001_002646	The time went by and the summer, the season of new green leaves came...{nl}Lydia Schaffen wandered around to find the one who'd killed her parents and relatives.{nl}The Goddesses were on her side after all.{nl}The time that she's been waiting for has finally come.{nl}
+QUEST_20151001_002646	The time went by and the summer, the season of new green leaves came...{nl}Lydia Schaffen wandered around to find the one who'd killed her parents and relatives.{nl}The goddesses were on her side after all.{nl}The time that she's been waiting for has finally come.{nl}
 QUEST_20151001_002647	One by one they fell in the dark to her unexpected arrows.{nl}Although it should have been an easy fight for them, they never knew where she was.{nl}The sound of her arrows ripped through air and skin.{nl}Soon there were no one other than Lydia Schaffen, who stood still.{nl}
 QUEST_20151001_002648	Lydia Schaffen raised her torch.{nl}The flame wavered ominously, causing her shadow to waver as well...{nl}She wanted to check the faces of the villains who killed her parents and neighbors as well as burnt the village.{nl}Many of the faces she saw for the first time, but some of them were familiar.{nl}They were loyal subordinates of Ruklys and she knew very well about them.{nl} If it had been a brighter time and different location, she may have noticed the incident before it occurred.{nl}But, the incident had occurred and it was irrevocable.{nl}Just as Lydia Schaffen had her reasons to kill her enemies, Ruklys now had his: to defeat her for killing his subordinates.{nl}
 QUEST_20151001_002649	With a gloomy sense of shame and unfamiliar embarrassment, she quietly picked up her bow and left the place.{nl}The news soon reached Ruklys.{nl}They both comforted themselves by thinking that they just fell into a wicked plan.{nl}But, it was useless.{nl}They felt the vague shadow of the wicked plan behind them.{nl}
-QUEST_20151001_002650	But, it was too late.{nl}There was nothing she could do except for put an end to Ruklys with the arrows that she now love and hate.{nl}Or else his sword will guide her to the Goddesses... there was nothing she could do. 
+QUEST_20151001_002650	But, it was too late.{nl}There was nothing she could do except for put an end to Ruklys with the arrows that she now love and hate.{nl}Or else his sword will guide her to the goddesses... there was nothing she could do. 
 QUEST_20151001_002651	$There is one more thing I must tell you. {nl}Follow the name of Ruklys.{nl}
 QUEST_20151001_002652	$His final battleground...{nl}Laima's revelation at the Fortress of the Land is waiting for you.{nl}
 QUEST_20151001_002653	Goddess Laima...{nl}The Revelator who you foretold has finally come...{nl}
-QUEST_20151001_002654	After a thousand years of sleep, I am finally able to meet you, the one whose coming the Goddess foretold.{nl}I am also relieved to see that the effort I put into building the Royal Mausoleum during my rule was not futile.{nl}
+QUEST_20151001_002654	After a thousand years of sleep, I am finally able to meet you, the one whose coming the goddess foretold.{nl}I am also relieved to see that the effort I put into building the Royal Mausoleum during my rule was not futile.{nl}
 QUEST_20151001_002655	Although I founded the kingdom,{nl}I wish to speak to you as the guardian of the revelation rather than as king.
-QUEST_20151001_002656	You are the Savior of this kingdom.{nl}I can feel that you will save this world and become the one who the Goddesses would rely upon.{nl}
-QUEST_20151001_002657	After spending a thousand years of worshiping the providence of the Goddess,{nl}I shall now show you the great will that was left to you in the revelation.
+QUEST_20151001_002656	You are the Savior of this kingdom.{nl}I can feel that you will save this world and become the one who the goddesses would rely upon.{nl}
+QUEST_20151001_002657	After spending a thousand years of worshiping the providence of the goddess,{nl}I shall now show you the great will that was left to you in the revelation.
 QUEST_20151001_002658	The soldiers will die if I don't make it. {nl}I have to be strong. 
 QUEST_20151001_002659	…Only after three years since Ruklys learned from my teachings…
 QUEST_20151001_002660	If the demons cross the dimensional crack and join hands together with their brethren at the Demon Prison...,{nl}the world will be in for another kind of threat.
@@ -2664,7 +2664,7 @@ QUEST_20151001_002671	The religious body of the tree of the truth worships the D
 QUEST_20151001_002672	The religious body of the tree of the truth will be the ones selected by the Divine Tree and they will help starting to build a new era.
 QUEST_20151001_002673	Margiris once told us. The salvation can't be achieved easily.{nl}What we are doing is washing off the sins of the ignorant ones and washing off our sins.{nl}The ones who die are because they are weak. Only the survivors would receive the salvation.
 QUEST_20151001_002674	The ones who came to this place before Yuta came here are the guys from the religious body of the tree of the truth.{nl}They are the disciples acknowledged by Goddess Zemyna.{nl}
-QUEST_20151001_002675	This land is blessed by Goddess Zemyna, so they thought they should make a will of the Goddess.{nl}How can I stop it.
+QUEST_20151001_002675	This land is blessed by Goddess Zemyna, so they thought they should make a will of the goddess.{nl}How can I stop it.
 QUEST_20151001_002676	Fake Box
 QUEST_20151001_002677	It doesn't seem to be this box.
 QUEST_20151001_002678	It is not enough to destroy the holy relics of the church order, you did release Karail..{nl}
@@ -2681,14 +2681,14 @@ QUEST_20151001_002688	Aldona! Zydrone!{nl}Now!
 QUEST_20151001_002689	Aldona, Zydrone..{nl}I'm sorry for being a burden to you both because of my feebleness.{nl}
 QUEST_20151001_002690	But, let's not waste any time.{nl}You've brought the Savior here.. who has the power to get rid of this disaster.{nl}
 QUEST_20151001_002691	I will ask the Savior to help me.{nl}You two should get ready to quickly make the Key of the Night Star.{nl}
-QUEST_20151001_002692	The many deaths of demons could not fill the emptiness in my heart. {nl}Once the Goddess's great mission for me is over, I will be left with a long life full of boring moments.
+QUEST_20151001_002692	The many deaths of demons could not fill the emptiness in my heart. {nl}Once the goddess's great mission for me is over, I will be left with a long life full of boring moments.
 QUEST_20151001_002693	Ugh, I thought it would die after its throat had been cut.{nl}I hope it can just behave now and die slowly.
 QUEST_20151001_002694	$A false revelation.. all this so you can lure me out to get rid of me?{nl}How disappointing to see that such trickery is the best that Laima can prepare.
 QUEST_20151001_002695	$But for all your preparations, you are powerless against me..{nl}It's amusing how your foolishness blinds you from the insurmountable gap of power between us.
 QUEST_20151001_002696	$Right. I can feel where the real revelation is located.{nl}Try struggling once more.
 QUEST_20151001_002697	So, this is where the revelation is hidden.
 QUEST_20151001_002698	$Demon Lord Magnox
-QUEST_20151001_002699	Such are the fools who follow the Goddess.{nl}Have you not witnessed enough to know me?{nl}All this time I've been waiting for you all to come at your own will.
+QUEST_20151001_002699	Such are the fools who follow the goddess.{nl}Have you not witnessed enough to know me?{nl}All this time I've been waiting for you all to come at your own will.
 QUEST_20151001_002700	After I defeat you, I will continuously disturb the priest until he opens the box himself.
 QUEST_20151001_002701	$I was able to retrieve my soul thanks to you.. Isn't this the Chain of Reversion that shredded my soul?
 QUEST_20151001_002702	{memo X}Collecting the Shiny Moss
@@ -2705,7 +2705,7 @@ QUEST_20151016_002712	At this rate...{nl}All life in this world will come to an 
 QUEST_20151016_002713	Please help...{nl}
 QUEST_20151016_002714	Only you...{nl}Only the Revelator can save this world.{nl}
 QUEST_20151016_002715	Please go to Klaipeda. {nl}And please..do everything you can to keep the Light of Salvation safe from the demons.
-QUEST_20151016_002716	While I may have built my sanctum here, the materials for making a Goddess scripture is found elsewhere. Thus we have founded this religious organization to look for the records of the Ancient Sages of the Rhud Order.
+QUEST_20151016_002716	While I may have built my sanctum here, the materials for making a goddess scripture is found elsewhere. Thus we have founded this religious organization to look for the records of the Ancient Sages of the Rhud Order.
 QUEST_20151016_002717	Kedoran Merchant Alliance Notice Board
 QUEST_20151016_002718	{memo X}This vicinity is Kedoran Merchant Alliance's excavation site.
 QUEST_20151016_002719	Received the benefits of the.. Kedoran Merchant Alliance.{nl}Somehow I'm full of energy.
@@ -2718,7 +2718,7 @@ QUEST_20151016_002725	{memo X}Kedoran Merchant Alliance's good is a bit far away
 QUEST_20151016_002726	{memo X}Kedoran Merchant Alliance's good is a far away in the upper right corner.
 QUEST_20151016_002727	{memo X}Kedoran Merchant Alliance's good is a far away in the upper end.
 QUEST_20151016_002728	{memo X}Kedoran Merchant Alliance's good is a far away in the upper left corner.
-QUEST_20151016_002729	{memo X}They say what is the use in the world with disappeared goddesses, but we believe Goddesses will one day return and save us.{nl}Is it wrong to pray so that the day will come sooner?{nl}These monuments were built with our devotion from our praying hearts.{nl}Until some strange person came and destroyed the monuments, it symbolized our prayers.
+QUEST_20151016_002729	{memo X}They say what is the use in the world with disappeared goddesses, but we believe goddesses will one day return and save us.{nl}Is it wrong to pray so that the day will come sooner?{nl}These monuments were built with our devotion from our praying hearts.{nl}Until some strange person came and destroyed the monuments, it symbolized our prayers.
 QUEST_20151016_002730	{memo X}If it's a normal monument, we prayed to release such an aura.[nl]It's not some corruption!{nl}Working under someone who neither understand or can hear, did the person who destoryed our monuments saw it as a corruption?
 QUEST_20151016_002731	{memo X}Do you finally understand?{nl}What your utter stupidity has caused?{nl}If you understand, start trying to think of a way to revert this.{nl}This can't simply be ignored.
 QUEST_20151016_002732	{memo X}Below, I believe there's someone destroying Nestospa's Monuments by disguising as Anastospa.{nl}Can you go and investigate?{nl}It might be dangerous, take this flare.{nl}Be careful.

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -8,7 +8,7 @@ QUEST_LV_0100_20150317_000007	$Fi... Finally! Has help arrived?{nl}Huh?! It's ju
 QUEST_LV_0100_20150317_000008	$What's that paper you're holding? It looks familiar...{nl}Let me see that! What are you doing? Hey, there's an adult speaking to you!
 QUEST_LV_0100_20150317_000009	$This paper, it's mine! I'm never giving it away again!!{nl}It's.. not something you need - I'll just rip it apart. There.
 QUEST_LV_0100_20150317_000010	$Sheesh, that's lame...
-QUEST_LV_0100_20150317_000011	$After all the Goddesses had vanished, these dreams were one of the first things that came up.{nl}Maybe one of these people will be the one who brings the Goddesses back.
+QUEST_LV_0100_20150317_000011	$After all the goddesses had vanished, these dreams were one of the first things that came up.{nl}Maybe one of these people will be the one who brings the goddesses back.
 QUEST_LV_0100_20150317_000012	$Soldier Blak
 QUEST_LV_0100_20150317_000013	$Be warned!{nl}Monsters are attacking, so all civilians must evacuate!{nl}Why are those civilians in the military zone anyway?{nl}
 QUEST_LV_0100_20150317_000014	$Ah, so you are the Revelator! I'm sorry, I didn't recognize you.{nl}Monsters are attacking the supply base at the moment.{nl}I need to get some important rations out from the base. Please help me!
@@ -38,7 +38,7 @@ QUEST_LV_0100_20150317_000037	$I feel so fed up having to endure this all the ti
 QUEST_LV_0100_20150317_000038	$Adjutant General Volda
 QUEST_LV_0100_20150317_000039	$Thank you very much, but you must be late for other things.{nl}Besides we can't just sit here and wait. We plan to keep attacking.
 QUEST_LV_0100_20150317_000040	$Secret Guardian
-QUEST_LV_0100_20150317_000041	$The Goddess already foresaw this.{nl}Nothing can escape from her vision.
+QUEST_LV_0100_20150317_000041	$The goddess already foresaw this.{nl}Nothing can escape from her vision.
 QUEST_LV_0100_20150317_000042	$Liaison Officer Niels
 QUEST_LV_0100_20150317_000043	$Hello.{nl}Have you seen an old man who has lost his way?{nl}His name is Jonas.{nl}
 QUEST_LV_0100_20150317_000044	$You haven't seen him?{nl}Now which direction would that feeble old fellow have wandered off towards?
@@ -85,7 +85,7 @@ QUEST_LV_0100_20150317_000084	$Hey, rookie, are you taking a break?{nl}Get some 
 QUEST_LV_0100_20150317_000085	$We will lure Gaigalas using Ducky Fat.{nl}Hey rookie, don't loaf around.
 QUEST_LV_0100_20150317_000086	$Today will be the last day for Gaigalas.{nl}Are you ready, rookie?
 QUEST_LV_0100_20150317_000087	$Next, we will get leather from Cronewts in Lengvas Garden.{nl}Hurry, soldier.
-QUEST_LV_0100_20150317_000088	$We will win for sure this time.{nl}The Goddesses are on our side.
+QUEST_LV_0100_20150317_000088	$We will win for sure this time.{nl}The goddesses are on our side.
 QUEST_LV_0100_20150317_000089	$You are pretty good for a rookie.{nl}It's disorganized here at the moment, so you can keep those ingredients for now.{nl}
 QUEST_LV_0100_20150317_000090	$Get to know our soldiers while I make preparations for the battle.{nl}I will call you before we confront Gaigalas.
 QUEST_LV_0100_20150317_000091	$When we burn the Ducky Fat, Gaigalas will appear after smelling the odor.{nl}Lengvas Garden will be a good place to burn it.
@@ -139,7 +139,7 @@ QUEST_LV_0100_20150317_000138	$When these people disappear, no one else notices.
 QUEST_LV_0100_20150317_000139	{memo X}Please defeat all monsters nearby to prevent anything from happening.{nl}There were reports that the monsters at the 1st Architects' Site had turned violent.
 QUEST_LV_0100_20150317_000140	$Splendid.{nl}We will be safe for now.
 QUEST_LV_0100_20150317_000141	{memo X}Monsters are coming!{nl}They probably found out I was released.
-QUEST_LV_0100_20150317_000142	$The Goddesses have sent you?{nl}I never thought that you would protect me.{nl}
+QUEST_LV_0100_20150317_000142	$The goddesses have sent you?{nl}I never thought that you would protect me.{nl}
 QUEST_LV_0100_20150317_000143	$Where did that huge scorpion go? This is very bad!
 QUEST_LV_0100_20150317_000144	$I should go see Dezic.{nl}I hope to see you again in the future.
 QUEST_LV_0100_20150317_000145	$Someone must have done something strange to the monsters protecting the Royal Mausoleum.{nl}What were they thinking?
@@ -164,7 +164,7 @@ QUEST_LV_0100_20150317_000163	$It was after Jonas went out to a visit with his s
 QUEST_LV_0100_20150317_000164	$Please take good care of Jonas.{nl}It would be a big problem if he got hurt.
 QUEST_LV_0100_20150317_000165	$Davio is at the right side of the camp.{nl}I hope the medicine works well.
 QUEST_LV_0100_20150317_000166	$Finally, I remember everything.{nl}I am the head of the family that protects the Royal Mausoleum... Who are you?{nl}
-QUEST_LV_0100_20150317_000167	$Revelator. If this is the will of the Goddess, then you must be qualified.{nl}You have a job to do, so follow me to Beacon Hill Pass.
+QUEST_LV_0100_20150317_000167	$Revelator. If this is the will of the goddess, then you must be qualified.{nl}You have a job to do, so follow me to Beacon Hill Pass.
 QUEST_LV_0100_20150317_000168	$I have made Niels and you worry...
 QUEST_LV_0100_20150317_000169	$I will lead the way and you will handle any monsters we encounter.{nl}I am counting on you.
 QUEST_LV_0100_20150317_000170	$The time is now. Please go on ahead to Beacon Hill Pass.
@@ -199,9 +199,9 @@ QUEST_LV_0100_20150317_000198	$Vaidotas
 QUEST_LV_0100_20150317_000199	{memo X}$That smell.. I think the purifying device in the mine is broken.{nl}We better repair it quickly. The kidnapped villagers might suffocate.
 QUEST_LV_0100_20150317_000200	$Do you know about the legend of Cunningham?{nl}The legend states that a great demon was sealed here in the Crystal Mine.{nl}There is a book with more details about it at the Mine Worker's Resting Place in Crystal Mine 2F.{nl}
 QUEST_LV_0100_20150317_000201	{memo X}$Anyway, my guess is that the demon is re-awakening and is controlling the Vubbes.{nl}The bishop's dream and the Legend of Cunningham... I feel they may be a sign that something huge is about to happen.{nl}
-QUEST_LV_0100_20150317_000202	$Only the Goddess would know if it will be hope or despair.{nl}
+QUEST_LV_0100_20150317_000202	$Only the goddess would know if it will be hope or despair.{nl}
 QUEST_LV_0100_20150317_000203	$The purifier can be easily fixed by anyone, but it may be hard to find the parts needed.{nl}In that case, use the compass that I gave you to search for them.{nl}
-QUEST_LV_0100_20150317_000204	$Well then, I have some things to do so I will meet you at 3F of the Crystal Mine.{nl}In the name of the Goddess, I pray for success in your struggles.
+QUEST_LV_0100_20150317_000204	$Well then, I have some things to do so I will meet you at 3F of the Crystal Mine.{nl}In the name of the goddess, I pray for success in your struggles.
 QUEST_LV_0100_20150317_000205	$If you can't find the parts needed to repair the purifier, use the compass I gave you.{nl}It'll help you find them.
 QUEST_LV_0100_20150317_000206	$Village Aunt
 QUEST_LV_0100_20150317_000207	$You've come to save us? Right?
@@ -214,7 +214,7 @@ QUEST_LV_0100_20150317_000213	$I get furious whenever I see those Vubbes who rui
 QUEST_LV_0100_20150317_000214	$I would have left already if this wasn't my hometown.{nl}Where on earth were all the Vubbes hiding before they crawled out?
 QUEST_LV_0100_20150317_000215	$Pharmacist Lady
 QUEST_LV_0100_20150317_000216	$Thanks for your help last time.{nl}Without you, I would have never gotten this much ingredients.
-QUEST_LV_0100_20150317_000217	{memo X}$Perhaps the person that the Goddess sent was you.{nl}You are the most merciful person I have ever seen among the Revelators.
+QUEST_LV_0100_20150317_000217	{memo X}$Perhaps the person that the goddess sent was you.{nl}You are the most merciful person I have ever seen among the Revelators.
 QUEST_LV_0100_20150317_000218	$Soldier Jace
 QUEST_LV_0100_20150317_000219	{memo X}$I will protect this village for my dead comrades.
 QUEST_LV_0100_20150317_000220	$Even if the world changes, I will never forgive the Vubbes.
@@ -223,17 +223,17 @@ QUEST_LV_0100_20150317_000222	$These are the rations that we gathered from East 
 QUEST_LV_0100_20150317_000223	$Thanks to you, I received this much food.{nl}I am relieved.
 QUEST_LV_0100_20150317_000224	$Knight Commander Uska
 QUEST_LV_0100_20150317_000225	$Is this slate the evidence of salvation?{nl}It just looks like an old slate to me.
-QUEST_LV_0100_20150317_000226	{memo X}$Ask the mayor of the Miners' Village about a way to Leaf Veil Plateau.{nl}I will send the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
+QUEST_LV_0100_20150317_000226	{memo X}$Ask the mayor of the Miners' Village about a way to Leaf Veil Plateau.{nl}I will send the message to the Paladin Master first. {nl}May the blessings of goddess be with you.
 QUEST_LV_0100_20150317_000227	$It would be good to ask the Bokor Master to interpret this slate.{nl}She lives at the end of Klaipeda's Residential Area so go pay her a visit.
 QUEST_LV_0100_20150317_000228	{memo X}$Use your time wisely.{nl}No one else fully knows your future.
 QUEST_LV_0100_20150317_000229	$So you finally returned.{nl}What did the Bokor Master tell you?
 QUEST_LV_0100_20150317_000230	{memo X}$I'm also curious about the girl who cracked the seal.{nl}This is not a seal that can easily be broken.
 QUEST_LV_0100_20150317_000231	{memo X}$If the Bokor Master told you that I would know it..{nl}There's one place that comes to mind.{nl}
-QUEST_LV_0100_20150317_000232	{memo X}$The high gardens that the Goddess mentioned could be an area within Leaf Veil Plateau. I heard the Paladin Master is there, uploading a long term promise. 
+QUEST_LV_0100_20150317_000232	{memo X}$The high gardens that the goddess mentioned could be an area within Leaf Veil Plateau. I heard the Paladin Master is there, uploading a long term promise. 
 QUEST_LV_0100_20150317_000233	$Miners' Village Mayor
 QUEST_LV_0100_20150317_000234	$Welcome. Aren't you our town's savior?{nl}
 QUEST_LV_0100_20150317_000235	{memo X}$Leaf Veil Plateau, huh? If you take the road between the two bridges below, you'll reach Silverstream Gorge. 
-QUEST_LV_0100_20150317_000236	{memo X}$So this revelation is from Goddess Laima and we have to collect all these for the Goddess to regain her powers?{nl}That is amazing.
+QUEST_LV_0100_20150317_000236	{memo X}$So this revelation is from goddess Laima and we have to collect all these for the goddess to regain her powers?{nl}That is amazing.
 QUEST_LV_0100_20150317_000237	$Oh, please do not reveal the fact that a revelation has been found unless it is absolutely necessary.{nl}Doing so may only create confusion if the rumors spread.
 QUEST_LV_0100_20150317_000238	Ah, you mean the report.{nl}At first, those Siaulagos did something strange to the supplies, but they ran away after a while when Sparnas came.{nl}
 QUEST_LV_0100_20150317_000239	I was spotted by those Siaulagos when they were running away, so I engaged in a battle..{nl}Yes.. And as you can see, I lost it. The report, I mean.{nl}Aren't they bastards?
@@ -245,7 +245,7 @@ QUEST_LV_0100_20150317_000244	We're not going to suffer anymore.{nl}Thanks for y
 QUEST_LV_0100_20150317_000245	It will be Ziedo Pond.{nl}I heard there are many Siaulambs, so be careful.
 QUEST_LV_0100_20150317_000246	I have not heard anything else about the bishop's dream.{nl}Sorry, I can't be of much help.
 QUEST_LV_0100_20150317_000247	$Klaipeda Guard Captain
-QUEST_LV_0100_20150317_000248	$Go ahead to Klaipeda.{nl}Commander Uska is waiting for you in Klaipeda Central Plaza.{nl}I heard the bishop also had a dream about the Goddess... it appears to concern that day.
+QUEST_LV_0100_20150317_000248	$Go ahead to Klaipeda.{nl}Commander Uska is waiting for you in Klaipeda Central Plaza.{nl}I heard the bishop also had a dream about the goddess... it appears to concern that day.
 QUEST_LV_0100_20150317_000249	$Klaipeda Guard
 QUEST_LV_0100_20150317_000250	$Thank you for making your way here.{nl}If there is still this much left even after Sir Titas handled it himself, can you imagine how it was before?
 QUEST_LV_0100_20150317_000251	$Mercenary Toby
@@ -269,12 +269,12 @@ QUEST_LV_0100_20150317_000268	$Thank you. You found it sooner than I expected.{n
 QUEST_LV_0100_20150317_000269	$If you follow the road to the north, you will find the Search Scout.{nl}Good luck.
 QUEST_LV_0100_20150317_000270	$Laimonas
 QUEST_LV_0100_20150317_000271	{memo X}$Have you ever offered worship to the Statue?{nl}If not, I'd really recommend it.
-QUEST_LV_0100_20150317_000272	$That depends on which Goddess it is.{nl}If you follow the road to the right you will find the Statue of Goddess Zemyna. 
+QUEST_LV_0100_20150317_000272	$That depends on which goddess it is.{nl}If you follow the road to the right you will find the Statue of Goddess Zemyna. 
 QUEST_LV_0100_20150317_000273	{memo X}$I do worry that the monsters might harm the Goddess Statue.
-QUEST_LV_0100_20150317_000274	$I am happy that the statue is unharmed.{nl}The monsters here know to fear the Goddess.{nl}
-QUEST_LV_0100_20150317_000275	$Go down the Shadow Forest Road and you should arrive at Klaipeda shortly.{nl}Well then, may the blessings of the Goddess be with you.
+QUEST_LV_0100_20150317_000274	$I am happy that the statue is unharmed.{nl}The monsters here know to fear the goddess.{nl}
+QUEST_LV_0100_20150317_000275	$Go down the Shadow Forest Road and you should arrive at Klaipeda shortly.{nl}Well then, may the blessings of the goddess be with you.
 QUEST_LV_0100_20150317_000276	{memo X}$Please do me a favor if you are headed to Klaipeda.{nl}It's not easy to go back and forth from Klaipeda because of the Infrorocktors nowadays.
-QUEST_LV_0100_20150317_000277	$Maybe taking care of the statues will make the Goddesses return sooner...
+QUEST_LV_0100_20150317_000277	$Maybe taking care of the statues will make the goddesses return sooner...
 QUEST_LV_0100_20150317_000278	{memo X}$Follow the road on the left at the camp crossroads.{nl}{-scp SCR_DIALOG_NPC_ANIM(
 QUEST_LV_0100_20150317_000279	$)} You'll meet the troops right away.
 QUEST_LV_0100_20150317_000280	$)}Alright, good job.{nl}You'll arrive at Klaipeda shortly if you follow the Shadow Forest Road.{nl}Don't forget to drop by Sir Uska.
@@ -291,19 +291,19 @@ QUEST_LV_0100_20150317_000290	$Thank you.{nl}I better go report the roaming Larg
 QUEST_LV_0100_20150317_000291	{memo X}$Weird... That is not a type of monster you'd face in a place like this.{nl}It must be hard to travel around.
 QUEST_LV_0100_20150317_000292	{memo X}$Assemble already?{nl}That's tough. There's still a pile of missions.
 QUEST_LV_0100_20150317_000293	{memo X}$First, defeat the Hanamings around here.{nl}Then, collect their petals.
-QUEST_LV_0100_20150317_000294	$Even if this wasn't about the Revelators, but the Goddesses returning instead,{nl}I wouldn't abandon my mission before it was over.
+QUEST_LV_0100_20150317_000294	$Even if this wasn't about the Revelators, but the goddesses returning instead,{nl}I wouldn't abandon my mission before it was over.
 QUEST_LV_0100_20150317_000295	{memo X}$Yes. This should be enough.{nl}Here is a pill that will restore your stamina instantly. I have enough of it so I will give you this as a gift.{nl}
 QUEST_LV_0100_20150317_000296	{memo X}$Stamina is consumed when you move.{nl}You can recover stamina by destroying a Tree Root Crystal or by resting.{nl}But you might not have time for that when you are being chased by monsters.{nl}That's when this pill comes in handy.
 QUEST_LV_0100_20150317_000297	{memo X}$I heard news from my men and was becoming worried.{nl}All is well if it ended up good.
 QUEST_LV_0100_20150317_000298	$Klaipeda Resident
-QUEST_LV_0100_20150317_000299	$)} {nl}When do you think the Goddess is coming back?{nl}Even if I ask the Revelators, all they say is that they must go to Klaipeda...
-QUEST_LV_0100_20150317_000300	$Are you a Revelator?{nl}Didn't the Goddess appear in your dream?{nl}I heard so from the soldiers.
+QUEST_LV_0100_20150317_000299	${nl}When do you think the goddess is coming back?{nl}Even if I ask the Revelators, all they say is that they must go to Klaipeda...
+QUEST_LV_0100_20150317_000300	$Are you a Revelator?{nl}Didn't the goddess appear in your dream?{nl}I heard so from the soldiers.
 QUEST_LV_0100_20150317_000301	$Trooper
-QUEST_LV_0100_20150317_000302	$I wonder what the Goddesses are doing...
+QUEST_LV_0100_20150317_000302	$I wonder what the goddesses are doing...
 QUEST_LV_0100_20150317_000303	{memo X}$Thank you for making your way here.{nl}I am Uska, the Knight Commander in charge of Siauliai and Klaipeda.
 QUEST_LV_0100_20150317_000304	{memo X}$The Bishop also dreamed of a revelation.{nl}He told me to send the Revelators to the Crystal Mine.{nl}
 QUEST_LV_0100_20150317_000305	$Let me know when you are ready to go to the Crystal Mine.{nl}I'll tell you the location and how to get in.
-QUEST_LV_0100_20150317_000306	$The bishop told us to send the Revelators to the Crystal Mine.{nl}He said the Goddess told him to do so.{nl}
+QUEST_LV_0100_20150317_000306	$The bishop told us to send the Revelators to the Crystal Mine.{nl}He said the goddess told him to do so.{nl}
 QUEST_LV_0100_20150317_000307	{memo X}$But the Miners' Village is at war with the Vubbes {nl}and its entrance is limited to authorized people only. Knight Aras is the one managing troops in the East Siauliai Woods. {nl}You should talk to him.
 QUEST_LV_0100_20150317_000308	{memo X}$Monsters have been around for a long time, {nl}but they only started becoming violent four years ago. {nl}The ones that were most affected would be the plant types. They did not exist before.{nl}
 QUEST_LV_0100_20150317_000309	$Of course, beasts were no exception.{nl}When monsters that seem to have fused with demons appeared, I thought the end was near.
@@ -372,7 +372,7 @@ QUEST_LV_0100_20150317_000371	They couldn't have gone far.{nl}It would have been
 QUEST_LV_0100_20150317_000372	$Mercenary Lindt
 QUEST_LV_0100_20150317_000373	Thank you again.{nl}I should return to my commander soon. I think I can return to him after I get some more rest.
 QUEST_LV_0100_20150317_000374	I knew you would.{nl}One more thing, the ground near the Closed Area is weak so the entrance has been blocked for a long time.{nl}
-QUEST_LV_0100_20150317_000375	The kidnapped people are veteran miners so they may know how to get in.{nl}Well then, may the blessings of the Goddess be with you.
+QUEST_LV_0100_20150317_000375	The kidnapped people are veteran miners so they may know how to get in.{nl}Well then, may the blessings of the goddess be with you.
 QUEST_LV_0100_20150317_000376	It wasn't long ago.{nl}I felt a strange power while performing experiments in the Closed Area.{nl}It was different from the mana that we know but it was very warm.{nl}
 QUEST_LV_0100_20150317_000377	{memo X}But some force did not allow me to approach, as if it had an owner already.{nl}A few days after the incident, the bishop dreamed about the evidence of salvation.{nl}
 QUEST_LV_0100_20150317_000378	{memo X}Perhaps the evidence of salvation is the force I felt...{nl}That's what I think.
@@ -380,7 +380,7 @@ QUEST_LV_0100_20150317_000379	$All I see are monsters and we're out of supplies.
 QUEST_LV_0100_20150317_000380	$Until I'm assigned a new task, I'm thinking of going back to my duties as a search scout.{nl}Observing the monsters, you know.
 QUEST_LV_0100_20150317_000381	{memo X}$The Miners' Village is under siege and entrance is prohibited for civilians.{nl}Remember that we can't guarantee your safety if you do not get my permission.
 QUEST_LV_0100_20150317_000382	{memo X}$You have to cheer up.{nl} Even Aras is holding on.
-QUEST_LV_0100_20150317_000383	$Goddess Zemyna overlooks the Earth.{nl}There are rumors that the Goddesses have abandoned us, but that's nonsense.{nl}The statues still shine beautifully when you pray to them.
+QUEST_LV_0100_20150317_000383	$Goddess Zemyna overlooks the Earth.{nl}There are rumors that the goddesses have abandoned us, but that's nonsense.{nl}The statues still shine beautifully when you pray to them.
 QUEST_LV_0100_20150317_000384	$Vubbes suddenly came pouring in into the Siauliai Woods from the Crystal Mines.{nl}Thus, the Miners' Village situated between the Mines and the Woods became a battlefield.{nl}
 QUEST_LV_0100_20150317_000385	$For safety reasons, I can't permit entrance to the Miners Village. {nl}Of course it would be a different story if your skill are good enough to ensure your own safety {nl}without the guards' protection.
 QUEST_LV_0100_20150317_000386	$Gosh, that could have been really dangerous.{nl}That huge thing was hiding so well.
@@ -391,7 +391,7 @@ QUEST_LV_0100_20150317_000390	{memo X}$In order to test if your skills are good 
 QUEST_LV_0100_20150317_000391	First, take back the farm from the Pokubus.{nl}This should be a fairly easy task.
 QUEST_LV_0100_20150317_000392	There seems to be a gap in the rock where you can insert something.
 QUEST_LV_0100_20150317_000393	Let's search Bulvjes Farm first.{nl}But don't chase them or something as it can be dangerous.
-QUEST_LV_0100_20150317_000394	$You're making me wonder if you're an envoy of the Goddess.{nl}Anyway, the supply camp is located further below the farm.
+QUEST_LV_0100_20150317_000394	$You're making me wonder if you're an envoy of the goddess.{nl}Anyway, the supply camp is located further below the farm.
 QUEST_LV_0100_20150317_000395	{memo X}
 QUEST_LV_0100_20150317_000396	The Crystal Mine has become infested with Vubbes, so be sure to stay together in groups of five.
 QUEST_LV_0100_20150317_000397	Equipment Merchant
@@ -413,19 +413,19 @@ QUEST_LV_0100_20150317_000412	{memo X}Hello.{nl}I can help you repair items but 
 QUEST_LV_0100_20150317_000413	$Klaipeda Resident
 QUEST_LV_0100_20150317_000414	$It's true these are tough times, but everyone is looking out for the soldiers.
 QUEST_LV_0100_20150317_000415	$Aside from everything else, I want to eat till I'm full.{nl}You need to eat to have strength.
-QUEST_LV_0100_20150317_000416	$Why have the Goddesses disappeared?{nl}Everyone is looking for where they've gone, but no one is asking why they've disappeared.
+QUEST_LV_0100_20150317_000416	$Why have the goddesses disappeared?{nl}Everyone is looking for where they've gone, but no one is asking why they've disappeared.
 QUEST_LV_0100_20150317_000417	$I can't eat, sleep, or move about freely because of those monsters.{nl}In the old days, we used gather herbs or pick fruits in the Siauliai Woods you know.
 QUEST_LV_0100_20150317_000418	$Everyone is talking about the war wherever you go.{nl}Like who and how much people are hurt or who's assigned to where.{nl}All the stories about the war makes me sick!
 QUEST_LV_0100_20150317_000419	$I heard they will send soldiers who aren't even trained into the nest of monsters.{nl}Might as well gather the old people and make them soldiers too.
-QUEST_LV_0100_20150317_000420	$My life is just a cycle of anxiety and anger.{nl}The Goddess should return soon.
+QUEST_LV_0100_20150317_000420	$My life is just a cycle of anxiety and anger.{nl}The goddess should return soon.
 QUEST_LV_0100_20150317_000421	$There are suddenly many people who have had a revelation in their dreams.{nl}Could it be a sign that something is about to happen again?{nl}
-QUEST_LV_0100_20150317_000422	$The bishop of Klaipeda saw a Goddess in his dream.{nl} Did you also have such a dream, Revelator?
+QUEST_LV_0100_20150317_000422	$The bishop of Klaipeda saw a goddess in his dream.{nl} Did you also have such a dream, Revelator?
 QUEST_LV_0100_20150317_000423	$Mother of a Soldier
 QUEST_LV_0100_20150317_000424	{memo X}$)}My son has enlisted in the Army.{nl}He said who would, if not him, at such difficult times like this.
 QUEST_LV_0100_20150317_000425	{memo X}$)}Monster are growing and the forest is too chaotic for people to live in.{nl}At least, Klaipeda is safe.
 QUEST_LV_0100_20150317_000426	$)}Even if Klaipeda is safe, aren't the other cities in chaos?{nl}Putting aside the capital, Fedimian has totally collapsed except for the Sacred Area.
 QUEST_LV_0100_20150317_000427	{memo X}$)}It's a good thing that my son accomplished his dream of becoming a solder...{nl}But the monsters are rising and I'm worried he might get hurt.
-QUEST_LV_0100_20150317_000428	$)}Maybe Klaipeda is where the Goddess has bestowed her blessings.{nl}I hope the blessings will also reach my son in the army.
+QUEST_LV_0100_20150317_000428	$)}Maybe Klaipeda is where the goddess has bestowed her blessings.{nl}I hope the blessings will also reach my son in the army.
 QUEST_LV_0100_20150317_000429	$)}My husband used to be a miner. I am relieved that he isn't anymore.{nl}It would be too dangerous if the monsters raid at times like this, wouldn't it?
 QUEST_LV_0100_20150317_000430	$)}Many refugees came from fallen towns.{nl}Our food supplies are running short but we still have to help each other.
 QUEST_LV_0100_20150317_000431	$I may not bring in the items of the best quality, but isn't having all items necessary a skill of its own?{nl}I've got to work hard to get through tough times.
@@ -481,16 +481,16 @@ QUEST_LV_0100_20150317_000480	$Thinking of the peaceful days in the past makes m
 QUEST_LV_0100_20150317_000481	$I want to run away to another place if I can.{nl}Is there a future for the kingdom?
 QUEST_LV_0100_20150317_000482	$I can't sleep well nowadays.{nl}It's all because of those monsters.
 QUEST_LV_0100_20150317_000483	$To live at peace in a world where monsters are running wild... Impossible.
-QUEST_LV_0100_20150317_000484	$Does salvation even exist?{nl}Hanging on each day in hopes of the Goddess's return is really miserable.
+QUEST_LV_0100_20150317_000484	$Does salvation even exist?{nl}Hanging on each day in hopes of the goddess's return is really miserable.
 QUEST_LV_0100_20150317_000485	$We can't go out nor can we just stay. Is this really ok?{nl}I can't seem to find an answer no matter how much I think about it.
 QUEST_LV_0100_20150317_000486	$Getting used to a world where we live together with monsters, what could be more terrible and scary?
 QUEST_LV_0100_20150317_000487	$I heard that there are people who study monsters.{nl}What is wrong with them?{nl}Those monsters are bad creatures that could attack us at any moment.
 QUEST_LV_0100_20150317_000488	$I'm afraid that Klaipeda might become like the capital.{nl}It's already being called the fallen city, no?
-QUEST_LV_0100_20150317_000489	$Many people are afraid of Bokors for summoning zombies.{nl}But we only curse the enemies of the Goddess.
+QUEST_LV_0100_20150317_000489	$Many people are afraid of Bokors for summoning zombies.{nl}But we only curse the enemies of the goddess.
 QUEST_LV_0100_20150317_000490	{memo X}$Intelligence, calm judgement and cold rationality.{nl}These are the qualities required for our Cryomancers.
 QUEST_LV_0100_20150317_000491	{memo X}Fire is grace sent to us by the Goddess Gabija.{nl}You cannot become a great Pyromancer if you overlook that.
 QUEST_LV_0100_20150317_000492	{memo X}$It is vain death that lies at the end for those who only seek dauntlessness.{nl}If you wish to achieve true justice, lift the shield of Peltasta.
-QUEST_LV_0100_20150317_000493	$After the Goddesses disappeared, the capital was destroyed on Medzio Diena.{nl}I hope more people will become Peltastas to protect the world.
+QUEST_LV_0100_20150317_000493	$After the goddesses disappeared, the capital was destroyed on Medzio Diena.{nl}I hope more people will become Peltastas to protect the world.
 QUEST_LV_0100_20150317_000494	$Rodelero Master
 QUEST_LV_0100_20150317_000495	{memo X}
 QUEST_LV_0100_20150317_000496	$Squire Master
@@ -510,7 +510,7 @@ QUEST_LV_0100_20150317_000509	People shouldn't do things they'll regret.{nl}Four
 QUEST_LV_0100_20150317_000510	Archer Master
 QUEST_LV_0100_20150317_000511	{memo X}Defeating enemies one by one from a distance is the beauty of the bow and arrow.{nl}It doesn't matter how many shots you have to take, the shots that actually hit are the ones that count, right?
 QUEST_LV_0100_20150317_000512	Priest Master
-QUEST_LV_0100_20150317_000513	To suspect the Goddess does a Priest no good, for only faith can support him.
+QUEST_LV_0100_20150317_000513	To suspect the goddess does a priest no good, for only faith can support him.
 QUEST_LV_0100_20150317_000514	Sadhu Master
 QUEST_LV_0100_20150317_000515	$Truthful and divine entities are inherent in all things.
 QUEST_LV_0100_20150317_000516	Rexipher
@@ -586,7 +586,7 @@ QUEST_LV_0100_20150317_000585	{memo X}
 QUEST_LV_0100_20150317_000586	$Goddess Saule
 QUEST_LV_0100_20150317_000587	{memo X}$To retrieve the revelation, please go to Fallen Worry Forest.{nl}Now is our chance, as the Demon Lord Bramble is trying to recover his power.
 QUEST_LV_0100_20150317_000588	$Royal Mausoleum Foundation Stone
-QUEST_LV_0100_20150317_000589	$I pass my words to the Revelator who comes here.{nl}I, the Great King Zachariel, sleep here to protect the goal of the Goddess. 
+QUEST_LV_0100_20150317_000589	$I pass my words to the Revelator who comes here.{nl}I, the Great King Zachariel, sleep here to protect the goal of the goddess. 
 QUEST_LV_0100_20150317_000590	$If the evil energy attack this place, please protect this place by waking the sleeping Guardians.{nl}{nl}
 QUEST_LV_0100_20150317_000591	$Royal Mausoleum Cube Manual
 QUEST_LV_0100_20150317_000592	$A Guardian who is corrupted by evil will forget its responsibility to protect the Royal Mausoleum.{nl}Defeat these Guardians near the large cubes.
@@ -599,22 +599,22 @@ QUEST_LV_0100_20150317_000598	$The Guardians are corrupted with evil energy.{nl}
 QUEST_LV_0100_20150317_000599	$The demons are trying to take over the roots of the Royal Mausoleum.{nl}If all controlling magic becomes corrupted, we can't protect the Royal Mausoleum anymore.
 QUEST_LV_0100_20150317_000600	$The Guardians' corruption is spreading like a plague.{nl}We need to look for a special way to stop it.
 QUEST_LV_0100_20150317_000601	$We need to destroy the corrupted Guardians that are sleeping.{nl}First, collect condensed magic from the jars nearby.
-QUEST_LV_0100_20150317_000602	$I pray to the Goddess for those sleeping Guardians.
+QUEST_LV_0100_20150317_000602	$I pray to the goddess for those sleeping Guardians.
 QUEST_LV_0100_20150317_000603	$We should destroy those Guardians before they awaken to the demons' commands.
 QUEST_LV_0100_20150317_000604	$Destroy the Guardians using the condensed magic source.{nl}If something interferes, destroy it as well.
 QUEST_LV_0100_20150317_000605	You should destroy them before they wake up.
 QUEST_LV_0100_20150317_000606	$It's very sad to listen to the commands of demons as the Guardians of the tomb.
 QUEST_LV_0100_20150317_000607	$This evil is very real.{nl}It could possibly reach the deepest parts of the Royal Mausoleum.
 QUEST_LV_0100_20150317_000608	Royal Mausoleum Blueprint
-QUEST_LV_0100_20150317_000609	$If the evil presence gets too close to the Goddess' revelation, the Guardians are programmed to destroy the Royal Mausoleum.
-QUEST_LV_0100_20150317_000610	$The evil presence is getting close to the Goddess' revelation.{nl}But it will never get the revelation.{nl}
+QUEST_LV_0100_20150317_000609	$If the evil presence gets too close to the goddess' revelation, the Guardians are programmed to destroy the Royal Mausoleum.
+QUEST_LV_0100_20150317_000610	$The evil presence is getting close to the goddess' revelation.{nl}But it will never get the revelation.{nl}
 QUEST_LV_0100_20150317_000611	$Revelator, go and get the source of the Royal Mausoleum's power from the Guardians.
 QUEST_LV_0100_20150317_000612	It was prepared to protect against beings that humans could not stand against.
 QUEST_LV_0100_20150317_000613	$Pour the source of the Royal Mausoleum's power into the jars.{nl}It will create a false revelation as a decoy.{nl}
 QUEST_LV_0100_20150317_000614	$The evil presence will never get the revelation.
 QUEST_LV_0100_20150317_000615	$The evil presence has obtained a false revelation.{nl}How foolish of it.{nl}
 QUEST_LV_0100_20150317_000616	$Put the Guardian's will into this jar and go to the last Guardian.{nl}It will give you the power to destroy the evil presence.
-QUEST_LV_0100_20150317_000617	$The evil presence will never get the Goddess' revelation.
+QUEST_LV_0100_20150317_000617	$The evil presence will never get the goddess' revelation.
 QUEST_LV_0100_20150317_000618	To have Guardians perform their mission, you need to correct the distorted control magic.
 QUEST_LV_0100_20150317_000619	$If the source of the Royal Mausoleum's power is corrupted, the Guardians will lose their mission.{nl}You can purify the origins of the Royal Mausoleum's power by lighting up the stone lanterns with the burning stone that is inside of a Guardian.
 QUEST_LV_0100_20150317_000620	Royal Mausoleum Magic Suppressor Manual
@@ -636,7 +636,7 @@ QUEST_LV_0100_20150317_000635	Royal Mausoleum Archives
 QUEST_LV_0100_20150317_000636	Wheelen's mark gives us power to face against the forces of evil.
 QUEST_LV_0100_20150317_000637	$Venucelos are very brave and loyal.{nl}But, if their loyalty is to the enemies, they are worthless.{nl}The dogs who can't protect the Royal Mausoleum will lose the leash with the king's name on it.
 QUEST_LV_0100_20150317_000638	$Great King Zachariel was proud to create the gigantic Guardians.{nl}He even put secret treasures inside of them, so that only the one who destroys these Guardians could get them.
-QUEST_LV_0100_20150317_000639	$The forces of evil will never reach the Goddess' revelation.
+QUEST_LV_0100_20150317_000639	$The forces of evil will never reach the goddess' revelation.
 QUEST_LV_0100_20150317_000640	Coben
 QUEST_LV_0100_20150317_000641	$I am looking for my brother.{nl}If you can help me, I may give you a reward.
 QUEST_LV_0100_20150317_000642	$He was a really fantastic person.{nl}I can't imagine myself being like him.
@@ -700,7 +700,7 @@ QUEST_LV_0100_20150317_000699	{memo X}
 QUEST_LV_0100_20150317_000700	$This monster is called a Moa. {nl}It ran away to the Leipsna Chapel Site to the west.{nl}
 QUEST_LV_0100_20150317_000701	{memo X}
 QUEST_LV_0100_20150317_000702	{memo X}Did Laima know that the world would turn out like this?{nl}She is the Goddess of destiny and forecasts.
-QUEST_LV_0100_20150317_000703	$It would not be strange if the world ended tomorrow.{nl}However, I just want to know. Why the Goddesses disappeared..
+QUEST_LV_0100_20150317_000703	$It would not be strange if the world ended tomorrow.{nl}However, I just want to know. Why the goddesses disappeared..
 QUEST_LV_0100_20150317_000704	$Press {Img F1 40 40} to use your remaining Status Points on the status you want to enhance.{nl}
 QUEST_LV_0100_20150317_000705	$Press {Img F10 40 40} to open the Help menu for more information.
 QUEST_LV_0100_20150317_000706	$Press {Img F3 40 40} to open the Skill window.{nl}Use your Skill Points on the skills you want to enhance, then click on 'O' to confirm. {nl}
@@ -786,7 +786,7 @@ QUEST_LV_0100_20150317_000785	The Yognomes are trying to eat the altar.{nl}I wan
 QUEST_LV_0100_20150317_000786	If I had any Holy Stones, I would stick them in the Yognomes' mouths.
 QUEST_LV_0100_20150317_000787	Follower Tiberius
 QUEST_LV_0100_20150317_000788	I am making a Holy Bomb to attack demons with.{nl}I can complete it if I obtain Purified Essence. Can you help me?
-QUEST_LV_0100_20150317_000789	Bombs in the church doesn't sound good, but..{nl}I think the Goddess will forgive me this time.
+QUEST_LV_0100_20150317_000789	Bombs in the church doesn't sound good, but..{nl}I think the goddess will forgive me this time.
 QUEST_LV_0100_20150317_000790	I want to test it out on Glizardon.{nl}I'll give you the Holy Bomb. Can you put it onto a Glizardon's back?
 QUEST_LV_0100_20150317_000791	If you think it'll be dangerous, I will also give you Romuva Holy Water.{nl}When you drink this water, you will be invisible to the demons for a short time.
 QUEST_LV_0100_20150317_000792	Run away after setting the bomb on the back of Glizardon.{nl}Look at its size. It will not be fast.
@@ -833,7 +833,7 @@ QUEST_LV_0100_20150317_000832	Monument of Lydia Schaffen
 QUEST_LV_0100_20150317_000833	My name is Lydia Schaffen.{nl}I will no longer endure this deep burden of sadness, I am going to tell the truth about Ruklys on this land.
 QUEST_LV_0100_20150317_000834	$There is no more charcoal besides what you have, so don't use it too freely.
 QUEST_LV_0100_20150317_000835	$I didn't know she studied with Ruklys, the traitor.{nl}Shoot. I've almost used up all the charcoal.
-QUEST_LV_0100_20150317_000836	Eventually, Ruklys failed.{nl}He was destroyed by those who were jealous of him.{nl}He left to the Goddess by my hands.
+QUEST_LV_0100_20150317_000836	Eventually, Ruklys failed.{nl}He was destroyed by those who were jealous of him.{nl}He left to the goddess by my hands.
 QUEST_LV_0100_20150317_000837	What was Lydia Schaffen's relationship with Ruklys?{nl}I am not smart enough to understand.
 QUEST_LV_0100_20150317_000838	{memo X}I leave Ruklys on this land with my regrets and tears.{nl}If there's someone who wants to continue his will, I want to leave my secret on this gravestone.{nl}I will summarize the long writings here.
 QUEST_LV_0100_20150317_000839	The stage that Ruklys had reached was astonishing.{nl}But, his noble mission was too difficult to be accomplished on this land.
@@ -864,7 +864,7 @@ QUEST_LV_0100_20150317_000863	{memo X}The demons' attacks are stronger than we e
 QUEST_LV_0100_20150317_000864	Follower Vaidutis
 QUEST_LV_0100_20150317_000865	I came to say that Gesti went up to the 2nd floor, and I let my guard down. {nl} I would have been in big trouble if not for you.
 QUEST_LV_0100_20150317_000866	I studied the barrier at the gate, but the power of the basement altar is insufficient. {nl} Could you supply me with Power Crystals from the Corylus?
-QUEST_LV_0100_20150317_000867	Maybe the Goddess knew it'd fail and that's why she said to wait for the Revelator. {nl} At least we hurt Gesti some, so that's good.
+QUEST_LV_0100_20150317_000867	Maybe the goddess knew it'd fail and that's why she said to wait for the Revelator. {nl} At least we hurt Gesti some, so that's good.
 QUEST_LV_0100_20150317_000868	Well done. {nl} Making the Light Crystal with this will be enough power to break the barrier.
 QUEST_LV_0100_20150317_000869	{memo X}Prepare yourself before bringing the Light Crystal to the gate. {nl}It can attract powerful monsters.
 QUEST_LV_0100_20150317_000870	I think I'll stay here to stop the demons from entering the basement.
@@ -884,7 +884,7 @@ QUEST_LV_0100_20150317_000883	Well done. {nl} It will probably be difficult for 
 QUEST_LV_0100_20150317_000884	{memo X}I'm thinking of converting the demons using the power of the altar. {nl} The converted demons will absorb the divine power and slowly start to die. {nl}
 QUEST_LV_0100_20150317_000885	But before that, it's important for us to understand the demons. {nl} Collect some demon souls for me.
 QUEST_LV_0100_20150317_000886	I remember the first time I converted the demons. {nl} I pray for their poor souls.
-QUEST_LV_0100_20150317_000887	Good job. {nl} If there are any good demons left, the Goddess will look after them.
+QUEST_LV_0100_20150317_000887	Good job. {nl} If there are any good demons left, the goddess will look after them.
 QUEST_LV_0100_20150317_000888	The Central Altar that suppresses the power of the demons suddenly stopped. {nl} Could you take a look at what's going on?
 QUEST_LV_0100_20150317_000889	Strange, it was definitely working.
 QUEST_LV_0100_20150317_000890	It was an ambush. {nl} We would have been in big trouble without your help.
@@ -897,7 +897,7 @@ QUEST_LV_0100_20150317_000896	Let's start by occupying the Bell Tower.
 QUEST_LV_0100_20150317_000897	From here, we can see what Gesti is going to do.
 QUEST_LV_0100_20150317_000898	Alright, bring the Seal of Space from the Sventove Central Altar. {nl} You can do it, right?
 QUEST_LV_0100_20150317_000899	You must know that the revelation is hidden in the sanctuary. {nl} The Seal of Space is the only key that will get you to the sanctuary. {nl}
-QUEST_LV_0100_20150317_000900	It's not just the Tenet Church. {nl} You can enter all the places that the Goddess hid.
+QUEST_LV_0100_20150317_000900	It's not just the Tenet Church. {nl} You can enter all the places that the goddess hid.
 QUEST_LV_0100_20150317_000901	The Seal of Space can only be used by the Revelator, so you won't be able to find the revelation right away. {nl}
 QUEST_LV_0100_20150317_000902	But the enemy is the Demon Queen herself. Even the Paladin Master couldn't defeat her.{nl}I should use the power of the Broken Altar.
 QUEST_LV_0100_20150317_000903	We can't do anything about the destroyed altar, but the fragments still have power. {nl} Gather the pieces and insert them in the 8 pillars of the Sventove Central Hall.
@@ -908,10 +908,10 @@ QUEST_LV_0100_20150317_000907	{memo X}I'm relieved you're beside me. {nl} I thin
 QUEST_LV_0100_20150317_000908	Good job. {nl} When this is over, I should gather all brothers and drive them away at once.
 QUEST_LV_0100_20150317_000909	I'll ring the bell and let you know when Gesti shows up, so have a safe trip on your way.
 QUEST_LV_0100_20150317_000910	{memo X}So you found the Seal of Space. {nl}Use the crest on the pillar beside me to go to the sanctuary. {nl} It is prepared for the Revelator only.
-QUEST_LV_0100_20150317_000911	May the blessings of the Goddess be with you.
+QUEST_LV_0100_20150317_000911	May the blessings of the goddess be with you.
 QUEST_LV_0100_20150317_000912	So Gesti just ran away. {nl} Fine. Since you got the revelation, we've completed the mission. {nl}
 QUEST_LV_0100_20150317_000913	{memo X}
-QUEST_LV_0100_20150317_000914	{memo X}When you find the revelation, tell the Paladin Master of the story you've been through so far. {nl} May the blessings of the Goddess be with you.
+QUEST_LV_0100_20150317_000914	{memo X}When you find the revelation, tell the Paladin Master of the story you've been through so far. {nl} May the blessings of the goddess be with you.
 QUEST_LV_0100_20150317_000915	Seems like Gesti has not notice yet. {nl}We better prepare the Divine Sphere.
 QUEST_LV_0100_20150317_000916	All the preparations have been made. {nl} The barriers of the church will soon weaken Gesti. {nl}
 QUEST_LV_0100_20150317_000917	Gesti will be enough for you to handle once she's weakened. {nl} When Gesti is cornered, I will make the final strike with the Divine Sphere.
@@ -929,8 +929,8 @@ QUEST_LV_0100_20150317_000928	{memo X}But this old body of mine does not follow 
 QUEST_LV_0100_20150317_000929	{memo X}
 QUEST_LV_0100_20150317_000930	It is too much for me to handle alone without any help from the other brothers. {nl} I'd better use the Malda Altar. {nl}
 QUEST_LV_0100_20150317_000931	{memo X}
-QUEST_LV_0100_20150317_000932	We still have a lot to do here.{nl}The Goddess told us to never give up.
-QUEST_LV_0100_20150317_000933	The world still needs more experience. {nl} We probably wouldn't have made it this far without the help of the Goddess.
+QUEST_LV_0100_20150317_000932	We still have a lot to do here.{nl}The goddess told us to never give up.
+QUEST_LV_0100_20150317_000933	The world still needs more experience. {nl} We probably wouldn't have made it this far without the help of the goddess.
 QUEST_LV_0100_20150317_000934	Activating the Tree Guard Post Barrier is taking longer than I thought. {nl} We have no time, let's charge it with demon souls instead.
 QUEST_LV_0100_20150317_000935	All souls are pure. {nl} So even if it's a demon's soul, it can still provide some divine power.
 QUEST_LV_0100_20150317_000936	So the Tree Guard Post Barrier has been charged with demon souls, huh. {nl} It still needs some final touches for completion, but I'll take care of it from here. {nl}Great job.
@@ -947,14 +947,14 @@ QUEST_LV_0100_20150317_000946	I received a mysterious charm from the elders that
 QUEST_LV_0100_20150317_000947	According to the elders, we are done with those Pantos.{nl}We can't continue the relationship anymore.
 QUEST_LV_0100_20150317_000948	This barrier is impossible to open from the outside. {nl} Fortunately, the entrance to the basement looks secure. {nl}
 QUEST_LV_0100_20150317_000949	However, it's too dangerous to enter the basement with the Divine Sphere. {nl} I'll wait here so you go to the 1st floor through the basement and open the barrier. {nl}
-QUEST_LV_0100_20150317_000950	You have done what no other could easily do.{nl}The Goddess must be proud of you.
+QUEST_LV_0100_20150317_000950	You have done what no other could easily do.{nl}The goddess must be proud of you.
 QUEST_LV_0100_20150317_000951	I would like to say that my faith is like a first-class blade that can cut through these demons, {nl}but in reality it isn't that simple. I hope you'll help us some.
 QUEST_LV_0100_20150317_000952	{memo X}
 QUEST_LV_0100_20150317_000953	Defeat the demons around the Tree Guard Post Barrier. {nl} The souls of those demons should be able to fill its divine powers a little. I'm counting on you!
 QUEST_LV_0100_20150317_000954	Very good. Flowers in the fields should act like flowers in the fields.{nl}Don't you think so?
-QUEST_LV_0100_20150317_000955	We are the people following the Paladin Master.{nl}We will defeat the people who disobey the Goddess.{nl}
+QUEST_LV_0100_20150317_000955	We are the people following the Paladin Master.{nl}We will defeat the people who disobey the goddess.{nl}
 QUEST_LV_0100_20150317_000956	Everyone has their reasons for following him.{nl}Some of them received benefits from him and some of them were already Paladins like Algis.
-QUEST_LV_0100_20150317_000957	Maybe the Goddess knew it would happen and that's why she waited for the savior.{nl}I feel like I put a big burden on your shoulders.{nl}
+QUEST_LV_0100_20150317_000957	Maybe the goddess knew it would happen and that's why she waited for the savior.{nl}I feel like I put a big burden on your shoulders.{nl}
 QUEST_LV_0100_20150317_000958	{memo X}
 QUEST_LV_0100_20150317_000959	This is the plan that was carried on for hundreds of years since the first Paladin.{nl}We should never fail this plan.
 QUEST_LV_0100_20150317_000960	$While I prepare to do the rubbings, please put the engravings at the Ruklys memorial in front of me. {nl} With you working with us, this should be easy. {nl}
@@ -1064,7 +1064,7 @@ QUEST_LV_0100_20150317_001063	This won't come out.
 QUEST_LV_0100_20150317_001064	Thanks.{nl}I will stay here until it becomes safe, and then run away.
 QUEST_LV_0100_20150317_001065	Furry Odd
 QUEST_LV_0100_20150317_001066	$Pleased to meet you. {nl}I am Furry Odd. I am a magician specialized in object variation.{nl}
-QUEST_LV_0100_20150317_001067	$I see the Revelator is here to help the Goddess.{nl}While you do so, can you help me collect Variation Mediators from the monsters?
+QUEST_LV_0100_20150317_001067	$I see the Revelator is here to help the goddess.{nl}While you do so, can you help me collect Variation Mediators from the monsters?
 QUEST_LV_0100_20150317_001068	$The magicians that ran away?{nl}What can we do.. For them, their lives are more important than the Goddess Gabija.{nl}I don't think they are cowards. They are just hopeless.
 QUEST_LV_0100_20150317_001069	Thanks. You are so reliable.
 QUEST_LV_0100_20150317_001070	$We have enough Mediators now so we can go defeat the remaining monsters.{nl}Do you want to come along?
@@ -1072,7 +1072,7 @@ QUEST_LV_0100_20150317_001071	$You are so great.{nl}I hope our magicians can be 
 QUEST_LV_0100_20150317_001072	$There's a problem.{nl}I think I saw a Yonazolem inside the Machinery Room.. It's too much for me.{nl}
 QUEST_LV_0100_20150317_001073	$I will take care of other monsters. Could you take care of Yonazolem, please?
 QUEST_LV_0100_20150317_001074	$I am not strong enough to face Yonazolem.{nl}It's fortunate that you are here.
-QUEST_LV_0100_20150317_001075	$Thank you so much for helping me. It's so good that you are here.{nl}May the Goddess bless you!
+QUEST_LV_0100_20150317_001075	$Thank you so much for helping me. It's so good that you are here.{nl}May the goddess bless you!
 QUEST_LV_0100_20150317_001076	{memo X}I can't stand it anymore. Please save me from the restraints.{nl}I will be released when you defeat the observers nearby.
 QUEST_LV_0100_20150317_001077	The time to retrieve my body and spirit is near.
 QUEST_LV_0100_20150317_001078	$I can't stand it anymore.{nl}Please destroy the watchers that imprison me.{nl}
@@ -1212,14 +1212,14 @@ QUEST_LV_0100_20150317_001211	{memo X}Golem, that's awesome. {nl} And you rememb
 QUEST_LV_0100_20150317_001212	I guess the Revelator really is different. {nl} You you seem to be different from the other Revelators too...
 QUEST_LV_0100_20150317_001213	You looked so cool when you defeated the Golem. {nl} Where did you learn to do that?
 QUEST_LV_0100_20150317_001214	I'm grateful for your help. {nl} Commander Uska is waiting for you in Klaipeda, so go find him.
-QUEST_LV_0100_20150317_001215	I firmly believe that the Goddess will return someday. No doubt about it. {nl} We have to believe it. If we do not believe in the Goddess then who will?
+QUEST_LV_0100_20150317_001215	I firmly believe that the goddess will return someday. No doubt about it. {nl} We have to believe it. If we do not believe in the goddess then who will?
 QUEST_LV_0100_20150317_001216	Please hurry and support the Miners' Village. {nl} Someone like you will be of great help.
 QUEST_LV_0100_20150317_001217	I heard the stories. So you defeated the Vubbe Fighter, huh? {nl} That's incredible.
 QUEST_LV_0100_20150317_001218	I was anxiously watching from a distance, but that fight was really awesome.
 QUEST_LV_0100_20150317_001219	Frankly, I'm scared. {nl}The Miners' Village, and now the Eastern Woods... Even Klaipeda is becoming dangerous.
 QUEST_LV_0100_20150317_001220	Although I've been very concerned about Miners' Village, {nl}at least you've calmed me down a bit, thanks.
 QUEST_LV_0100_20150317_001221	Healer Lady
-QUEST_LV_0100_20150317_001222	We pray that the blessings of the Goddess will always be with the Revelator who saved us.
+QUEST_LV_0100_20150317_001222	We pray that the blessings of the goddess will always be with the Revelator who saved us.
 QUEST_LV_0100_20150317_001223	I'm helping the refugees. {nl} The monsters attacked the village.
 QUEST_LV_0100_20150317_001224	$Mine Manager Brinker
 QUEST_LV_0100_20150317_001225	Still anxious. {nl} But thanks to you things are better than before.
@@ -1244,7 +1244,7 @@ QUEST_LV_0100_20150317_001243	Honestly, I thought it would be hard to stand stil
 QUEST_LV_0100_20150317_001244	{memo X}It will be better to fight them face to face instead of hiding.{nl}It will be even better if the opponents are the demons.
 QUEST_LV_0100_20150317_001245	{memo X}So humans can also defeat the demon king.{nl}I can't believe it.
 QUEST_LV_0100_20150317_001246	{memo X}Too bad that Gesti wasn't killed, but still you did a great job.{nl}It will end soon..
-QUEST_LV_0100_20150317_001247	You fought hard.{nl}May the Goddess bless you in the future.
+QUEST_LV_0100_20150317_001247	You fought hard.{nl}May the goddess bless you in the future.
 QUEST_LV_0100_20150317_001248	Let's pay more attention to the safety of our people here.{nl}Where is Jonas' maid?
 QUEST_LV_0100_20150317_001249	When I focus on the research, I sometimes don't know even when the monsters come.{nl}To think back about that moment, it is still frightening.
 QUEST_LV_0100_20150317_001250	$Start being more careful.{nl}I almost got involved in your carelessness.
@@ -1282,7 +1282,7 @@ QUEST_LV_0100_20150317_001281	Mercenary Eta
 QUEST_LV_0100_20150317_001282	I will come back soon so don't worry.{nl}This was an easy thing when I was young.
 QUEST_LV_0100_20150317_001283	How will the commander scold us this time..
 QUEST_LV_0100_20150317_001284	Archaeologist Laudi
-QUEST_LV_0100_20150317_001285	The Goddess and the demons.. Zachariel's Royal Mausoleum and the secret of the artifacts...
+QUEST_LV_0100_20150317_001285	The goddess and the demons.. Zachariel's Royal Mausoleum and the secret of the artifacts...
 QUEST_LV_0100_20150317_001286	Morkus Jonas
 QUEST_LV_0100_20150317_001287	$That guy the Old Man kept talking about, is he going to come at all??
 QUEST_LV_0100_20150317_001288	$The old man told us.{nl}When you go against your destiny, that also is a part of your destiny.{nl}Maybe the reason why we are trying hard is because that's our destiny.
@@ -1319,7 +1319,7 @@ QUEST_LV_0100_20150317_001318	How can I put all these materials in order?
 QUEST_LV_0100_20150317_001319	A person who uses a demon's name.. He must be crazy.
 QUEST_LV_0100_20150317_001320	Wounded Historian Laulas
 QUEST_LV_0100_20150317_001321	$There was a man taking over the excavation site.{nl}I feel powerless. How is he controlling those monsters?
-QUEST_LV_0100_20150317_001322	$Hurry! We must slow Rexipher somehow.{nl}No matter what the Goddess' will may be, It won't do us good if everything falls in his hands.
+QUEST_LV_0100_20150317_001322	$Hurry! We must slow Rexipher somehow.{nl}No matter what the goddess' will may be, It won't do us good if everything falls in his hands.
 QUEST_LV_0100_20150317_001323	$Ruklys Memorial
 QUEST_LV_0100_20150317_001324	Who decapitated Ruklys?{nl}Who is calling Ruklys a traitor?{nl}
 QUEST_LV_0100_20150317_001325	$The King tyrannized more as his spirit waned, and devastated his citizens' lives.{nl}I didn't die with him, so I am going to leave his spirit on this monument.
@@ -1354,7 +1354,7 @@ QUEST_LV_0100_20150317_001353	Don't forget to send my regards to the Klaipeda Ch
 QUEST_LV_0100_20150317_001354	When you are ready, please go to Aras in the Eastern Woods.
 QUEST_LV_0100_20150317_001355	Welcome! {nl} Oh, you're the Revelator. I really wanted to meet you. {nl}
 QUEST_LV_0100_20150317_001356	This is a Warp Scroll. {nl} You can go to any Goddess Statue or return to previous location by using it. {nl}
-QUEST_LV_0100_20150317_001357	{memo X}We'll give you more than what the Knights asked for so please help us find the Goddesses.
+QUEST_LV_0100_20150317_001357	{memo X}We'll give you more than what the Knights asked for so please help us find the goddesses.
 QUEST_LV_0100_20150317_001358	{memo X}I think Large Kepa is still out there. {nl} Would you take a look?
 QUEST_LV_0100_20150317_001359	{memo X}It was there right? {nl} My senses are never wrong. 
 QUEST_LV_0100_20150317_001360	Even though Klaipeda is just around the corner, the supply situation here is not very good. {nl} Just think about how much worse it would be in other areas. 
@@ -1364,12 +1364,12 @@ QUEST_LV_0100_20150317_001363	$Rocktortuga is coming this way. {nl}Please lend u
 QUEST_LV_0100_20150317_001364	Have you seen any baby Poata? {nl} We better drive them out quickly so that the mother Poata won't keep showing up. 
 QUEST_LV_0100_20150317_001365	The Vubbes have built their base outside the village. {nl} Now that we don't even have troops, something serious might happen if we don't drive them out of their base. 
 QUEST_LV_0100_20150317_001366	Thank you so much for your bravery. 
-QUEST_LV_0100_20150317_001367	How can I express my gratitude. {nl}I'm sure the Goddess sent you to us.
+QUEST_LV_0100_20150317_001367	How can I express my gratitude. {nl}I'm sure the goddess sent you to us.
 QUEST_LV_0100_20150317_001368	This patient told us that Chafer has appeared. {nl} Can you help us out and go check on it?
 QUEST_LV_0100_20150317_001369	Now, I have to treat this patient... So thank you.
 QUEST_LV_0100_20150317_001370	Those refugees are probably having a hard time getting here because of the monsters.
 QUEST_LV_0100_20150317_001371	I can't help but think about it since he's worked here for so long.
-QUEST_LV_0100_20150317_001372	Thank you. Now I can feel at ease and return to the village. {nl} May the blessing of the Goddess be with you always.
+QUEST_LV_0100_20150317_001372	Thank you. Now I can feel at ease and return to the village. {nl} May the blessing of the goddess be with you always.
 QUEST_LV_0100_20150317_001373	Being attacked by the Golem will get them back to their senses. 
 QUEST_LV_0100_20150317_001374	Usually, you can't find them no matter how hard you try. {nl} Strange huh?
 QUEST_LV_0100_20150317_001375	$I am pleased that my friend was able to go back safely.{nl}I was worried because of the stories that Molich is wandering around.
@@ -1387,7 +1387,7 @@ QUEST_LV_0100_20150317_001386	Powerless Security Guard
 QUEST_LV_0100_20150317_001387	I was attacked by Hogmas at Traceless Ruins.{nl}Fortunately, I was able to survive, but I need to find that box.
 QUEST_LV_0100_20150317_001388	Thanks for caring.{nl}Be careful of those Hogmas.
 QUEST_LV_0100_20150317_001389	They probably haven't gone that far.{nl}I hope the necklace is safe even if others are not.
-QUEST_LV_0100_20150317_001390	There was nothing in the chest?{nl}Oh my Goddess, that can't be good.
+QUEST_LV_0100_20150317_001390	There was nothing in the chest?{nl}Oh my goddess, that can't be good.
 QUEST_LV_0100_20150317_001391	We should find that necklace.{nl}If not, I will be kicked out.
 QUEST_LV_0100_20150317_001392	When you use this scroll, the necklace will shine.{nl}You will be able to find it easily, even if it has been dropped on the ground or is in the hands of Hogmas.
 QUEST_LV_0100_20150317_001393	If the necklace is that important, don't you think their boss would want it?
@@ -1444,19 +1444,19 @@ QUEST_LV_0100_20150317_001443	$If that evil energy spreads to other forests..{nl
 QUEST_LV_0100_20150317_001444	Believer Evaldas
 QUEST_LV_0100_20150317_001445	$Everyone is tired, but the evil energy never stops. So, we at least try to stay happy. {nl} However, I don't know how long I can keep feeling happy.
 QUEST_LV_0100_20150317_001446	Believer Zaneta
-QUEST_LV_0100_20150317_001447	$I want to tell to the people out there that we are still here.{nl}The Goddess always tells us that everything will be alright when the revelation comes.
+QUEST_LV_0100_20150317_001447	$I want to tell to the people out there that we are still here.{nl}The goddess always tells us that everything will be alright when the revelation comes.
 QUEST_LV_0100_20150317_001448	Believer Simas
 QUEST_LV_0100_20150317_001449	{memo X}
 QUEST_LV_0100_20150317_001450	{memo X}There are rumors about Golems appearing so don't go far too deep. {nl} It will be safer to take the bigger roads where there are less monsters or just head straight to Klaipeda.
-QUEST_LV_0100_20150317_001451	So, I guess there is actually someone good among those who say they've dreamed of the Goddess.
-QUEST_LV_0100_20150317_001452	$I'm relieved that there are people who say they dreamed of a Goddess. {nl} But there seem to be too many of them.
-QUEST_LV_0100_20150317_001453	$A dream of one of the missing Goddesses. Isn't that something amazing?
+QUEST_LV_0100_20150317_001451	So, I guess there is actually someone good among those who say they've dreamed of the goddess.
+QUEST_LV_0100_20150317_001452	$I'm relieved that there are people who say they dreamed of a goddess. {nl} But there seem to be too many of them.
+QUEST_LV_0100_20150317_001453	$A dream of one of the missing goddesses. Isn't that something amazing?
 QUEST_LV_0100_20150317_001454	The colleague who I used to work with has disappeared.{nl}He was definitely with me at the Forest of Fireflies, but I won't go back there. It's scary.
 QUEST_LV_0100_20150317_001455	Where is he. I am scared.
 QUEST_LV_0100_20150317_001456	{memo X}My colleague is dead?{nl}That's nonsense. If I had not tempted him..{nl}
-QUEST_LV_0100_20150317_001457	{memo X}This map is useless now since my colleague is dead.{nl}Please pray that my colleague would go to the Goddess safely.
+QUEST_LV_0100_20150317_001457	{memo X}This map is useless now since my colleague is dead.{nl}Please pray that my colleague would go to the goddess safely.
 QUEST_LV_0100_20150317_001458	I'm screwed. Monsters took my bag. {nl}The bag contained everything I recorded on my journey.. What should I do?{nl}
-QUEST_LV_0100_20150317_001459	The Goddess has surely sent you to help!{nl}Those monsters went down from here.
+QUEST_LV_0100_20150317_001459	The goddess has surely sent you to help!{nl}Those monsters went down from here.
 QUEST_LV_0100_20150317_001460	I still have lots of things to do..
 QUEST_LV_0100_20150317_001461	{memo X}The adventure can continue if I get my diary back.{nl}I am happy..
 QUEST_LV_0100_20150317_001462	Long time no see. {nl}I have a favor to ask you. Can you do me a favor?{nl}
@@ -1468,7 +1468,7 @@ QUEST_LV_0100_20150317_001467	{memo X}
 QUEST_LV_0100_20150317_001468	I keep thinking about my colleague.{nl}I'll never see him again, right..
 QUEST_LV_0100_20150317_001469	Soul of Varkis
 QUEST_LV_0100_20150317_001470	{memo X}I can't leave with all my things left here
-QUEST_LV_0100_20150317_001471	I don't have any reason to stay in this land anymore.{nl}I will go meet the Goddess..
+QUEST_LV_0100_20150317_001471	I don't have any reason to stay in this land anymore.{nl}I will go meet the goddess..
 QUEST_LV_0100_20150317_001472	{memo X}It was made long ago, but any stones will break it.
 QUEST_LV_0100_20150317_001473	Monument
 QUEST_LV_0100_20150317_001474	$We have all become like wind in the canyon.{nl}Although we have left, our times together will always remain with you.
@@ -1539,7 +1539,7 @@ QUEST_LV_0100_20150317_001538	$I'm holding this because it looks like it's about
 QUEST_LV_0100_20150317_001539	$We won't be able to handle it if this wall opens. {nl}How will you stop them then if people are already running away now?
 QUEST_LV_0100_20150317_001540	$Alright. That'll be enough.
 QUEST_LV_0100_20150317_001541	$I must go back to the village. {nl} But as you can see my arms are shaking. {nl} Can you defeat the monsters while I rest my arms for a while?
-QUEST_LV_0100_20150317_001542	$The Goddesses are so heartless. {nl} Had the Goddesses not disappeared, the monsters wouldn't be invading. 
+QUEST_LV_0100_20150317_001542	$The goddesses are so heartless. {nl} Had the goddesses not disappeared, the monsters wouldn't be invading. 
 QUEST_LV_0100_20150317_001543	$Now I can return to the village with peace of mind. {nl} This grace I shall never forget.
 QUEST_LV_0100_20150317_001544	$I came here to hide from the monsters, but even this area is becoming dangerous. {nl} I'm trying to make it back to the village, so can you bring the other refugees to me?
 QUEST_LV_0100_20150317_001545	$I see you came back safely. {nl} Well then, I must also prepare to leave.
@@ -1548,7 +1548,7 @@ QUEST_LV_0100_20150317_001547	$Somehow I'll treat this man. Can you defeat the m
 QUEST_LV_0100_20150317_001548	$In order for these people to safely return to the village,{nl}we have to defeat these monsters.
 QUEST_LV_0100_20150317_001549	$Thank you. The patient also regained his consciousness. {nl} Though.. I think there is a problem.
 QUEST_LV_0100_20150317_001550	{memo X}$This has to be because there is the evidence of salvation or something. {nl}I'm sure that's where the villagers were taken away to.
-QUEST_LV_0100_20150317_001551	$The Goddess must have sent help... {nl}Follow the pathway on the right to find the Vubbe Outpost.
+QUEST_LV_0100_20150317_001551	$The goddess must have sent help... {nl}Follow the pathway on the right to find the Vubbe Outpost.
 QUEST_LV_0100_20150317_001552	{memo X}$Thank you for saving me. {nl} Seems like you're the Revelator who's looking for evidence of salvation. {nl}
 QUEST_LV_0100_20150317_001553	{memo X}$I was taken in late so I was left here, the others were all brought to the mine. {nl} I'll tell you the rest of the story in the Crystal Mine.
 QUEST_LV_0100_20150317_001554	$You came. {nl} First, let's clear the wagons blocking the way into the mines. {nl}
@@ -1561,7 +1561,7 @@ QUEST_LV_0100_20150317_001560	$Mine Manager
 QUEST_LV_0100_20150317_001561	$I'm hanging on somehow but I'm losing strength in my arms.
 QUEST_LV_0100_20150317_001562	$I should have been more careful. {nl} It's all my fault.
 QUEST_LV_0100_20150317_001563	$I have my roots deep in hunting. {nl} Don't worry about me. Go look after the others.
-QUEST_LV_0100_20150317_001564	$As the mayor, I cannot just leave the village like this. {nl} How could the Goddesses be so indifferent?
+QUEST_LV_0100_20150317_001564	$As the mayor, I cannot just leave the village like this. {nl} How could the goddesses be so indifferent?
 QUEST_LV_0100_20150317_001565	{memo X}$Aren't you a Revelator? The Goddess must've sent help. {nl} In order to enter the mine, you must save a young man name Vaidotas first. {nl}He was kidnapped and brought to the Vubbe Outpost. {nl} Please, I'm begging for your help.
 QUEST_LV_0100_20150317_001566	Kind Owl Sculptor
 QUEST_LV_0100_20150317_001567	There are so many wandering spirits these days.{nl}This really..
@@ -1603,9 +1603,9 @@ QUEST_LV_0100_20150317_001602	Thanks for saving me.{nl}I don't understand how I 
 QUEST_LV_0100_20150317_001603	It seems that the Guide Owl finally made a decision.{nl}It once tried hard to bring Sequoia back to the way it used to before..{nl}
 QUEST_LV_0100_20150317_001604	{memo X}Anyways, It's good.{nl}I need the Essence of Spirit from the spirit that is wandering around the grave of unknown warrior.{nl}You can do anything, just bring us the Essence.
 QUEST_LV_0100_20150317_001605	The spirits that were wandering for a long time are like monsters.
-QUEST_LV_0100_20150317_001606	Wow, you collected those Essences.{nl}When you go back to the Guide Owl, it will empower your weapon with the power of spirits.{nl}I am not sure if that will result in a positive outcome..Only Goddess will know.
+QUEST_LV_0100_20150317_001606	Wow, you collected those Essences.{nl}When you go back to the Guide Owl, it will empower your weapon with the power of spirits.{nl}I am not sure if that will result in a positive outcome... Only a goddess will know.
 QUEST_LV_0100_20150317_001607	It is a personal matter, but there is an angry owl at Cross Hill near here.{nl}But, after it fell into a deep sleep due to an incident, it is obsessed with evil power.{nl}Please wake up that angry owl and persuade it to gain it's consciousness again.{nl}
-QUEST_LV_0100_20150317_001608	If it doesn't listen to you..{nl}Then just destroy it and let it go to the Goddess.
+QUEST_LV_0100_20150317_001608	If it doesn't listen to you..{nl}Then just destroy it and let it go to the goddess.
 QUEST_LV_0100_20150317_001609	I will do anything to bring it back to it's normal status.
 QUEST_LV_0100_20150317_001610	This is the symbol of the Guide Owl which guided his spirit.{nl}When it sleeps for a long time, it gets influenced by monsters.{nl}Many of its allies changed like that.{nl}
 QUEST_LV_0100_20150317_001611	I am sorry. Let me be alone for a while.
@@ -1732,11 +1732,11 @@ QUEST_LV_0100_20150317_001731	Jilgyung is all around here so you can easily find
 QUEST_LV_0100_20150317_001732	There are many Tinis when you climb up the hill from the road down.{nl}8 big scoops will do.
 QUEST_LV_0100_20150317_001733	We don't have time collect the potion jars again.{nl}Let's go steal the jars that Zigris stole from us. They are the ones who started this.
 QUEST_LV_0100_20150317_001734	Monsters really like the Essences of Spirits.{nl}They become strong when they absorb the power.
-QUEST_LV_0100_20150317_001735	If it goes wrong.. then go meet the Gatekeeper Owl.{nl}He is most clever among us.{nl}May the Goddess bless you.
-QUEST_LV_0100_20150317_001736	Nice to meet you, follower of the Goddess. {nl} Do you know about learning attributes?
-QUEST_LV_0100_20150317_001737	Welcome, you who follow the goal of the Goddess.{nl}Do you know about training attributes?
+QUEST_LV_0100_20150317_001735	If it goes wrong.. then go meet the Gatekeeper Owl.{nl}He is most clever among us.{nl}May the goddess bless you.
+QUEST_LV_0100_20150317_001736	Nice to meet you, follower of the goddess. {nl} Do you know about learning attributes?
+QUEST_LV_0100_20150317_001737	Welcome, you who follow the goal of the goddess.{nl}Do you know about training attributes?
 QUEST_LV_0100_20150317_001738	Now do you understand what attributes are? {nl} Acquiring attributes will help you to easily defeat your enemies. {nl}
-QUEST_LV_0100_20150317_001739	Healing and helping others is the mission of the Clerics. {nl} How can you ignore people seeking help in the name of the Goddess?
+QUEST_LV_0100_20150317_001739	Healing and helping others is the mission of the Clerics. {nl} How can you ignore people seeking help in the name of the goddess?
 QUEST_LV_0100_20150317_001740	People are suffering in body and mind from the wounds of Medzio Diena.{nl} They need our help.
 QUEST_LV_0100_20150317_001741	$I am sorry, but can you please find my companion, Badat.{nl}I haven't heard anything from him since he left to do some research.
 QUEST_LV_0100_20150317_001742	I don't know where he is gone.{nl}He will be in danger without protection from mercenaries.
@@ -1806,18 +1806,18 @@ QUEST_LV_0100_20150317_001805	It's not your fault that Spion turned out like thi
 QUEST_LV_0100_20150317_001806	Okay. What happened to the monster's dead body?{n}
 QUEST_LV_0100_20150317_001807	Okay.{nl}This would have never happened if I found the identity of the broker sooner...{nl}Pitt, Bran, I am so incompetent... I am so sorry.
 QUEST_LV_0100_20150317_001808	I want to thank you.{nl}You made them real soldiers.
-QUEST_LV_0100_20150317_001809	We must concentrate on capturing those demons now. May the Goddess bless you.
+QUEST_LV_0100_20150317_001809	We must concentrate on capturing those demons now. May the goddess bless you.
 QUEST_LV_0100_20150317_001810	No one will help you even if you are defeated by Golems.{nl}You should save yourself.
 QUEST_LV_0100_20150317_001811	Well done.{nl}I will take care of that myself.{nl}Those Siaulambs should practice running away from now on.
 QUEST_LV_0100_20150317_001812	I can't stand this anymore.{nl}I will defeat it myself.{nl}You follow me too. If you could help us, that will really help us out.
 QUEST_LV_0100_20150317_001813	Thanks for saying that.{nl}I will wait at Malkos Felled Area.
-QUEST_LV_0100_20150317_001814	If I was a little richer, then I would have hired a personal mercenary.{nl}It was my mistake to rely on the Goddess' blessing too much.
+QUEST_LV_0100_20150317_001814	If I was a little richer, then I would have hired a personal mercenary.{nl}It was my mistake to rely on the goddess' blessing too much.
 QUEST_LV_0100_20150317_001815	I know many people are missing, but no one tries to find them.{nl}They don't even know those people even existed.
 QUEST_LV_0100_20150317_001816	We should make some money when the world is in chaos.{nl}Ah, never mind.
 QUEST_LV_0100_20150317_001817	Farewell to this land when this is over.{nl}I never saw that scary man before.
 QUEST_LV_0100_20150317_001818	No one will believe what I saw.{nl}I learned something interesting from it.
 QUEST_LV_0100_20150317_001819	I will lure Saugas.{nl}Bring me the poison from Woodfung near Alkune Stairway.{nl}And please also bring me the stone with vigor.{nl}
-QUEST_LV_0100_20150317_001820	It's fortunate that you two are okay.{nl}Thanks for recognizing me. May the Goddess bless you.
+QUEST_LV_0100_20150317_001820	It's fortunate that you two are okay.{nl}Thanks for recognizing me. May the goddess bless you.
 QUEST_LV_0100_20150317_001821	Good luck.
 QUEST_LV_0100_20150317_001822	I would feel more comfortable doing it myself, but I took an arrow to the knee before, and it aches quite a bit.
 QUEST_LV_0100_20150317_001823	If you look closely at the stones across Apynys Habitat, it will definitely appear.{nl}I hope the artifacts haven't been digested fully yet.
@@ -1850,8 +1850,8 @@ QUEST_LV_0100_20150317_001849	{memo X}This map contains all the locations of the
 QUEST_LV_0100_20150317_001850	{memo X}
 QUEST_LV_0100_20150317_001851	No antidotes yet?{nl}His pulse is fading.{nl}
 QUEST_LV_0100_20150317_001852	Thank you!{nl}Fortunately, he is breathing again.{nl}
-QUEST_LV_0100_20150317_001853	We'll rest a little more and return when he regains his strength.{nl}May the Goddess bless you.
-QUEST_LV_0100_20150317_001854	$The Revelator is here?! Thank the Goddess.{nl}I am Rexipher, a historian. I am studying the Royal Mausoleum.{nl}
+QUEST_LV_0100_20150317_001853	We'll rest a little more and return when he regains his strength.{nl}May the goddess bless you.
+QUEST_LV_0100_20150317_001854	$The Revelator is here?! Thank the goddess.{nl}I am Rexipher, a historian. I am studying the Royal Mausoleum.{nl}
 QUEST_LV_0100_20150317_001855	$We already have most of the answers.{nl}But for the last answer, I need to borrow your power as the Revelator.
 QUEST_LV_0100_20150317_001856	{memo X}There are things that only Revelator could see.{nl}The questions from the owner of the tomb..
 QUEST_LV_0100_20150317_001857	It is so good to meet a person like you, I guess this is the blessing of the god.
@@ -1912,7 +1912,7 @@ QUEST_LV_0100_20150317_001911	I saw fragments buried in the ground as I ran away
 QUEST_LV_0100_20150317_001912	It's okay if you quit.{nl}I can't do anything at the moment due to those monsters.
 QUEST_LV_0100_20150317_001913	This is enough.{nl}I will be finished if I bring these back.
 QUEST_LV_0100_20150317_001914	$Thanks.{nl}They even appeared in my dreams.
-QUEST_LV_0100_20150317_001915	$I will pray for the Goddess to bless you.{nl}You should stop him no matter what.
+QUEST_LV_0100_20150317_001915	$I will pray for the goddess to bless you.{nl}You should stop him no matter what.
 QUEST_LV_0100_20150317_001916	$I came here after hearing that her epitaph is here, but it will be difficult to find it all alone.{nl}I hope you can be an ally. Are you interested?
 QUEST_LV_0100_20150317_001917	$He is the traitor of the Kadumel Era and the owner of Earth Tower.{nl}He was regarded as the best swordsman, even when he was young, and many people followed him.
 QUEST_LV_0100_20150317_001918	$He was too greedy, so he started a coup de tat.{nl}If the great merchant Premier Eminent wasn't there, then history could have been much different.
@@ -1948,7 +1948,7 @@ QUEST_LV_0100_20150317_001947	$Infroburks play an important role in this spell.{
 QUEST_LV_0100_20150317_001948	$The Infroburk you brought me are not enough.{nl}Please try harder.
 QUEST_LV_0100_20150317_001949	Well done.{nl}This will be enough.
 QUEST_LV_0100_20150317_001950	{memo X}Thank you for making your way here. {nl} I am Knight Commander Uska and I am in charge of Siauliai and Klaipeda. {nl}
-QUEST_LV_0100_20150317_001951	{memo X}The Bishop told me to send the Revelator to the Crystal Mine as soon as they arrive. {nl} The Goddess told him in his dreams that the evidence of salvation would be found there. {nl}
+QUEST_LV_0100_20150317_001951	{memo X}The Bishop told me to send the Revelator to the Crystal Mine as soon as they arrive. {nl} The goddess told him in his dreams that the evidence of salvation would be found there. {nl}
 QUEST_LV_0100_20150317_001952	The monsters there are extremely dangerous so you be careful.
 QUEST_LV_0100_20150317_001953	{memo X}All right. {nl} Oh, do not forget to offer worship to the Goddess Statue before you leave. {nl}
 QUEST_LV_0100_20150317_001954	{memo X}Also, drop by the Item Merchant for the warp scrolls I left with him.
@@ -1959,7 +1959,7 @@ QUEST_LV_0100_20150317_001958	Tyrant Kadumel, Premier Eminent who was renowned a
 QUEST_LV_0100_20150317_001959	There are many artifacts here that praise the heroes of that time.{nl}And there are many side stories of them as well.
 QUEST_LV_0100_20150317_001960	$When you use the stone on Infroburks and defeat them, they will automatically come to me.{nl}Okay then, I am counting on you.
 QUEST_LV_0100_20150317_001961	She is the most impressive archer in history.{nl}She defeated Ruklys, who was a traitor and a great swordsman, with a single arrow.{nl}
-QUEST_LV_0100_20150317_001962	That's why all archers want to purchase things that are related to her, even if they are expensive.{nl}She is like a Goddess to us archers.
+QUEST_LV_0100_20150317_001962	That's why all archers want to purchase things that are related to her, even if they are expensive.{nl}She is like a goddess to us archers.
 QUEST_LV_0100_20150317_001963	$There was a priest called Maven in the past.{nl}He is the person who built the Great Cathedral.{nl}
 QUEST_LV_0100_20150317_001964	$Maven lived for a long time and had three disciples.{nl}The first one was Ruklys and the second one was Lydia Schaffen.{nl}
 QUEST_LV_0100_20150317_001965	$And when Lydia Schaffen grew old, Agailla Flurry became the last disciple.{nl}As the other two disciples were, Agailla Flurry was a great person.
@@ -1985,12 +1985,12 @@ QUEST_LV_0100_20150317_001984	Now is the time to defeat it.{nl}We spent a long t
 QUEST_LV_0100_20150317_001985	$Fire will never catch on the thorny vines here.{nl}And I don't want to touch them due to their evil energy.
 QUEST_LV_0100_20150317_001986	$Good job.{nl}I was worried that you would get hurt, but I guess I underestimated you.
 QUEST_LV_0100_20150317_001987	$Four years ago, this forest was a normal forest.{nl}But it became like this after Bramble went deep into the forest.
-QUEST_LV_0100_20150317_001988	Who would have thought that they would use the power of our own altar?{nl}I don't know how I can face the Goddess now.
+QUEST_LV_0100_20150317_001988	Who would have thought that they would use the power of our own altar?{nl}I don't know how I can face the goddess now.
 QUEST_LV_0100_20150317_001989	Believer Bronius
 QUEST_LV_0100_20150317_001990	$I only survived because of you.{nl}I should warn the other Believers to be careful.
 QUEST_LV_0100_20150317_001991	Believer Jurga
 QUEST_LV_0100_20150317_001992	{memo X}$I can feel Bramble is suffering.{nl}He is getting retribution for extracting all vigor from this land.
-QUEST_LV_0100_20150317_001993	You're the Savior the Goddess sent. What an honor. {nl} Are you ready to fight Bramble?
+QUEST_LV_0100_20150317_001993	You're the Savior the goddess sent. What an honor. {nl} Are you ready to fight Bramble?
 QUEST_LV_0100_20150317_001994	You need to be prepared if you want to defeat Bramble. {nl} First, take this.
 QUEST_LV_0100_20150317_001995	It will be hard for Bramble to recover now.{nl}We can save the dying trees as well.
 QUEST_LV_0100_20150317_001996	Try to hold it in even if it's dirty. {nl} This is the best I can do.
@@ -2009,8 +2009,8 @@ QUEST_LV_0100_20150317_002008	$We just need to restore the Obelisk to meet Godde
 QUEST_LV_0100_20150317_002009	$Please bring that venom to the Village Priest at Cerpe Crossroads.
 QUEST_LV_0100_20150317_002010	$So you finished making the dye. {nl} Now please go and draw in new letters according to the faint patterns left on the Obelisk. {nl}
 QUEST_LV_0100_20150317_002011	The Obelisk is located at Slepingas Stream.
-QUEST_LV_0100_20150317_002012	I'm sure the Goddesses will be very pleased with you.
-QUEST_LV_0100_20150317_002013	$You're almost done. {nl} After completing the rituals to cleanse your body, you will be able to meet the Goddess. {nl}
+QUEST_LV_0100_20150317_002012	I'm sure the goddesses will be very pleased with you.
+QUEST_LV_0100_20150317_002013	$You're almost done. {nl} After completing the rituals to cleanse your body, you will be able to meet the goddess. {nl}
 QUEST_LV_0100_20150317_002014	{memo X}
 QUEST_LV_0100_20150317_002015	$Use this tranquilizer on the Black Maize and extract its venom. {nl} The Maize needs to be weakened for the tranquilizer to work.
 QUEST_LV_0100_20150317_002016	Thank you so much! {nl}By the way, what was that vibration?
@@ -2029,7 +2029,7 @@ QUEST_LV_0100_20150317_002028	$It's probably in the bigger barrels. {nl} They wo
 QUEST_LV_0100_20150317_002029	$Don't worry, it's safe. They will not explode.
 QUEST_LV_0100_20150317_002030	$It was in a small barrel? {nl} I must be getting old and mixed up. {nl} Normal people would have been incinerated, but a Revelator surely is different.
 QUEST_LV_0100_20150317_002031	{memo X}
-QUEST_LV_0100_20150317_002032	God or Goddess, their title isn't really that important. {nl} Eventually, aren't we all just one being? {nl}
+QUEST_LV_0100_20150317_002032	God or goddess, their title isn't really important. {nl} Eventually, aren't we all just one being? {nl}
 QUEST_LV_0100_20150317_002033	Is this hard to comprehend? {nl} You will understand it one day.
 QUEST_LV_0100_20150317_002034	Here, this is a Languid Herb Bomb. {nl} Take it to Melaginags Cliff.
 QUEST_LV_0100_20150317_002035	Now, hurry. {nl} We can finally end it this time.
@@ -2075,7 +2075,7 @@ QUEST_LV_0100_20150317_002074	$Goddess Saule said to absolutely not speak of our
 QUEST_LV_0100_20150317_002075	{memo X}This is all my fault. I shouldn't have underestimated it.
 QUEST_LV_0100_20150317_002076	{memo X}
 QUEST_LV_0100_20150317_002077	I am okay about the sample so just break it so that it won't activate.{nl}I am gonna take a look at it myself.
-QUEST_LV_0100_20150317_002078	$I get angry every time I enter that Thorn Forest.{nl}How could such dirty things happen to the Goddess' sacred forest?
+QUEST_LV_0100_20150317_002078	$I get angry every time I enter that Thorn Forest.{nl}How could such dirty things happen to the goddess' sacred forest?
 QUEST_LV_0100_20150317_002079	{memo X}$Help me. Merogs are after me.{nl}When they are grouped up like that, I can't face them.
 QUEST_LV_0100_20150317_002080	Good. {nl} Now, we're going to destroy the roots of Bramble.
 QUEST_LV_0100_20150317_002081	$Believer Samantha
@@ -2114,7 +2114,7 @@ QUEST_LV_0100_20150317_002113	I am keeping my eyes on Bramble after receiving th
 QUEST_LV_0100_20150317_002114	$It was a real honor to meet you.{nl}For your future, I will pray to Goddess Saule.
 QUEST_LV_0100_20150317_002115	{memo X}Do not disturb Zachariel's rest
 QUEST_LV_0100_20150317_002116	{memo X}I told you that there's an way to block those demons at Fedimian.{nl}I will complete the jewel of prominence here and help the Goddess Gabija.{nl}
-QUEST_LV_0100_20150317_002117	I hope the Goddess stands still until then.
+QUEST_LV_0100_20150317_002117	I hope the goddess stands still until then.
 QUEST_LV_0100_20150317_002118	{memo X}Well done.{nl}But, this is just an empty stone.{nl}You can complete it by empowering it with various ingredients.
 QUEST_LV_0100_20150317_002119	{memo X}I will fill the Jewel of Prominence with Flame Vapor.{nl}There is a Flame Vapor with magic possesed in it at the reading room. 
 QUEST_LV_0100_20150317_002120	{memo X}You should search for it hard.{nl}The Flame Vapor is not clearly visible.
@@ -2159,17 +2159,17 @@ QUEST_LV_0100_20150317_002158	Aren't you the Revelator? {nl} So, what brings you
 QUEST_LV_0100_20150317_002159	Goddess Saule? {nl} We haven't seen her for a long time. {nl}
 QUEST_LV_0100_20150317_002160	$The reason is that the portal leading to Goddess Saule doesn't open. {nl}I think it's because the Holy Pond is corrupted.
 QUEST_LV_0100_20150317_002161	The Tanus in Zvelgian Vacant Lot carry Purifying Stones. {nl} Those will be able to purify the Pond.
-QUEST_LV_0100_20150317_002162	$Just like there are many demons, the same goes for the Goddesses. {nl} The five Goddesses are just the ones who became well known.
+QUEST_LV_0100_20150317_002162	$Just like there are many demons, the same goes for the goddesses. {nl} The five goddesses are just the ones who became well known.
 QUEST_LV_0100_20150317_002163	$Our village serves the Goddess Saule, who overlooks the sun. {nl}We used to go see her a lot through the portal, but one day that portal closed.
 QUEST_LV_0100_20150317_002164	{memo X}I haved carved the owls for a long time.{nl}At one point in time, they got their lives and determination.{nl}
 QUEST_LV_0100_20150317_002165	{memo X}When I gained my consciousness, a few hundreds of years have passed.
 QUEST_LV_0100_20150317_002166	{memo X}Carvers should be careful not to exaggerate their skills. They should be humble.
 QUEST_LV_0100_20150317_002167	$It is a good sign that you, the Revelator, came here.{nl}We've been waiting for you for a long time.
 QUEST_LV_0100_20150317_002168	$Please come to our village.{nl}The villagers will really like you.{nl}For sure.
-QUEST_LV_0100_20150317_002169	$The fact that we were able meet was through the Goddess' guidance.
+QUEST_LV_0100_20150317_002169	$The fact that we were able meet was through the goddess' guidance.
 QUEST_LV_0100_20150317_002170	$Please refrain from thinking about any suffering. We have all received a blessing.
-QUEST_LV_0100_20150317_002171	Trust the Goddess.{nl}We can be together in the tree.
-QUEST_LV_0100_20150317_002172	$We will be saved by sticking together.{nl}The Goddess had told us to do that.
+QUEST_LV_0100_20150317_002171	Trust the goddess.{nl}We can be together in the tree.
+QUEST_LV_0100_20150317_002172	$We will be saved by sticking together.{nl}The goddess had told us to do that.
 QUEST_LV_0100_20150317_002173	Not yet?{nl}Where is the girl?
 QUEST_LV_0100_20150317_002174	{memo X}I can't use my power since I was deceivied by the demon's trick.{nl}You should find my power to guide you to the revelation.
 QUEST_LV_0100_20150317_002175	$That portal is a gate to lies.{nl}Laima has brought you to me because of that.
@@ -2177,11 +2177,11 @@ QUEST_LV_0100_20150317_002176	$Demon Lord Bramble absolutely can never be forgiv
 QUEST_LV_0100_20150317_002177	$Bramble must be recovering his power even at this moment.{nl}Please meet the Believers at Gate Route.
 QUEST_LV_0100_20150317_002178	$Please be careful of the Beholder's tricks at Gate Route.
 QUEST_LV_0100_20150317_002179	{memo X}I am gonna stay here and recover my lost energy.{nl}I don't wanna create chaos in this world so please do not tell my existence to anyone.
-QUEST_LV_0100_20150317_002180	{memo X}The Mausoleum you should go can be reached only through the portal that I have opened for you.{nl}May the Goddess bless you.
+QUEST_LV_0100_20150317_002180	{memo X}The Mausoleum you should go can be reached only through the portal that I have opened for you.{nl}May the goddess bless you.
 QUEST_LV_0100_20150317_002181	$It seems that the rain just won't stop. In fact, it rarely stops.{nl}Do you think this is because of the evil energy?
 QUEST_LV_0100_20150317_002182	$These thorny vines just keep growing even after we cut them.{nl}But it's better than leaving them.
 QUEST_LV_0100_20150317_002183	$Even if Bramble disappears, I think things are going to stay like this for a while.{nl}The entire forest is covered with thorny vines. And they are huge.
-QUEST_LV_0100_20150317_002184	$You seem to live up to your reputation. {nl} The people in our village just cowardly, hoping that the Goddess will take care of everything.
+QUEST_LV_0100_20150317_002184	$You seem to live up to your reputation. {nl} The people in our village just cowardly, hoping that the goddess will take care of everything.
 QUEST_LV_0100_20150317_002185	$By the way, did you see a young man from our village? {nl} I told him to go check if the portal is working, but I have not heard back since then.
 QUEST_LV_0100_20150317_002186	Thank you. {nl} The portal is at Nugria Sanctum.
 QUEST_LV_0100_20150317_002187	Injured Villager
@@ -2212,9 +2212,9 @@ QUEST_LV_0100_20150317_002211	Broker between the life and death of humans. {nl} 
 QUEST_LV_0100_20150317_002212	You don't look like a delivery man. What's up?{nl}
 QUEST_LV_0100_20150317_002213	There's no head of a Long-Branched Tree in here. Should I get it for them?
 QUEST_LV_0100_20150317_002214	$Klaipeda is a small and quiet town. {nl} We haven't had so many people come to town before.
-QUEST_LV_0100_20150317_002215	$Did the Goddess mention her whereabouts in the dream of revelation?
+QUEST_LV_0100_20150317_002215	$Did the goddess mention her whereabouts in the dream of revelation?
 QUEST_LV_0100_20150317_002216	$Go ahead to Klaipeda. {nl}Commander Uska is waiting for you at the Central Plaza.{nl}
-QUEST_LV_0100_20150317_002217	$I heard the bishop also had a dream about a Goddess, so it probably has something to do with that.
+QUEST_LV_0100_20150317_002217	$I heard the bishop also had a dream about a goddess, so it probably has something to do with that.
 QUEST_LV_0100_20150317_002218	That girl. {nl} She just appeared in town some time ago. {nl}
 QUEST_LV_0100_20150317_002219	I mean she didn't speak and her clothes were all dirty. {nl} She seemed hungry so I brought her home to feed her some food and this happened.
 QUEST_LV_0100_20150317_002220	I mean the girl who was confined together with us before. {nl} Do you think she has a family? It seemed like she could not speak at all. {nl}
@@ -2228,7 +2228,7 @@ QUEST_LV_0100_20150317_002227	{memo X}
 QUEST_LV_0100_20150317_002228	Oh, the Accessory Merchant said she has a gift for you. {nl} Would you mind visiting her?
 QUEST_LV_0100_20150317_002229	You can meet the Accessory Merchant if you go straight to the left from here.
 QUEST_LV_0100_20150317_002230	Accessory Merchant
-QUEST_LV_0100_20150317_002231	Nice to meet you! Are you the Revelator chasing the dream of the Goddess? {nl} I'd like to give you this accessory as a present. {nl}
+QUEST_LV_0100_20150317_002231	Nice to meet you! Are you the Revelator chasing the dream of the goddess? {nl} I'd like to give you this accessory as a present. {nl}
 QUEST_LV_0100_20150317_002232	{memo X}If armor protects you from physical attacks, accessories protect you from magic attacks. {nl} I hope this will be useful for you.
 QUEST_LV_0100_20150317_002233	You can meet the Accessory Merchant if you go straight to the left from here. {nl}
 QUEST_LV_0100_20150317_002234	Ah, I was waiting for you.{nl}Are you the person chosen by the Eyes of the Great King Zachariel?
@@ -2277,23 +2277,23 @@ QUEST_LV_0100_20150317_002276	They call the trail to the Great Cathedral, Pilgri
 QUEST_LV_0100_20150317_002277	{memo X}$Welcome. {nl} Only hard-to-find stuff here.
 QUEST_LV_0100_20150317_002278	Klaipeda Peddler
 QUEST_LV_0100_20150317_002279	$I came all the way from Klaipeda to pray. {nl} That another disaster never occurs, and that my son who joined the army will be able to come back and see me.
-QUEST_LV_0100_20150317_002280	$My husband and I come here to pray every time we come here from Klaipeda. {nl} I know the Goddess protected us during Medzio Diena, but I hope she can hear out at least one of my wishes.
+QUEST_LV_0100_20150317_002280	$My husband and I come here to pray every time we come here from Klaipeda. {nl} I know the goddess protected us during Medzio Diena, but I hope she can hear out at least one of my wishes.
 QUEST_LV_0100_20150317_002281	Don't you ever think about going to the Great Cathedral.{nl}Besides the dangers due to its deterioration..
 QUEST_LV_0100_20150317_002282	$Yes. If you want to go to the Great Cathedral, you have to pass through Pilgrim's Way.{nl}Ah well.. the spirits of fallen Pilgrims remain over there. They probably prey on the travellers there.
 QUEST_LV_0100_20150317_002283	Seal of Vubbe Tribe, Horn of Pantos, Heart of Merog, Teeth of Hogma. {nl} That is a lot! {nl}
 QUEST_LV_0100_20150317_002284	The bootys that you've obtained are not to be boasted about.{nl}How about we bet?
 QUEST_LV_0100_20150317_002285	{memo X}
 QUEST_LV_0100_20150317_002286	Haha, I lost.{nl}You are great as I heard so. Here, it's your reward as promised/
-QUEST_LV_0100_20150317_002287	$I have buried a Revelator once in the past.{nl}He burdened the Goddess and placed too much faith in his abilities.
+QUEST_LV_0100_20150317_002287	$I have buried a Revelator once in the past.{nl}He burdened the goddess and placed too much faith in his abilities.
 QUEST_LV_0100_20150317_002288	$It's frightening to think that blunder happened at all.{nl}I don't even know if I will have to bury another Revelator in the future.. I don't know about you either.
 QUEST_LV_0100_20150317_002289	Are you proud of your skills to talk to me at this moment while the time passes?
 QUEST_LV_0100_20150317_002290	{memo X}If a person becomes a handful of soils after his death, can you imagine how he will be treated.{nl}The soils that once conquered this world..
 QUEST_LV_0100_20150317_002291	{memo X}Yes. You managed to avoid being like me. Yes..
-QUEST_LV_0100_20150317_002292	Without the blessing from the Goddess, You must be near the Goddess now.{nl}But lots of people can't do that anymore.{nl}
+QUEST_LV_0100_20150317_002292	Without the blessing from the goddess, You must be near the goddess now.{nl}But lots of people can't do that anymore.{nl}
 QUEST_LV_0100_20150317_002293	{memo X}
 QUEST_LV_0100_20150317_002294	{memo X}We can't revive the people who died by Chapparitions.{nl}I feel sorry, but we can't just do nothing.
 QUEST_LV_0100_20150317_002295	Innocent Spirit
-QUEST_LV_0100_20150317_002296	Do not be surprised. {nl} There's something to give you before returning to the Goddess. {nl}
+QUEST_LV_0100_20150317_002296	Do not be surprised. {nl} There's something to give you before returning to the goddess. {nl}
 QUEST_LV_0100_20150317_002297	I want to apologize to my sister who left house because of me but now I can't even do that. {nl} Can you find my sister and give her this necklace for me?
 QUEST_LV_0100_20150317_002298	My brother asked you to give this necklace to me? {nl} Where is my brother?
 QUEST_LV_0100_20150317_002299	Innocent Soldier
@@ -2331,10 +2331,10 @@ QUEST_LV_0100_20150317_002330	$Frankly, I'm afraid of what the world will turn i
 QUEST_LV_0100_20150317_002331	Cyrenia Odell
 QUEST_LV_0100_20150317_002332	Hmm.. where is this place?{nl}What about Rexipher? Where is he?
 QUEST_LV_0100_20150317_002333	$Oh? The woman. I forgot.{nl}I will release her as promised. Do try to keep her alive.
-QUEST_LV_0100_20150317_002334	Sincerity is our strength. {nl} There will be no problems if you sincerely believe and follow the Goddess.
+QUEST_LV_0100_20150317_002334	Sincerity is our strength. {nl} There will be no problems if you sincerely believe and follow the goddess.
 QUEST_LV_0100_20150317_002335	$My throat hurts.. I think being confined in there damaged my throat. {nl} I wonder about the girl who was with us? Where did she go?
 QUEST_LV_0100_20150317_002336	Aren't you the Revelator who saved us last time? {nl} We were more than glad to see you back then.
-QUEST_LV_0100_20150317_002337	The Goddess must have sent you.{nl}If that's not it.. we already.. It's too scary to think about it.
+QUEST_LV_0100_20150317_002337	The goddess must have sent you.{nl}If that's not it.. we already.. It's too scary to think about it.
 QUEST_LV_0100_20150317_002338	It was horrible in captivity. {nl} The Vubbes would come and smelled us.. {nl} and make us dig here and there using pickaxes..
 QUEST_LV_0100_20150317_002339	Rexipher... Was he really a demon?
 QUEST_LV_0100_20150317_002340	$You saved us. Thank you so much. {nl} But I have a question for you.
@@ -2353,7 +2353,7 @@ QUEST_LV_0100_20150317_002352	{memo X}The demons have been chasing the revelatio
 QUEST_LV_0100_20150317_002353	$There are two Demon Kings and one Demon Queen with many Demon Lords to serve them.{nl}Giltine is the one that rules over them all.{nl}
 QUEST_LV_0100_20150317_002354	All these catastrophes are her plans. {nl} The disasters will continue and at the end of it will be the end of the human race. {nl}
 QUEST_LV_0100_20150317_002355	I am a very fatal existence for them as I can see all of this. {nl}That's why Giltine will try to revert me to the world's waters. {nl}
-QUEST_LV_0100_20150317_002356	Also, they will extend their evil powers to the Goddesses who go against their will. {nl}
+QUEST_LV_0100_20150317_002356	Also, they will extend their evil powers to the goddesses who go against their will. {nl}
 QUEST_LV_0100_20150317_002357	But, disasters are happening just as I saw them to be. {nl}And it means that the hope, which I saw further away, will also definitely come. {nl}
 QUEST_LV_0100_20150317_002358	Dear Savior, our sister Saule is losing her light. {nl} Find her at the back of the light from the colorful valley and you will be guided to the next revelation.
 QUEST_LV_0100_20150317_002359	$Revelation of Crystal Mine
@@ -3377,7 +3377,7 @@ QUEST_LV_0100_20150317_003376	About the possessed soul
 QUEST_LV_0100_20150317_003377	$Truth of the Suspicious Seal Stone (2)
 QUEST_LV_0100_20150317_003378	I will release the soul by defeating Stone Whale
 QUEST_LV_0100_20150317_003379	{memo X}NPCChat/FTOWER45_SQ_04 /Now I am really free
-QUEST_LV_0100_20150317_003380	Goddess of Tower
+QUEST_LV_0100_20150317_003380	Goddess Tower
 QUEST_LV_0100_20150317_003381	{memo X}Notice /Go upstairs and find Goddess Gabija #5
 QUEST_LV_0100_20150317_003382	$Demon Lord Helgasercle
 QUEST_LV_0100_20150317_003383	The Fearless Ones
@@ -3898,9 +3898,9 @@ QUEST_LV_0100_20150317_003897	$Defeat the Large Kepa in the area that the Search
 QUEST_LV_0100_20150317_003898	$Return to the Search Scout
 QUEST_LV_0100_20150317_003899	$Return to the Search Scout and tell him that the Large Kepa was defeated.
 QUEST_LV_0100_20150317_003900	$Talk to Knight Commander Uska
-QUEST_LV_0100_20150317_003901	$Knight Commander Uska is looking for people who came to Klaipeda after witnessing the dream of Goddess. Meet Sir Uska and tell him about the Dream of Revelation.
-QUEST_LV_0100_20150317_003902	$Knight Commander Uska is looking for people who came to Klaipeda after witnessing the dream of Goddess. Meet Sir Uska and tell him about the Dream of Revelation.
-QUEST_LV_0100_20150317_003903	$When ready, talk to Sir Uska about going to the Crystal Mine as told by the Goddess in the bishop's dream.
+QUEST_LV_0100_20150317_003901	$Knight Commander Uska is looking for people who came to Klaipeda after witnessing the dream of goddess. Meet Sir Uska and tell him about the Dream of Revelation.
+QUEST_LV_0100_20150317_003902	$Knight Commander Uska is looking for people who came to Klaipeda after witnessing the dream of goddess. Meet Sir Uska and tell him about the Dream of Revelation.
+QUEST_LV_0100_20150317_003903	$When ready, talk to Sir Uska about going to the Crystal Mine as told by the goddess in the bishop's dream.
 QUEST_LV_0100_20150317_003904	$Go to the Eastern Woods Base Camp
 QUEST_LV_0100_20150317_003905	$The Eastern Woods Base Camp seems to be in danger because of monster accumulation. Let's go and have a look.
 QUEST_LV_0100_20150317_003906	$Defeat the Poata in the Eastern Woods Base Camp
@@ -4480,7 +4480,7 @@ QUEST_LV_0100_20150317_004479	{memo X}You need to go to the Crystal Mine as told
 QUEST_LV_0100_20150317_004480	$The Hunter says that monsters stole all the relief supplies meant for the villagers. {nl}Try to pick up at least what's left on the road.
 QUEST_LV_0100_20150317_004481	$Gathered all the relief supplies. Talk to the Hunter. 
 QUEST_LV_0100_20150317_004482	$Talk to Mine Manager Brinker
-QUEST_LV_0100_20150317_004483	$You need to go to the Crystal Mine as told by the Goddess in the bishop's dream but you can't just leave the refugees. Mine Manager Brinker is standing by the wall with one hand on the wall. Ask what is happening.
+QUEST_LV_0100_20150317_004483	$You need to go to the Crystal Mine as told by the goddess in the bishop's dream but you can't just leave the refugees. Mine Manager Brinker is standing by the wall with one hand on the wall. Ask what is happening.
 QUEST_LV_0100_20150317_004484	$Collect stones for reinforcement from the rubble nearby
 QUEST_LV_0100_20150317_004485	$The wall may collapse if Brinker releases his hands off the wall. Let's look for some rocks nearby to block the holes on the wall for Brinker.
 QUEST_LV_0100_20150317_004486	$Give the reinforcement stones to Brinker
@@ -4491,7 +4491,7 @@ QUEST_LV_0100_20150317_004490	$Defeat the monsters nearby so that Brinker can re
 QUEST_LV_0100_20150317_004491	$Tell Brinker that it is safe
 QUEST_LV_0100_20150317_004492	$Tell Brinker that he can return safely. 
 QUEST_LV_0100_20150317_004493	$Talk to the Healer Lady
-QUEST_LV_0100_20150317_004494	$You need to go to the Crystal Mines as told by the Goddess in the bishop's dream but you can't just leave the refugees. Help the Healer Lady to treat the injured people.
+QUEST_LV_0100_20150317_004494	$You need to go to the Crystal Mines as told by the goddess in the bishop's dream but you can't just leave the refugees. Help the Healer Lady to treat the injured people.
 QUEST_LV_0100_20150317_004495	$Bringing the Refugees
 QUEST_LV_0100_20150317_004496	$Healer Lady is asking a favor for you to bring the other refugees. Bring the couple near the Statue of Goddess Zemyna to the Healer Lady.
 QUEST_LV_0100_20150317_004497	$Turn over the refugees to the Healer Lady
@@ -4503,7 +4503,7 @@ QUEST_LV_0100_20150317_004502	$Defeated the monsters. Tell the lady to go back t
 QUEST_LV_0100_20150317_004503	$Talk to the Miners' Village Mayor
 QUEST_LV_0100_20150317_004504	$Talk to the mayor again to enter the Crystal Mines. 
 QUEST_LV_0100_20150317_004505	$Rescue Vaidotas who is kidnapped by the Vubbes
-QUEST_LV_0100_20150317_004506	$The Goddess's revelation is important but you can't leave the kidnapped villagers. To save the villagers trapped in the Crystal Mine, go to the Vubbe Outpost and save Vaidotas first.
+QUEST_LV_0100_20150317_004506	$The goddess's revelation is important but you can't leave the kidnapped villagers. To save the villagers trapped in the Crystal Mine, go to the Vubbe Outpost and save Vaidotas first.
 QUEST_LV_0100_20150317_004507	$Intercept the Vubbe raid
 QUEST_LV_0100_20150317_004508	$The Mayor seems to have a problem. Talk to him.
 QUEST_LV_0100_20150317_004509	$Defeat the Vubbes who invaded the village
@@ -4657,7 +4657,7 @@ QUEST_LV_0100_20150317_004656	Pass the second test
 QUEST_LV_0100_20150317_004657	Defeat the Sequoia of the test
 QUEST_LV_0100_20150317_004658	Passed the third test
 QUEST_LV_0100_20150317_004659	Pass the third test
-QUEST_LV_0100_20150317_004660	Destroy the statue of the Goddess of the test
+QUEST_LV_0100_20150317_004660	Destroy the Goddess Statue of Test
 QUEST_LV_0100_20150317_004661	Use the key
 QUEST_LV_0100_20150317_004662	Use the key to open the way to Thorn Forest
 QUEST_LV_0100_20150317_004663	Move to Thorn Forest
@@ -4709,7 +4709,7 @@ QUEST_LV_0100_20150317_004708	Read the epitaph of the Royal Mausoleum
 QUEST_LV_0100_20150317_004709	$Prevent the Guardians from destroying the Royal Mausoleum
 QUEST_LV_0100_20150317_004710	$Talk to the Guardian's Stone Statue.
 QUEST_LV_0100_20150317_004711	$Prevent the collapse of the Royal Mausoleum by defeating Bearkaras
-QUEST_LV_0100_20150317_004712	The determination of the king is trying to destroy the Royal Mausoleum to prevent Rexipher from reaching the will of the Goddess. Defeat Bearkaras to prevent the collapse of the Royal Mausoleum.
+QUEST_LV_0100_20150317_004712	The determination of the king is trying to destroy the Royal Mausoleum to prevent Rexipher from reaching the will of the goddess. Defeat Bearkaras to prevent the collapse of the Royal Mausoleum.
 QUEST_LV_0100_20150317_004713	Defeat Bearkaras
 QUEST_LV_0100_20150317_004714	$Talk to the Secret Guardian
 QUEST_LV_0100_20150317_004715	$Continue to chase after Rexipher deeper into the Royal Mausoleum and prevent the demons from damaging the Royal Mausoleum.
@@ -4718,16 +4718,16 @@ QUEST_LV_0100_20150317_004717	$The Secret Guardian is trying to stop Rexipher fr
 QUEST_LV_0100_20150317_004718	$You have collected all the magic sources. Return to the Secret Guardian.
 QUEST_LV_0100_20150317_004719	Obtain %s by defeating Madakia
 QUEST_LV_0100_20150317_004720	Obtain the Soul Pot
-QUEST_LV_0100_20150317_004721	$The Secret Guardian told you that the Royal Mausoleum of the Great King Zachariel was actually made to defeat Rexipher according to the forecast by the Goddess. Talk to the Secret Guardian.
+QUEST_LV_0100_20150317_004721	$The Secret Guardian told you that the Royal Mausoleum of the Great King Zachariel was actually made to defeat Rexipher according to the forecast by the goddess. Talk to the Secret Guardian.
 QUEST_LV_0100_20150317_004722	$Pour the sources of the magic into a jar
-QUEST_LV_0100_20150317_004723	$The Secret Guardian told you that the Royal Mausoleum of the Great King Zachariel was actually made to defeat Rexipher according to the forecast by the Goddess. Recharge the sources of the magic power of the Mausoleum to the prepared pots.
+QUEST_LV_0100_20150317_004723	$The Secret Guardian told you that the Royal Mausoleum of the Great King Zachariel was actually made to defeat Rexipher according to the forecast by the goddess. Recharge the sources of the magic power of the Mausoleum to the prepared pots.
 QUEST_LV_0100_20150317_004724	$You have poured all the sources of magic into all the jars. Talk to the Secret Guardian.
 QUEST_LV_0100_20150317_004725	$You felt like you've heard the sound of demons' cries. Talk to the Secret Guardian.
 QUEST_LV_0100_20150317_004726	{memo X}Lure and absorb Madakia into the pot
 QUEST_LV_0100_20150317_004727	$You should deal a fatal blow to Rexipher with the will of the Guardians. Place the Soul Pot, and lure the Guardians to it in order to fill it.
 QUEST_LV_0100_20150317_004728	$You filled the wills of the Guardians into the pot. Talk to the Secret Guardian.
 QUEST_LV_0100_20150317_004729	$Give the pot to the Secret Guardian
-QUEST_LV_0100_20150317_004730	$Now is the time to attack Rexipher and find the revelation of the Goddess. Prepare the pot with the wills of the Guardians.
+QUEST_LV_0100_20150317_004730	$Now is the time to attack Rexipher and find the revelation of the goddess. Prepare the pot with the wills of the Guardians.
 QUEST_LV_0100_20150317_004731	Defeat Rexipher
 QUEST_LV_0100_20150317_004732	All the energies of the Royal Mausoleum are restraining Rexipher. Defeat Rexipher.
 QUEST_LV_0100_20150317_004733	Go to the burial chamber of the Royal Mausoleum
@@ -4876,14 +4876,14 @@ QUEST_LV_0100_20150317_004875	{memo X}
 QUEST_LV_0100_20150317_004876	{memo X}
 QUEST_LV_0100_20150317_004877	{memo X}
 QUEST_LV_0100_20150317_004878	Go to the Mage Tower
-QUEST_LV_0100_20150317_004879	$Grita told you that the Goddess Gabija is resisting the attacks of the demons at the Mage Tower. Go to the Mage Tower to help the Goddess.
+QUEST_LV_0100_20150317_004879	$Grita told you that the Goddess Gabija is resisting the attacks of the demons at the Mage Tower. Go to the Mage Tower to help the goddess.
 QUEST_LV_0100_20150317_004880	Talk to Grita
 QUEST_LV_0100_20150317_004881	You finally arrived inside the Mage Tower. Talk to Grita.
 QUEST_LV_0100_20150317_004882	Light up the signal
-QUEST_LV_0100_20150317_004883	$Grita told you that Gabija was protecting the tower, but since the monsters are still around, something bad must have happened to the Goddess. Light up the signal at the left hallway to let the Goddess know that you are here.
+QUEST_LV_0100_20150317_004883	$Grita told you that Gabija was protecting the tower, but since the monsters are still around, something bad must have happened to the goddess. Light up the signal at the left hallway to let the goddess know that you are here.
 QUEST_LV_0100_20150317_004884	$You successfully lit up the signal. Talk to Grita again.
 QUEST_LV_0100_20150317_004885	$Defeat the Rubblems
-QUEST_LV_0100_20150317_004886	$You lit up a signal to let the Goddess know that help is coming. Discuss what to do next with Grita.
+QUEST_LV_0100_20150317_004886	$You lit up a signal to let the goddess know that help is coming. Discuss what to do next with Grita.
 QUEST_LV_0100_20150317_004887	$Check the 1st Transport Magic Circle
 QUEST_LV_0100_20150317_004888	$Grita told you that using the Transport Magic Circle is the fastest way to go upstairs. Go to the 1st Transport Magic Circle to see whether it is working correctly.
 QUEST_LV_0100_20150317_004889	$You defeated the monsters that were rushing in and arrived at the place where the 1st Transport Magic Circle is located at. Talk to Grita.{nl}{nl}Grita finished checking the 1st Transport Magic Circle. Ask Grita if it works.
@@ -4987,7 +4987,7 @@ QUEST_LV_0100_20150317_004986	$Defeat Helgasercle
 QUEST_LV_0100_20150317_004987	Use the Jewel of Prominence
 QUEST_LV_0100_20150317_004988	You should help Gabija now with the Jewel of Prominence. Put the jewels in the center of Keturidu great hall. 
 QUEST_LV_0100_20150317_004989	Talk to Goddess Gabija
-QUEST_LV_0100_20150317_004990	You received the revelation from the Goddess.{nl}Ask the Goddess what to do next.
+QUEST_LV_0100_20150317_004990	You received the revelation from the goddess.{nl}Ask the goddess what to do next.
 QUEST_LV_0100_20150317_004991	$Now it's time to destroy the 2nd Valve. Talk to Grita.
 QUEST_LV_0100_20150317_004992	$Grita told you that the 2nd Valve is in the Central Control Room. Go to the Central Control Room.
 QUEST_LV_0100_20150317_004993	$Antares touched the wrong part of the valve, so the valve exploded. Talk to Grita.
@@ -5379,8 +5379,8 @@ QUEST_LV_0100_20150317_005378	Barely defeated Cactusvel. Check if Cyrenia Odell 
 QUEST_LV_0100_20150317_005379	Defeat Rexipher's summon
 QUEST_LV_0100_20150317_005380	Tell Cyrenia Odell about what happened.
 QUEST_LV_0100_20150317_005381	{memo X}Follow Rexipher and enter Mausoleum
-QUEST_LV_0100_20150317_005382	Cyrenia Odell says Rexipher's objective is the thing hidden in the Royal Mausoleum by the Great King Zachariel for the Goddess. Follow Rexipher into the Royal Mausoleum.
-QUEST_LV_0100_20150317_005383	Defeat Rexipher's subordinates
+QUEST_LV_0100_20150317_005382	Cyrenia Odell says Rexipher's objective is the thing hidden in the Royal Mausoleum by the Great King Zachariel for the goddess. Follow Rexipher into the Royal Mausoleum.
+QUEST_LV_0100_20150317_005383	Defeat Rexipher's servants
 QUEST_LV_0100_20150317_005384	Talk to Epigraphist Schmid
 QUEST_LV_0100_20150317_005385	{memo X}
 QUEST_LV_0100_20150317_005386	{memo X}Restore Ruklys Memorial Stone
@@ -5392,14 +5392,14 @@ QUEST_LV_0100_20150317_005391	Open the Gate
 QUEST_LV_0100_20150317_005392	Defeat Mummyghast. Open the church gates. 
 QUEST_LV_0100_20150317_005393	Opened the church gates. Talk to Follower Donatas. 
 QUEST_LV_0100_20150317_005394	Check the last gravestone
-QUEST_LV_0100_20150317_005395	Find the last gravestone of Lydia Schaffen in the Goddess' old courtyard and be enlightened. 
+QUEST_LV_0100_20150317_005395	Find the last gravestone of Lydia Schaffen in Goddess' Ancient Garden and be enlightened. 
 QUEST_LV_0100_20150317_005396	Talk to Hunter Talus
-QUEST_LV_0100_20150317_005397	$Hunter Talus in the Goddess' Ancient Garden is looking for someone's help.
+QUEST_LV_0100_20150317_005397	$Hunter Talus in Goddess' Ancient Garden is looking for someone's help.
 QUEST_LV_0100_20150317_005398	$Make Fire Hardened arrowheads
 QUEST_LV_0100_20150317_005399	$Hunter Talus asked you to make Fire Hardened Arrowheads. Defeat the Infroburks at the Shiluma Altar Site, and use the leftover flame to heat the arrow that Tallus gave you. 
 QUEST_LV_0100_20150317_005400	$Made the heated arrowheads. Give them to Talus.
 QUEST_LV_0100_20150317_005401	$Talk to Necromancer Drasius
-QUEST_LV_0100_20150317_005402	$Drasius in the Goddess' Ancient Garden is looking for someone to help his experiment.
+QUEST_LV_0100_20150317_005402	$Drasius in Goddess' Ancient Garden is looking for someone to help his experiment.
 QUEST_LV_0100_20150317_005403	$Bring the sacrifices to the offering pot at Dumbla Pond. 
 QUEST_LV_0100_20150317_005404	$Drasius asked you to bring the sacrifices to the offering pot at Dumbla Pond for a necromancy experiment.
 QUEST_LV_0100_20150317_005405	$Defeat the uncontrollable Necroventer
@@ -5629,8 +5629,8 @@ QUEST_LV_0100_20150317_005628	{memo X}Stone Whale that was guarding Hauberk woke
 QUEST_LV_0100_20150317_005629	Release the Seal Stone
 QUEST_LV_0100_20150317_005630	Return to Hauberk and release his last soul and wish for the future.
 QUEST_LV_0100_20150317_005631	Defeat the Stone Whale
-QUEST_LV_0100_20150317_005632	Find Goddess in Mage Tower 5th Floor
-QUEST_LV_0100_20150317_005633	Look for the Goddess in Mage Tower 5th Floor
+QUEST_LV_0100_20150317_005632	Find the goddess in Mage Tower 5F
+QUEST_LV_0100_20150317_005633	Look for the goddess in Mage Tower 5F
 QUEST_LV_0100_20150317_005634	$Destroy the Magic Suppressor prepared by Helgasercle
 QUEST_LV_0100_20150317_005635	$Destroy all the Magic Suppressors that Helgasercle prepared on the 5th floor of the Mage Tower.
 QUEST_LV_0100_20150317_005636	$Find and defeat Helgasercle who invaded the Mage Tower.
@@ -5704,11 +5704,11 @@ QUEST_LV_0100_20150317_005703	Get Mushcaria's Enchanted Mane
 QUEST_LV_0100_20150317_005704	Talk to Goddess Saule
 QUEST_LV_0100_20150317_005705	The lady trapped was Goddess Saule. Talk to Goddess Saule.
 QUEST_LV_0100_20150317_005706	Destroy the restraining magic circles.
-QUEST_LV_0100_20150317_005707	Goddess Saule has been trapped by the demons and can't use her powers. Destroy the binding magic circle that is restraining the Goddess in Drugys Courtyard and Vapsva Vacant Lot. 
+QUEST_LV_0100_20150317_005707	Goddess Saule has been trapped by the demons and can't use her powers. Destroy the binding magic circle that is restraining the goddess in Drugys Courtyard and Vapsva Vacant Lot. 
 QUEST_LV_0100_20150317_005708	Destroyed all the restraining magic circles. Talk to Goddess Saule. 
 QUEST_LV_0100_20150317_005709	Check the barrier at Saule Grand Shrine
 QUEST_LV_0100_20150317_005710	You are blocked by the barrier. Check the barrier at Saule Grand Shrine.
-QUEST_LV_0100_20150317_005711	Defeat the demon restraining the Goddess.
+QUEST_LV_0100_20150317_005711	Defeat the demon restraining the goddess.
 QUEST_LV_0100_20150317_005712	The barrier disappeared and you can see someone trapped by the demon. First, defeat the demon. 
 QUEST_LV_0100_20150317_005713	{memo X}Talk to the lady
 QUEST_LV_0100_20150317_005714	{memo X}Defeated the demons that were trapping the lady. She seens to have a strong and holy power. Talk to the lady.
@@ -5720,10 +5720,10 @@ QUEST_LV_0100_20150317_005719	There is a binding magic circle imbued with dark e
 QUEST_LV_0100_20150317_005720	Defeat Merge
 QUEST_LV_0100_20150317_005721	Removed the magic circle that was trapping Goddess Saule, but it is not enough. Talk to Goddess Saule again.
 QUEST_LV_0100_20150317_005722	Collect the offering tools at Altar Grand Gallery.
-QUEST_LV_0100_20150317_005723	Goddess Saule says the observer Clymen hid into the dimensional crack, but her strength isn't recovered yet so she cannot find him. Find the offering tools at Altar Grand Gallery to help the Goddess regain her powers. 
+QUEST_LV_0100_20150317_005723	Goddess Saule says the observer Clymen hid into the dimensional crack, but her strength isn't recovered yet so she cannot find him. Find the offering tools at Altar Grand Gallery to help the goddess regain her powers. 
 QUEST_LV_0100_20150317_005724	{memo This line is used when both giving multiple items and a single item}Give it to Goddess Saule
-QUEST_LV_0100_20150317_005725	Found the materials to help the Goddess. Give them to the Goddess.
-QUEST_LV_0100_20150317_005726	Done preparing to help the Goddess regain her strength. Talk to Goddess Saule.
+QUEST_LV_0100_20150317_005725	Found the materials to help the goddess. Give them to the goddess.
+QUEST_LV_0100_20150317_005726	Done preparing to help the goddess regain her strength. Talk to Goddess Saule.
 QUEST_LV_0100_20150317_005727	Defeat the monsters nearby.
 QUEST_LV_0100_20150317_005728	$Goddess Saule says defeating the monsters nearby will help in finding Clymen. Defeat the monsters and suppress the evil energy.
 QUEST_LV_0100_20150317_005729	Seems like Goddess Saule found the demons. Return to Goddess Saule.
@@ -5737,7 +5737,7 @@ QUEST_LV_0100_20150317_005736	Remove restraining sphere that is trapping Goddess
 QUEST_LV_0100_20150317_005737	Use the key to release Goddess Saule from the restraining sphere.
 QUEST_LV_0100_20150317_005738	Goddess Saule is freed. Talk to her.
 QUEST_LV_0100_20150317_005739	{memo X}Defeated Bramble and got the revelation. Return to Goddess Saule. 
-QUEST_LV_0100_20150317_005740	The revelation tells you to go to Great King Zachariel's Royal Mausoleum. Talk to the Goddess.
+QUEST_LV_0100_20150317_005740	The revelation tells you to go to Great King Zachariel's Royal Mausoleum. Talk to the goddess.
 QUEST_LV_0100_20150317_005741	{memo X}
 QUEST_LV_0100_20150317_005742	{memo X}
 QUEST_LV_0100_20150317_005743	$Collect Purifying Stones from Tanu
@@ -5772,7 +5772,7 @@ QUEST_LV_0100_20150317_005771	{memo X}
 QUEST_LV_0100_20150317_005772	Hidden Royal Mausoleum Book appeared
 QUEST_LV_0100_20150317_005773	A book hidden somewhere in Royal Mausoleum 5F appeared. Talk to it.
 QUEST_LV_0100_20150317_005774	Get the mission item
-QUEST_LV_0100_20150317_005775	The Royal Mausoleum Book wants blood stone. Better get it before the book disappears. Lizardmen in the Goddess' Ancient Garden could have them.
+QUEST_LV_0100_20150317_005775	The Royal Mausoleum Book wants blood stone. Better get it before the book disappears. Lizardmen in Goddess' Ancient Garden could have them.
 QUEST_LV_0100_20150317_005776	Talk to the Royal Mausoleum Book
 QUEST_LV_0100_20150317_005777	Talk to the book again. If the book disappeared, you have to wait until it appears again. 
 QUEST_LV_0100_20150317_005778	Bring %s
@@ -5886,7 +5886,7 @@ QUEST_LV_0100_20150317_005885	{memo X}Get the Slate
 QUEST_LV_0100_20150317_005886	{memo X}The girl who was with the villagers appeared, took the slate in the seal and disappeared. Can't tell what that is but let's bring the slate.
 QUEST_LV_0100_20150317_005887	Talk to Knight Commander Uska
 QUEST_LV_0100_20150317_005888	{memo X}You went to Crystal Mines to find the evidence of salvation but all you found was a mysterious slate. Talk to Klaipeda Knight Commander Uska about the slate.
-QUEST_LV_0100_20150317_005889	You followed the revelation of the Goddess that the bishop saw in this dreams and obtained the Mysterious Slate. Talk to Knight Commander Uska about the Mysterious Slate.
+QUEST_LV_0100_20150317_005889	You followed the revelation of the goddess that the bishop saw in this dreams and obtained the Mysterious Slate. Talk to Knight Commander Uska about the Mysterious Slate.
 QUEST_LV_0100_20150317_005890	Ask the Bokor Master for interpretation of the revelation
 QUEST_LV_0100_20150317_005891	{memo X}Ask Bokor Mama about this slate. She lives in the left end of Klaipeda residential area.
 QUEST_LV_0100_20150317_005892	The slate found in the Crystal Mines is both the revelation and Goddess Laima herself. It contains a message about finding the next revelation in a holy church. Return to Sir Uska as the Bokor Master says.
@@ -6084,16 +6084,16 @@ QUEST_LV_0100_20150317_006083	$Found the belongings of Necromancer Drasius near 
 QUEST_LV_0100_20150317_006084	Collected all the lost experiment materials. Give it to Drasius.
 QUEST_LV_0100_20150317_006085	$Defeat Long-Branched Trees and get %s
 QUEST_LV_0100_20150317_006086	$Defeat Long-Branched Trees
-QUEST_LV_0100_20150317_006087	Drasius is waiting for someone's help in the old yard of Goddess.
+QUEST_LV_0100_20150317_006087	$Necromancer Drasius in Goddess' Ancient Garden is waiting for someone to help him.
 QUEST_LV_0100_20150317_006088	Collect Waterweed
-QUEST_LV_0100_20150317_006089	Drasius asked you to collect Waterweed needed for the experiment. Get the Waterweed at Kriakil Brook.
+QUEST_LV_0100_20150317_006089	Necromancer Drasius asked you to collect Waterweed needed for the experiment. Get the Waterweed at Kriakul Brook.
 QUEST_LV_0100_20150317_006090	Collected enough Waterweed. Return to Drasius. 
 QUEST_LV_0100_20150317_006091	$Lizardman Mind-Control
 QUEST_LV_0100_20150317_006092	$Mind-controlled Lizardmen
 QUEST_LV_0100_20150317_006093	$Drasius needs Lizardmen for necromancy. Use the mind-control stone on Lizardmen near the Dumbla Pond and attack to brainwash it.
 QUEST_LV_0100_20150317_006094	$Gathered enough Lizardman. Return to Drasius. 
 QUEST_LV_0100_20150317_006095	$Mind-controlled Infroburk
-QUEST_LV_0100_20150317_006096	$Drasius needs Infroburk for necromancy. Use the mind-control stone on Infroburks near the Nardyma Twin Waterfalls and attack to brainwash it.
+QUEST_LV_0100_20150317_006096	$Drasius needs Infroburk for necromancy. Use the mind-control stone on Infroburks near the Nardyma Twin Waterfall and attack to brainwash it.
 QUEST_LV_0100_20150317_006097	$Gathered enough from Infroburk. Return to Drasius. 
 QUEST_LV_0100_20150317_006098	{memo X}Worship the statue and talk to Tools merchant
 QUEST_LV_0100_20150317_006099	{memo X}Prepare to leave for the East Forest by worshipping the Goddess Statue in Central Plaza.
@@ -6225,7 +6225,7 @@ QUEST_LV_0100_20150317_006224	Destroy the Summoning Crystal
 QUEST_LV_0100_20150317_006225	Talk to Believer Onute
 QUEST_LV_0100_20150317_006226	Goddess Saule Believer Onute needs your help.
 QUEST_LV_0100_20150317_006227	Defeat Archon and the demon summoning circle.
-QUEST_LV_0100_20150317_006228	$Believer Onute is angry that the altar turned into a demon summoning circle. Defeat Archon and destroy the demon summoning circle to teach them a lesson about the Goddess' powers.
+QUEST_LV_0100_20150317_006228	$Believer Onute is angry that the altar turned into a demon summoning circle. Defeat Archon and destroy the demon summoning circle to teach them a lesson about the goddess' powers.
 QUEST_LV_0100_20150317_006229	Report to Believer Onute
 QUEST_LV_0100_20150317_006230	Got rid of all the ominous things Onute mentioned. Report to Believer Onute.
 QUEST_LV_0100_20150317_006231	Talk to Believer Bronius
@@ -6247,7 +6247,7 @@ QUEST_LV_0100_20150317_006246	Talk to Believer Jurga
 QUEST_LV_0100_20150317_006247	You cut off Bramble's roots. Return and talk to Believer Jurga.
 QUEST_LV_0100_20150317_006248	Defeat Gaigalas
 QUEST_LV_0100_20150317_006249	Destroy Bramble's Root
-QUEST_LV_0100_20150317_006250	Believer Jurga is following the Goddess in watching over Bramble and is waiting for you. 
+QUEST_LV_0100_20150317_006250	Believer Jurga is following the goddess in watching over Bramble and is waiting for you. 
 QUEST_LV_0100_20150317_006251	{memo X}Get Merog's stinger and make Thorn Flower stimulant
 QUEST_LV_0100_20150317_006252	{memo X}Bramble says he needs to make medication for withstanding the evil energy before getting into the battle. Go to Kruva swell and get Merog's stingers. 
 QUEST_LV_0100_20150317_006253	{memo X}Collect all of Merog's stingers needed. Return to Jurga.
@@ -6264,7 +6264,7 @@ QUEST_LV_0100_20150317_006263	$You agreed to meet Believer Jurga in Giliaii Cour
 QUEST_LV_0100_20150317_006264	Defeat Bramble and retrieve the revelation
 QUEST_LV_0100_20150317_006265	Arrived at Giliaii Courtyard, where Bramble is. Defeat it and retrieve the revelation!
 QUEST_LV_0100_20150317_006266	Obtain the revelation
-QUEST_LV_0100_20150317_006267	$Successfully defeated Bramble! Get the Goddess' revelation.
+QUEST_LV_0100_20150317_006267	$Successfully defeated Bramble! Get the goddess' revelation.
 QUEST_LV_0100_20150317_006268	Defeat Bramble
 QUEST_LV_0100_20150317_006269	$Ask Goddess Saule about the revelation
 QUEST_LV_0100_20150317_006270	{memo X}You need to go back to Goddess Saule to ask for the meanings
@@ -6331,7 +6331,7 @@ QUEST_LV_0100_20150317_006330	{memo X}
 QUEST_LV_0100_20150317_006331	{memo X}
 QUEST_LV_0100_20150317_006332	{memo X}
 QUEST_LV_0100_20150317_006333	Beholder's Careful Trick
-QUEST_LV_0100_20150317_006334	The mysterious Beholder appeared to try and shake your belief in the Goddess. 
+QUEST_LV_0100_20150317_006334	The mysterious Beholder appeared to try and shake your belief in the goddess. 
 QUEST_LV_0100_20150317_006335	Believer Jurga says there are more things to do other than making the stimulant. Talk to Believer Jurga.
 QUEST_LV_0100_20150317_006336	Destroy Bramble's roots.
 QUEST_LV_0100_20150317_006337	$Jurga says we must destroy the roots placed to heal Bramble's wound. The roots are in Sviesa Hill Areas and Tankinta Vacant Lot.
@@ -6405,8 +6405,8 @@ QUEST_LV_0100_20150317_006404	{memo X}Mr. Juan asked you to bring him Vubbe Thei
 QUEST_LV_0100_20150317_006405	{memo X}Acquired Vubbe Thief's Leather! Bring it to Mr. Juan.
 QUEST_LV_0100_20150323_006406	$Now take the Seal Release Crystal and go to Ramstis Ridge. {nl}The Disciples of Gustas will teach you how to unleash the seal there. 
 QUEST_LV_0100_20150323_006407	$Were you not guided yet?{nl}It's the Disciples of Gustas in Ramstis Ridge.{nl}It is made to let only the chosen one enter.
-QUEST_LV_0100_20150323_006408	$Ask the mayor of the Miners' Village for directions to Gele Plateau. {nl}I will send the message to the Paladin Master first. {nl}May the blessings of Goddess be with you.
-QUEST_LV_0100_20150323_006409	$The high gardens that the Goddess mentioned could be an area within Gele Plateau. {nl}I heard the Paladin Master is there, upholding a long term promise. 
+QUEST_LV_0100_20150323_006408	$Ask the mayor of the Miners' Village for directions to Gele Plateau. {nl}I will send the message to the Paladin Master first. {nl}May the blessings of goddess be with you.
+QUEST_LV_0100_20150323_006409	$The high gardens that the goddess mentioned could be an area within Gele Plateau. {nl}I heard the Paladin Master is there, upholding a long term promise. 
 QUEST_LV_0100_20150323_006410	{memo X}
 QUEST_LV_0100_20150323_006411	{memo X}
 QUEST_LV_0100_20150323_006412	{memo X}If you ever fight against us Rodeleros, better be careful of your legs. {nl}Swords pop out from below the shield. {nl}
@@ -6465,7 +6465,7 @@ QUEST_LV_0100_20150323_006464	{memo X}Don't worry. I'll give you the recipe. {nl
 QUEST_LV_0100_20150323_006465	$Is the antidote ready yet? {nl}The situation's grave. He is gradually getting worse.
 QUEST_LV_0100_20150323_006466	$Evoniphon sure employed a vicious poison. {nl}We need to hunt him down before he causes more damage... 
 QUEST_LV_0100_20150323_006467	$Oh, is this the antidote? {nl}Thank you very much. I will let them take it right away. {nl}
-QUEST_LV_0100_20150323_006468	$If it wasn't for you, many workers would have lost their lives for nothing. {nl}I will report about this to Sir Uska. {nl}Truly... You were sent by the Goddess!{nl}
+QUEST_LV_0100_20150323_006468	$If it wasn't for you, many workers would have lost their lives for nothing. {nl}I will report about this to Sir Uska. {nl}Truly... You were sent by the goddess!{nl}
 QUEST_LV_0100_20150323_006469	$The monsters in the Owl Burial Ground should be a fair bet for you. {nl}Right? 
 QUEST_LV_0100_20150323_006470	{memo X}The Chaparition in Escanciu Village took a lot of lives. {nl}Please defeat that monster in the name of the Goddess.
 QUEST_LV_0100_20150323_006471	{memo X}I'm sorry but can you burn this oration in front of the epitaph in Rukas Plateau? {nl}You have explored different areas of the valley. {nl}I think you are more than qualified to comfort their souls. 
@@ -6575,7 +6575,7 @@ QUEST_LV_0100_20150323_006574	Pilgrim Witas collapsed helplessly. Talk to him.
 QUEST_LV_0100_20150323_006575	Pilgrim Witas died. Make a grave for him.
 QUEST_LV_0100_20150323_006576	Pilgrim Theophilis is suddenly looking for you. Talk to him.
 QUEST_LV_0100_20150323_006577	Theophilis took out the Necklace of Envy from Succubus eyes. Talk to him again.
-QUEST_LV_0100_20150323_006578	The details of slate found in Crystal Mines mentions revelation of the Goddess about blocking the threats to Gele Plateau. Report about it to Commander Uska.
+QUEST_LV_0100_20150323_006578	The details of slate found in Crystal Mines mentions revelation of the goddess about blocking the threats to Gele Plateau. Report about it to Commander Uska.
 QUEST_LV_0100_20150323_006579	$Knight Commander Uska thinks the high gardens in the revelation refers to an area in Gele Plateau and told you to go to the Paladin Master. Drop by the Mayor of the Miners' Village and ask for directions to Gele Plateau.
 QUEST_LV_0100_20150323_006580	Treasure Hunter of Stele Road is waiting for someone's help.
 QUEST_LV_0100_20150323_006581	$Talk to the Wandering Spirit of Escanciu Village.
@@ -6805,13 +6805,13 @@ QUEST_LV_0100_20150428_006804	{memo X}Checking/MAKING/3/TRACK_BEFORE/None/F_line
 QUEST_LV_0100_20150428_006805	To Starving Demon's Way
 QUEST_LV_0100_20150428_006806	{memo X}To Pioneering area of Gytise
 QUEST_LV_0100_20150428_006807	Talk to Knight Titas again
-QUEST_LV_0100_20150428_006808	You dreamed about the Goddess telling you to go to Klaipeda, but Knight Titas is asking you whether you could tell the order of gathering to them. Talk to Sir Titas again.
+QUEST_LV_0100_20150428_006808	You dreamed about the goddess telling you to go to Klaipeda, but Knight Titas is asking you whether you could tell the order of gathering to them. Talk to Sir Titas again.
 QUEST_LV_0100_20150428_006809	Extinguished the research diary on the fire place
 QUEST_LV_0100_20150428_006810	You burned all diaries to calm his soul. Talk to the spirit of the adventurer, Varkis.
 QUEST_LV_0100_20150428_006811	Meet the Blacksmith of Klaipeda
 QUEST_LV_0100_20150428_006812	Meet the Blacksmith of Klaipeda as Pipoti has told you.
 QUEST_LV_0100_20150428_006813	Before you release the important seal at Ramstis Ridge, you should first talk to the Disciple of Gustas.
-QUEST_LV_0100_20150428_006814	As the Goddess told you in the dream of the bishop, you should first go to Crystal Mine, but you can't just see and ignore the villagers who are evacuating. Let's help the angry hunter.
+QUEST_LV_0100_20150428_006814	As the goddess told you in the dream of the bishop, you should first go to Crystal Mine, but you can't just see and ignore the villagers who are evacuating. Let's help the angry hunter.
 QUEST_LV_0100_20150428_006815	Talk to Vaidotas in Crystal Mine 1F
 QUEST_LV_0100_20150428_006816	{memo X}Grita said in order to activate the Tower's Barrier Device again, it would need a great amount of energy. Set the gem Grita gave you on the ground and recharge the gem with the monsters' life force.
 QUEST_LV_0100_20150428_006817	You recharged the gem with the monsters' life force.  Talk to Grita about how to activate the Barrier Device
@@ -6885,7 +6885,7 @@ QUEST_LV_0100_20150511_006884	Varkis' Spirit
 QUEST_LV_0100_20150511_006885	{memo X}That is my adventure journal.. lots of my diaries are hidden at Rukas Plateau besides that..{nl}I want you to retrieve those..
 QUEST_LV_0100_20150511_006886	{memo X}That object is not useful to me anymore now..{nl}If you could find those diaries, I will make you the completed version.
 QUEST_LV_0100_20150511_006887	{memo X}Here it is..{nl}The completed version.. I will leave now..
-QUEST_LV_0100_20150511_006888	The one who fell while researching..{nl}Gone back to the Goddess by becoming a part of the canyon.{nl}Saddened mind would penetrate the gold stones, the liquor that is poured would permeate onto the ground for tears..{nl}
+QUEST_LV_0100_20150511_006888	The one who fell while researching..{nl}Gone back to the goddess by becoming a part of the canyon.{nl}Saddened mind would penetrate the gold stones, the liquor that is poured would permeate onto the ground for tears..{nl}
 QUEST_LV_0100_20150511_006889	{memo X}Notice/Unfortunately, Varkis passed away. {nl}But, if you go to Varkis' camp, you will meet his spirit#5
 QUEST_LV_0100_20150511_006890	$The Eternal Adventure (1)
 QUEST_LV_0100_20150511_006891	{memo X}Notice/It is written that the next material is hidden on the way to the neck of the snake cliff!#5
@@ -6914,17 +6914,17 @@ QUEST_LV_0100_20150511_006913	It seems that the newcomer seems to be in a troubl
 QUEST_LV_0100_20150511_006914	{memo X}The unstable owl told you that it would be better to face Sequoia with divine power. Let's collect the wooden pieces with the divine power of the broken owl sculpture in them. 
 QUEST_LV_0100_20150511_006915	At the end of Stone Pillar Hill, the portal that leads to the secret location of the Royal Mausoleum was opened after releasing all the seals! Use the portal to go to the secret place.
 QUEST_LV_0100_20150511_006916	Treasure Hunter Eden is saying confidently that he is sure that the Tama swallowed all the artifacts. Defeat Tamas and look for the artifacts.
-QUEST_LV_0100_20150714_006917	I am sure you are competent enough.{nl}Everything was guided by the Goddesses.
+QUEST_LV_0100_20150714_006917	I am sure you are competent enough.{nl}Everything was guided by the goddesses.
 QUEST_LV_0100_20150714_006918	$The gold that the monsters in this area have will be enough.{nl}Bring it to the herb merchant at Kapas Highway.
 QUEST_LV_0100_20150714_006919	I feel dizzy.{nl}What am I doing here?
-QUEST_LV_0100_20150714_006920	I wish the Goddesses were here.{nl}I don't want to see anything sad anymore.
+QUEST_LV_0100_20150714_006920	I wish the goddesses were here.{nl}I don't want to see anything sad anymore.
 QUEST_LV_0100_20150714_006921	{memo X}Is this slate the evidence of salvation?{nl}It just looks like an old slate to me.
 QUEST_LV_0100_20150714_006922	Don't waste any time.
 QUEST_LV_0100_20150714_006923	Of course, you should first show your skills.{nl}Defeat Desert Chupabras and Zinutes.
 QUEST_LV_0100_20150714_006924	If you are going to help me, please also take care of the Large Gray Chupacabras.{nl}They often steal the supplies.
 QUEST_LV_0100_20150714_006925	$When you defeat Chupacabras, a Large Gray Chupacabra will appear.{nl}Okay then, I am counting on you.
 QUEST_LV_0100_20150714_006926	$I can charge more to get everything else back in order, but that toolbox... {nl}That Moa took the heart and soul of a stonemason...
-QUEST_LV_0100_20150714_006927	$I thank you in the name of the Goddess!{nl}We should first eliminate the filthy Cockatrices that are spreading the disease.
+QUEST_LV_0100_20150714_006927	$I thank you in the name of the goddess!{nl}We should first eliminate the filthy Cockatrices that are spreading the disease.
 QUEST_LV_0100_20150714_006928	You better eliminate the severed souls as quickly as possible.{nl}Wouldn't it be scary if they resurrected again?
 QUEST_LV_0100_20150714_006929	The attacks from the demons are quite aggressive.{nl}I think they would be discouraged if we could somehow defeat the Glizardons...
 QUEST_LV_0100_20150714_006930	I would like to ask you to defeat Pawndel and Pawnd.{nl}They are demon sisters and they are quite a nuisance.
@@ -6953,7 +6953,7 @@ QUEST_LV_0100_20150714_006952	$Be careful. This place is full of evil energy fro
 QUEST_LV_0100_20150714_006953	$Ah, it's you, Revelator! Could you help me?{nl}I am trying to burn down the thorny vines that are full of evil energy.
 QUEST_LV_0100_20150714_006954	$There is a demon that I want you to defeat.{nl}This monster is called Rikaus and it's at Thorny Pillar Garden. It has been spreading an evil energy.
 QUEST_LV_0100_20150714_006955	$I heard a very ominous voice. It was a voice searching for you.{nl}Please be careful...
-QUEST_LV_0100_20150714_006956	$I never thought I would meet someone other than a Believer in this place full of thorny vines and monsters.{nl}It's difficult without the protection of the Goddess. Don't you think so, Revelator?{nl}
+QUEST_LV_0100_20150714_006956	$I never thought I would meet someone other than a Believer in this place full of thorny vines and monsters.{nl}It's difficult without the protection of the goddess. Don't you think so, Revelator?{nl}
 QUEST_LV_0100_20150714_006957	$Just as I thought. We the Believers are also having a hard time due to the thorny vines.{nl}Can you help us, please?
 QUEST_LV_0100_20150714_006958	$The evil energy was first felt in Kvailas Forest. {nl}The force was very strong so it will remain this way for a while even if you defeat Bramble.
 QUEST_LV_0100_20150714_006959	$The evil energy of Kvailas Forest is becoming stronger and our Believers are becoming weak. {nl}I am worried that we may lose to the forces of evil. If only the Revelator was with us...
@@ -6980,7 +6980,7 @@ QUEST_LV_0100_20150714_006979	I am sure the magical power still remains.{nl}Ther
 QUEST_LV_0100_20150714_006980	It's fortunate that the magical power still remains.{nl}First, let's stop the magic generating stone near the room of senses.
 QUEST_LV_0100_20150714_006981	I hid the magic generating stones among the fakes in the room of senses.{nl}But, with the brooch you found, you will be able to distinguish the real ones from the fakes.
 QUEST_LV_0100_20150714_006982	Keep this in mind. Pick out the real magic generating stones and stop the magical power.{nl}If you touch on the fakes, all magic generating stones will be activated again.
-QUEST_LV_0100_20150714_006983	I felt earnestness for the first time in hundreds of years.{nl}To prevent it from ending meaninglessly, I will pray to the Goddesses.
+QUEST_LV_0100_20150714_006983	I felt earnestness for the first time in hundreds of years.{nl}To prevent it from ending meaninglessly, I will pray to the goddesses.
 QUEST_LV_0100_20150714_006984	The magical power that came from the room of senses has completely disappeared.{nl}Now, we just have to block the room of rituals.
 QUEST_LV_0100_20150714_006985	The room of rituals is slightly different from the room of senses.{nl}Although, they are the same that you have to shut down the magical power of all magic generating stones.{nl}
 QUEST_LV_0100_20150714_006986	You will know how to handle it when you control it yourself.{nl}But, if you feel something went wrong, use the magical power of Valius.
@@ -6996,13 +6996,13 @@ QUEST_LV_0100_20150714_006995	I will tell you one more time. You should not thin
 QUEST_LV_0100_20150714_006996	In fact, I am okay even if I disappear like this.{nl}It's so thankful that you care for me, but I don't want you to get hurt.
 QUEST_LV_0100_20150714_006997	We are almost at the moment of being released from the restraint that was on us for hundreds of years.{nl}
 QUEST_LV_0100_20150714_006998	I can be saved. I... finally...{nl}I can't thank you enough.{nl}
-QUEST_LV_0100_20150714_006999	I will now leave to the Goddesses.{nl}Thank you. Thank you so much...
+QUEST_LV_0100_20150714_006999	I will now leave to the goddesses.{nl}Thank you. Thank you so much...
 QUEST_LV_0100_20150714_007000	How's going?{nl}We can alleviate the strange energy in this region when we enhance the magic circle.
 QUEST_LV_0100_20150714_007001	{memo X}If I only had little more time...{nl}My documents... I can't leave them...
 QUEST_LV_0100_20150714_007002	{memo X}The objects are useless to me now...{nl}Okay. Maybe you... My documents at Dykyne Fork...
 QUEST_LV_0100_20150714_007003	I don't have regrets anymore... but, be careful about that man.
 QUEST_LV_0100_20150714_007004	$Let's see, while I am cleaning this...{nl}Sorry, but can you take care of the tablet at Gruitis Hall with the brush and rubbing tools I brought?
-QUEST_LV_0100_20150714_007005	Will be wandering when the string of the destiny disconnects...{nl}It must mean Laima Goddess... But there's a rumor that she appeared... It's complicated.
+QUEST_LV_0100_20150714_007005	Will be wandering when the string of the destiny disconnects...{nl}It must mean Goddess Laima... But there's a rumor that she appeared... It's complicated.
 QUEST_LV_0100_20150714_007006	$When someone is born with a silver spoon in his mouth, life will be good for him.
 QUEST_LV_0100_20150714_007007	{nl}What, what the hell...
 QUEST_LV_0100_20150714_007008	$It's too soon to give up now.{nl}When I went to Vseio Cliffs, I saw one more tablet.{nl}
@@ -7025,7 +7025,7 @@ QUEST_LV_0100_20150714_007024	A small village becomes a big village and then a c
 QUEST_LV_0100_20150714_007025	I told you a while ago, but if possible, I would have pulled it out.{nl}Please beware of the surroundings near you.
 QUEST_LV_0100_20150714_007026	Difficult, difficult...{nl}The words are hard to understand.
 QUEST_LV_0100_20150714_007027	I guess it was the Metal Plate.{nl}It was lucky that the well was dried... If not, it could have been horrible.{nl}
-QUEST_LV_0100_20150714_007028	I will organize them and show you later.{nl}You are the Revelator. They will help your journey to find the Goddesses.
+QUEST_LV_0100_20150714_007028	I will organize them and show you later.{nl}You are the Revelator. They will help your journey to find the goddesses.
 QUEST_LV_0100_20150714_007029	It seems that the Metal Plates that you've brought can't be worked due to the rusts.{nl}Why did they record on the Metal Plate...
 QUEST_LV_0100_20150714_007030	In fact, I didn't know what this Metal Plate was.{nl}Since this place is the hometown of Demetrius, I came here expecting something may be present.{nl}
 QUEST_LV_0100_20150714_007031	Nothing was engraved on it, rather it was full of rusts.
@@ -7060,7 +7060,7 @@ QUEST_LV_0100_20150714_007059	Can you give this to Justas?
 QUEST_LV_0100_20150714_007060	So Alruida did it and the Metal Plate that we didn't know...{nl}Okay. We solved all the puzzles. Please wait a bit.
 QUEST_LV_0100_20150714_007061	Justas must be waiting.{nl}Please give it to him.
 QUEST_LV_0100_20150714_007062	I never thought that the Metal Plate would explode. I am sorry.{nl}I will gather the contents all at once later and show you.
-QUEST_LV_0100_20150714_007063	These are the contents that I never thought about.{nl}The Goddesses and the humans once used to live together. And the demons?{nl}
+QUEST_LV_0100_20150714_007063	These are the contents that I never thought about.{nl}The goddesses and the humans once used to live together. And the demons?{nl}
 QUEST_LV_0100_20150714_007064	If Demetrius is sane, this record... okay.{nl}I promised you that I will show you the record so read the copy yourself.{nl}Well done indeed!
 QUEST_LV_0100_20150714_007065	They were gentle monsters but suddenly became vicious. {nl}Have you also heard anything like this?
 QUEST_LV_0100_20150714_007066	Revelator, we are in trouble. Please help us!{nl}As you can see, the workers are dying due to the monsters' poison.{nl}
@@ -7131,17 +7131,17 @@ QUEST_LV_0100_20150714_007130	Succeeded?{nl}I think there's something that conne
 QUEST_LV_0100_20150714_007131	Priest Ramelie
 QUEST_LV_0100_20150714_007132	The sealed tower that was protected by the Revelator is being attacked again.{nl}But, it can't be protected by us and the villagers.
 QUEST_LV_0100_20150714_007133	The first seal of the sealed tower is already destroyed by the attacks from the demons.{nl}The second seal still remains, but I don't know how long we can hold up.
-QUEST_LV_0100_20150714_007134	The Goddess asked us to protect the seal. {nl}Now, only one we can trust is you, the Revelator.
+QUEST_LV_0100_20150714_007134	The goddess asked us to protect the seal. {nl}Now, only one we can trust is you, the Revelator.
 QUEST_LV_0100_20150714_007135	Is the seal okay?{nl}I don't know how many times I've prayed to wish that you are okay.
 QUEST_LV_0100_20150714_007136	Now is the time to restore the first seal.{nl}I know it's going to be hard, but I can't seek help for this.
-QUEST_LV_0100_20150714_007137	Are you really going to help? How grateful...{nl}First fill the crest of Austeja Goddess with the sacred energy near the altar.{nl}
-QUEST_LV_0100_20150714_007138	When you dedicate the completed crest of the Goddess to the sealed tower, the seal will be filled again.{nl}
-QUEST_LV_0100_20150714_007139	Even if you've done the dedication, you can't seal the vicious energy completely. {nl}This attack will not be the last. I hope the Goddess return fast.
-QUEST_LV_0100_20150714_007140	We can't just rely everything on the Goddess.{nl}But, I don't know if we could hold up anymore.
+QUEST_LV_0100_20150714_007137	Are you really going to help? How grateful...{nl}First fill the crest of Goddess Austeja with the sacred energy near the altar.{nl}
+QUEST_LV_0100_20150714_007138	When you dedicate the completed crest of the goddess to the sealed tower, the seal will be filled again.{nl}
+QUEST_LV_0100_20150714_007139	Even if you've done the dedication, you can't seal the vicious energy completely. {nl}This attack will not be the last. I hope the goddess return fast.
+QUEST_LV_0100_20150714_007140	We can't just rely everything on the goddess.{nl}But, I don't know if we could hold up anymore.
 QUEST_LV_0100_20150714_007141	I am so grateful since you are helping us with the restoration of the seal.{nl}But, I don't know how long this seal would hold up... I hope Austeja comes back soon.
 QUEST_LV_0100_20150714_007142	I will comfort this.{nl}
-QUEST_LV_0100_20150714_007143	Their pain, resentment, wrath and sadness...{nl}I hope they all forget in the arms of the Goddess.
-QUEST_LV_0100_20150714_007144	The Chapparition in Escanciu Village took away many lives.{nl}Defeat it in the name of the Goddess.
+QUEST_LV_0100_20150714_007143	Their pain, resentment, wrath and sadness...{nl}I hope they all forget in the arms of the goddess.
+QUEST_LV_0100_20150714_007144	The Chapparition in Escanciu Village took away many lives.{nl}Defeat it in the name of the goddess.
 QUEST_LV_0100_20150714_007145	I'm sorry...but,{nl}Can you burn this oration in front of the epitaph at Nepatogu Field in Rukas Plateau? {nl}You have explored different areas of the valley. I think you are more than qualified to comfort their souls.
 QUEST_LV_0100_20150714_007146	{memo X}key to check the map #7
 QUEST_LV_0100_20150714_007147	{memo X}Notice/!/The box appeared!{nl}Check the box inside while avoiding monsters' attacks!#7
@@ -7386,14 +7386,14 @@ QUEST_LV_0100_20150714_007385	{memo X}Notice/You've found the treasures!#5
 QUEST_LV_0100_20150714_007386	Big Accident
 QUEST_LV_0100_20150714_007387	I have many things to do
 QUEST_LV_0100_20150714_007388	Examining the magic circle
-QUEST_LV_0100_20150714_007389	The sealed tower of the Goddesses(1)
+QUEST_LV_0100_20150714_007389	The Sealed Tower of the Goddess (1)
 QUEST_LV_0100_20150714_007390	I will help to protect the sealed tower
 QUEST_LV_0100_20150714_007391	Tell him that it can't be helped
 QUEST_LV_0100_20150714_007392	Looking at the sealed tower
-QUEST_LV_0100_20150714_007393	The sealed tower of the Goddesses(2)
+QUEST_LV_0100_20150714_007393	The Sealed Tower of the Goddess (2)
 QUEST_LV_0100_20150714_007394	I will help the rest
 QUEST_LV_0100_20150714_007395	Say Farewell
-QUEST_LV_0100_20150714_007396	The sealed tower of the Goddesses(3)
+QUEST_LV_0100_20150714_007396	The Sealed Tower of the Goddess (3)
 QUEST_LV_0100_20150714_007397	{memo X}Restoring the seal/SITABSORB/2/TRACK_BEFORE/None
 QUEST_LV_0100_20150714_007398	{memo X}Notice/You've restored the first seal at the sealed tower!#4
 QUEST_LV_0100_20150714_007399	$Varkis is being attacked by Lithorex! Defeat Lithorex and rescue him.
@@ -7760,7 +7760,7 @@ QUEST_LV_0100_20150730_007759	{memo X}The Tree Sect of the Truth crossed here
 QUEST_LV_0100_20150730_007760	and entered the Mausoleum of Karail
 QUEST_LV_0100_20150730_007761	{memo X}.{nl}They are going to looking for something that will be used to spread their doctrines...{nl}If you get a chance to go to the Mausoleum of Karail, please investigate about them.{nl}I think they are insane.
 QUEST_LV_0100_20150730_007762	{memo X}You are not here... Where have you disappeared to... Zemyna Goddess...
-QUEST_LV_0100_20150730_007763	About the sacred object of the Goddess
+QUEST_LV_0100_20150730_007763	About the sacred object of the goddess
 QUEST_LV_0100_20150730_007764	{memo X}The reason why the grave guard was mad
 QUEST_LV_0100_20150730_007765	{memo X}Yuta told you that he came here to look for the Goddess.
 QUEST_LV_0100_20150730_007766	{memo X}I am not interested.
@@ -8072,7 +8072,7 @@ QUEST_LV_0100_20150908_008071	$Dismantling the Cask
 QUEST_LV_0100_20150908_008072	$As the cask opened, the lower part of the small sculpture has appeared
 QUEST_LV_0100_20150908_008073	$Looking at the piece that has a wing shape
 QUEST_LV_0100_20150908_008074	$As you touched the wing shaped piece, a Corrupted suddenly emerged!
-QUEST_LV_0100_20150908_008075	$Putting the statue of the Goddess on the magic circle
+QUEST_LV_0100_20150908_008075	$Putting the Goddess Statue on the magic circle
 QUEST_LV_0100_20150908_008076	$Go to the field beside and check the crops!
 QUEST_LV_0100_20150908_008077	$You've arrived at Kvailas Forest where Bramble is hiding!
 QUEST_LV_0100_20150908_008078	I think I feel better now
@@ -8099,14 +8099,14 @@ QUEST_LV_0100_20150918_008098	$Ah, you said you came to tell me about the order 
 QUEST_LV_0100_20150918_008099	$Have you ever tried offering worship to a Goddess Statue?{nl}The Goddesses might have vanished, but I believe they are still out there somewhere.
 QUEST_LV_0100_20150918_008100	$I was worried that the monsters would cause harm to the Goddess Statue.{nl}As much as the world is messed up.. That would be terrible.
 QUEST_LV_0100_20150918_008101	$This has really gotten out of hand.{nl}Who knew that Kepas could grow so big...{nl}I wonder if it's because of Medzio Diena?
-QUEST_LV_0100_20150918_008102	Don't forget to worship a Goddess Statue when you see one.{nl}I'm sure doing so will bestow a blessing upon you.{nl}I firmly believe that the Goddesses have not forsaken us.
+QUEST_LV_0100_20150918_008102	Don't forget to worship a Goddess Statue when you see one.{nl}I'm sure doing so will bestow a blessing upon you.{nl}I firmly believe that the goddesses have not forsaken us.
 QUEST_LV_0100_20150918_008103	$This is not the type of monster that can be encountered here so it is rather strange.{nl}This world is such a mess now.
 QUEST_LV_0100_20150918_008104	$We need to assemble already?{nl}The world may be on the brink of destruction, but I can't accept this kind of insane order. {nl}I have enough missions on my hands as it is.
 QUEST_LV_0100_20150918_008105	$Alright. This should be enough.{nl}Here is a pill that instantly restores your stamina...{nl}I'll give you one as a gift since I have plenty.{nl}
 QUEST_LV_0100_20150918_008106	You can recover stamina through Tree Root Crystals or by taking a rest.{nl}But, you won't have time for that when you are being chased by monsters. {nl}This potion will come in handy in situations like that.
 QUEST_LV_0100_20150918_008107	$I heard the news from my men and I was starting to become worried.{nl}With how messed up the world is, if that ended well, all is well.{nl}
 QUEST_LV_0100_20150918_008108	$It's not like there weren't any monsters at all four years ago, but they weren't so ferocious. {nl}Plant-type monsters seem to have been affected the most, as they weren't like this before.
-QUEST_LV_0100_20150918_008109	That's it, that's how you do it. Easy, right?{nl}There is no way to tell what is going to become of this world now that the Goddesses have left,{nl}so we have to steadily put effort into things ourselves.
+QUEST_LV_0100_20150918_008109	That's it, that's how you do it. Easy, right?{nl}There is no way to tell what is going to become of this world now that the goddesses have left,{nl}so we have to steadily put effort into things ourselves.
 QUEST_LV_0100_20150918_008110	A shield that is advanced to level 4 will be enough.{nl}The determination should be checked.
 QUEST_LV_0100_20150918_008111	You are so determined unlike other guys nowadays.{nl}You can come to learn from me anytime you want.
 QUEST_LV_0100_20150918_008112	$During your travels you might discover Goddess Statues scattered all over the kingdom.{nl}Worship these statues and you will certainly receive their blessings.
@@ -8120,7 +8120,7 @@ QUEST_LV_0100_20150918_008119	$There might be more of these Large Kepas roaming 
 QUEST_LV_0100_20150918_008120	$It was just as I thought, right? It was this instinct that kept me alive during Medzio Diena.
 QUEST_LV_0100_20150918_008121	$It's been too long, my men should've come back, but I haven't heard anything from them yet.{nl}I know it's been four years since Medzio Diena, but my men have been getting too relaxed recently.
 QUEST_LV_0100_20150918_008122	
-QUEST_LV_0100_20150918_008123	With the Goddesses disappearing, and monsters like the Golem appearing... {nl}Is there really any hope?
+QUEST_LV_0100_20150918_008123	With the goddesses disappearing, and monsters like the Golem appearing... {nl}Is there really any hope?
 QUEST_LV_0100_20150918_008124	How was it? Were there many skills that seemed useful?{nl}If you use skills effectively, they will be very useful in combat.{nl}
 QUEST_LV_0100_20150918_008125	If that's the case, you will become bait and take care of the Royal Mausoleum defense device at Sesija Entrance.{nl}I will only say this once, so you better listen carefully.
 QUEST_LV_0100_20150918_008126	No one can disturb the eternal sleep of the great king.
@@ -8148,12 +8148,12 @@ QUEST_LV_0100_20150918_008147	$Collect Hogma Teeth
 QUEST_LV_0100_20150918_008148	Pursue Rexipher at the Royal Mausoleum Entrance
 QUEST_LV_0100_20151001_008149	Do you know the legend of Cunningham? {nl}It's a legend about how a great demon was trapped in the Crystal Mine in the past. {nl}
 QUEST_LV_0100_20151001_008150	I assume that the trapped demon has finally woken up to control the Vubbes. {nl}The dream of the bishop and the legend of Cunningham... {nl}I wonder if it is a forewarning of a great event that's about to happen.{nl}
-QUEST_LV_0100_20151001_008151	Only the Goddess knows if it will be hope or despair. {nl}You can read the details about it in a book found at Mine Worker's Resting Place on 2F.
+QUEST_LV_0100_20151001_008151	Only the goddess knows if it will be hope or despair. {nl}You can read the details about it in a book found at Mine Worker's Resting Place on 2F.
 QUEST_LV_0100_20151001_008152	Anyway, it seems like the Vubbes surely destroyed the purifiers. {nl}We have to fix it first before the hostages run out of air. 
 QUEST_LV_0100_20151001_008153	I will protect this village for my dead comrades.
 QUEST_LV_0100_20151001_008154	If the Bokor Master told you that I would know it..{nl}There's one place that comes to mind.{nl}
-QUEST_LV_0100_20151001_008155	You're saying something that's really hard to believe. {nl}You mean this revelation is Goddess Laima's and we have to collect all these for the Goddesses to return?{nl}
-QUEST_LV_0100_20151001_008156	$Goddess Laima is often called the recording Goddess. {nl}When the Great King Zachariel formed this kingdom, the only record of it was bestowed by Goddess Laima.  {nl}
+QUEST_LV_0100_20151001_008155	You're saying something that's really hard to believe. {nl}You mean this revelation is Goddess Laima's and we have to collect all these for the goddesses to return?{nl}
+QUEST_LV_0100_20151001_008156	$Goddess Laima is often called the recording goddess. {nl}When the Great King Zachariel formed this kingdom, the only record of it was bestowed by Goddess Laima.  {nl}
 QUEST_LV_0100_20151001_008157	I'd like to ask you a favor. {nl}I have sinned because I was not able to fulfill my duties of guarding the kingdom on Medzio Diena. {nl}
 QUEST_LV_0100_20151001_008158	But I am not a Revelator. {nl}Even if I want to make up for my sins, my duty at the moment is to protect the many citizens of Klaipeda. {nl}
 QUEST_LV_0100_20151001_008159	So please find all the revelations. {nl}I will put my position as the Knight Commander of Klaipeda on the line and help you deal with it. 
@@ -8182,14 +8182,14 @@ QUEST_LV_0100_20151001_008181	It is a shame to look back once a man starts his j
 QUEST_LV_0100_20151001_008182	I'm sure my brother stood firm and accepted his final moments. {nl}However, I still think he could've lived more meaningfully {nl}if he had just turned away from his ambition...
 QUEST_LV_0100_20151001_008183	I'm thinking of converting the demons using the power of the altar. {nl} The converted demons will absorb the divine power and slowly start to die. {nl}
 QUEST_LV_0100_20151001_008184	So you found the Seal of Space. {nl}Honestly, I did not believe it when my friend, the Paladin Master, said a Savior would come. {nl}
-QUEST_LV_0100_20151001_008185	That's how bad the situation was. {nl}My family and friends all went to the Goddess... {nl}It seemed like there was no hope anymore in this world. {nl}
+QUEST_LV_0100_20151001_008185	That's how bad the situation was. {nl}My family and friends all went to the goddess... {nl}It seemed like there was no hope anymore in this world. {nl}
 QUEST_LV_0100_20151001_008186	Here, use the Seal of Space on the pillar beside me and go to the sanctuary. {nl}It is prepared only for the Revelator. 
 QUEST_LV_0100_20151001_008187	I was there when the Divine Tree was destroying the capital. {nl}But I was not able to stop it. I was not able to save everyone.{nl}This will remain in my heart like a needle and it hurts me forever. 
 QUEST_LV_0100_20151001_008188	$But you were different. You have the power to save everyone. {nl}All the followers, the Watchers, even the wishes that me and the first Paladin longed for... {nl} 
 QUEST_LV_0100_20151001_008189	Right. {nl}Did you mention that you need to find Goddess Saule? {nl}
-QUEST_LV_0100_20151001_008190	The colorful stream mentioned in the revelation starts at above the Veja Ravine. {nl}Well then, may the blessings of Goddess be with you.
+QUEST_LV_0100_20151001_008190	The colorful stream mentioned in the revelation starts at above the Veja Ravine. {nl}Well then, may the blessings of goddess be with you.
 QUEST_LV_0100_20151001_008191	When you find the revelation, tell the Paladin Master of the story you've been through so far. {nl}He must be the one most anxious about it. {nl}
-QUEST_LV_0100_20151001_008192	I will gather all the prayers for my family and friends and offer it to you. {nl}May the blessings of Goddess be with you...
+QUEST_LV_0100_20151001_008192	I will gather all the prayers for my family and friends and offer it to you. {nl}May the blessings of goddess be with you...
 QUEST_LV_0100_20151001_008193	But this old body of mine does not follow my will anymore. {nl}Now I can only trust my old friend Algis and you. {nl}
 QUEST_LV_0100_20151001_008194	Go. The the Tenet Church is in Tenet Garden.{nl}My lifelong wish.. Be sure to stop the revelation from falling into the hands of Gesti.
 QUEST_LV_0100_20151001_008195	$Please bring me the Mali seeds in the way to Labure Highway. {nl} They would be a good source of magic for the shaman doll. {nl} {nl}
@@ -8205,19 +8205,19 @@ QUEST_LV_0100_20151001_008204	$This forest is also growing dark. {nl}Many people
 QUEST_LV_0100_20151001_008205	Too bad that Gesti wasn't killed, but still you did a great job.{nl}It will end soon..
 QUEST_LV_0100_20151001_008206	Without Airine, I would have died.{nl}Of course, I really appreciate for your help.
 QUEST_LV_0100_20151001_008207	$It's all my fault.{nl}Schmid is dead.. what can I do alone...
-QUEST_LV_0100_20151001_008208	$Prayers and ceremonies are not the only ways of serving the Goddess. {nl}Serving the world through physical training is also an important mission of the cleric. 
-QUEST_LV_0100_20151001_008209	$There are two ways to connect with the Goddess. {nl}An ardent belief for her, and the sound of silver dropping into her offering box. Just those two. 
+QUEST_LV_0100_20151001_008208	$Prayers and ceremonies are not the only ways of serving the goddess. {nl}Serving the world through physical training is also an important mission of the cleric. 
+QUEST_LV_0100_20151001_008209	$There are two ways to connect with the goddess. {nl}An ardent belief for her, and the sound of silver dropping into her offering box. Just those two. 
 QUEST_LV_0100_20151001_008210	$The magic to control time is the essence of all magics.{nl}These are Agailla Flurry's words.
 QUEST_LV_0100_20151001_008211	I heard a Revelator defeated the Demon Lord ransacking the Royal Mausoleum.{nl}As a person undergoing training, I am ashamed that I couldn't go out and fight.
 QUEST_LV_0100_20151001_008212	The bishop is praying in closure. {nl}When you are ready, please go to Aras in the Eastern Woods.
-QUEST_LV_0100_20151001_008213	I'll give you more than what the knight asked me to give so please help us find the Goddesses. {nl}
-QUEST_LV_0100_20151001_008214	Klaipeda is full of hope and expectations for the Revelators who dreamed of the Goddess. {nl}I am also one of them. {nl}
+QUEST_LV_0100_20151001_008213	I'll give you more than what the knight asked me to give so please help us find the goddesses. {nl}
+QUEST_LV_0100_20151001_008214	Klaipeda is full of hope and expectations for the Revelators who dreamed of the goddess. {nl}I am also one of them. {nl}
 QUEST_LV_0100_20151001_008215	I'll give you more than what the knight asked me to give. {nl}Since we have many Revelators, things will get better, right? 
 QUEST_LV_0100_20151001_008216	$You mean you actually drove away the Demon Lord from the Crystal Mine... {nl}Thank you for restoring in me something that I had lost for a while. Hope. 
 QUEST_LV_0100_20151001_008217	The first Paladin and the Tenet Church fulfilled their duties. {nl}Right.. The time has finally come. Together with the Revelator. 
 QUEST_LV_0100_20151001_008218	$I heard the monsters in Kateen Forest are eating up the Owl Sculptures I've made. {nl}I'm sure they are trying to use the souls for something else. Like for nourishment... 
 QUEST_LV_0100_20151001_008219	$Did you know? A Revelator defeated the Demon Lord in the Crystal Mine. {nl}Do you think that with disaster also comes hope? 
-QUEST_LV_0100_20151001_008220	$When I first saw the Revelators, I wondered if they were worthy of that name. {nl}But they saved the Crystal Mine and the Tenet Church. {nl}There is definitely a Savior whom the Goddess sent. 
+QUEST_LV_0100_20151001_008220	$When I first saw the Revelators, I wondered if they were worthy of that name. {nl}But they saved the Crystal Mine and the Tenet Church. {nl}There is definitely a Savior whom the goddess sent. 
 QUEST_LV_0100_20151001_008221	I heard some Revelator defeated the Demon Lord in Crystal Mine. {nl}That's incredible. Aren't Demon Lords the greatest among the demons? 
 QUEST_LV_0100_20151001_008222	Did you hear about the Revelator who stopped the Demon Queen at the Tenet Church? {nl}It would have been better if she was killed for good, {nl}but she is the Demon Queen after all, someone that even the Paladin Master wasn't able to defeat. {nl}That is awesome enough. 
 QUEST_LV_0100_20151001_008223	$As a Hunter, my instinct says the monsters in this forest are showing unusual movement. {nl}As if they are controlled by something. 
@@ -8226,11 +8226,11 @@ QUEST_LV_0100_20151001_008225	$Just as I thought. The monsters in this forest we
 QUEST_LV_0100_20151001_008226	If it was my hometown, if a demon occupied the Mines, everyone would have attacked it and celebrated. {nl}Anyway, I don't know who that Revelator is but this weak kingdom finally found someone useful. 
 QUEST_LV_0100_20151001_008227	A sacred church had to go through such bad things. The clerics of this kingdom are planning something unusual.{nl}But it's a good thing to have protected the Tenet Church. It means they have the guts, don't you think? {nl}{nl}
 QUEST_LV_0100_20151001_008228	The Vubbes suddenly rushed out of the Mines. {nl}I have no idea what's going on. Do you have anything that comes to mind? 
-QUEST_LV_0100_20151001_008229	We won't know if the Revelators really dreamed of the Goddess. It could even be a trick of the demons. {nl}But didn't someone among them save the Tenet Church. {nl}From the Demon Lord even. 
+QUEST_LV_0100_20151001_008229	We won't know if the Revelators really dreamed of the goddess. It could even be a trick of the demons. {nl}But didn't someone among them save the Tenet Church. {nl}From the Demon Lord even. 
 QUEST_LV_0100_20151001_008230	It's a relief a Revelator drove away the Demon Lord from the mines. I was scared another Medzio Diena would happen. {nl}But I felt something warm... Was it just my delusion? {nl}It was a pure and good energy.
 QUEST_LV_0100_20151001_008231	$It's such good news that a Revelator helped drive away the Demon Lord of the Crystal Mine.{nl}But I felt a strange and sacred energy... Could it have been just a delusion? {nl}It is hard to describe it.  
 QUEST_LV_0100_20151001_008232	$Do you think Medzio Diena and the demons are related? {nl}I mean look at the Tenet Church. It was as if the demons were waiting for that moment...{nl}Come to think of it, the Revelators could have been ones who set the stage. 
-QUEST_LV_0100_20151001_008233	$I made it through the wild monsters and you made through the Thorn Forest. {nl}I'm sure you're not looking for the Goddess... So what's the matter? 
+QUEST_LV_0100_20151001_008233	$I made it through the wild monsters and you made through the Thorn Forest. {nl}I'm sure you're not looking for the goddess... So what's the matter? 
 QUEST_LV_0100_20151001_008234	$I heard the historians were attacked by the Demon Lord at King's Plateau. {nl}So it means the disaster was forewarned a thousand years ago? {nl}Anyway, it's a relief the Revelator was able to stop it. 
 QUEST_LV_0100_20151001_008235	$In between this Gorge Area and Klaipeda is the Thorn Forest that is full of evil energy. {nl}It was just a normal and peaceful forest before but..{nl}You making it through the forest... Does it mean the forest is now purified? 
 QUEST_LV_0100_20151001_008236	$There is still so much left undiscovered about the Great King Zachariel.{nl}But since the demons live longer than us... This must have been what they were preying at. {nl}I don't know who it is but it's a good thing the Revelator stopped it. We might even have had another Medzio Diena.
@@ -8246,19 +8246,19 @@ QUEST_LV_0100_20151001_008245	If the Demon Lord invaded the Royal Mausoleum, the
 QUEST_LV_0100_20151001_008246	$Now the demons even bear the face of a human. {nl}I heard some Revelator stopped the Demon Lord in the Royal Mausoleum,{nl} but I wonder how many demons are now hiding amongst humans. 
 QUEST_LV_0100_20151001_008247	This place holds records of the hidden side of history. {nl}Time is an absolute thing. It just depends on how you look at it. 
 QUEST_LV_0100_20151001_008248	I heard a Revelator stopped the Demon Lord that was eyeing the Royal Mausoleum. {nl}It may be a bit overboard to make a connection between Medzio Diena and a king from a thousand years ago... {nl}But I'm sure there is something that we are all forgot.
-QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before Medzio Diena.{nl}Thanks to the Goddess sending us the Revelator, we finally make an end to the long battle. 
+QUEST_LV_0100_20151001_008249	The demons have been continuously attacking the Mage Tower even before Medzio Diena.{nl}Thanks to the goddess sending us the Revelator, we finally make an end to the long battle. 
 QUEST_LV_0100_20151001_008250	$The weight of history feels astoundingly heavy when you stand in this place. {nl}Maybe you can find a clue about Medzio Diena here. 
 QUEST_LV_0100_20151001_008251	$I keep thinking that Medzio Diena might have just been a process.{nl}If not, then why would the demons go after a mausoleum that is over a thousand years old? {nl}It's a good some thing some Revelator stopped it. 
 QUEST_LV_0100_20151001_008252	$Everyone knew that Helgasercle showed an obsession towards the Mage Tower since centuries ago. {nl}Whatever is in that tower, we can finally see the end of it. {nl}That's a great thing. 
-QUEST_LV_0100_20151001_008253	$First the Tenet Church and now the Great Cathedral...{nl}But they say it was all resolved by the Revelator, so I am hopeful that things will get better.{nl}Not minding the gossip of the world and doing what you must is what's good for the Goddess and the kingdom. 
+QUEST_LV_0100_20151001_008253	$First the Tenet Church and now the Great Cathedral...{nl}But they say it was all resolved by the Revelator, so I am hopeful that things will get better.{nl}Not minding the gossip of the world and doing what you must is what's good for the goddess and the kingdom. 
 QUEST_LV_0100_20151001_008254	$The rumor that a Revelator saved the Mage Tower is something that even someone like me, {nl}who is not interested in the gossips of the world, will take in. {nl}I'm surprised that there was a even one person who was good enough from anybody there. 
 QUEST_LV_0100_20151001_008255	Hergasercle was an incarnation of obsession. {nl}The chain of obsession was broken thanks to the Revelator but its souls is not something that can be saved. 
 QUEST_LV_0100_20151001_008256	$I heard a Revelator defeated the Demon Lord who sullied the wise teachings of Maven. {nl}Now it is time for us priests to come forward. {nl}We should put away our regrets about failing to protect the Great Cathedral and atone for our sins. 
 QUEST_LV_0100_20151001_008257	My colleague is dead?{nl}That can't be. Only if I had not tempted him...{nl}
-QUEST_LV_0100_20151001_008258	This map is useless to me now, without my colleague.{nl}Please pray that my colleague goes to the Goddess safely.
+QUEST_LV_0100_20151001_008258	This map is useless to me now, without my colleague.{nl}Please pray that my colleague goes to the goddess safely.
 QUEST_LV_0100_20151001_008259	$I can't leave everything behind...
 QUEST_LV_0100_20151001_008260	What do we do? {nl}The Vubbes rushed in and kidnapped the villagers!
-QUEST_LV_0100_20151001_008261	You are the Revelator, right? {nl}The Goddess must have helped. {nl}
+QUEST_LV_0100_20151001_008261	You are the Revelator, right? {nl}The goddess must have helped. {nl}
 QUEST_LV_0100_20151001_008262	{memo X}This is all because of the dream of the bishop of Klaipeda. {nl}What is he talking about evidence of salvation in the Crystal Mine. I have never seen such thing. {nl}
 QUEST_LV_0100_20151001_008263	I'm not sure if that is the reason but the Vubbes suddenly rushed out of the Crystal Mine. {nl}Those Vubbes took all the villagers they see into the mines. {nl}
 QUEST_LV_0100_20151001_008264	Please... Save the villagers. {nl}I beg of you!
@@ -8267,21 +8267,21 @@ QUEST_LV_0100_20151001_008266	Hold on! There is something you should know. {nl}W
 QUEST_LV_0100_20151001_008267	Ye..Yes..{nl}Find a young man named Vaidotas!{nl}
 QUEST_LV_0100_20151001_008268	That fellow knows well about the purifiers in the Crystal Mine. {nl}It hasn't been long since he was taken away by the Vubbes so he must be in the Vubbe Outpost. 
 QUEST_LV_0100_20151001_008269	{memo X}You want to learn my skills?{nl}It's not hard for me to teach you, but would you be able to handle it?
-QUEST_LV_0100_20151001_008270	The Goddess always told us to help those around us.{nl}By helping others near you, you will help your spirit as well.
+QUEST_LV_0100_20151001_008270	The goddess always told us to help those around us.{nl}By helping others near you, you will help your spirit as well.
 QUEST_LV_0100_20151001_008271	Great King Zachariel's ordeal is not easy.{nl}With the skill you have, he should have acknowledged you.
-QUEST_LV_0100_20151001_008272	$The kingdom has lost all hope. {nl}It does not have any will to stand firm anymore and is just crying out for the Goddesses.{nl}
-QUEST_LV_0100_20151001_008273	$In recent times however, people have come forward saying they dreamed of the Goddess. {nl}You are one such person, Revelator. {nl}
-QUEST_LV_0100_20151001_008274	{memo X}Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the Goddess told him the evidence of salvation will be found in the Crystal Mine. {nl}
+QUEST_LV_0100_20151001_008272	$The kingdom has lost all hope. {nl}It does not have any will to stand firm anymore and is just crying out for the goddesses.{nl}
+QUEST_LV_0100_20151001_008273	$In recent times however, people have come forward saying they dreamed of the goddess. {nl}You are one such person, Revelator. {nl}
+QUEST_LV_0100_20151001_008274	{memo X}Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the goddess told him the evidence of salvation will be found in the Crystal Mine. {nl}
 QUEST_LV_0100_20151001_008275	$Knight Aras at the Eastern Woods is in charge of that so go and meet him. 
-QUEST_LV_0100_20151001_008276	$Four years has passed since that incident, why is the Goddess sending us Revelators now... {nl}I guess someone like me may not be able to understand the deeper meaning of the Goddess' will.
+QUEST_LV_0100_20151001_008276	$Four years has passed since that incident, why is the goddess sending us Revelators now... {nl}I guess someone like me may not be able to understand the deeper meaning of the goddess' will.
 QUEST_LV_0100_20151001_008277	But, at least I know that the Revelators are our only hope.{nl}
 QUEST_LV_0100_20151001_008278	Well then, go on to the Eastern Woods. {nl}Don't forget to worship the Statue of Goddess Ausrine in the central plaza before you leave. {nl}
 QUEST_LV_0100_20151001_008279	Also, be sure to drop by the Item Merchant.{nl}I have left some warp scrolls for Revelators like you. 
 QUEST_LV_0100_20151001_008280	I can feel Bramble suffering.{nl}He is getting retribution for extracting all vigor from this land.
-QUEST_LV_0100_20151001_008281	I am not afraid of dying.{nl}The Goddess Saule will guide me well.
+QUEST_LV_0100_20151001_008281	I am not afraid of dying.{nl}Goddess Saule will guide me well.
 QUEST_LV_0100_20151001_008282	The portal that you tried to open was a false gateway.{nl}That portal leads to where all of the world's knowledge is.
 QUEST_LV_0100_20151001_008283	I have been fighting the Demon Lord Bramble, who tried to take over the revelation. {nl}I have fought with it night and day to be able to hand the revelation to you. {nl}
-QUEST_LV_0100_20151001_008284	But, Medzio Diena broke the balance of strength. {nl}The Goddesses lost most of their strength since that day. {nl}
+QUEST_LV_0100_20151001_008284	But, Medzio Diena broke the balance of strength. {nl}The goddesses lost most of their strength since that day. {nl}
 QUEST_LV_0100_20151001_008285	Bramble took that chance to steal the revelation and seal me in this place. {nl}Because only I know how to interpret the revelation.{nl} 
 QUEST_LV_0100_20151001_008286	But I did not give into Bramble's order to interpret the revelation.{nl}That is why he made a plot to open a portal to where all the knowledge of the world is. {nl}
 QUEST_LV_0100_20151001_008287	The residents of this area are victims of the plot to open that portal. {nl}To find a way to get the revelation using your power as the savior... Something brutal was done. {nl}
@@ -8300,13 +8300,13 @@ QUEST_LV_0100_20151001_008299	My Believers are waiting for you in Gate Route. {n
 QUEST_LV_0100_20151001_008300	I have carved many owls for a long time to help Goddess Ausrine.{nl}At one point in time, they got their lives and determination.{nl}
 QUEST_LV_0100_20151001_008301	Medzio Diena was just the beginning. {nl}A forest far away from the capital such as this one is also starting to soak its way into the evil energy. {nl} 
 QUEST_LV_0100_20151001_008302	I will be able to guide you to the revelation if I use all the strength left in me. {nl}That is why you should release me. 
-QUEST_LV_0100_20151001_008303	But please don't reveal my existence for now. {nl}It is the nature of humans to want to depend on something. {nl}If they find out about the helplessness of the Goddesses, this world will be full of chaos and sighs. 
+QUEST_LV_0100_20151001_008303	But please don't reveal my existence for now. {nl}It is the nature of humans to want to depend on something. {nl}If they find out about the helplessness of the goddesses, this world will be full of chaos and sighs. 
 QUEST_LV_0100_20151001_008304	That portal is.. a fantasy... No. A portal going to Goddess Saule. {nl} Anyway, opening the portal is very important.
-QUEST_LV_0100_20151001_008305	If armor protects you from physical attacks, accessories protect you from magic attacks. {nl} I hope this will be useful for you.{nl}Nice to meet you!{nl}Are you the Revelator who dreamed of the Goddess? {nl}
-QUEST_LV_0100_20151001_008306	Everyone in Klaipeda is talking about it. {nl}I wonder if the Revelators really saw the missing Goddesses in their dreams... and where is that dream... {nl}
-QUEST_LV_0100_20151001_008307	I am curious to know more about the dream but I'm sure they can't tell me about it.{nl}But that's fine since I believe that the Revelators are people who will find the Goddesses. {nl}
+QUEST_LV_0100_20151001_008305	If armor protects you from physical attacks, accessories protect you from magic attacks. {nl} I hope this will be useful for you.{nl}Nice to meet you!{nl}Are you the Revelator who dreamed of the goddess? {nl}
+QUEST_LV_0100_20151001_008306	Everyone in Klaipeda is talking about it. {nl}I wonder if the Revelators really saw the missing goddesses in their dreams... and where is that dream... {nl}
+QUEST_LV_0100_20151001_008307	I am curious to know more about the dream but I'm sure they can't tell me about it.{nl}But that's fine since I believe that the Revelators are people who will find the goddesses. {nl}
 QUEST_LV_0100_20151001_008308	Please take this accessory. {nl}If the armor protects you from physical attacks, accessories protect you from magic attacks. {nl} 
-QUEST_LV_0100_20151001_008309	I hope it will be useful for you. {nl}May the blessings of Goddess be with you...
+QUEST_LV_0100_20151001_008309	I hope it will be useful for you. {nl}May the blessings of goddess be with you...
 QUEST_LV_0100_20151001_008310	The poison of Scorpio, it was somewhat strange.{nl}Well. It already happened so what can I do anyway. I won't mind as long as it doesn't threaten my life.
 QUEST_LV_0100_20151001_008311	Oh I'm causing such trouble.. Thank you for helping me. {nl}You just have to make a magic circle with the firewood I give you and burn the voodoo doll on top of it.
 QUEST_LV_0100_20151001_008312	The crops died when you did what you were told to do? {nl}It's okay. I was told that the bad energy within the crops will go away like that. {nl}
@@ -8314,7 +8314,7 @@ QUEST_LV_0100_20151001_008313	This is tough. {nl}Many might be killed..
 QUEST_LV_0100_20151001_008314	Huh? You killed it because it tried to eat people? {nl}Ah.. well then, never mind. I will report it to the baron myself.
 QUEST_LV_0100_20151001_008315	This is the last one. {nl}The magic circle at Darbas Entrance will have a lot of monsters that will interfere. {nl}With the divine power suppressed, the monsters are naturally drawn to that area.
 QUEST_LV_0100_20151001_008316	The baron is doing something to purify this farm. {nl}But recently the crops are dying and people are starting to fall sick. {nl}
-QUEST_LV_0100_20151001_008317	If the magic circles are really a lie, then you should be able to remove the magic circles at Tylila Path with the Goddess' power. {nl}I mean something like the Goddess Statue. Is there any way to get it?
+QUEST_LV_0100_20151001_008317	If the magic circles are really a lie, then you should be able to remove the magic circles at Tylila Path with the goddess' power. {nl}I mean something like the Goddess Statue. Is there any way to get it?
 QUEST_LV_0100_20151001_008318	If I only had little more time...{nl}My documents... I can't leave them...
 QUEST_LV_0100_20151001_008319	These things are useless to me now...{nl}Okay. Maybe you... My documents at Dykyne Fork...
 QUEST_LV_0100_20151001_008320	Gerda
@@ -8392,7 +8392,7 @@ QUEST_LV_0100_20151001_008391	{memo X}Thank you for what just happened. {nl}Ah, 
 QUEST_LV_0100_20151001_008392	{memo X}{nl}I expected it to be polluted but.. I mean who would have thought it would be this bad? {nl}Making a sanctuary like this here is bad enough but those Nestos. {nl}What are they thinking leaving it corrupted like this.
 QUEST_LV_0100_20151001_008393	{memo X}{nl}Can you help me out for a while? 
 QUEST_LV_0100_20151001_008394	{memo X}I belong to the Anastos. {nl}The Nestos still pursue unconditional belief even at this point when the Goddesses are all gone. {nl}That's why they are building sanctuaries here and there. 
-QUEST_LV_0100_20151001_008395	{nl}What's the use of sanctuaries when the Goddesses are all gone? {nl}When you know it will just be corrupted like this even if you build it. {nl}On the other hand, the Anastos pursue practicality. 
+QUEST_LV_0100_20151001_008395	{nl}What's the use of sanctuaries when the goddesses are all gone? {nl}When you know it will just be corrupted like this even if you build it. {nl}On the other hand, the Anastos pursue practicality. 
 QUEST_LV_0100_20151001_008396	{memo X}{nl}People come first, mopping up the demons come first, and what's the use of faith when the Goddess themselves abandoned us?  
 QUEST_LV_0100_20151001_008397	{memo X}There is another sanctuary over there. {nl}I will finish burning this sanctuary so please destroy the one over there. {nl}We need to teach those Nestos as lesson. 
 QUEST_LV_0100_20151001_008398	{memo X}{nl}I'm sure the sanctuary over there is also fuming red enegy. {nl}A sign of corruption. 
@@ -8428,8 +8428,8 @@ QUEST_LV_0100_20151001_008427	{memo X}Albi...nas...?
 QUEST_LV_0100_20151001_008428	{memo X}{nl}Uh...
 QUEST_LV_0100_20151001_008429	{memo X}{nl}Nope. I can't think of anyone on Anastos with that name. {nl}Moreover, he told you go burn and destroy the Nestos sanctuary? {nl}Oh my god...
 QUEST_LV_0100_20151001_008430	{memo X}{nl}Nonsense. We don't do such a thing. {nl}I think we need to investigate on that matter. {nl}We give danger signal fires when we send out people for investigation {nl}and we ran out of it just now. {nl}Can you find some firepowder that are used to make the danger signal fires? 
-QUEST_LV_0100_20151001_008431	We all service the Goddess. That is why we're on the pilgrimages. {nl}It's just a small difference in how we see the world. 
-QUEST_LV_0100_20151001_008432	{nl}Nestos people say that we should believe in the Goddesses unconditionally even if they disappeared, {nl}while we, the Anastos, pursue something more practical. 
+QUEST_LV_0100_20151001_008431	We all serve the goddess. That is why we're on the pilgrimages. {nl}It's just a small difference in how we see the world. 
+QUEST_LV_0100_20151001_008432	{nl}Nestospa's people say that we should believe in the goddesses unconditionally even if they disappeared, {nl}while we, the Anastospa, pursue something more practical. 
 QUEST_LV_0100_20151001_008433	{nl}Defeating demons, improving the qualities of human lives... we have to aim for those things.
 QUEST_LV_0100_20151001_008434	{memo X}Monsters are all around so it will be difficult to obtain the materials.
 QUEST_LV_0100_20151001_008435	{memo X}But, Albinas... We don't feel good about it.
@@ -8439,8 +8439,8 @@ QUEST_LV_0100_20151001_008438	{memo X}Fabius is a moderatist among Anastos, so h
 QUEST_LV_0100_20151001_008439	{memo X}Since Fabius left... we would somehow get some answer.{nl}But, I don't feel good about it. Is there any information...
 QUEST_LV_0100_20151001_008440	{memo X}{nl}Ah! Barte over ther must know something.{nl}He arrived here while traveling various locations.{nl}How about we ask about Albinas there?
 QUEST_LV_0100_20151001_008441	It's just a different perspective of looking at the world. {nl}The topic they cover the most...
-QUEST_LV_0100_20151001_008442	{nl}The disappearances of the Goddesses were done spontaneously so are we going to still follow then after they abandoned us...{nl}Another problem is whether we, humans should continue to manage the world where the Goddesses have disappeared...
-QUEST_LV_0100_20151001_008443	{nl}Are we going to aim for the truth or trust the Goddessses and pray... that will be the difference.{nl}But, they are just conflicting each other and they don't deny each others' existences.
+QUEST_LV_0100_20151001_008442	{nl}The disappearances of the goddesses were done spontaneously so are we going to still follow then after they abandoned us...{nl}Another problem is whether we, humans should continue to manage the world where the goddesses have disappeared...
+QUEST_LV_0100_20151001_008443	{nl}Are we going to aim for the truth or trust the goddessses and pray... that will be the difference.{nl}But, they are just conflicting each other and they don't deny each others' existences.
 QUEST_LV_0100_20151001_008444	{memo X}She is rather progressive.{nl}So since she is not close to me... I want you to go to her.
 QUEST_LV_0100_20151001_008445	Barte
 QUEST_LV_0100_20151001_008446	{memo X}{nl}Ah, yes. I am called Barte.{nl}I was on a journey until recently. I am thinking about leaving again.
@@ -8467,7 +8467,7 @@ QUEST_LV_0100_20151001_008466	{memo X}You are safe.{nl}I've heard from Fabius.{n
 QUEST_LV_0100_20151001_008467	It's bad enough that they were killed by the Vubbes, but even their keepsakes are being abused. How awful...
 QUEST_LV_0100_20151001_008468	Thank you. {nl} My comrades will now be able to rest in peace.
 QUEST_LV_0100_20151001_008469	It hurts to think about giving these keepsakes to my dead comrades' families.
-QUEST_LV_0100_20151001_008470	Thank you very much. {nl} My comrades can now rest in peace with the Goddesses.
+QUEST_LV_0100_20151001_008470	Thank you very much. {nl} My comrades can now rest in peace with the goddesses.
 QUEST_LV_0100_20151001_008471	{memo X}Damn. {nl}It's too wide, so let's move separately.{nl}
 QUEST_LV_0100_20151001_008472	{memo X}First, you go deep into that place.{nl}Who knows? The demons with the special power may possess something.{nl}
 QUEST_LV_0100_20151001_008473	{memo X}I am so mad.{nl}There isn't anything special and the demons didn't have anything.{nl}
@@ -8480,19 +8480,19 @@ QUEST_LV_0100_20151001_008479	{memo X}Monocle is looking for the hidden object t
 QUEST_LV_0100_20151001_008480	{memo X}Go there and check.{nl}Like a while ago, the demons may appear and there may be really strong demons there... I will hide myself here.
 QUEST_LV_0100_20151001_008481	{memo X}An outsider comes here... Who are you?{nl}How did you come here?
 QUEST_LV_0100_20151001_008482	{memo X}It is really big so you will recognize it when you see it.
-QUEST_LV_0100_20151001_008483	{memo X}I will introduce myself first.{nl}I am the manager of the Fortress of the Great Earth.{nl}Who are you?{nl}
+QUEST_LV_0100_20151001_008483	{memo X}I will introduce myself first.{nl}I am the manager of the Fortress of the Land.{nl}Who are you?{nl}
 QUEST_LV_0100_20151001_008484	{memo X}Okay. You don't have to explain anymore.{nl}I can feel you are full of sacred power.{nl}
 QUEST_LV_0100_20151001_008485	{memo X}I know the special power which Ruklys hid here exists.{nl}If it is your task to find it, then I will help for sure.
 QUEST_LV_0100_20151001_008486	You can't say no nor ask for reasons to the kingdom orders.{nl}But as I lived here for my life, I have many things to think.{nl}
-QUEST_LV_0100_20151001_008487	The kingdom order told us to ban anyone's entrance here, but I think the Goddess made us to meet each other here.{nl}The Goddess is not under the kingdom.{nl}
+QUEST_LV_0100_20151001_008487	The kingdom order told us to ban anyone's entrance here, but I think the goddess made us to meet each other here.{nl}The goddess is not under the kingdom.{nl}
 QUEST_LV_0100_20151001_008488	{memo X}If it is about the Goddess, then I will do the guide.{nl}At least, there aren't anything here so let's go to the next area.
 QUEST_LV_0100_20151001_008489	{memo X}Ah, I totally forgot.{nl}I've prepared many things to block the intruders, but I totally forgot about them.{nl}
 QUEST_LV_0100_20151001_008490	I need a certificate.{nl}It was created to attack the ones who are not permitted ferociously.{nl}
 QUEST_LV_0100_20151001_008491	{memo X}To make a certificate, we first need a mushroom.{nl}There are many mushrooms at the lower area so please get me one.
-QUEST_LV_0100_20151001_008492	I will help anything that is related to the Goddesses.{nl}Finally, an opportunity has come in my boring life.
+QUEST_LV_0100_20151001_008492	I will help anything that is related to the goddesses.{nl}Finally, an opportunity has come in my boring life.
 QUEST_LV_0100_20151001_008493	They are enough to make the certificate.{nl}Please wait a bit.
 QUEST_LV_0100_20151001_008494	{memo X}What I can do for you is to put my sign on the certificate.{nl}But, I am too old to use magic.{nl}
-QUEST_LV_0100_20151001_008495	{memo X}But, I am sure the energy that is flowing around the Fortress of the Great Earth could substitute my weak power.{nl}Please gather all of those.{nl}The monsters who've lived here for a long time must have the crystal of the great earth.
+QUEST_LV_0100_20151001_008495	{memo X}But, I am sure the energy that is flowing around the Fortress of the Land could substitute my weak power.{nl}Please gather all of those.{nl}The monsters who've lived here for a long time must have the crystal of the great earth.
 QUEST_LV_0100_20151001_008496	{memo X}I am not like the old days.{nl}When I made that certificate, I thought I would never make anymore.
 QUEST_LV_0100_20151001_008497	{memo X}I never knew that I would be making this again... Please wait.{nl}I will make it quickly.
 QUEST_LV_0100_20151001_008498	{memo X}Let's go more deep inside. {nl}I hope you can find the one that you are looking for. {nl}
@@ -8503,7 +8503,7 @@ QUEST_LV_0100_20151001_008502	{memo X}Please receive it.{nl}My devices won't att
 QUEST_LV_0100_20151001_008503	{memo X}I've protected this place for my entire life, but I don't know anything about the revelation which you are looking for.{nl}But, the spirit that lived in the era of Ruklys may know something.
 QUEST_LV_0100_20151001_008504	But, those spirits are dangerous.{nl}Since they only have the thoughts of that time. Their hatred towards the kingdom soldiers.
 QUEST_LV_0100_20151001_008505	{memo X}The Soul Stones that read the memories of the spirits are beside me.{nl}I've created them. I've tried to read their memories in the past many times.{nl}
-QUEST_LV_0100_20151001_008506	But, what we received in return were only hatred.{nl}For them, we are just kingdom soldiers that are trying to occupy the Fortress of the Great Earth.
+QUEST_LV_0100_20151001_008506	But, what we received in return were only hatred.{nl}For them, we are just kingdom soldiers that are trying to occupy the Fortress of the Land.
 QUEST_LV_0100_20151001_008507	{memo X}It is unfortunate, but to make them not to go crazy, you would need the token of the restraint.
 QUEST_LV_0100_20151001_008508	It is very complex to make the token of the restraint.{nl}We've failed that time, but since we have you this time, it will be much easier this time.{nl}
 QUEST_LV_0100_20151001_008509	I will tell you in steps, so please first bring the eggs of Rajatad.
@@ -8516,7 +8516,7 @@ QUEST_LV_0100_20151001_008515	As I told you before, I've tried to look at the me
 QUEST_LV_0100_20151001_008516	But, now I have you and the token of restraint.{nl}If we could bring the spirits, we may able to read the memories with the soul stones that are beside me.
 QUEST_LV_0100_20151001_008517	Please bring the spirits here with the token of the restraint.{nl}I will get prepared.
 QUEST_LV_0100_20151001_008518	Please bring the spirits fast.{nl}I am also curious.
-QUEST_LV_0100_20151001_008519	{memo X}They are breaking something after receiving an order from Ruklys.{nl}I think that may be related to the revelation of the Goddesses.
+QUEST_LV_0100_20151001_008519	{memo X}They are breaking something after receiving an order from Ruklys.{nl}I think that may be related to the revelation of the goddesses.
 QUEST_LV_0100_20151001_008520	{memo X}I should find out about the device which Ruklys destroyed.
 QUEST_LV_0100_20151001_008521	{memo X}We can look at the detailed memories of the spirits by enhancing the token of the restraint.{nl}Due to enhanced token of the restraint, the spirits would resist. If the spirits resist, suppress them with your power and use the token of the spirit.
 QUEST_LV_0100_20151001_008522	I have no choice even if the spirits suffer. {nl}That's the best way I can help you.
@@ -8525,12 +8525,12 @@ QUEST_LV_0100_20151001_008524	{memo X}Please put the vitality of the monsters in
 QUEST_LV_0100_20151001_008525	That's an old method.{nl}If we complete this, you may able to see the memories of the spirits that were with Ruklys.
 QUEST_LV_0100_20151001_008526	{memo X}Even we if we know the method, it is useless if we can't execute it.{nl}I wasn't able to obtain the vitalities of the monsters...
 QUEST_LV_0100_20151001_008527	Good. {nl}That's the token of the restraint.{nl}
-QUEST_LV_0100_20151001_008528	Don't care that much even if we use the demons.{nl}What's important is that we should look for the revelation of the Goddess.
-QUEST_LV_0100_20151001_008529	Are there spirits that are wandering around the Fortress of the Great Earth without going to the Goddesses?{nl}I can't see them suffering anymore.
+QUEST_LV_0100_20151001_008528	Don't care that much even if we use the demons.{nl}What's important is that we should look for the revelation of the goddess.
+QUEST_LV_0100_20151001_008529	Are there spirits that are wandering around the Fortress of the Land without going to the goddesses?{nl}I can't see them suffering anymore.
 QUEST_LV_0100_20151001_008530	I can only help you to make the owl sculptures.{nl}Those owls would guide the spirits that lost their ways.
-QUEST_LV_0100_20151001_008531	Can you put the owl sculptures at the Fortress of the Great Earth?{nl}If you guide the spirits to the owl sculptures, then you would be able to go beside the Goddesses.
+QUEST_LV_0100_20151001_008531	Can you put the owl sculptures at the Fortress of the Land?{nl}If you guide the spirits to the owl sculptures, then you would be able to go beside the goddesses.
 QUEST_LV_0100_20151001_008532	I can't quit carving the owl sculptures.{nl}When I stop carving, then that means the peaceful days have come.
-QUEST_LV_0100_20151001_008533	Thanks.{nl}The Goddesses must have given use long lives to fulfill these.
+QUEST_LV_0100_20151001_008533	Thanks.{nl}The goddesses must have given use long lives to fulfill these.
 QUEST_LV_0100_20151001_008534	{memo X}I don't have time to think about those treasures.{nl}I also care for the kingdom. I know that the revelation should not fall into the hands of the demons.{nl}
 QUEST_LV_0100_20151001_008535	{memo X}I should meet Eminent around here.{nl}Let's check with Monocle without being noticed by Eminent.
 QUEST_LV_0100_20151001_008536	This is as I thought... He is not like the guardian of the revelation.{nl}Otherwise, are the demons the guardians of the revelation?{nl}
@@ -8545,15 +8545,15 @@ QUEST_LV_0100_20151001_008544	{memo X}Let's pull out the demon flags that are ne
 QUEST_LV_0100_20151001_008545	{memo X}Ah, if you go late, Eminent may suspect you.{nl}Go meet Eminent as the magic circle gets activated.
 QUEST_LV_0100_20151001_008546	I believe that Ruklys has not colluded with the demons.{nl}If not, what I saw are all lies.
 QUEST_LV_0100_20151001_008547	Have you collected all the parts?{nl}Give it to me. I can restore it.
-QUEST_LV_0100_20151001_008548	I want you to meet the revelation of the Goddess fast.{nl}To fulfill my lifelong wish...
+QUEST_LV_0100_20151001_008548	I want you to meet the revelation of the goddess fast.{nl}To fulfill my lifelong wish...
 QUEST_LV_0100_20151001_008549	{memo X}I will not hide it anymore.{nl}I am Premier Eminent and I used to serve King Kadumel.{nl}
 QUEST_LV_0100_20151001_008550	{memo X}It's up to you to believe, but I want you to give me an opportunity to at least explain this.
 QUEST_LV_0100_20151001_008551	I am sure that you know this place is the last battlefield where Ruklys resisted until his death.{nl}And Ruklys was also the guardian of the revelation like his master, Maven.{nl}
 QUEST_LV_0100_20151001_008552	But, as the defeat came, he crossed the line which he should not have crossed.{nl}He made an alliance with the demons.{nl}
-QUEST_LV_0100_20151001_008553	{memo X}The Fortress of the Great Earth is full of vicious demons and monsters. {nl}That's why I brought my army here.{nl}
-QUEST_LV_0100_20151001_008554	{memo X}It was a long battle. But the battle ended with my victory.{nl}And then the voices of the Goddess was heard. To protect the revelation.{nl}
+QUEST_LV_0100_20151001_008553	{memo X}The Fortress of the Land is full of vicious demons and monsters. {nl}That's why I brought my army here.{nl}
+QUEST_LV_0100_20151001_008554	{memo X}It was a long battle. But the battle ended with my victory.{nl}And then the voices of the goddess was heard. To protect the revelation.{nl}
 QUEST_LV_0100_20151001_008555	But, I don't know how Ruklys hid the revelation.{nl}He is just a half guardian.{nl}
-QUEST_LV_0100_20151001_008556	It's up to you to believe this story, but look at me in front of you.{nl}I've been living with the blessing from the Goddesses for the last 600 years.{nl}
+QUEST_LV_0100_20151001_008556	It's up to you to believe this story, but look at me in front of you.{nl}I've been living with the blessing from the goddesses for the last 600 years.{nl}
 QUEST_LV_0100_20151001_008557	{memo X}And I've met you at the end.{nl}And you pulled me to the place where the revelation is.{nl}
 QUEST_LV_0100_20151001_008558	It is my honor since I can be helpful to you. {nl}I was suffering from the sense of shame since I don't know what the half guardian could do.{nl}
 QUEST_LV_0100_20151001_008559	{memo X}Let's finish the explanation here and go look for the revelation of the Goddesses.{nl}I have things to prepare so I will go there first.{nl}
@@ -8576,7 +8576,7 @@ QUEST_LV_0100_20151001_008575	{memo X}The demons did not attack Premier Eminent?
 QUEST_LV_0100_20151001_008576	{memo X}I need to check it. {nl}Let's go together and meet that Eminent guy. {nl}
 QUEST_LV_0100_20151001_008577	{memo X}We will know for sure if you check that guy with the Monocle. 
 QUEST_LV_0100_20151001_008578	Mirtis is gone but the Vubbes are still following Mirtis's commands. {nl}And there is also a rumor that even stronger and more dangerous Vubbes were seen. {nl}
-QUEST_LV_0100_20151001_008579	Most of them died while returning with the prince's men.{nl}But they were not guided by the Goddess even after their death. {nl}
+QUEST_LV_0100_20151001_008579	Most of them died while returning with the prince's men.{nl}But they were not guided by the goddess even after their death. {nl}
 QUEST_LV_0100_20151001_008580	I want to mourn for those who died unfairly. {nl}Would you like to join me? 
 QUEST_LV_0100_20151001_008581	Chapparition will not bring back the lives of those who died.{nl}It's a sad thing.. But we can't just leave it like that. 
 QUEST_LV_0100_20151001_008582	What? You're not a reaper? {nl}But since you've seen my face, you will be cursed. {nl}
@@ -8587,7 +8587,7 @@ QUEST_LV_0100_20151001_008586	I heard that Erikas who is the friend of Legwyn fo
 QUEST_LV_0100_20151001_008587	So he doesn't even know where the grave of Legwyn family is...{nl}I feel like he is a liar.{nl}
 QUEST_LV_0100_20151001_008588	Then we have no choice.{nl}As Erikas said, can you find Legwyn at Mires Grave using the scroll for the dead?{nl}I will stay here so that Erikas would not escape. 
 QUEST_LV_0100_20151001_008589	So she didn't really tell us the location of Legwyn grave because she doesn't know...?{nl}Didn't she say she would tell you if you give her some money?
-QUEST_LV_0100_20151001_008590	The one who woke me up as I was about to go beside the Goddesses... {nl}Okay. Do you need anything from me?{nl}
+QUEST_LV_0100_20151001_008590	The one who woke me up as I was about to go beside the goddesses... {nl}Okay. Do you need anything from me?{nl}
 QUEST_LV_0100_20151001_008591	There was a story behind that. But, what Erikas said is right.{nl}I was chasing after the hunter of Kartas with my subordinates.{nl}But, it was too much for us.{nl}
 QUEST_LV_0100_20151001_008592	So I've told Erikas who used to live near there to lend us her power to defeat the hunter of Kartas.{nl}Erikas asked for some collateral in return for lending us the blessed crystal.{nl}
 QUEST_LV_0100_20151001_008593	He told me that we would be able to defeat the hunter with that crystal.{nl}But, it was difficult for us to just seal that demon.{nl}We substituted our lives for sealing that demon.
@@ -8618,7 +8618,7 @@ QUEST_LV_0100_20151001_008617	Thanks for helping me this far.{nl}Now, listen to 
 QUEST_LV_0100_20151001_008618	I can feel some evil energy.{nl}Since I don't want you get dirty, let's finish this quickly.
 QUEST_LV_0100_20151001_008619	Place the Wrongful Teeth near the seal. {nl}Then, our last mission will start.
 QUEST_LV_0100_20151001_008620	Everything is over...{nl}It is so fortunate that it ended even after our deaths
-QUEST_LV_0100_20151001_008621	Thanks. Please pass this crystal to my daughter's friend.{nl}Now, I will return to the Goddesses with my subordinates.{nl}
+QUEST_LV_0100_20151001_008621	Thanks. Please pass this crystal to my daughter's friend.{nl}Now, I will return to the goddesses with my subordinates.{nl}
 QUEST_LV_0100_20151001_008622	When you meet my daughter, please tell her that I am so sorry.{nl}And that I love her... please don't forget.
 QUEST_LV_0100_20151001_008623	Who is that girl who Legwyn tried to protect until his death?{nl}But, I am sure that he will rest in peace. Since his last mission has been fulfilled.{nl}
 QUEST_LV_0100_20151001_008624	Now, I will return this to Erikas.{nl}I really appreciate for your help on behalf of my friend, Justina Legwyn.
@@ -8658,7 +8658,7 @@ QUEST_LV_0100_20151001_008657	It noisy around here so I guess the chasers are ne
 QUEST_LV_0100_20151001_008658	If we just stay here, then we would get attacked without notifying anything...{nl}
 QUEST_LV_0100_20151001_008659	Please take me to Irmantas.{nl}We have to tell the ones who are following the determination of Lydia Schaffen that they are colluded with the demons!
 QUEST_LV_0100_20151001_008660	If only I didn't get this injury, they would be easy to defeat...{nl}Where is Irmantas now?
-QUEST_LV_0100_20151001_008661	No... I feel like I am going to lose consciousness if I walk little more.{nl}I feel like I am hearing the voice... of the Goddess.{nl}
+QUEST_LV_0100_20151001_008661	No... I feel like I am going to lose consciousness if I walk little more.{nl}I feel like I am hearing the voice... of the goddess.{nl}
 QUEST_LV_0100_20151001_008662	After I ran away from the Astral Tower, I've never seen a person who is so kind and reliable like you.{nl}If something happens to me... {nl}
 QUEST_LV_0100_20151001_008663	Please tell Irmantas about the plot of Iganas with this letter.{nl}
 QUEST_LV_0100_20151001_008664	Let's go. {nl}I will cheer myself up a bit.{nl}
@@ -8676,7 +8676,7 @@ QUEST_LV_0100_20151001_008675	In order to move my spirit piece, I need the cryst
 QUEST_LV_0100_20151001_008676	With that power, I will be with you.
 QUEST_LV_0100_20151001_008677	I can't quit this journey.{nl}Only I can eliminate Giltine and her subordinates from this world.{nl}
 QUEST_LV_0100_20151001_008678	As you ripped me off, I will get a revenge on them...
-QUEST_LV_0100_20151001_008679	This will be enough.{nl}I promise to you. If you help me, I will fight against the demons for the Goddesses and the humans.{nl}
+QUEST_LV_0100_20151001_008679	This will be enough.{nl}I promise to you. If you help me, I will fight against the demons for the goddesses and the humans.{nl}
 QUEST_LV_0100_20151001_008680	If you hate the demons, then you can trust me.{nl}The ones who've been betrayed will never forget.{nl}
 QUEST_LV_0100_20151001_008681	When the spirit was ripped into pieces, I decided myself.{nl}If I would have to look for my spirit for thousands of years, I will never forget them...
 QUEST_LV_0100_20151001_008682	The power of the spirit if gradually recovering with the demonic power.{nl}The knowledge I've forgotten is gradually coming back.{nl}
@@ -8722,22 +8722,22 @@ QUEST_LV_0100_20151001_008721	{memo X}I saw the magic circles activate. Are you 
 QUEST_LV_0100_20151001_008722	You defeated Eminent and obtained the revelation? {nl}Wow, you're way better than I thought... {nl}
 QUEST_LV_0100_20151001_008723	Anyway, I also feel like I've helped bring peace to the world and it beats my heart. {nl}But I still have some work to do. You know, right? 
 QUEST_LV_0100_20151001_008724	I feel lucky to have met you among the many Revelators. {nl}You saved the world, right? 
-QUEST_LV_0100_20151001_008725	I hope you stay safe, more than anything. {nl}May the Goddess bless you!
+QUEST_LV_0100_20151001_008725	I hope you stay safe, more than anything. {nl}May the goddess bless you!
 QUEST_LV_0100_20151001_008726	Uh... Is that an army note? {nl}
 QUEST_LV_0100_20151001_008727	Right. Those belong to my colleagues. {nl}I don't know when it would be, but I want to send their keepsakes back to their hometown someday. 
 QUEST_LV_0100_20151001_008728	Speaking of which, could you give me that army note?
 QUEST_LV_0100_20151001_008729	Hopefully, I will be able to return to hometown together with the keepsakes of my colleagues. {nl}And my colleagues would surely want that too. 
 QUEST_LV_0100_20151001_008730	I will surely bring it back to hometown. {nl}My fellows will want that too. 
-QUEST_LV_0100_20151001_008731	Come to think of it, there was a Goddess's divine object in Sielva Prayer Room. {nl}I think offering a prayer to that divine object will give us some answers. {nl}
+QUEST_LV_0100_20151001_008731	Come to think of it, there was a goddess's divine object in Sielva Prayer Room. {nl}I think offering a prayer to that divine object will give us some answers. {nl}
 QUEST_LV_0100_20151001_008732	The dead ones that wake up again are the problems. {nl}Why don't we purify them and keep them from waking up. {nl}
 QUEST_LV_0100_20151001_008733	We break their coffin before they wake up. {nl}Even for the dead ones, it will be better than forcibly waking up. {nl}What do you think? Will you help? 
 QUEST_LV_0100_20151001_008734	You must be careful not to open the coffin lid when you break the coffin. {nl}When the coffin opens, the dead will jump out and attack.
 QUEST_LV_0100_20151001_008735	Good work. {nl}I'm sure they will also thank you for making them rest in peace. {nl}
 QUEST_LV_0100_20151001_008736	The problem is that divine object. {nl}I can't approach anywhere near it because of the barrier. 
 QUEST_LV_0100_20151001_008737	Maybe the gravekeeper would know something about the divine object and the barrier...{nl}But the gravekeeper doesn't like me. We had a thing in the past. {nl}
-QUEST_LV_0100_20151001_008738	I met the gravekeeper while working on purifying in the name of the Goddess. {nl}I was actually helping the gravekeeper but he was really mad about it. {nl}
-QUEST_LV_0100_20151001_008739	The gravekeeper stands at the end of Vevapi Aisle. {nl}Can you ask him about the divine object of the Goddess for me? 
-QUEST_LV_0100_20151001_008740	A divine object of the Goddess? {nl}What. Are you in a team with that rude Bokor? {nl}
+QUEST_LV_0100_20151001_008738	I met the gravekeeper while working on purifying in the name of the goddess. {nl}I was actually helping the gravekeeper but he was really mad about it. {nl}
+QUEST_LV_0100_20151001_008739	The gravekeeper stands at the end of Vevapi Aisle. {nl}Can you ask him about the divine object of the goddess for me? 
+QUEST_LV_0100_20151001_008740	A divine object of the goddess? {nl}What. Are you in a team with that rude Bokor? {nl}
 QUEST_LV_0100_20151001_008741	Get out of this grave site. {nl}Just thinking about that Bokor brings back my anger. {nl}
 QUEST_LV_0100_20151001_008742	That Bokor went around breaking the coffins of the dead saying they rise back! {nl}I don't understand how he can do such a thing with a sane mind!
 QUEST_LV_0100_20151001_008743	Divine object that you can't even approach... {nl}I understand if they block the monsters or demons from getting close to it but even humans, that I don't understand.
@@ -8751,7 +8751,7 @@ QUEST_LV_0100_20151001_008750	Burying it back in the ground is not all. {nl}Pay 
 QUEST_LV_0100_20151001_008751	What are you waiting for! Move quickly! {nl}I cannot.. handle it anymore. 
 QUEST_LV_0100_20151001_008752	Sorry for being sharp a while ago. I was a bit sensitive. {nl}Actually, having to point the blades to people whom I should take care of as a gravekeeper is not something I am comfortable with. {nl}
 QUEST_LV_0100_20151001_008753	Thank you for giving them peace for me. 
-QUEST_LV_0100_20151001_008754	Anyway, I know of the divine object of the Goddess that the Bokor mentioned.{nl}Those guys from Tree of Truth order made it one day. {nl}
+QUEST_LV_0100_20151001_008754	Anyway, I know of the divine object of the goddess that the Bokor mentioned.{nl}Those guys from Tree of Truth order made it one day. {nl}
 QUEST_LV_0100_20151001_008755	Maybe that is why the dead rose... {nl}I had my suspicions but I couldn't approach it either. {nl}
 QUEST_LV_0100_20151001_008756	Ah! That's right. {nl}Since long time ago, some Bokor or Necromancer not in their sane minds used to come here secretly. {nl}They used to do insane experiments on the dead who are rested in here. {nl}
 QUEST_LV_0100_20151001_008757	So my father learned how to make shaman dolls from the guards nearby Klaipeda. {nl}He said if you put spells on the shaman dolls, it finds the power that messes with the grave and destroys it or something? {nl}
@@ -8764,12 +8764,12 @@ QUEST_LV_0100_20151001_008763	It's the shaman doll that father used. {nl}If we d
 QUEST_LV_0100_20151001_008764	If the shaman doll attacked the divine object, then it means it detected an eveil enery. {nl}But the shaman doll was the one destroyed... {nl}
 QUEST_LV_0100_20151001_008765	Anyway, if the barrier broke, then your friend Bokor must be able to identify it. {nl}What about going back to that Bokor and asking him? 
 QUEST_LV_0100_20151001_008766	Huh? You really broke the barrier? {nl}See, I knew the gravekeeper would help. {nl}
-QUEST_LV_0100_20151001_008767	Actually, I was a but suspicious myself. {nl}I felt a bad energy from the barrier considering that it was something that covered the divine object of the Goddess. 
-QUEST_LV_0100_20151001_008768	Anyway, since the barrier is now broken, let's go together. {nl}If it really is a divine object of the Goddess, then it will react to the prayer for the Goddess. {nl}
+QUEST_LV_0100_20151001_008767	Actually, I was a but suspicious myself. {nl}I felt a bad energy from the barrier considering that it was something that covered the divine object of the goddess. 
+QUEST_LV_0100_20151001_008768	Anyway, since the barrier is now broken, let's go together. {nl}If it really is a divine object of the goddess, then it will react to the prayer for the goddess. {nl}
 QUEST_LV_0100_20151001_008769	Will you go ahead first? {nl}I will follow as soon as I'm ready for the prayer. 
 QUEST_LV_0100_20151001_008770	A Shaman doll.. Evil energy... It really is suspicious.
-QUEST_LV_0100_20151001_008771	Thank you for saving me. I almost went to the Goddess. {nl}I guess it is a lie that it was a divine object of the Goddess. {nl}
-QUEST_LV_0100_20151001_008772	The object of the Goddess would not summon such a monster. {nl}I smell something fishy with that Tree of Truth order. 
+QUEST_LV_0100_20151001_008771	Thank you for saving me. I almost went to the goddess. {nl}I guess it is a lie that it was a divine object of the goddess. {nl}
+QUEST_LV_0100_20151001_008772	The object of the goddess would not summon such a monster. {nl}I smell something fishy with that Tree of Truth order. 
 QUEST_LV_0100_20151001_008773	Since the object here was not real, now we must find the trace of Goddess Zemyna from somewhere else. {nl}It's ok. If something like this makes me frustrated, then I would not have kept my journey until here. {nl}
 QUEST_LV_0100_20151001_008774	But before I leave, I must help the gravekeeper and keep the fuss down. {nl}Now that the evil object is gone, my abilities will help keep this place calm. {nl}
 QUEST_LV_0100_20151001_008775	I want to show my sincerity to the gravekeeper, but, the image of him being angry at me holds me back. {nl}If you're on the way to the gravekeeper, can you send him my sincerity as well? 
@@ -8826,7 +8826,7 @@ QUEST_LV_0100_20151001_008825	Why are you pestering me when you won't even tell 
 QUEST_LV_0100_20151001_008826	I will understand if you play rough with him in case he doesn't listen to you. 
 QUEST_LV_0100_20151001_008827	What are you? {nl}Why are you disturbing other people's gravesites? {nl}
 QUEST_LV_0100_20151001_008828	I have lived my life honestly.{nl}And you think I have hidden some document with the record of my sins?{nl}Stop speaking nonsense and go away! 
-QUEST_LV_0100_20151001_008829	If you are really on the Goddess' side, then you have no reason to stand seeing something that disgraces her name. {nl}What are you waiting for? {nl} 
+QUEST_LV_0100_20151001_008829	If you are really on the goddess' side, then you have no reason to stand seeing something that disgraces her name. {nl}What are you waiting for? {nl} 
 QUEST_LV_0100_20151001_008830	Such awful people. {nl}Setting that up as a sacred object... {nl}
 QUEST_LV_0100_20151001_008831	I think that seal has weakened the energy of that thing. {nl}It must have thought that we're on the same side. {nl}
 QUEST_LV_0100_20151001_008832	Anyway, since you've taken care of that horrible thing, I will believe what you say. 
@@ -8844,7 +8844,7 @@ QUEST_LV_0100_20151001_008843	I'm sure the black crystals are the traces of evil
 QUEST_LV_0100_20151001_008844	Ah, I will take care of the fallen dead bodies. {nl}For now there is something more important to do. 
 QUEST_LV_0100_20151001_008845	Yeah, this will be enough. {nl}I will prepare the shaman doll right away. Hold on. 
 QUEST_LV_0100_20151001_008846	What? You are not a follower of that order? {nl}Are you telling me to believe you? {nl}
-QUEST_LV_0100_20151001_008847	Alright. {nl}Then destroy that divine object that they claim to have received the blessings of the Goddess. {nl}
+QUEST_LV_0100_20151001_008847	Alright. {nl}Then destroy that divine object that they claim to have received the blessings of the goddess. {nl}
 QUEST_LV_0100_20151001_008848	I have never seen a blessed diving object fume evil energy. {nl}I think that object is messing this gravesite. 
 QUEST_LV_0100_20151001_008849	I brought the Kaliss land owners list to my grave to stop the corruption of the next generation. {nl}But to think of it, this record has now become useless. {nl}
 QUEST_LV_0100_20151001_008850	Since they will siege for this document again. {nl}
@@ -9093,7 +9093,7 @@ QUEST_LV_0100_20151001_009092	{memo X}The sacred young tree at the forest
 QUEST_LV_0100_20151001_009093	{memo X}The device with the spirits
 QUEST_LV_0100_20151001_009094	Baron Secretary Arunas asked me to get rid of the strange energy by holding a special ritual. After making a magic circle with wood, I need to burn a voodoo doll on top of it.
 QUEST_LV_0100_20151001_009095	You burnt the spell doll, but strangely the crops withered. Report this to Arunas.
-QUEST_LV_0100_20151001_009096	Put the statue of the Goddess on the magic field at Talia trail.
+QUEST_LV_0100_20151001_009096	Put the Goddess Statue on the magic circle at Tylila Path.
 QUEST_LV_0100_20151001_009097	Albina wants you to remove the remaining three magic fields. Among them, talk to her about the magic field at the Tarvas entrance.
 QUEST_LV_0100_20151001_009098	It is difficult to destroy the magic circle at Darbas Entrance because of the interfering monsters. Destroy the monsters who rush in and the magic circle.
 QUEST_LV_0100_20151001_009099	You successfully destroyed the magic field at Tarvas entrance. Report to Albina.
@@ -9422,7 +9422,7 @@ QUEST_LV_0100_20151001_009421	You better give the old military scrip to Mortimer
 QUEST_LV_0100_20151001_009422	Talk to Bokor Juta
 QUEST_LV_0100_20151001_009423	Bokor Juta seems to be in a trouble. Talk to Juta.
 QUEST_LV_0100_20151001_009424	Defeat the dead that have been revived.
-QUEST_LV_0100_20151001_009425	Bokor Juta came here to look for Gemina Goddess and the place is full of dead. Defeat the dead who are disturbing the praying of Juta.
+QUEST_LV_0100_20151001_009425	Bokor Juta came here to look for Goddess Zemyna, but the place is full of the dead. Defeat the dead who are disturbing the praying of Juta.
 QUEST_LV_0100_20151001_009426	Report to Juta
 QUEST_LV_0100_20151001_009427	You've defeated all the dead as requested by Bokor Juta. Go back to Juta and talk to him.
 QUEST_LV_0100_20151001_009428	You've defeated all the dead as requested by Juta. Talk to Juta to ask if there's anything more you can help with.
@@ -9582,7 +9582,7 @@ QUEST_LV_0100_20151016_009581	$But some force prevented me from approaching it, 
 QUEST_LV_0100_20151016_009582	$Perhaps that force I felt was the Light of Salvation...{nl}That's what I think.
 QUEST_LV_0100_20151016_009583	$This is all because of the dream of the bishop of Klaipeda. {nl}What's all this about a 'Light of Salvation' in the Crystal Mine? I have never seen such thing. {nl}
 QUEST_LV_0100_20151016_009584	$Thank you for saving me.{nl}You must also be a Revelator who has come in search of the Light of Salvation.{nl}
-QUEST_LV_0100_20151016_009585	$Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the Goddess told him the evidence of salvation will be found in the Crystal Mine. {nl}
+QUEST_LV_0100_20151016_009585	$Anyway, the bishop himself also had a dream while praying in closure. {nl}In his dream, the goddess told him the evidence of salvation will be found in the Crystal Mine. {nl}
 QUEST_LV_0100_20151016_009586	{memo X}
 QUEST_LV_0100_20151016_009587	{memo X}
 QUEST_LV_0100_20151016_009588	Really?{nl}Is this really okay..{nl}
@@ -9626,13 +9626,13 @@ QUEST_LV_0100_20151016_009625	{memo X}
 QUEST_LV_0100_20151016_009626	{memo X}
 QUEST_LV_0100_20151016_009627	{memo X}
 QUEST_LV_0100_20151016_009628	Thank you so much for saving me!{nl}I am Albinas from Anastos.{nl}
-QUEST_LV_0100_20151016_009629	This is a tombstone erected by the people of Nestos as an offering to the Goddess.{nl}As you can see, it has become so defiled that it is attracting mobs of monsters.{nl}
-QUEST_LV_0100_20151016_009630	What could Nestos possibly be thinking..{nl}What good are sanctums and tombstones when the Goddess is missing?{nl}
+QUEST_LV_0100_20151016_009629	This is a tombstone erected by the people of Nestos as an offering to the goddess.{nl}As you can see, it has become so defiled that it is attracting mobs of monsters.{nl}
+QUEST_LV_0100_20151016_009630	What could Nestos possibly be thinking..{nl}What good are sanctums and tombstones when the goddess is missing?{nl}
 QUEST_LV_0100_20151016_009631	They can keep making them, but they're all just going to get defiled like this.{nl}
-QUEST_LV_0100_20151016_009632	Unlike them, the people of Anastos have a good grasp of reality.{nl}We know that our priority should be saving the people we can actually see before us and getting rid of the demons, rather than thinking about the Goddess who is already gone.
+QUEST_LV_0100_20151016_009632	Unlike them, the people of Anastos have a good grasp of reality.{nl}We know that our priority should be saving the people we can actually see before us and getting rid of the demons, rather than thinking about the goddess who is already gone.
 QUEST_LV_0100_20151016_009633	{memo X}
-QUEST_LV_0100_20151016_009634	Even though the Goddess is gone now, Nestos continues to pursue its faith blindly.{nl}That is why they keep building these sanctuaries everywhere.
-QUEST_LV_0100_20151016_009635	{nl}Human life comes first, and then our next priority is wiping out the demons we can see before us, and beyond that, as long as the Goddess has abandoned us, is there even a need for faith anymore?
+QUEST_LV_0100_20151016_009634	Even though the goddess is gone now, Nestos continues to pursue its faith blindly.{nl}That is why they keep building these sanctuaries everywhere.
+QUEST_LV_0100_20151016_009635	{nl}Human life comes first, and then our next priority is wiping out the demons we can see before us, and beyond that, as long as the goddess has abandoned us, is there even a need for faith anymore?
 QUEST_LV_0100_20151016_009636	Thank you so much for agreeing to help me.{nl}We really need to teach Nestos a lesson.{nl}
 QUEST_LV_0100_20151016_009637	{memo X}
 QUEST_LV_0100_20151016_009638	{memo X}
@@ -9644,7 +9644,7 @@ QUEST_LV_0100_20151016_009643	{memo X}
 QUEST_LV_0100_20151016_009644	{memo X}
 QUEST_LV_0100_20151016_009645	{memo X}
 QUEST_LV_0100_20151016_009646	You'll take responsibility and restore the tombstone?{nl}I really don't like you, but if you're willing to do that, I guess I've got no choice.
-QUEST_LV_0100_20151016_009647	I'm only agreeing to this for the Goddess's sake.{nl}Luckily there are lots of stones around here.{nl}
+QUEST_LV_0100_20151016_009647	I'm only agreeing to this for the goddess's sake.{nl}Luckily there are lots of stones around here.{nl}
 QUEST_LV_0100_20151016_009648	{memo X}
 QUEST_LV_0100_20151016_009649	{memo X}
 QUEST_LV_0100_20151016_009650	Are you almost done yet? If you're going to take responsibility, you should get hustlin'.{nl}Don't just linger around here wasting time.
@@ -10624,7 +10624,7 @@ QUEST_LV_0100_20151022_010623
 QUEST_LV_0100_20151102_010624
 QUEST_LV_0100_20151102_010625
 QUEST_LV_0100_20151102_010626
-QUEST_LV_0100_20151102_010627	$The forces of evil will never reach the Goddess' revelation.
+QUEST_LV_0100_20151102_010627	$The forces of evil will never reach the goddess' revelation.
 QUEST_LV_0100_20151102_010628	$If you're worried for your safety, I will also give you this Romuva Holy Water.{nl}When you drink this water, you will be invisible to the demons for a short time.
 QUEST_LV_0100_20151102_010629	Welcome! {nl} Oh, so you're the Revelator. I really wanted to meet you. {nl}
 QUEST_LV_0100_20151102_010630

--- a/QUEST_LV_0100.tsv
+++ b/QUEST_LV_0100.tsv
@@ -8392,7 +8392,7 @@ QUEST_LV_0100_20151001_008391	{memo X}Thank you for what just happened. {nl}Ah, 
 QUEST_LV_0100_20151001_008392	{memo X}{nl}I expected it to be polluted but.. I mean who would have thought it would be this bad? {nl}Making a sanctuary like this here is bad enough but those Nestos. {nl}What are they thinking leaving it corrupted like this.
 QUEST_LV_0100_20151001_008393	{memo X}{nl}Can you help me out for a while? 
 QUEST_LV_0100_20151001_008394	{memo X}I belong to the Anastos. {nl}The Nestos still pursue unconditional belief even at this point when the Goddesses are all gone. {nl}That's why they are building sanctuaries here and there. 
-QUEST_LV_0100_20151001_008395	{nl}What's the use of sanctuaries when the goddesses are all gone? {nl}When you know it will just be corrupted like this even if you build it. {nl}On the other hand, the Anastos pursue practicality. 
+QUEST_LV_0100_20151001_008395	{nl}What's the use of sanctuaries when the goddesses are all gone? {nl}When you know it will just be corrupted like this even if you build it. {nl}On the other hand, the Anastospa pursue practicality. 
 QUEST_LV_0100_20151001_008396	{memo X}{nl}People come first, mopping up the demons come first, and what's the use of faith when the Goddess themselves abandoned us?  
 QUEST_LV_0100_20151001_008397	{memo X}There is another sanctuary over there. {nl}I will finish burning this sanctuary so please destroy the one over there. {nl}We need to teach those Nestos as lesson. 
 QUEST_LV_0100_20151001_008398	{memo X}{nl}I'm sure the sanctuary over there is also fuming red enegy. {nl}A sign of corruption. 
@@ -8904,7 +8904,7 @@ QUEST_LV_0100_20151001_008903	{memo X}Restore the Sanctuary (1)
 QUEST_LV_0100_20151001_008904	{memo X}Restore the Sanctuary (2)
 QUEST_LV_0100_20151001_008905	I'm sorry about it
 QUEST_LV_0100_20151001_008906	{memo X}Restore the Sanctuary (3)
-QUEST_LV_0100_20151001_008907	Meeting the Anastos
+QUEST_LV_0100_20151001_008907	Meeting the Anastospa
 QUEST_LV_0100_20151001_008908	{memo X}Do you know someone named Albinas?
 QUEST_LV_0100_20151001_008909	Story of Anastos
 QUEST_LV_0100_20151001_008910	{memo X}Anastos and Nestos
@@ -9625,20 +9625,20 @@ QUEST_LV_0100_20151016_009624	{memo X}
 QUEST_LV_0100_20151016_009625	{memo X}
 QUEST_LV_0100_20151016_009626	{memo X}
 QUEST_LV_0100_20151016_009627	{memo X}
-QUEST_LV_0100_20151016_009628	Thank you so much for saving me!{nl}I am Albinas from Anastos.{nl}
-QUEST_LV_0100_20151016_009629	This is a tombstone erected by the people of Nestos as an offering to the goddess.{nl}As you can see, it has become so defiled that it is attracting mobs of monsters.{nl}
-QUEST_LV_0100_20151016_009630	What could Nestos possibly be thinking..{nl}What good are sanctums and tombstones when the goddess is missing?{nl}
+QUEST_LV_0100_20151016_009628	Thank you so much for saving me!{nl}I am Albinas from the Anastospa.{nl}
+QUEST_LV_0100_20151016_009629	This is a tombstone erected by the people of Nestospa as an offering to the goddess.{nl}As you can see, it has become so defiled that it is attracting mobs of monsters.{nl}
+QUEST_LV_0100_20151016_009630	What could Nestospa possibly be thinking..{nl}What good are sanctums and tombstones when the goddess is missing?{nl}
 QUEST_LV_0100_20151016_009631	They can keep making them, but they're all just going to get defiled like this.{nl}
-QUEST_LV_0100_20151016_009632	Unlike them, the people of Anastos have a good grasp of reality.{nl}We know that our priority should be saving the people we can actually see before us and getting rid of the demons, rather than thinking about the goddess who is already gone.
+QUEST_LV_0100_20151016_009632	Unlike them, the people of Anastospa have a good grasp of reality.{nl}We know that our priority should be saving the people we can actually see before us and getting rid of the demons, rather than thinking about the goddess who is already gone.
 QUEST_LV_0100_20151016_009633	{memo X}
-QUEST_LV_0100_20151016_009634	Even though the goddess is gone now, Nestos continues to pursue its faith blindly.{nl}That is why they keep building these sanctuaries everywhere.
+QUEST_LV_0100_20151016_009634	Even though the goddess is gone now, Nestospa continues to pursue its faith blindly.{nl}That is why they keep building these sanctuaries everywhere.
 QUEST_LV_0100_20151016_009635	{nl}Human life comes first, and then our next priority is wiping out the demons we can see before us, and beyond that, as long as the goddess has abandoned us, is there even a need for faith anymore?
-QUEST_LV_0100_20151016_009636	Thank you so much for agreeing to help me.{nl}We really need to teach Nestos a lesson.{nl}
+QUEST_LV_0100_20151016_009636	Thank you so much for agreeing to help me.{nl}We really need to teach Nestospa a lesson.{nl}
 QUEST_LV_0100_20151016_009637	{memo X}
 QUEST_LV_0100_20151016_009638	{memo X}
 QUEST_LV_0100_20151016_009639	What is this..{nl}
 QUEST_LV_0100_20151016_009640	Who're you? {nl}Who do you think you are, touching our tombstone?
-QUEST_LV_0100_20151016_009641	This is Nestos's sacred tombstone.{nl}Are you the one that did this to our tombstone?
+QUEST_LV_0100_20151016_009641	This is Nestospa's sacred tombstone.{nl}Are you the one that did this to our tombstone?
 QUEST_LV_0100_20151016_009642	I've never seen or heard of anyone like that.{nl}
 QUEST_LV_0100_20151016_009643	{memo X}
 QUEST_LV_0100_20151016_009644	{memo X}
@@ -9669,8 +9669,8 @@ QUEST_LV_0100_20151016_009668	Let's see..{nl} This one's here.. That one's not h
 QUEST_LV_0100_20151016_009669	Oh, yes.{nl} You've found them all.
 QUEST_LV_0100_20151016_009670	{nl}What was it you wanted to ask me about?
 QUEST_LV_0100_20151016_009671	Albinas?{nl} I haven't heard that name before.
-QUEST_LV_0100_20151016_009672	And you say he spoke of Anastos and told you to destroy the tombstone?{nl} No way, we would never do anything like that.{nl}
-QUEST_LV_0100_20151016_009673	Both Nestos and we are people who revere the goddess and are focused in our faith.{nl} Though we are a bit more realistic in our pursuits than the people of Nestos are.
+QUEST_LV_0100_20151016_009672	And you say he spoke of Anastospa and told you to destroy the tombstone?{nl} No way, we would never do anything like that.{nl}
+QUEST_LV_0100_20151016_009673	Both Nestospa and we are people who revere the goddess and are focused in our faith.{nl} Though we are a bit more realistic in our pursuits than the people of Nestos are.
 QUEST_LV_0100_20151016_009674	{memo X}
 QUEST_LV_0100_20151016_009675	{memo X}
 QUEST_LV_0100_20151016_009676	{memo X}

--- a/QUEST_LV_0200.tsv
+++ b/QUEST_LV_0200.tsv
@@ -15,22 +15,22 @@ QUEST_LV_0200_20150317_000014	$Weak Owl Sculpture
 QUEST_LV_0200_20150317_000015	$My power is slowly weakening. {nl} Even though there are many souls that need guidance...
 QUEST_LV_0200_20150317_000016	$Scared Owl Sculpture
 QUEST_LV_0200_20150317_000017	$The holy power of the forest is weakening. {nl} What will happen to us after it's gone?!
-QUEST_LV_0200_20150317_000018	$It's too scary. {nl} This never happened when the Goddess was still around...
+QUEST_LV_0200_20150317_000018	$It's too scary. {nl} This never happened when the goddess was still around...
 QUEST_LV_0200_20150317_000019	$Sincere Owl Sculpture
 QUEST_LV_0200_20150317_000020	$This forest is cursed... it consumes the owls. {nl} I have hardly anything to compel bravery from others.
 QUEST_LV_0200_20150317_000021	$Ever since that huge tree suddenly arose, this forest has changed into something horrid. {nl} Even the trees' roots frighten whoever stares at them.
 QUEST_LV_0200_20150317_000022	$Devoted Owl Sculpture
 QUEST_LV_0200_20150317_000023	$Someone was held captive. {nl} I have a feeling he's going to disappear...
-QUEST_LV_0200_20150317_000024	$The sacred force created by the Goddess has not completely dissipated. {nl}Will it be able to suppress this devastation? {nl}
+QUEST_LV_0200_20150317_000024	$The sacred force created by the goddess has not completely dissipated. {nl}Will it be able to suppress this devastation? {nl}
 QUEST_LV_0200_20150317_000025	$The chief gave me power.{nl}I won't be scared.
 QUEST_LV_0200_20150317_000026	$I'm not going to be afraid anymore. I will never be eaten by monsters.
 QUEST_LV_0200_20150317_000027	$Painful Owl Sculpture
 QUEST_LV_0200_20150317_000028	$I'm suffering every day.{nl}Perhaps, I will also be eaten by monsters.
-QUEST_LV_0200_20150317_000029	$This forest is increasingly covered with demons.{nl}Where is the Goddess?
+QUEST_LV_0200_20150317_000029	$This forest is increasingly covered with demons.{nl}Where is the goddess?
 QUEST_LV_0200_20150317_000030	$I was chosen by the chief... {nl} I'll do my best to defeat the monsters.
-QUEST_LV_0200_20150317_000031	$The chief is also struggling like this..{nl}Never will I be eaten until the Goddess comes back.
+QUEST_LV_0200_20150317_000031	$The chief is also struggling like this..{nl}Never will I be eaten until the goddess comes back.
 QUEST_LV_0200_20150317_000032	Subordinate Owl 3
-QUEST_LV_0200_20150317_000033	$We have always been here at this place, but where is the Goddess who've always looked after us?
+QUEST_LV_0200_20150317_000033	$We have always been here at this place, but where is the goddess who've always looked after us?
 QUEST_LV_0200_20150317_000034	$Do we exist only for guiding humans' souls?
 QUEST_LV_0200_20150317_000035	$Soldier Dominic
 QUEST_LV_0200_20150317_000036	$I've been ordered to protect this place with my life and to do some reconnaissance at the same time.{nl}I don't know exactly what they expect me to do.
@@ -139,7 +139,7 @@ QUEST_LV_0200_20150317_000138	I can feel the closest flag from here is near Gatv
 QUEST_LV_0200_20150317_000139	$Earnest Owl Chief Sculpture
 QUEST_LV_0200_20150317_000140	$Thank you so much. {nl}The other owls must have gained confidence because of you.
 QUEST_LV_0200_20150317_000141	$Weak Owl Sculpture
-QUEST_LV_0200_20150317_000142	$It really was too late..{nl}The Goddess really can be harsh sometimes..
+QUEST_LV_0200_20150317_000142	$It really was too late..{nl}The goddess really can be harsh sometimes..
 QUEST_LV_0200_20150317_000143	$I have one last request. {nl}Can you burn the Owls so they could rest in peace?
 QUEST_LV_0200_20150317_000144	$Do you think my allies can reach Goddess Ausrine safely?
 QUEST_LV_0200_20150317_000145	$Thank you so much. {nl}First bring me the Oil from Oil Boxes on the way to Neuoder Field.
@@ -198,11 +198,11 @@ QUEST_LV_0200_20150317_000197	{memo X}Because of our plan, we may be sent to the
 QUEST_LV_0200_20150317_000198	The portal at the military district is our only hope.
 QUEST_LV_0200_20150317_000199	Hunter Talus
 QUEST_LV_0200_20150317_000200	$I am looking for a few artifacts of Lydia Schaffen, who built the Tower of Stars.{nl}The famous archer who shot Ruklys' chest.
-QUEST_LV_0200_20150317_000201	$Kingdom Army Guard Retia
+QUEST_LV_0200_20150317_000201	$Royal Army Guard Retia
 QUEST_LV_0200_20150317_000202	{memo X}Because of the Stone Frosts that were created due to Ruklys' rebellion a few hundreds years ago, the land turned into a wasteland.
 QUEST_LV_0200_20150317_000203	{memo X}We will allow you to enter since the Knights of Kaliss requested us to do so, but please stay where our gaze remains.
 QUEST_LV_0200_20150317_000204	{memo X}After Medzio Diena 4 years ago, Benas was appointed as the chief commander for the forces here.{nl}He ordered to take good care of the road leading to the Fortress of the Land.
-QUEST_LV_0200_20150317_000205	{memo X}If you are not in a hurry, please defeat the monsters in area A.{nl}That will be the first step for you to contribute to the Goddess and the Kingdom..{nl}Of course, I will promise you enough rewards.
+QUEST_LV_0200_20150317_000205	{memo X}If you are not in a hurry, please defeat the monsters in area A.{nl}That will be the first step for you to contribute to the goddess and the Kingdom..{nl}Of course, I will promise you enough rewards.
 QUEST_LV_0200_20150317_000206	{memo X}Rebel Commander Ruklys, and the citizens here engaged in an evil conduct{nl}despite the selections from the great merchant, Premier Eminent. The result is this place.
 QUEST_LV_0200_20150317_000207	{memo X}That's not bad. Maybe the guards can use it.
 QUEST_LV_0200_20150317_000208	{memo X}After Medzio Diena, the Stone Frosts are occurring irregularly.{nl}Due to irregular Stone Frosts, we lost many of our soldiers on this wasteland.{nl}And we set the petrification devices limitedly here at the square of lamentation and we check the frequency of the frosts and move out the soldiers accordingly.
@@ -262,7 +262,7 @@ QUEST_LV_0200_20150317_000261	{memo X}I was ordered to take back their keepsakes
 QUEST_LV_0200_20150317_000262	{memo X}The authorities do not take it well that tens of soldiers were sacrificed for support activities. {nl}That's why the Royal Army and the Knights of Kaliss have become distant.
 QUEST_LV_0200_20150317_000263	{memo X}You may not believe it but I might have been standing there too. {nl}Good thing I was off duty that day.. I don't even want to think about it. {nl}I will deliver this to the families of the deceased.
 QUEST_LV_0200_20150317_000264	{memo X}How are you traveler, although, I don't know why you are passing through this place..
-QUEST_LV_0200_20150317_000265	{memo X}Ah, so you are the famous Revelator. I've heard a lot about you from my colleagues in Klaipeda. {nl}They say you go around to save the world according to the will of the Goddess?
+QUEST_LV_0200_20150317_000265	{memo X}Ah, so you are the famous Revelator. I've heard a lot about you from my colleagues in Klaipeda. {nl}They say you go around to save the world according to the will of the goddess?
 QUEST_LV_0200_20150317_000266	{memo X}Then let me make a good offer, I found a way to turn back this Petrified City. Can you help me? {nl}First, get rid of the monsters around here. I have to be safe first before I can tell you anything, right?
 QUEST_LV_0200_20150317_000267	{memo X}The Cryomancers in Klaipeda are stubborn and arrogant. If you feel something like that from me, then that's your delusion. {nl}There is Cryomancer as humane and warm-hearted as me.
 QUEST_LV_0200_20150317_000268	{memo X}Did you dry the seeds? Good, anyway.
@@ -390,7 +390,7 @@ QUEST_LV_0200_20150317_000389	$We, the Rearguard Unit, are in charge of controll
 QUEST_LV_0200_20150317_000390	$We need to regain the forest captured by the monsters. {nl}We will not fall back this time!
 QUEST_LV_0200_20150317_000391	$If we retreat, Klaipeda will be totally isolated.{nl}
 QUEST_LV_0200_20150317_000392	$Troops in the frontlines don't know what hardships we go through. {nl}They think that they're the only ones who have their lives on the line.
-QUEST_LV_0200_20150317_000393	$It would be nice if the Goddess send us her blessings at times like this.. {nl}Honestly, we're exhausted.
+QUEST_LV_0200_20150317_000393	$It would be nice if the goddess send us her blessings at times like this.. {nl}Honestly, we're exhausted.
 QUEST_LV_0200_20150317_000394	$Do you think there will be an end to this war? {nl}Frankly, I'm scared.
 QUEST_LV_0200_20150317_000395	$The Rearguard Units are doing their best, but the supply situation remains horrible.
 QUEST_LV_0200_20150317_000396	$Is Helgasercle attacking again? {nl}If that's the case, this battle will be a very long one..
@@ -407,7 +407,7 @@ QUEST_LV_0200_20150317_000406	{memo X}But if you help me out, I will give you so
 QUEST_LV_0200_20150317_000407	{memo X}It's nothing much, really. {nl}The symbol of pilgrim on the Starving Demon's Way outside Fedimian will do.
 QUEST_LV_0200_20150317_000408	{memo X}Nevermind if you can't. {nl}But if you can, that'd be awesome.
 QUEST_LV_0200_20150317_000409	{memo X}Oh, you got it... {nl}Well, aren't reckless challenges the fun in life?
-QUEST_LV_0200_20150317_000410	$The monsters are eating my companions. {nl}I still have some holy power from the Goddess, but it won't last long.
+QUEST_LV_0200_20150317_000410	$The monsters are eating my companions. {nl}I still have some holy power from the goddess, but it won't last long.
 QUEST_LV_0200_20150317_000411	Officer Danus
 QUEST_LV_0200_20150317_000412	Many cities will become isolated if we don't get back this forest.. {nl}But the situation isn't on our side.
 QUEST_LV_0200_20150317_000413	This forest doesn't even have Owl Sculptures. {nl}Makes you feel like you really don't want to come back.
@@ -437,28 +437,28 @@ QUEST_LV_0200_20150317_000436	Villager Cahill
 QUEST_LV_0200_20150317_000437	$I don't get why the old man is like that to me.
 QUEST_LV_0200_20150317_000438	I think I can understand him now. {nl}But it would be much better if he treated me kindly.
 QUEST_LV_0200_20150317_000439	$A bow once made can fire many times, but arrows are gone once shot away. {nl}That's why we never stop making them.
-QUEST_LV_0200_20150317_000440	{memo X}I don't think prayers and ceremonies are the only way to serve the Goddess. {nl}Serving the world through physical training is also an important mission of the cleric. {nl}That is what a Monk is.
+QUEST_LV_0200_20150317_000440	{memo X}I don't think prayers and ceremonies are the only way to serve the goddess. {nl}Serving the world through physical training is also an important mission of the cleric. {nl}That is what a Monk is.
 QUEST_LV_0200_20150317_000441	I'm sick of Fedimian. {nl}Where could my brother be..
 QUEST_LV_0200_20150317_000442	For what did my brother.. {nl}How important could that thing be..
 QUEST_LV_0200_20150317_000443	$Fedimian is still under reconstruction. {nl}The Holy Area is better off; the other areas are so bad you can't even enter them.
 QUEST_LV_0200_20150317_000444	$I'll probably be working again from now on. {nl}You gotta be busy to feel alive.
 QUEST_LV_0200_20150317_000445	I would have been in trouble if not for your help. {nl}Fedimian is still under construction and there aren't any proper medical facilities.
-QUEST_LV_0200_20150317_000446	{memo X}There are two ways to approach the Goddess. {nl}Strong belief for the Goddess and the sound of silver dropping on the offering box. {nl}We're just being honest here. Don't you think the same?
+QUEST_LV_0200_20150317_000446	{memo X}There are two ways to approach the goddess. {nl}Strong belief for the goddess and the sound of silver dropping on the offering box. {nl}We're just being honest here. Don't you think the same?
 QUEST_LV_0200_20150317_000447	{memo X}I don't really mind the rumours but do people believe that spell can retain your youth? {nl}Well, maybe it can but.. {nl}Ah, I don't want to talk about it anymore.
 QUEST_LV_0200_20150317_000448	Supplies Officer
 QUEST_LV_0200_20150317_000449	$There's always a shortage of supplies and we're always tired.
 QUEST_LV_0200_20150317_000450	$The Rearguard Unit always complains the supplies are late or inadequate. {nl}But we have our own problems.
 QUEST_LV_0200_20150317_000451	$Oh, you got them. Thank you. {nl}Please go back to the monster's nest and burn the Destroyed Owls.
 QUEST_LV_0200_20150317_000452	$Terrible things are happening. {nl}Can't we just go back to the peaceful days?
-QUEST_LV_0200_20150317_000453	$The Goddess can be so cruel. {nl}Please pray that my colleagues may rest in peace.
+QUEST_LV_0200_20150317_000453	$The goddess can be so cruel. {nl}Please pray that my colleagues may rest in peace.
 QUEST_LV_0200_20150317_000454	$Pilgrim Liliya
 QUEST_LV_0200_20150317_000455	{memo X}If I die, please bury me..{nl}Make my body unseen..{nl}If I lose my breath, please bury me..
 QUEST_LV_0200_20150317_000456	{memo X}And if you meet a pilgrim named Julius, please tell him these words.. tell him goodbye..
 QUEST_LV_0200_20150317_000457	Pilgrim's Memo
 QUEST_LV_0200_20150317_000458	{memo X}This land is cursed by Naktis. {nl}I may die but let it be known to the pilgrims who pass this place. {nl}Demon Lord Naktis drove cursed Tree Root Crystals around this Ray-lit Land, and those Tree Root Crystals are spreading curse of indolence to the pilgrims.
-QUEST_LV_0200_20150317_000459	{memo X}You must destroy the Tree Root Crystals to avoid the curse. {nl}May the Goddess' blessings be with the pilgrims.
+QUEST_LV_0200_20150317_000459	{memo X}You must destroy the Tree Root Crystals to avoid the curse. {nl}May the goddess' blessings be with the pilgrims.
 QUEST_LV_0200_20150317_000460	{memo X}Who? {nl}
-QUEST_LV_0200_20150317_000461	{memo X}Anyway, do you have any food? Please give me somthing to eat.. I can't stand the hunger anymore. I can't move. Hey, if you have faith in the Goddess, please get me some food.
+QUEST_LV_0200_20150317_000461	{memo X}Anyway, do you have any food? Please give me somthing to eat.. I can't stand the hunger anymore. I can't move. Hey, if you have faith in the goddess, please get me some food.
 QUEST_LV_0200_20150317_000462	{memo X}Even the meat of those wild monsters is fine. Eating the whole world is not enough.. Uh.. I'm hungry.
 QUEST_LV_0200_20150317_000463	{memo X}Not yet? I think I can even eat you now.
 QUEST_LV_0200_20150317_000464	{memo X}Aakk! That's right!! Give me that! I will eat it all!
@@ -529,8 +529,8 @@ QUEST_LV_0200_20150317_000528	{memo X}The Scripture!!!
 QUEST_LV_0200_20150317_000529	{memo X}Please bring it! {nl}One of the pilgrim souls trapped here somewhere must have it!!
 QUEST_LV_0200_20150317_000530	{memo X}This is it!{nl}Oh, thank you. I can finally make the drug!
 QUEST_LV_0200_20150317_000531	{memo X}If you use this, the soul inside the monster will shine. {nl}Defeat those monsters so that the souls may rest in peace.
-QUEST_LV_0200_20150317_000532	{memo X}They were sneaky and careful. {nl}They made the seminarians betray and kill each other. {nl}People who were supposed to become priests and spread the love of the Goddess to others betraying and killing themselves, and their souls trapped in the altar for the rage against each other..{nl}
-QUEST_LV_0200_20150317_000533	{memo X}And I mean in the altar where we offer ceremonies to the Goddess. {nl}I may be injured but I'm still alive and I can't forgive those monsters. How much more for the pilgrims who were killed like that.. {nl}That's why the souls in the altar are full of anger.
+QUEST_LV_0200_20150317_000532	{memo X}They were sneaky and careful. {nl}They made the seminarians betray and kill each other. {nl}People who were supposed to become priests and spread the love of the goddess to others betraying and killing themselves, and their souls trapped in the altar for the rage against each other..{nl}
+QUEST_LV_0200_20150317_000533	{memo X}And I mean in the altar where we offer ceremonies to the goddess. {nl}I may be injured but I'm still alive and I can't forgive those monsters. How much more for the pilgrims who were killed like that.. {nl}That's why the souls in the altar are full of anger.
 QUEST_LV_0200_20150317_000534	{memo X}I hope the shining soul will brighten your way. {nl}
 QUEST_LV_0200_20150317_000535	{memo X}They will also be thankful to you.
 QUEST_LV_0200_20150317_000536	{memo X}I felt the peace of souls released even from afar. {nl}
@@ -554,17 +554,17 @@ QUEST_LV_0200_20150317_000553	{memo X}
 QUEST_LV_0200_20150317_000554	{memo X}(The notice is half broken. Can't read all the writings.)
 QUEST_LV_0200_20150317_000555	Altar Notice
 QUEST_LV_0200_20150317_000556	{memo X}You can receive blessings by offering money. {nl}Amount of offerings that can be received from each pilgrim differs.
-QUEST_LV_0200_20150317_000557	{memo X}{nl}{nl}May the grace of the Goddess be with you. {nl}-- Manager : [Pardoner Master] Maistes Goldmunt
+QUEST_LV_0200_20150317_000557	{memo X}{nl}{nl}May the grace of the goddess be with you. {nl}-- Manager : [Pardoner Master] Maistes Goldmunt
 QUEST_LV_0200_20150317_000558	{memo X}You can receive blessings by offering goods. {nl}Lure fresh goods from the monsters nearby.
-QUEST_LV_0200_20150317_000559	{memo X}{nl}The grace of the Goddess be with you, always. {nl}--Manager : [Priest Master] Vorable
+QUEST_LV_0200_20150317_000559	{memo X}{nl}The grace of the goddess be with you, always. {nl}--Manager : [Priest Master] Vorable
 QUEST_LV_0200_20150317_000560	{memo X}Worship the Sanctum here. {nl}Blessings will be with you.
-QUEST_LV_0200_20150317_000561	{memo X}{nl}May the grace of the Goddess be with you.{nl}-- Manager : [Cleric Master] Rosalia
+QUEST_LV_0200_20150317_000561	{memo X}{nl}May the grace of the goddess be with you.{nl}-- Manager : [Cleric Master] Rosalia
 QUEST_LV_0200_20150317_000562	{memo X}The cover of scripture on the altar smells like blood. Did the monsters eat all other pages?
 QUEST_LV_0200_20150317_000563	{memo X}You can receive blessings by offering clear water. {nl}Fetch clean water from the stream.{nl}
-QUEST_LV_0200_20150317_000564	{memo X}The blessings of the Goddess will purify your soul like the clear water. {nl}-- Manager : [Oracle Master] Apolonia Barbora
-QUEST_LV_0200_20150317_000565	{memo X}You will receive blessings if you offer reed flowers. {nl}Offer the reed flowers that can be found near the Purple Tree Fault Forest's Farewell Bridge. {nl}The grace of the Goddess be with you, always. {nl}-- Manager : [Druid Master] Gina Greene
-QUEST_LV_0200_20150317_000566	{memo X}You must offer money to the Sanctum. {nl}The blessings of the Goddess will be with you. {nl}May you receive the grace of the Goddess. {nl}-- Manager : [Pardoner Master] Maistes Goldmunt
-QUEST_LV_0200_20150317_000567	{memo X}Pay worship to this Sanctum. {nl}The blessings of the Goddess will be with those who lay themselves low. {nl}May the grace of the Goddess be with you in your ordeals. {nl}--Manager : [Krivis Master] Hercus
+QUEST_LV_0200_20150317_000564	{memo X}The blessings of the goddess will purify your soul like the clear water. {nl}-- Manager : [Oracle Master] Apolonia Barbora
+QUEST_LV_0200_20150317_000565	{memo X}You will receive blessings if you offer reed flowers. {nl}Offer the reed flowers that can be found near the Purple Tree Fault Forest's Farewell Bridge. {nl}The grace of the goddess be with you, always. {nl}-- Manager : [Druid Master] Gina Greene
+QUEST_LV_0200_20150317_000566	{memo X}You must offer money to the Sanctum. {nl}The blessings of the goddess will be with you. {nl}May you receive the grace of the goddess. {nl}-- Manager : [Pardoner Master] Maistes Goldmunt
+QUEST_LV_0200_20150317_000567	{memo X}Pay worship to this Sanctum. {nl}The blessings of the goddess will be with those who lay themselves low. {nl}May the grace of the goddess be with you in your ordeals. {nl}--Manager : [Krivis Master] Hercus
 QUEST_LV_0200_20150317_000568	Sanctum
 QUEST_LV_0200_20150317_000569	{memo X}Will you offer money and receive blessings?
 QUEST_LV_0200_20150317_000570	{memo X}Find goods to use for offering.
@@ -585,7 +585,7 @@ QUEST_LV_0200_20150317_000584	{memo X}You mean the Sanctum in Purple Tree Fault 
 QUEST_LV_0200_20150317_000585	{memo X}Oh, I heard the rumours but is it that bad?
 QUEST_LV_0200_20150317_000586	{memo X}I guess Naktis is not an easy Demon Lord. {nl}Sounds like the the Sanctum is polluted by monsters near it. {nl}Find the badge of the Sanctum from the monsters nearby and burn it in front of the Sanctum. {nl}
 QUEST_LV_0200_20150317_000587	{memo X}Even if the Sanctum is purified, it might not turn back to it's original form but it will function again.
-QUEST_LV_0200_20150317_000588	{memo X}Naktis must be looking for clues for entering the Cathedral. {nl}If my prediction is right, it's not only the Purple Tree Fault Forest but all of Pilgrim's Way that must be that way. {nl}If you do reach the Cathedral, please defeat Naktis. {nl}We have to stop the demons from getting their hand on the Goddess' revelations.
+QUEST_LV_0200_20150317_000588	{memo X}Naktis must be looking for clues for entering the Cathedral. {nl}If my prediction is right, it's not only the Purple Tree Fault Forest but all of Pilgrim's Way that must be that way. {nl}If you do reach the Cathedral, please defeat Naktis. {nl}We have to stop the demons from getting their hand on the goddess' revelations.
 QUEST_LV_0200_20150317_000589	You must burn it at the sanctum. Please.
 QUEST_LV_0200_20150317_000590	{memo X}Will you fetch clear water?
 QUEST_LV_0200_20150317_000591	{memo X}Will you prove your faith by offering flowers?
@@ -680,7 +680,7 @@ QUEST_LV_0200_20150317_000679	Haha.. You're incredibly strong like Scott says, h
 QUEST_LV_0200_20150317_000680	$I have a favor. {nl}Can you take this Wing Fragment to our Owl Chief at Neuoder Field?
 QUEST_LV_0200_20150317_000681	$This Wing Fragment is the Brave Owl's. {nl}It's a very sad and painful thing.
 QUEST_LV_0200_20150317_000682	$This is a fragment of my friend's wing. {nl}It was broken off by the monsters.
-QUEST_LV_0200_20150317_000683	$Please. Deliver this Wing Fragment to the other owls. {nl}It still has the power of the Goddess left in it so it will encourage them. {nl}
+QUEST_LV_0200_20150317_000683	$Please. Deliver this Wing Fragment to the other owls. {nl}It still has the power of the goddess left in it so it will encourage them. {nl}
 QUEST_LV_0200_20150317_000684	$This is a fragment of Owl Chief's wing.. {nl}Thank you. We will continue to work hard!
 QUEST_LV_0200_20150317_000685	$The other owls are in Kongfiska Hill and Clover Highland. {nl}I believe that this strength will help at least a bit.
 QUEST_LV_0200_20150317_000686	$Isn't that a fragment of the chief's wing? {nl}
@@ -738,7 +738,7 @@ QUEST_LV_0200_20150317_000737	$No one would want to forget their hometown. {nl}W
 QUEST_LV_0200_20150317_000738	$Thank you very much. {nl}Now they can rest in peace. {nl}
 QUEST_LV_0200_20150317_000739	$Please pray for them at the Garden of Consolation later when you have time.
 QUEST_LV_0200_20150317_000740	$You are a very kind person. {nl}Butterfly Fragrance only grow in bushes at Butterfly Tomb.
-QUEST_LV_0200_20150317_000741	$We guide souls to Goddess Ausrine. {nl}But it's a big problem now because the number of souls is multiplying while the Goddess is not around.
+QUEST_LV_0200_20150317_000741	$We guide souls to Goddess Ausrine. {nl}But it's a big problem now because the number of souls is multiplying while the goddess is not around.
 QUEST_LV_0200_20150317_000742	$Sad Owl Sculpture
 QUEST_LV_0200_20150317_000743	$Help! {nl}A Throneweaver is destroying us.
 QUEST_LV_0200_20150317_000744	$Monsters were around even before. {nl}But ever since that tree emerged in the capital, they began to destroy us. {nl}
@@ -780,10 +780,10 @@ QUEST_LV_0200_20150317_000779	$Thank you for following me. {nl}Weave in some Ell
 QUEST_LV_0200_20150317_000780	$Good work. Now it's time for revenge.
 QUEST_LV_0200_20150317_000781	$This is my last favor. {nl}It's at Grobis Crossroads. Please finish our last mission with this decoy.
 QUEST_LV_0200_20150317_000782	$If your life is in danger, don't hesitate to run. {nl}I don't want you to get caught up avenging us.
-QUEST_LV_0200_20150317_000783	$Whew. Now my men and I can rest in peace. {nl}We will meet the Goddess soon. I will pray for her grace towards you.
+QUEST_LV_0200_20150317_000783	$Whew. Now my men and I can rest in peace. {nl}We will meet the goddess soon. I will pray for her grace towards you.
 QUEST_LV_0200_20150317_000784	$Thank you. Thank you very much.{nl}First, please get some Legs of Solid Wood from the Bushspiders at Purple Fountain.
 QUEST_LV_0200_20150317_000785	$Well. I don't know what I'm still doing here. {nl}That Owl that's supposed to guide us is not saying a word either.
-QUEST_LV_0200_20150317_000786	$Maybe we can go back to the Goddess if we achieve what we were not able to. {nl}
+QUEST_LV_0200_20150317_000786	$Maybe we can go back to the goddess if we achieve what we were not able to. {nl}
 QUEST_LV_0200_20150317_000787	$That fellow worries a lot. {nl}I said it's not Deadborn but he's still like that.
 QUEST_LV_0200_20150317_000788	$It's worth a shot if it's Saltistter. {nl}But if it's Deadborn, then I'm outta here.
 QUEST_LV_0200_20150317_000789	$I never heard of any Deadborn sightings in Kateen Forest.
@@ -830,7 +830,7 @@ QUEST_LV_0200_20150317_000829	$You're here. {nl}Are you ready? {nl}
 QUEST_LV_0200_20150317_000830	$The battle has begun. Troops have entered Izdaginakas Highway already. {nl}It will be a big help if you fight with them.
 QUEST_LV_0200_20150317_000831	$The plan will not fail. {nl}I promise this to Johan's troops.
 QUEST_LV_0200_20150317_000832	{memo X}It looks like you've done more than Roy's part. {nl}If it wasn't for you, we would not have been successful. {nl}
-QUEST_LV_0200_20150317_000833	$I hope the blessings of the Goddess are with you on your journey.
+QUEST_LV_0200_20150317_000833	$I hope the blessings of the goddess are with you on your journey.
 QUEST_LV_0200_20150317_000834	{memo X}I can't close my eyes before we defeat that monster.
 QUEST_LV_0200_20150317_000835	When will this pitiful feeling end. {nl}When I look at the souls, I don't think it will end.
 QUEST_LV_0200_20150317_000836	$I can suffice with delayed supplies or reinforcements. {nl}But telling us to just wait around is too much.
@@ -878,11 +878,11 @@ QUEST_LV_0200_20150317_000877	$This Great Cathedral is a legacy of Maven, the fi
 QUEST_LV_0200_20150317_000878	$It has been worth the long wait. {nl}Although my body is like this, I am overflowing with emotion right now.
 QUEST_LV_0200_20150317_000879	$This will be enough.
 QUEST_LV_0200_20150317_000880	$I believe a scripture will hold the Spirit Essences well enough. {nl}Unfortunately, they are all at Pamaldu Groom. {nl}
-QUEST_LV_0200_20150317_000881	$Although I'm just a spirit, I have offered myself to the Goddess. {nl}I want to be placed in a scripture.
+QUEST_LV_0200_20150317_000881	$Although I'm just a spirit, I have offered myself to the goddess. {nl}I want to be placed in a scripture.
 QUEST_LV_0200_20150317_000882	$Are you done with the ritual? {nl}Check if this scripture can call me correctly.
 QUEST_LV_0200_20150317_000883	$Splendid. {nl}Now you must solve the secret of the Great Cathedral and get the revelation. {nl}
 QUEST_LV_0200_20150317_000884	$Of course, there will be hardship. {nl}The burden of the holy mission will surely weigh down on your shoulders. {nl}
-QUEST_LV_0200_20150317_000885	$But only you and the Goddess can save this world..{nl}Even knowing my body would turn out like this, I desired to guide you.
+QUEST_LV_0200_20150317_000885	$But only you and the goddess can save this world..{nl}Even knowing my body would turn out like this, I desired to guide you.
 QUEST_LV_0200_20150317_000886	{memo X}Don't worry. You just have to finish the bowl to hold me. {nl}First, gather the Essence of Soul. {nl}
 QUEST_LV_0200_20150317_000887	$Oh, the vessel should be completed at the Altar of Stability. {nl}I have spent centuries without a body, so I hope you get a decent scripture.
 QUEST_LV_0200_20150317_000888	{memo X}It's simple. {nl}Use the scripture of soul in your inventory.
@@ -901,7 +901,7 @@ QUEST_LV_0200_20150317_000900	{memo X}I can't forgive them for making the tower 
 QUEST_LV_0200_20150317_000901	{memo X}You better watch out. {nl}Why do you think even the wizards ran away?
 QUEST_LV_0200_20150317_000902	{memo X}We can help Goddess Gabija if we have the Jewel of Prominence.
 QUEST_LV_0200_20150317_000903	{memo X}Now that the trasport magic circle is destroyed, we have to go head to head.
-QUEST_LV_0200_20150317_000904	{memo X}I think I can remember something.. But first, it's important to go to the Goddess.
+QUEST_LV_0200_20150317_000904	{memo X}I think I can remember something.. But first, it's important to go to the goddess.
 QUEST_LV_0200_20150317_000905	{memo X}Uhg, my head aches.. {nl}Maybe it's because of the crazy old man a while ago..
 QUEST_LV_0200_20150317_000906	This is endless. I want to just burn it all.
 QUEST_LV_0200_20150317_000907	I will make them pay for doing this to our tower!
@@ -914,7 +914,7 @@ QUEST_LV_0200_20150317_000913	$Don't compare me to the old folk who carve owls o
 QUEST_LV_0200_20150317_000914	Supply Soldier
 QUEST_LV_0200_20150317_000915	$I don't know about the frontlines but it makes no sense to complain to the Rearguard Unit. {nl}The Rearguards must work well for supplies to make it through.
 QUEST_LV_0200_20150317_000916	$I can't even count how many monsters I had to fight on my way here. {nl}
-QUEST_LV_0200_20150317_000917	$Being in this battle for so long, I even wonder if there really was a Goddess. {nl}I wonder if this is a dream, or whether we can wake up from it.
+QUEST_LV_0200_20150317_000917	$Being in this battle for so long, I even wonder if there really was a goddess. {nl}I wonder if this is a dream, or whether we can wake up from it.
 QUEST_LV_0200_20150317_000918	$Even with the escort troops protecting us, I almost got myself killed twice.
 QUEST_LV_0200_20150317_000919	$The supply troop is safer compared to other troops. {nl}But they do a lot more manual labor, so people avoid it.
 QUEST_LV_0200_20150317_000920	$The longer the battle goes on, the more soldiers are deserting. {nl}It's really frustrating.
@@ -946,7 +946,7 @@ QUEST_LV_0200_20150317_000945	I thought I just had to match the properties of th
 QUEST_LV_0200_20150317_000946	Oh, I heard from Titas but I didn't think that's you. I feel reassured. {nl}Well then, please support the monster extermination mission.
 QUEST_LV_0200_20150317_000947	$The other clerics are at the Grand Corridor, Penitence Route, and the Sanctuary. {nl}Research is important but I hope they are safe. {nl}{nl}If you see the other clerics, please send them my regards. {nl}They are in dangerous places.
 QUEST_LV_0200_20150317_000948	Priest Inea
-QUEST_LV_0200_20150317_000949	{memo X}Why is the Goddess leaving those blasphemous monsters alone.. {nl}Is this also the will of the Goddess?
+QUEST_LV_0200_20150317_000949	{memo X}Why is the goddess leaving those blasphemous monsters alone.. {nl}Is this also the will of the goddess?
 QUEST_LV_0200_20150317_000950	{memo X}It's not easy to get samples. {nl}There is not enough for research too.
 QUEST_LV_0200_20150317_000951	{memo X}Ah, there was definitely a reaction this time. {nl}I would have had a hard time if it wasn't for your help. Thank you!
 QUEST_LV_0200_20150317_000952	{memo X}We need to take care of it before it reaches Naktis. {nl}Please defeat the demons and find the holy relic of salvation.
@@ -1029,7 +1029,7 @@ QUEST_LV_0200_20150317_001028	{memo X}Was it you who Joseph was looking for? {nl
 QUEST_LV_0200_20150317_001029	$After all, I've placed all of my faith in the priests, but I just can't it any longer.{nl}That's why I want to hire someone who is skillful like you. {nl}I will compensate you well.
 QUEST_LV_0200_20150317_001030	$I don't know what the priests are doing, because anyone would know that the monsters are after the honey.
 QUEST_LV_0200_20150317_001031	$I made a request to Klaipeda, but they have not been responding since they lack the manpower.{nl}And it is not easy to hire mercenaries in this area.{nl}
-QUEST_LV_0200_20150317_001032	$Thus, the only ones I can count on are the Revelators.{nl}You're looking for a Goddess? We once had a Goddess in our village.
+QUEST_LV_0200_20150317_001032	$Thus, the only ones I can count on are the Revelators.{nl}You're looking for a goddess? We once had a goddess in our village.
 QUEST_LV_0200_20150317_001033	$Look carefully for undamaged beehives.{nl}With luck, you might obtain some beehives that are in good condition.
 QUEST_LV_0200_20150317_001034	$Oh, this one is quite big.{nl}Good job.
 QUEST_LV_0200_20150317_001035	$Now, go to Vulvini Farm.{nl}If we could provide proof that the monsters are after the honey, the priests should stop only thinking about their altars.{nl}
@@ -1071,21 +1071,21 @@ QUEST_LV_0200_20150317_001070	$I would briefly explain the situation to you now,
 QUEST_LV_0200_20150317_001071	$I am relieved by your words.{nl}If we can't hold them back all of Siauliai Woods may be destroyed, so I am counting on you.{nl}
 QUEST_LV_0200_20150317_001072	$I will explain everything to you in detail after you come back.{nl}Please get rid of the monsters.
 QUEST_LV_0200_20150317_001073	{memo X}I am now a little relieved.{nl}My greeting was a bit late. I am Priest Raeli serving Goddess Austeja.
-QUEST_LV_0200_20150317_001074	$The purification back then?{nl}Unlike the other Revelators who succumbed to the evil energy, I purified you in the name of the Goddess.{nl}
-QUEST_LV_0200_20150317_001075	$The Goddesses have already blessed the villagers, they just don't know about it.{nl}The Goddesses don't want chaos.
+QUEST_LV_0200_20150317_001074	$The purification back then?{nl}Unlike the other Revelators who succumbed to the evil energy, I purified you in the name of the goddess.{nl}
+QUEST_LV_0200_20150317_001075	$The goddesses have already blessed the villagers, they just don't know about it.{nl}The goddesses don't want chaos.
 QUEST_LV_0200_20150317_001076	$It is good to hear that you feel involved.{nl}
 QUEST_LV_0200_20150317_001077	$We need to purify those demons to obtain something.{nl}Please obtain the branches of the bee trees near the village. They are endowed with the power of Goddess Austeja.
 QUEST_LV_0200_20150317_001078	$We should get this done quickly, before the monsters rush in again.
 QUEST_LV_0200_20150317_001079	$You brought them. Good.{nl}
 QUEST_LV_0200_20150317_001080	$Remember how I said that there are two sources of evil energy?{nl}For them both, I will make an orb that will restore the seal for this area.
 QUEST_LV_0200_20150317_001081	$First, bring me some demons' ashes that I will make the orb with.{nl}When the demons are pierced with these bee tree branches,{nl}they will be overwhelmed by the branch's divine power and turn into ash.{nl}
-QUEST_LV_0200_20150317_001082	$Obviously, the Goddess' powers can only indirectly affect demons. {nl}You will have to exhaust some of the demon's HP before using a branch on it.
+QUEST_LV_0200_20150317_001082	$Obviously, the goddess' powers can only indirectly affect demons. {nl}You will have to exhaust some of the demon's HP before using a branch on it.
 QUEST_LV_0200_20150317_001083	$Well done. {nl}It is uncomfortable to use the demons as sacrifice but.. we're now reaching the final stage.
-QUEST_LV_0200_20150317_001084	$Take this orb. I made it in a hurry, so it's not complete yet. {nl}You must fill it with magic at a place that is full of the Goddess' holy energy.
+QUEST_LV_0200_20150317_001084	$Take this orb. I made it in a hurry, so it's not complete yet. {nl}You must fill it with magic at a place that is full of the goddess' holy energy.
 QUEST_LV_0200_20150317_001085	$Palama Cliff is the nearest place you can do this at, so please head there. {nl}The demons will be marching in soon, so please hurry.
 QUEST_LV_0200_20150317_001086	$This will be enough. {nl}Please prepare before you restore the seal. It might become a tough battle.
 QUEST_LV_0200_20150317_001087	$The weakened seal tower is near Stulr Road. {nl}I'm getting a little bothered about how quiet the demons have been recently.
-QUEST_LV_0200_20150317_001088	$Please hurry. I can feel that the seal is weak. {nl}May you have the Goddess' blessings..
+QUEST_LV_0200_20150317_001088	$Please hurry. I can feel that the seal is weak. {nl}May you have the goddess' blessings..
 QUEST_LV_0200_20150317_001089	$I believe you are the Revelator who purified the sealed tower?
 QUEST_LV_0200_20150317_001090	$I have been suppressing the evil energy here.
 QUEST_LV_0200_20150317_001091	$Please restore the seal tower at Spring Light Woods.
@@ -1109,27 +1109,27 @@ QUEST_LV_0200_20150317_001108	$That makes me feel better. {nl}How I wish they'd 
 QUEST_LV_0200_20150317_001109	$Priest Dazine
 QUEST_LV_0200_20150317_001110	$Revelator. I assume you've heard the story from Goddess Austeja. {nl}That there are a number of Revelators who were addled by the evil energy attacking the village while trying to restore the seal here. {nl}
 QUEST_LV_0200_20150317_001111	$There is a way to save them. {nl}We can purify them if we find the symbol of Goddess Austeja.
-QUEST_LV_0200_20150317_001112	$First regain the Goddess' symbol and then use it to restore the Austeja Altar. {nl} Purifying the Revelators will come next.
+QUEST_LV_0200_20150317_001112	$First regain the goddess' symbol and then use it to restore the Austeja Altar. {nl} Purifying the Revelators will come next.
 QUEST_LV_0200_20150317_001113	$Whether it's to restore the weakened seal or to cure the addled Revelators, {nl}We will need that symbol.
 QUEST_LV_0200_20150317_001114	{memo X}The damage is worse than at the seal in the shaking field. {nl}The evil forces are fuming out stronger.
-QUEST_LV_0200_20150317_001115	$Fortunately, the Goddess blessed the villagers with her divine protection before focusing her effort on the seal.. {nl}The Revelators from before had no way of knowing about this, their fates were sealed.
+QUEST_LV_0200_20150317_001115	$Fortunately, the goddess blessed the villagers with her divine protection before focusing her effort on the seal.. {nl}The Revelators from before had no way of knowing about this, their fates were sealed.
 QUEST_LV_0200_20150317_001116	$This is it, Revelator. {nl}This will save the addled Revelators.
 QUEST_LV_0200_20150317_001117	$The addled Revelators will march towards here soon. {nl}Please purify them before anyone gets hurt.
 QUEST_LV_0200_20150317_001118	$Luckily, they did minimal damage. {nl}Now, if we can restore the seal, this will never have to repeat.
 QUEST_LV_0200_20150317_001119	$Restore the weakened seal towers using the symbol of Goddess Austeja.{nl}There is the Rankis Seal and the Ranka Seal.
 QUEST_LV_0200_20150317_001120	$The demons found out about the source of evil energy and so relentlessly attacked to destroy the seal. {nl}I'm sure if the seal is strengthened well this time, they will retreat after a while.
 QUEST_LV_0200_20150317_001121	$But we don't know what will happen next.{nl} We just have to believe that Goddess Austeja will take care of everything if anything happens.
-QUEST_LV_0200_20150317_001122	{memo X}But one thing that worries me is that.. {nl}The symbol was destroyed once so it might not be fully restored again. {nl}Of course everything will depend.. on the Goddess..{nl}
+QUEST_LV_0200_20150317_001122	{memo X}But one thing that worries me is that.. {nl}The symbol was destroyed once so it might not be fully restored again. {nl}Of course everything will depend.. on the goddess..{nl}
 QUEST_LV_0200_20150317_001123	Merchant Dulke
 QUEST_LV_0200_20150317_001124	$Oh no, what do I do? {nl}I lost all my wares while running away from the monsters. {nl}But I'm afraid I might lose my mind like the other Revelators if I go back for it now.
 QUEST_LV_0200_20150317_001125	$At a glance, you wouldn't be able to tell if they are a human or a monster. {nl}They would have a blank, soulless stare and when called, it would disappear while making a strange noise.
-QUEST_LV_0200_20150317_001126	$And there are more than just one or two of them. {nl}Yet, I think the people in our village are still normal..{nl}Could the Goddess have protected us with her blessings?
+QUEST_LV_0200_20150317_001126	$And there are more than just one or two of them. {nl}Yet, I think the people in our village are still normal..{nl}Could the goddess have protected us with her blessings?
 QUEST_LV_0200_20150317_001127	$Please help me. {nl}I just started my business with everything I got, and now I'm afraid I'm about to end up with nothing.
 QUEST_LV_0200_20150317_001128	$Oh, I could never thank you enough.. yes, this is my stuff. {nl}And I thought it was weird that you were fine, unlike the other Revelators. You truly are a special one.
 QUEST_LV_0200_20150317_001129	Villager Emil
 QUEST_LV_0200_20150317_001130	$I used to travel in and out of town, but the priests told me to stay put, saying the seal is dangerous.{nl}That seal really is nothing for me, it's the demons that are scary.
-QUEST_LV_0200_20150317_001131	$I have to have a livelihood. {nl}The other villagers here just spend all day looking up to the priests and the Goddess.
-QUEST_LV_0200_20150317_001132	$I've seen other Revelators here that got all weird, but you seem fine.{nl}Did you meet the Goddess or something? {nl}Well, you did some great work. I wish I was as strong as you are.
+QUEST_LV_0200_20150317_001131	$I have to have a livelihood. {nl}The other villagers here just spend all day looking up to the priests and the goddess.
+QUEST_LV_0200_20150317_001132	$I've seen other Revelators here that got all weird, but you seem fine.{nl}Did you meet the goddess or something? {nl}Well, you did some great work. I wish I was as strong as you are.
 QUEST_LV_0200_20150317_001133	Pharmacist Tiana
 QUEST_LV_0200_20150317_001134	$Priest Dazine asked me for medicine to cure future addled Revelators with. {nl}But I ran out of Spring Light Grass.. and I'm scared of the demons.
 QUEST_LV_0200_20150317_001135	$You're such a sweet person. {nl}Oh, Spring Light Grass is not easy to find. {nl}It only appears when it's reacting to this honey jelly.
@@ -1142,7 +1142,7 @@ QUEST_LV_0200_20150317_001141	You can't enter it now becuase the doors are seale
 QUEST_LV_0200_20150317_001142	{memo X}The portal to the bishop's hidden room opened. {nl}You can go in the portal.
 QUEST_LV_0200_20150317_001143	$There was an order from the church to move all the relics to somewhere safe. {nl}But look at how horrible things have turned out.
 QUEST_LV_0200_20150317_001144	{memo X}How can they do this to the sacred things that contain the words of the great bishops..{nl}It's so resentful to see it just scattered among those blasphemous monsters.
-QUEST_LV_0200_20150317_001145	{memo X}Fortunately it does not seem damaged. {nl}If only I was stronger, I would have purified those monsters in the name of the Goddess.
+QUEST_LV_0200_20150317_001145	{memo X}Fortunately it does not seem damaged. {nl}If only I was stronger, I would have purified those monsters in the name of the goddess.
 QUEST_LV_0200_20150317_001146	$Some relics hide themselves when they feel an evil force. {nl}When that happens, you just can't find it no matter how hard you try.
 QUEST_LV_0200_20150317_001147	{memo X}That's why I brought the beads that can detect holiness{nl}but look at those monsters' eyes. {nl}They might kill us as soon as we find the sacred things.
 QUEST_LV_0200_20150317_001148	Yes, good work. {nl}We've found the important things so we can ask the sisters for the other things.
@@ -1982,7 +1982,7 @@ QUEST_LV_0200_20150317_001981	{memo X}Collect %s stuck on a rock
 QUEST_LV_0200_20150317_001982	{memo X}Scott heard from the soldiers from the felled area that the grass that has unique color is growing. Collect the unique grass from Naudingas felled area.
 QUEST_LV_0200_20150317_001983	{memo X}You have collected enough unique grass. Return to Scott.
 QUEST_LV_0200_20150317_001984	Gather %s
-QUEST_LV_0200_20150317_001985	{memo X}You should cross here to look for the sculptor of Kateen Forest which the revelation of the Goddess is indicating, but the man with unnormal clothes is investigating something diligently. Talk to him what's going on.
+QUEST_LV_0200_20150317_001985	{memo X}You should cross here to look for the sculptor of Kateen Forest which the revelation of the goddess is indicating, but the man with unnormal clothes is investigating something diligently. Talk to him what's going on.
 QUEST_LV_0200_20150317_001986	{memo X}Scott said he came here to investigate the dangerous incident that occurred here and suggested you to move with him. To aid his investigation, please collect the tree barks from Vubbes that are carrying spears.
 QUEST_LV_0200_20150317_001987	{memo X}You have collected enough tree barks. Return to Scott.
 QUEST_LV_0200_20150317_001988	{memo X}Obtain %s by defeating Red Vubbes
@@ -1998,9 +1998,9 @@ QUEST_LV_0200_20150317_001997	$The Scared Owl asked you to send it's friend's Wi
 QUEST_LV_0200_20150317_001998	$Talk with the Earnest Owl Chief Sculpture
 QUEST_LV_0200_20150317_001999	$The Earnest Owl Chief looks sad after receiving the Wing Fragment. Talk with the Earnest Owl Chief.
 QUEST_LV_0200_20150317_002000	$Send the wing to the Devoted Owl Sculpture
-QUEST_LV_0200_20150317_002001	$The Earnest Owl Chief wants you to pass his Wing Fragment that is endowed with the power of the Goddess to the owls in this region. Give the Wing Fragment to the Devoted Owl Sculpture at Kongfiska Hill.
+QUEST_LV_0200_20150317_002001	$The Earnest Owl Chief wants you to pass his Wing Fragment that is endowed with the power of the goddess to the owls in this region. Give the Wing Fragment to the Devoted Owl Sculpture at Kongfiska Hill.
 QUEST_LV_0200_20150317_002002	$Hand the Wing Fragment to the Painful Owl Sculpture
-QUEST_LV_0200_20150317_002003	$The Earnest Owl Chief wants you to pass his Wing Fragment that is endowed with the power of the Goddess to the owls in this region. Give the Wing Fragment to the Painful Owl Sculpture at Clover Highland.
+QUEST_LV_0200_20150317_002003	$The Earnest Owl Chief wants you to pass his Wing Fragment that is endowed with the power of the goddess to the owls in this region. Give the Wing Fragment to the Painful Owl Sculpture at Clover Highland.
 QUEST_LV_0200_20150317_002004	$Report to the Earnest Owl Chief Sculpture
 QUEST_LV_0200_20150317_002005	$You've handed over the Wing Fragments to all the owls. Return and report to the Earnest Owl Chief.
 QUEST_LV_0200_20150317_002006	$Defeat the monsters that are attacking the Owl Sculpture
@@ -2075,7 +2075,7 @@ QUEST_LV_0200_20150317_002074	$You've collected enough Butterfly Fragrance to gi
 QUEST_LV_0200_20150317_002075	$Prayer for the Regretful Souls
 QUEST_LV_0200_20150317_002076	$The souls that passed away sadly sleep at the Garden of Consolation near the Goddess Statue. Pray in front of the Goddess Statue and calm the souls.
 QUEST_LV_0200_20150317_002077	$Perform the Memorial Ceremony
-QUEST_LV_0200_20150317_002078	$As you prayed in front of the Goddess, the regretful souls started to gather toward the Goddess Statue! Protect these souls for a specified time frame.
+QUEST_LV_0200_20150317_002078	$As you prayed in front of the goddess, the regretful souls started to gather toward the Goddess Statue! Protect these souls for a specified time frame.
 QUEST_LV_0200_20150317_002079	$Talk to the Sad Owl Sculpture
 QUEST_LV_0200_20150317_002080	$There are many Owl Sculptures that guide the souls in Kateen Forest. Listen to the story of the Sad Owl Sculpture.
 QUEST_LV_0200_20150317_002081	$Collect Ridimed Leaves
@@ -2095,12 +2095,12 @@ QUEST_LV_0200_20150317_002094	$The souls were being tied with branches. By relea
 QUEST_LV_0200_20150317_002095	$Talk to Sad Owl Sculpture
 QUEST_LV_0200_20150317_002096	{memo X}There are not only restrained spirits among wandering spirits. Listen to the detailed story from the sorrowful owl.
 QUEST_LV_0200_20150317_002097	$Persuade the souls that lost their way
-QUEST_LV_0200_20150317_002098	{memo X}The sorrowful owl told you that the spirits that went to the statue of the Goddess for comfort are agonizing themselves so something must be wrong. Persuade the spirits that try to go to the Goddess Statue and take them to the sorrowful owl.
+QUEST_LV_0200_20150317_002098	{memo X}The sorrowful owl told you that the spirits that went to the statue of the goddess for comfort are agonizing themselves so something must be wrong. Persuade the spirits that try to go to the Goddess Statue and take them to the sorrowful owl.
 QUEST_LV_0200_20150317_002099	{memo X}The sorrowful owl heard enough stories about what's happening to the spirits. Return to the sorrowful owl and ask what happened.
 QUEST_LV_0200_20150317_002100	$The Sad Owl spoke with the souls. Talk to the Sad Owl again.
 QUEST_LV_0200_20150317_002101	$Find out what happened at Amolallul Hill.
 QUEST_LV_0200_20150317_002102	$The souls are claiming that the Goddess Statue at Amolallul Hill were calling them but, the Sad Owl told you that there isn't a statue there. Go to Amolallul Hill to find out exactly what happened.
-QUEST_LV_0200_20150317_002103	$A Corrupted disguised itself as a Goddess Statue. Demons masquerading as Goddesses are unforgivable. Return and report this to the Sad Owl.
+QUEST_LV_0200_20150317_002103	$A Corrupted disguised itself as a Goddess Statue. Demons masquerading as goddesses are unforgivable. Return and report this to the Sad Owl.
 QUEST_LV_0200_20150317_002104	Defeat the Gray Golem that suddenly appeared
 QUEST_LV_0200_20150317_002105	Advance to defeat the Gray Golem that suddenly appeared
 QUEST_LV_0200_20150317_002106	After you touched an unknown monster, a Gray Golem suddenly appeared!
@@ -2214,11 +2214,11 @@ QUEST_LV_0200_20150317_002213	You've protected Soldier Aspas from the monsters. 
 QUEST_LV_0200_20150317_002214	{memo X}Defeat the Keparaiders that are attacking
 QUEST_LV_0200_20150317_002215	{memo X}Enter the Square of Lamentation
 QUEST_LV_0200_20150317_002216	{memo X}Enter the Square of Lamentation
-QUEST_LV_0200_20150317_002217	Talk to Kingdom Army Guard Retia
-QUEST_LV_0200_20150317_002218	{memo X}Talk to the Kingdom Army
+QUEST_LV_0200_20150317_002217	Talk to Royal Army Guard Retia
+QUEST_LV_0200_20150317_002218	{memo X}Talk to the Royal Army
 QUEST_LV_0200_20150317_002219	{memo X}The Royal Army, Retia is waiting for someone's help at the Square of Lamentation
 QUEST_LV_0200_20150317_002220	{memo X}The Royal Army, Retia asked you to defeat the monsters at A region.
-QUEST_LV_0200_20150317_002221	You defeated the monsters as Kingdom Army Guard Retia requested from you. Return to Retia.
+QUEST_LV_0200_20150317_002221	You defeated the monsters as Royal Army Guard Retia requested from you. Return to Retia.
 QUEST_LV_0200_20150317_002222	{memo X}Check the petrification device
 QUEST_LV_0200_20150317_002223	{memo X}The Royal Army, Retia has asked you to check the petrification devices that are installed at various places in the Square of Lamentation.
 QUEST_LV_0200_20150317_002224	{memo X}As the Royal Army, Retia requested to you, you checked the petrificaion devices. The reactions on the devices are abnormal. Let's go back to Retia.
@@ -2226,7 +2226,7 @@ QUEST_LV_0200_20150317_002225	Eliminate weak frosts
 QUEST_LV_0200_20150317_002226	{memo X}The Royal Army, Retia asked you to eliminate all weak Stone Frosts at Area, A. Use the scroll to absorb Stone Frosts to eliminate weak Stone Frosts as you discover them.
 QUEST_LV_0200_20150317_002227	{memo X}As the Royal Army, Retia requested to you, you eliminated all weak Stone Frosts. Return to Retia.
 QUEST_LV_0200_20150317_002228	{memo X}The Royal Army, Retia requested you to defeat Sparnashorns that attack the kingdom soldiers before the Stone Frosts start. When Stone Frosts start from A area, you will be able to see Sparnashorn. Check the petrification device again to seee whether Stone Frosts started.
-QUEST_LV_0200_20150317_002229	As Kingdom Army Guard Retia requested to you, you successfully defeated Sparnashorns before the stone frosts started. Return to Retia.
+QUEST_LV_0200_20150317_002229	As Royal Army Guard Retia requested to you, you successfully defeated Sparnashorns before the stone frosts started. Return to Retia.
 QUEST_LV_0200_20150317_002230	Talk to Graverobber Hubertas
 QUEST_LV_0200_20150317_002231	{memo X}Graverobber Hubertas is waiting for someone's help at the Square of Lamentation
 QUEST_LV_0200_20150317_002232	{memo X}Graverobber Hubertas asked you to defeat the monsters at A area so he can start to excavate some stuffs.
@@ -2251,7 +2251,7 @@ QUEST_LV_0200_20150317_002250	{memo X}You've collected fragrant stone powders as
 QUEST_LV_0200_20150317_002251	{memo X}Rub the fragrant stone powders
 QUEST_LV_0200_20150317_002252	{memo X}Graverobber Benjaminas told you to rub the fragrant stone powders on the monsters in area A to lure Saltistter.
 QUEST_LV_0200_20150317_002253	{memo X}As Benjaminas suggested to you, you rubbed the powders on the monsters. Before Saltistter appears, let's go back to Benjaminas to carry on to the next plan.
-QUEST_LV_0200_20150317_002254	Graverobber Benjaminas has asked you to tell that Saltistter has appeared as planned to Kingdom Army Guard Retia. When the soldiers go out of the camp to face Saltistter, the colleagues of Benjaminas would move safely.
+QUEST_LV_0200_20150317_002254	Graverobber Benjaminas has asked you to tell that Saltistter has appeared as planned to Royal Army Guard Retia. When the soldiers go out of the camp to face Saltistter, the colleagues of Benjaminas would move safely.
 QUEST_LV_0200_20150317_002255	Graverobber Benjaminas and his accomplices passed safely. Let's go back to Graverobber Benjaminas.
 QUEST_LV_0200_20150317_002256	Defeat Saltistter
 QUEST_LV_0200_20150317_002257	Talk to Guard Gofden
@@ -2358,22 +2358,22 @@ QUEST_LV_0200_20150317_002357	Obtain the nucleus of the frost
 QUEST_LV_0200_20150317_002358	{memo X}Graverobber Steponas asked you to defeat Stone Frosters and obtain the nucleus of the frosts which The Knights of Kaliss has asked you.
 QUEST_LV_0200_20150317_002359	{memo X}Graverobber Steponas obtained the nuclues of the frosts from Stone Frosters. Let's go back to Steponas.
 QUEST_LV_0200_20150317_002360	Obtain %s from Stone Frosters
-QUEST_LV_0200_20150317_002361	Talk with Kingdom Army Guard Rofdel
-QUEST_LV_0200_20150317_002362	Kingdom Army Guard Rofdel is looking for someone who could help you at the main district of the Petrified City.
+QUEST_LV_0200_20150317_002361	Talk with Royal Army Guard Rofdel
+QUEST_LV_0200_20150317_002362	Royal Army Guard Rofdel is looking for someone who could help you at the main district of the Petrified City.
 QUEST_LV_0200_20150317_002363	{memo X}Collect the stone powders
 QUEST_LV_0200_20150317_002364	{memo X}The kingdom soldier Rofdel wants you to defeat monsters to fix the tower and also wants you to obtain some petrification powders from them.
 QUEST_LV_0200_20150317_002365	{memo X}As the kingdom soldier Rofdel requested from you, you've obtained enough petrification powders. Let's go back to Rofdel.
 QUEST_LV_0200_20150317_002366	Obtain %s by defeating the monsters
 QUEST_LV_0200_20150317_002367	Destroy the records that are petrified
-QUEST_LV_0200_20150317_002368	Kingdom Army Guard Rofdel has asked you to destroy the petrified records that are at the Vadova dock.
-QUEST_LV_0200_20150317_002369	You've destroyed all the petrified records as the Kingdom Army Guard Rofdel requested to you. Return to Rofdel.
+QUEST_LV_0200_20150317_002368	Royal Army Guard Rofdel has asked you to destroy the petrified records that are at the Vadova dock.
+QUEST_LV_0200_20150317_002369	You've destroyed all the petrified records as the Royal Army Guard Rofdel requested to you. Return to Rofdel.
 QUEST_LV_0200_20150317_002370	{memo X}Destroy the petrified monster
 QUEST_LV_0200_20150317_002371	{memo X}The kingdom soldier Rofdel asked you to destroy the petrified monster at the collapsed Amosi dock.
 QUEST_LV_0200_20150317_002372	{memo X}As the kingdom soldier Rofdel requested to you, you destroyed the petrified monster. Let's go back to Rofdel.
 QUEST_LV_0200_20150317_002373	{memo X}Destroy the petrified monster
 QUEST_LV_0200_20150317_002374	Put flyers
-QUEST_LV_0200_20150317_002375	Kingdom Army Guard Rofdel asked you to put the flyer on the bulletin board to conciliate the thieves.
-QUEST_LV_0200_20150317_002376	You've put the flyers in the various places in the main district, as Kingdom Army Guard Rofdel asked you to. Let's go back to Rofdel.
+QUEST_LV_0200_20150317_002375	Royal Army Guard Rofdel asked you to put the flyer on the bulletin board to conciliate the thieves.
+QUEST_LV_0200_20150317_002376	You've put the flyers in the various places in the main district, as Royal Army Guard Rofdel asked you to. Let's go back to Rofdel.
 QUEST_LV_0200_20150317_002377	Talk to Wilhelmina Carriot
 QUEST_LV_0200_20150317_002378	Wilhelmina Carriot is seeking for someone's help at the inner district of the Petrified City.
 QUEST_LV_0200_20150317_002379	{memo X}Wilhelmina Carriot wants you to defeat the monsters at Kovos Hall.
@@ -2589,7 +2589,7 @@ QUEST_LV_0200_20150317_002588	$Purified all the addled Revelators. Talk to Pries
 QUEST_LV_0200_20150317_002589	$Cured all the addled Revelators. Ask Priest Dazine what to do next. {nl}{nl}With the addled Revelators now purified, talk to Priest Dazine about the seal.
 QUEST_LV_0200_20150317_002590	$Restore the Rankis Seal and the Ranka Seal
 QUEST_LV_0200_20150317_002591	$The seal towers that sealed the forces of evil were all destroyed by the monsters. The Symbol of Austeja can restore a little bit of power to the Seal. {nl}{nl}The Seal Towers that sealed the forces of evil were all destroyed by the monsters. The Symbol of Austeja can restore a little bit of power to the Seal.
-QUEST_LV_0200_20150317_002592	$Restore the Goddess' powers to Rankis Seal Tower and Ranka Seal Tower
+QUEST_LV_0200_20150317_002592	$Restore the goddess' powers to Rankis Seal Tower and Ranka Seal Tower
 QUEST_LV_0200_20150317_002593	$Restored power to the first destroyed tower. Now, I have to restore power of the other destroyed tower as well.
 QUEST_LV_0200_20150317_002594	$Goddess Austeja appeared and is trying to tell you something. Listen to what she is saying.
 QUEST_LV_0200_20150317_002595	$Check the Spring Light Woods Altar
@@ -2993,7 +2993,7 @@ QUEST_LV_0200_20150317_002992	$Defeat the Mushwort that destroyed the Owl
 QUEST_LV_0200_20150317_002993	$Talk with the Weak Owl
 QUEST_LV_0200_20150317_002994	$The Weak Owl is very sad after receiving the fragments of the Owls. Talk to the Weak Owl again.
 QUEST_LV_0200_20150317_002995	$Obtain Oil from the Oil Box
-QUEST_LV_0200_20150317_002996	$The Weak Owl wants you to burn the Destroyed Owls to send their spirits to the Goddesses. Obtain Oil from the Oil Boxes on the way to Neuoder Field.
+QUEST_LV_0200_20150317_002996	$The Weak Owl wants you to burn the Destroyed Owls to send their spirits to the goddesses. Obtain Oil from the Oil Boxes on the way to Neuoder Field.
 QUEST_LV_0200_20150317_002997	$An Owl Sculpture fell on the Ishrai Crossroads. Get near it and try to stand it up.
 QUEST_LV_0200_20150317_002998	$Burn the destroyed fragments of the Sculptures so that the Owls can rest in peace eternally
 QUEST_LV_0200_20150317_002999	$Burn the destroyed Owl Sculptures using the Oil as the Weak Owl requested. The Destroyed Owls are at the end of Ishrai Crossroads.
@@ -3198,7 +3198,7 @@ QUEST_LV_0200_20150323_003197	$Meat.. Meat!{nl}Please give it to me fast. Fast!
 QUEST_LV_0200_20150323_003198	$Wait, that music box.. What is it?{nl}
 QUEST_LV_0200_20150323_003199	$My memories.. She..{nl}Give it to me! That's mine!
 QUEST_LV_0200_20150323_003200	{memo X}Damn. What was I doing?{nl}Ahah. Liliya.. My Liliya!{nl}
-QUEST_LV_0200_20150323_003201	$We left for a pilgrimage to the Great Cathedral to receive the blessings of the Goddesses to celebrate our wedding.{nl}But then, that evil Naktis.. that unforgivable Demon Lord.{nl}
+QUEST_LV_0200_20150323_003201	$We left for a pilgrimage to the Great Cathedral to receive the blessings of the goddesses to celebrate our wedding.{nl}But then, that evil Naktis.. that unforgivable Demon Lord.{nl}
 QUEST_LV_0200_20150323_003202	{memo X}Stole her music box and necklace and gave them to the monsters and cursed her with gluttony.{nl}As if to laugh at Maven's lessons.
 QUEST_LV_0200_20150323_003203	{memo X}Wait. My head is shaking because of the curse. {nl}I still have a lot more to say.. I don't know if I would be able to endure until then.
 QUEST_LV_0200_20150323_003204	$I heard the Asellus at the Hollow Tree Forest have purifying powers.{nl}I should be able to endure with its purification.
@@ -3216,7 +3216,7 @@ QUEST_LV_0200_20150323_003215	{memo X}The food that was stolen by my son is mixe
 QUEST_LV_0200_20150323_003216	$To be honest with you, I don't know if I will be able to save my son with this.{nl} I need hope, I mean.. I need some reliable results.
 QUEST_LV_0200_20150323_003217	$When you throw these Food Scraps to the monsters, some of them might eat the food.{nl}If you attack them a lot afterwards, they will throw up. Bring me what they throw up.{nl}
 QUEST_LV_0200_20150323_003218	$If there are not enough Food Scraps, you can get some more at Ishiblysh Square.
-QUEST_LV_0200_20150323_003219	$The Condensed Cursed Energy. It indeed worked. {nl}Now I should just wait for my son to throw up.{nl}Thank you so much. May the blessings of the Goddesses be with you always..{nl}{nl}
+QUEST_LV_0200_20150323_003219	$The Condensed Cursed Energy. It indeed worked. {nl}Now I should just wait for my son to throw up.{nl}Thank you so much. May the blessings of the goddesses be with you always..{nl}{nl}
 QUEST_LV_0200_20150323_003220	$I am sorry, but I am a bit busy.{nl}I have many things going on in my head, so could you just please go now?
 QUEST_LV_0200_20150323_003221	$What the hell was that..{nl}You saved me. I am sorry about before.
 QUEST_LV_0200_20150323_003222	{memo X}While my brothers were on the their way to the pilgrimage, they all died due to the tricks from the demons.{nl}I feel sorry for my brothers who can't return to the godddesses.{nl}
@@ -3224,8 +3224,8 @@ QUEST_LV_0200_20150323_003223	$I might be down a bit, but I want to help them so
 QUEST_LV_0200_20150323_003224	$I was going to release the souls that were locked in this altar.{nl}But, it didn't work. Was there something wrong with my prayer?
 QUEST_LV_0200_20150323_003225	$I was broken off from the group due to my injury, but became sensitive to what lay ahead.{nl}After all, I saw a group of demons move on out.{nl}
 QUEST_LV_0200_20150323_003226	{memo X}That night.. I hid behind the grass forest and had to look at everything. {nl}Everyone was pointing guns at each other. They were so close to each other..{nl}
-QUEST_LV_0200_20150323_003227	{memo X}And they were so absorbed with madness even after their death so they could not even return to the Goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
-QUEST_LV_0200_20150323_003228	$Maybe, everything so far was fated so that I would become a priest. Oh, Goddesses..
+QUEST_LV_0200_20150323_003227	{memo X}And they were so absorbed with madness even after their death so they could not even return to the goddesses.{nl}That's why I wanted to give them the eternal sleep.{nl}
+QUEST_LV_0200_20150323_003228	$Maybe, everything so far was fated so that I would become a priest. Oh, goddesses..
 QUEST_LV_0200_20150323_003229	$I can't move with my legs like this.{nl}Why'd it have to be like this.. The only one I can trust is you.
 QUEST_LV_0200_20150323_003230	$Before I left for my pilgrimage, I overheard the stories about the Revelators.{nl}And you are really special among them. Can you listen to me little more?
 QUEST_LV_0200_20150323_003231	{memo X}It was really horrible. Those brothers who used to be keen to each other hurt each other..{nl}And the demons cheated on those brothers who died.{nl}
@@ -3238,12 +3238,12 @@ QUEST_LV_0200_20150323_003237	$I remembered what's missing. A scripture!{nl}One 
 QUEST_LV_0200_20150323_003238	$Unfortunately, I lost my Scripture in the mess.{nl}If I had it, I would have remembered that right away.
 QUEST_LV_0200_20150323_003239	$This is it. Many mysteries are being solved because of you.{nl}Let's see, why don't we try a different method this time?
 QUEST_LV_0200_20150323_003240	{memo X}The spirits inside the monsters' stomach will shine when you use this medicine this time.{nl}When you defeat that monster, the spirits that were tied there will be freed.{nl}
-QUEST_LV_0200_20150323_003241	{memo X}My brothers are blaming each other and crying out in madness even after their death.{nl}At the altar of the Goddesses.{nl}
-QUEST_LV_0200_20150323_003242	$Even a living being like myself could never forgive it, how would the souls feel?{nl}How could I make priests, those who should spread the love of the Goddesses, do such a thing?
-QUEST_LV_0200_20150323_003243	$They will definitely thank you.{nl}I hope the blessing of the Goddess lights your way.{nl}
+QUEST_LV_0200_20150323_003241	{memo X}My brothers are blaming each other and crying out in madness even after their death.{nl}At the altar of the goddesses.{nl}
+QUEST_LV_0200_20150323_003242	$Even a living being like myself could never forgive it, how would the souls feel?{nl}How could I make priests, those who should spread the love of the goddesses, do such a thing?
+QUEST_LV_0200_20150323_003243	$They will definitely thank you.{nl}I hope the blessing of the goddess lights your way.{nl}
 QUEST_LV_0200_20150323_003244	$This method will be effective for sure.{nl}It must be. If not..
 QUEST_LV_0200_20150323_003245	$Thank you so much for everything so far.{nl}Because of you, my brothers can rest in peace now.
-QUEST_LV_0200_20150323_003246	$Ah, not only my brothers are trapped here.{nl}When you see a soul that needs saving, please do not just leave it, but save it in the name of the Goddess.
+QUEST_LV_0200_20150323_003246	$Ah, not only my brothers are trapped here.{nl}When you see a soul that needs saving, please do not just leave it, but save it in the name of the goddess.
 QUEST_LV_0200_20150323_003247	$The demons were looking for this thing while teasing spirits.{nl}Maybe it has something to do with the Great Cathedral at the end of the Pilgrims' Way.{nl}
 QUEST_LV_0200_20150323_003248	$Ah, something came to mind now that you mention the Great Cathedral.{nl}I have this crafting recipe, but I have no idea how to use it.{nl}
 QUEST_LV_0200_20150323_003249	$But if there's anyone who could help all the spirits lay into eternal rest..{nl}It would be the owner of this land.{nl}
@@ -3253,38 +3253,38 @@ QUEST_LV_0200_20150323_003252	$You may have to dedicate some flowers, or you may
 QUEST_LV_0200_20150323_003253	{memo X}You helped the restrained spirits to sleep eternally?{nl}Oh my god.. This craft manual definitely belongs to you. {nl}
 QUEST_LV_0200_20150323_003254	$This artifact was left to me by my grandfather. He gave it to me because I had always dreamed to become a priest.{nl}This is meaningless to me now. I will create a commemoration for my colleagues here and live on.
 QUEST_LV_0200_20150323_003255	{memo X}Guide Purple Tree Fault Forest
-QUEST_LV_0200_20150323_003256	$There are many blessed sanctums in the Forest of Prayer. {nl}All pilgrims who cross here should pray in front of these sanctums and receive the blessings of the Goddesses.{nl}
+QUEST_LV_0200_20150323_003256	$There are many blessed sanctums in the Forest of Prayer. {nl}All pilgrims who cross here should pray in front of these sanctums and receive the blessings of the goddesses.{nl}
 QUEST_LV_0200_20150323_003257	$Each sanctum is managed by a master of the cleric class. {nl}If you find any problems at a sanctum, go meet the class master that manages that sanctum.
 QUEST_LV_0200_20150323_003258	$The detailed locations of each sanctum..{nl}(The notice board is broken in half, so you can't read the rest.)
 QUEST_LV_0200_20150323_003259	$Sanctum Notice Board
-QUEST_LV_0200_20150323_003260	$When you make a contribution to prove your belief, you will receive blessings from the Goddesses.{nl}Please understand that the amount of the contribution one can make differs by the individual.{nl}
+QUEST_LV_0200_20150323_003260	$When you make a contribution to prove your belief, you will receive blessings from the goddesses.{nl}Please understand that the amount of the contribution one can make differs by the individual.{nl}
 QUEST_LV_0200_20150323_003261	$May the blessing of good fortune be with you today.{nl}-- Sanctum Manager : [Pardoner Master] Mistes Goldmund
-QUEST_LV_0200_20150323_003262	$Show your determination to defeat enemies for the Goddesses.{nl}Sacrifice their vicious beings to the sanctum as proof of your belief.
-QUEST_LV_0200_20150323_003263	$May the blessings of the Goddesses be with you always.{nl}-- Sanctum Manager : [Priest Master] Boruble
-QUEST_LV_0200_20150323_003264	$The Goddesses will only answer to truthful prayers.{nl}
-QUEST_LV_0200_20150323_003265	$May the blessings of the Goddesses be with you always.{nl}-- Sanctum Manager : [Cleric Master] Rosalia
+QUEST_LV_0200_20150323_003262	$Show your determination to defeat enemies for the goddesses.{nl}Sacrifice their vicious beings to the sanctum as proof of your belief.
+QUEST_LV_0200_20150323_003263	$May the blessings of the goddesses be with you always.{nl}-- Sanctum Manager : [Priest Master] Boruble
+QUEST_LV_0200_20150323_003264	$The goddesses will only answer to truthful prayers.{nl}
+QUEST_LV_0200_20150323_003265	$May the blessings of the goddesses be with you always.{nl}-- Sanctum Manager : [Cleric Master] Rosalia
 QUEST_LV_0200_20150323_003266	$A scripture cover page with a vague smell of blood. Did the monsters swallow the other pages?
-QUEST_LV_0200_20150323_003267	$Pure Water that purifies the spirits.{nl}This is also the mighty power of the Goddesses.{nl}
+QUEST_LV_0200_20150323_003267	$Pure Water that purifies the spirits.{nl}This is also the mighty power of the goddesses.{nl}
 QUEST_LV_0200_20150323_003268	$The stream near the sanctums has been purified, so get Pure Water from Rieszhkio City.{nl}-- Sanctum Manager : [Oracle Master] Apolonija Barbora{nl}
-QUEST_LV_0200_20150323_003269	$All life that flourishes on this land are the results of the blessings of the Goddesses.{nl}Appreciate the Goddesses with beautiful flowers.{nl}
-QUEST_LV_0200_20150323_003270	$May the blessings of the Goddesses be with you always.{nl}-- Sanctum Manager : [Druid Master] Gina Greene{nl}
+QUEST_LV_0200_20150323_003269	$All life that flourishes on this land are the results of the blessings of the goddesses.{nl}Appreciate the goddesses with beautiful flowers.{nl}
+QUEST_LV_0200_20150323_003270	$May the blessings of the goddesses be with you always.{nl}-- Sanctum Manager : [Druid Master] Gina Greene{nl}
 QUEST_LV_0200_20150323_003271	$If you prove your belief by making contributions, you will receive our blessing.{nl}For advice on this belief, please purchase warp scrolls from the stand and visit our master.{nl}
-QUEST_LV_0200_20150323_003272	$Lower yourself in front of the Goddesses and leave everything to them.{nl}The Goddesses will bless the ones who truly confess their wrongdoings.{nl}
-QUEST_LV_0200_20150323_003273	$May the Goddesses remove your ordeals.{nl}-- Sanctum Manager : [Krivis Master] Hercus
-QUEST_LV_0200_20150323_003274	$Make contributions to appreciate the Goddesses.{nl}The blessing will be with you always.
-QUEST_LV_0200_20150323_003275	$Pray in front of the Goddesses.{nl}Sacrifice the vicious monsters to prove your belief.
+QUEST_LV_0200_20150323_003272	$Lower yourself in front of the goddesses and leave everything to them.{nl}The goddesses will bless the ones who truly confess their wrongdoings.{nl}
+QUEST_LV_0200_20150323_003273	$May the goddesses remove your ordeals.{nl}-- Sanctum Manager : [Krivis Master] Hercus
+QUEST_LV_0200_20150323_003274	$Make contributions to appreciate the goddesses.{nl}The blessing will be with you always.
+QUEST_LV_0200_20150323_003275	$Pray in front of the goddesses.{nl}Sacrifice the vicious monsters to prove your belief.
 QUEST_LV_0200_20150323_003276	$I already knew that Pilgrim's Way was ruined with Naktis' curse.{nl}But I didn't know that even the sanctums were corrupted.. It's such a shame.
 QUEST_LV_0200_20150323_003277	{memo X}It would be the best if I do it myself, but I can't leave this place behind.{nl}I want you to purify the Sanctums with this divine water.{nl}
 QUEST_LV_0200_20150323_003278	$I heard the congregation sent the disciples, but I guess it didn't turn out right.{nl}I think the everything will be alright since you will do it. But I am still uneasy.
 QUEST_LV_0200_20150323_003279	$The statue of Goddess Vakarine at the Forest of Prayer..{nl}Naktis.. How would have one ever known that she would ruin the teachings of Archbishop Maven.
 QUEST_LV_0200_20150323_003280	$In any case, we could at least do some emergency procedures.{nl}Collect Grey Gypsum Fragments and repair it with dewdrops that are endowed with the blessings of the morning star.
-QUEST_LV_0200_20150323_003281	$I hope the Goddesses protect you.{nl}Not only the statues of the Goddesses, but the sanctums also would have many problems.
+QUEST_LV_0200_20150323_003281	$I hope the goddesses protect you.{nl}Not only the statues of the goddesses, but the sanctums also would have many problems.
 QUEST_LV_0200_20150323_003282	$By 'corrupted sanctums', you mean the Forest of Prayer, right?{nl}I thought I had prepared a lot for that, but I guess Naktis' curse was even stronger.
 QUEST_LV_0200_20150323_003283	$I hid my Symbol of Faith in the sanctums to prepare for times like this.{nl}That symbol enables you to find the monsters who have swallowed the badges of the sanctum.{nl}
 QUEST_LV_0200_20150323_003284	$Find the badges of the sanctum and burn them in front of the sanctum.{nl}It may not return to how it used to be, but you will be able to purify it a bit.
-QUEST_LV_0200_20150323_003285	$The blessing that cleanses evil energy.{nl}Oh, Goddesses, bless us with purified water.
-QUEST_LV_0200_20150323_003286	$A floral tribute to the Goddesses.{nl}The pleasure and joy of collecting flowers.
-QUEST_LV_0200_20150323_003287	$I was able to get one step closer to the Goddesses due to my contribution.{nl}May the blessing be with you always.
+QUEST_LV_0200_20150323_003285	$The blessing that cleanses evil energy.{nl}Oh, goddesses, bless us with purified water.
+QUEST_LV_0200_20150323_003286	$A floral tribute to the goddesses.{nl}The pleasure and joy of collecting flowers.
+QUEST_LV_0200_20150323_003287	$I was able to get one step closer to the goddesses due to my contribution.{nl}May the blessing be with you always.
 QUEST_LV_0200_20150323_003288	$You know that Pilgrim's Way holds the lessons of Maven right?{nl}To be able to cast a curse on humans as if they originally sinned... Naktis sure is formidable.
 QUEST_LV_0200_20150323_003289	$I feel hurt whenever I think about my son.{nl}I can't believe that my son who left for the pilgrimage to the Great Cathedral received the curse..
 QUEST_LV_0200_20150323_003290	$Hey.. Please wait. You will face great danger if you just go on like that.{nl}This place has a very dangerous curse cast upon it. {nl}
@@ -3338,12 +3338,12 @@ QUEST_LV_0200_20150323_003337	$I know this might come out wrong but, I only trus
 QUEST_LV_0200_20150323_003338	So we created the incident.{nl}Our actions.. I am so sorry.{nl}
 QUEST_LV_0200_20150323_003339	$I'm scared Goddess Austeja won't come back to protect our village..{nl}But, I am even more scared of the monsters in front of my eyes.
 QUEST_LV_0200_20150323_003340	$I refuse to just wait around as the priests have said.{nl}I refuse to be driven around by those monsters anymore.
-QUEST_LV_0200_20150323_003341	$I don't want to doubt the Goddesses.{nl}But the priests don't tell us anything.. Isn't that strange?
+QUEST_LV_0200_20150323_003341	$I don't want to doubt the goddesses.{nl}But the priests don't tell us anything.. Isn't that strange?
 QUEST_LV_0200_20150323_003342	$There's so much distrust between our priests and the villagers right now.{nl}I don't want to create a mess..{nl}
 QUEST_LV_0200_20150323_003343	$The only thing I could tell to the villagers who were wounded was to wait..{nl}Even if it was the monsters' doing. Reality is cruel.
 QUEST_LV_0200_20150323_003344	$A thorn forest.. If it weren't for you, this place would have became just like that.{nl}I feel grateful to the villagers since I believe they guided you to me.
 QUEST_LV_0200_20150323_003345	The seal here was able to be protected by you.{nl}But, I can't relax yet because the seal of Spring Light Wood is still left.
-QUEST_LV_0200_20150323_003346	My sister Laima has told me about this in the past.{nl}The Goddesses have a duty to save humans, but the humans also have a duty to save us.
+QUEST_LV_0200_20150323_003346	My sister Laima has told me about this in the past.{nl}The goddesses have a duty to save humans, but the humans also have a duty to save us.
 QUEST_LV_0200_20150323_003347	Farmer Druva
 QUEST_LV_0200_20150323_003348	$I don't care about the monsters or the seals.{nl}Someone else getting hurt is their problem. We clear?
 QUEST_LV_0200_20150323_003349	$Times like this are an opportunity.{nl}Prices for agricultural products are increasing due to the monsters.
@@ -3351,13 +3351,13 @@ QUEST_LV_0200_20150323_003350	$I was a refugee from the capital.{nl}I moved here
 QUEST_LV_0200_20150323_003351	$Ah, I am so hungry.. I can't endure any longer.{nl}Hey. Is there something to eat?
 QUEST_LV_0200_20150323_003352	$I can't do anything since I am starving to death..
 QUEST_LV_0200_20150323_003353	$I came here to save my son who is cursed.{nl}If you see a young man who is about to starve to death, let me know.
-QUEST_LV_0200_20150323_003354	{memo X}I will return to my hometown with my son.{nl}Yes. The Revelator of the Goddesses helped us.
+QUEST_LV_0200_20150323_003354	{memo X}I will return to my hometown with my son.{nl}Yes. The Revelator of the goddesses helped us.
 QUEST_LV_0200_20150323_003355	{memo X}I want to see my son being healthy again.{nl}It's too painful to wait until my son to throw up the vicious energy.
 QUEST_LV_0200_20150323_003356	What should I do about it to save the spirits?
 QUEST_LV_0200_20150323_003357	These are not Maven's teachings.{nl}They are just Naktis' curse.
 QUEST_LV_0200_20150323_003358	$There are four more necklaces besides this necklace, each with a teaching of Maven.{nl}They are all meaningless to me.
 QUEST_LV_0200_20150323_003359	$We all promised each other to become good priests.{nl}It feels like that moment was just the day before yesterday.. Just a meaningless dream.
-QUEST_LV_0200_20150323_003360	$Witas really.. went back to the Goddess.{nl}This is all the curse's doing, please don't feel guilty about it.{nl}
+QUEST_LV_0200_20150323_003360	$Witas really.. went back to the goddess.{nl}This is all the curse's doing, please don't feel guilty about it.{nl}
 QUEST_LV_0200_20150323_003361	$Ah, if you see the Tree of Faith, please restore it.{nl}I heard that tree blocks the curse's energy.
 QUEST_LV_0200_20150323_003362	$If it weren't for you, Maven's teachings would have been left cursed until the end.{nl}You saved this land. Witas' spirit as well.
 QUEST_LV_0200_20150323_003363	I heard that all the necklaces of Maven can be combined together through a special method.{nl}I heard the crafting recipe is present somewhere, but I don't know where it is.
@@ -3370,7 +3370,7 @@ QUEST_LV_0200_20150323_003369	I tried my best to hide Maven's secret, but..{nl}N
 QUEST_LV_0200_20150323_003370	Priest Goda
 QUEST_LV_0200_20150323_003371	$The Great Cathedral has collapsed, but it still keeps its beauty.{nl}Especially, the secrets of Archbishop Maven, they look amazing every time we see them.
 QUEST_LV_0200_20150323_003372	$Archbishop Maven contributed everything building this Great Cathedral.{nl}All that was collapsed on Medzio Diena.. destiny is too harsh.
-QUEST_LV_0200_20150323_003373	$Farewell is short, but the relationship lasts long.{nl}Someday we will meet again by the Goddess.
+QUEST_LV_0200_20150323_003373	$Farewell is short, but the relationship lasts long.{nl}Someday we will meet again by the goddess.
 QUEST_LV_0200_20150323_003374	Priest Prosit
 QUEST_LV_0200_20150323_003375	$Do you think the Great Cathedral will return to its normal state one day?{nl}I mean at least before I close my eyes.
 QUEST_LV_0200_20150323_003376	$I want to tell them that we should retake the Great Cathedral.{nl}But, I know we are not ready yet..
@@ -3553,11 +3553,11 @@ QUEST_LV_0200_20150323_003552	{memo X}As you can see, this place is full of wate
 QUEST_LV_0200_20150323_003553	{memo X}When you see the place near the magic circle, you will see the monsters with flames on them.{nl}Long time ago, I was able to put the flames on some of them in order to eliminate the magic circle, but after that I was so busy here.{nl}When you go there and put them into the magic circle, the field will break.
 QUEST_LV_0200_20150323_003554	{memo X}Still not completed?
 QUEST_LV_0200_20150323_003555	{memo X}Wow amazing.{nl}Thanks!
-QUEST_LV_0200_20150323_003556	{memo X}But, the magic circles are still left.{nl}Is there some way we could borrow the mighty power of the Goddesses..{nl}Only if there were the statues of the Goddesses..
+QUEST_LV_0200_20150323_003556	{memo X}But, the magic circles are still left.{nl}Is there some way we could borrow the mighty power of the goddesses..{nl}Only if there were the statues of the goddesses..
 QUEST_LV_0200_20150323_003557	{memo X}Starting from the one day, those barons' plunderings increased a lot and many magic circles were created a lot. Somehow, some of them were less shiny.{nl}Anyways, when you get near the bright ones, it will be hard to eliminate them since you may get hurt.{nl}Of course, the most difficult task is to avoid the eyes of the barons and continue to do this task.
 QUEST_LV_0200_20150323_003558	{memo X}{nl}I don't know exactly who you are, but you are the perfect candidate to help us since you are not well known here.
 QUEST_LV_0200_20150323_003559	{memo X}Yoana has it?{nl}If we put them in the magic circle, don't you think the field would break?
-QUEST_LV_0200_20150323_003560	{memo X}You came well at the right time. I tied them up with the sticky fluid.{nl}.. As I expected. This is the statue of the Goddess.{nl}You tied them up with the fluid from the monsters.. I am so sorry..
+QUEST_LV_0200_20150323_003560	{memo X}You came well at the right time. I tied them up with the sticky fluid.{nl}.. As I expected. This is the statue of the goddess.{nl}You tied them up with the fluid from the monsters.. I am so sorry..
 QUEST_LV_0200_20150323_003561	{memo X}{nl}You need this? Take it.
 QUEST_LV_0200_20150323_003562	{memo X}I am counting on you.
 QUEST_LV_0200_20150323_003563	{memo X}Really?{nl}My predictions are all correct.{nl}Thank you.
@@ -3569,7 +3569,7 @@ QUEST_LV_0200_20150323_003568	{memo X}Ah, thank you.
 QUEST_LV_0200_20150323_003569	{memo X}There is an unstable sealed magic circle down there. {nl}The baron told me that the seal which prevents the strange energy spurting out from the places nearby is not perfect yet so the energy is leaking out. However, the problem is that it doesn't look like that.{nl}It is suspicious.{nl}Now we have to tie up these pieces, so can you find more about the energy on behalf of me?
 QUEST_LV_0200_20150323_003570	Hmm.. It is almost completed now.{nl}We have enough reasons.. the food, almost everything.{nl}Now, we just have one more to go..
 QUEST_LV_0200_20150323_003571	My wish is not something big. We just want to live.{nl}Harvest for one year and stay full until the next harvest. {nl}We, farmers want only that.
-QUEST_LV_0200_20150323_003572	{memo X}{nl}If that one thing doesn't get accomplished, we have no choice, but to stand up.{nl}Against the source of the plunderings.{nl}Also if the process of the plunderings ruin the mighty power of the Goddess, and the objective of the plunderings results from the greed of one person, we do have to get mad about it.
+QUEST_LV_0200_20150323_003572	{memo X}{nl}If that one thing doesn't get accomplished, we have no choice, but to stand up.{nl}Against the source of the plunderings.{nl}Also if the process of the plunderings ruin the mighty power of the goddess, and the objective of the plunderings results from the greed of one person, we do have to get mad about it.
 QUEST_LV_0200_20150323_003573	We do have to check whether the farmers would particpate.{nl}I will give you the sheet so please get their signatures on the sheet.{nl}Along with the date for the execution, this sheet confirms that we all act together for the same purpose.
 QUEST_LV_0200_20150323_003574	{nl}How could I request this to you..{nl}I am so sorry. If this gets completed, we will do the rest ourselves.
 QUEST_LV_0200_20150323_003575	This task will give you some trouble.{nl}The farmers are not that simple.
@@ -3582,7 +3582,7 @@ QUEST_LV_0200_20150323_003581	{memo X}Now, leave the things to us here.{nl}Thank
 QUEST_LV_0200_20150323_003582	$I mean the second secret. {nl}Unfortunately, it seems that Naktis' subordinates have taken the lead.{nl}
 QUEST_LV_0200_20150323_003583	$I am investigating on how to undo Naktis' curse here.{nl}For the sake of those who are suffering from the curse, can you get me samples of the demons?
 QUEST_LV_0200_20150323_003584	$Well darn. We should be experimenting, not imagining things.{nl}I am sorry, but could you get me samples of other demons?
-QUEST_LV_0200_20150323_003585	How come the Goddesses leave those filthy demons like that..{nl}Is this also what the Goddesses want?
+QUEST_LV_0200_20150323_003585	How come the goddesses leave those filthy demons like that..{nl}Is this also what the goddesses want?
 QUEST_LV_0200_20150323_003586	{memo X}We should just finish it before it gets in the hands of Naktis.{nl}Defeat the demons and find the divine artifacts of the salvation.
 QUEST_LV_0200_20150323_003587	$We don't have much time left to stay in the Great Cathedral.{nl}In the meantime, we should find clues on how to release the curse.
 QUEST_LV_0200_20150323_003588	$We should find out how Naktis' curse influences the psychology of humans..{nl}It really is a tough nut to crack.
@@ -3594,7 +3594,7 @@ QUEST_LV_0200_20150323_003593	Priest Ruodell
 QUEST_LV_0200_20150323_003594	{memo X}Hmm, I know it is an order from the congregation, but we should first retrieve the Great Cathedral..{nl}Then we would be able to get an answer for the curse as well.
 QUEST_LV_0200_20150323_003595	$I don't know if we will be able to find a way to release the curse if things continue like this.{nl}If I only had the power, I would have driven all demons out from the Great Cathedral.
 QUEST_LV_0200_20150323_003596	Priest Yosana
-QUEST_LV_0200_20150323_003597	$The congregation told us that they will retake the Great Cathedral once ' curse is resolved.{nl}It just isn't right to leave the Great Cathedral, which supported the Goddesses, like this for 4 years.
+QUEST_LV_0200_20150323_003597	$The congregation told us that they will retake the Great Cathedral once ' curse is resolved.{nl}It just isn't right to leave the Great Cathedral, which supported the goddesses, like this for 4 years.
 QUEST_LV_0200_20150323_003598	$We lost many documents in the Great Cathedral due to Naktis' subordinates.{nl}Whenever I think about it, I feel so bad that we lost them..{nl}Those documents were over a hundred years old..
 QUEST_LV_0200_20150323_003599	Priest Alisha
 QUEST_LV_0200_20150323_003600	$Are the Thistles not ready yet?{nl}If they come late, the medicine will dry out.
@@ -3605,13 +3605,13 @@ QUEST_LV_0200_20150323_003604	Pilgrim Orville
 QUEST_LV_0200_20150323_003605	$Please help me.{nl}I ran away and got here by avoiding the monsters, but I can't find a friend of mine who came with me.
 QUEST_LV_0200_20150323_003606	{memo X}Please find my friend.{nl}I lived so hard until now, so I can't just die here.
 QUEST_LV_0200_20150323_003607	Priest Loana
-QUEST_LV_0200_20150323_003608	{memo X}Thanks for helping us.{nl}The Goddess help the ones who try their best, and I think it was you, the Revelator.
+QUEST_LV_0200_20150323_003608	{memo X}Thanks for helping us.{nl}The goddess help the ones who try their best, and I think it was you, the Revelator.
 QUEST_LV_0200_20150323_003609	It is getting stronger.
 QUEST_LV_0200_20150323_003610	{memo X}So the true nature of the curse was Chapparitions.{nl}I was busy with the curse of Naktis so I think its so fortunate.{nl}
 QUEST_LV_0200_20150323_003611	$Ah, can you send this report to Priest Aden if you get a chance to go back to the Main Chamber?{nl}
 QUEST_LV_0200_20150323_003612	$The Revelation is being protected by the five keys of Maven.{nl}To get those keys, you must solve all the secrets.{nl}
 QUEST_LV_0200_20150323_003613	{memo X}Then I should go back to your small pocket for a minute.{nl}Do not trust anyone.
-QUEST_LV_0200_20150323_003614	{memo X}The Goddesses want you and Hauberk to defeat the pawns of Blut so that the 1st zone gets released from the control of the demons.{nl}To do so, you should disturb the conciousness of the subordinates who try to free the Blut.{nl}Could you defeat the monsters at the gathering place of Rituala?
+QUEST_LV_0200_20150323_003614	{memo X}The goddesses want you and Hauberk to defeat the pawns of Blut so that the 1st zone gets released from the control of the demons.{nl}To do so, you should disturb the conciousness of the subordinates who try to free the Blut.{nl}Could you defeat the monsters at the gathering place of Rituala?
 QUEST_LV_0200_20150323_003615	{memo X}Blut's
 QUEST_LV_0200_20150323_003616	{memo X}They tried to break the loosened barriers and run away outside.{nl}Get some help from Hauberks if you can.
 QUEST_LV_0200_20150323_003617	{memo X}Well done. I feel that the barriers in this region are more enhanced now.
@@ -3621,12 +3621,12 @@ QUEST_LV_0200_20150323_003620	{memo X}So you want to save the Goddesses? You mad
 QUEST_LV_0200_20150323_003621	{memo X}Unlike the other guys, I can't possess your body.{nl}So please carry my pieces of the seal now and enter inside.{nl}I will guide you from there.
 QUEST_LV_0200_20150323_003622	{memo X}Blut are facing against Kupole Zydrone at Nuzikalti Hall.{nl}Zydrone would try his best to resist, but I can't keep them anymore with our power only.
 QUEST_LV_0200_20150323_003623	{memo X}The only way to weaken Blut is to get the secreting glands that Blut shared with his subordinates and weaken his influence.{nl}There are Blut's guys near Byeaulleo Hideout. Get the secreting glands of Blut from them.
-QUEST_LV_0200_20150323_003624	{memo X}The Goddess is facing against the Demon Lord somewhere in the prison.{nl}She desperately needs help from you and Hauberk.
+QUEST_LV_0200_20150323_003624	{memo X}The goddess is facing against the Demon Lord somewhere in the prison.{nl}She desperately needs help from you and Hauberk.
 QUEST_LV_0200_20150323_003625	{memo X}Good. I will eliminate this from this world.{nl}Blut would feel like as if he lost it's feelers.{nl}It will be a big help to Zydrone.
 QUEST_LV_0200_20150323_003626	{memo X}The battle with Blut will be hard for us.{nl}Hauberk should help us. We should grant the substance to Hauberk again.
 QUEST_LV_0200_20150323_003627	{memo X}{nl}Blut sealed his power at his altar for his escape.{nl}If Hauberk could absorb that, it will be a great help to us.{nl}Go to the concentrated area. Control the altar there.
 QUEST_LV_0200_20150323_003628	{memo X}{nl}If you succeed on granting substance to Hauberk, please go see Zydrone.{nl}We are really running out of time now.
-QUEST_LV_0200_20150323_003629	{memo X}The power of the demons reject the power of the Goddesses. Only Hauberk can do this.
+QUEST_LV_0200_20150323_003629	{memo X}The power of the demons reject the power of the goddesses. Only Hauberk can do this.
 QUEST_LV_0200_20150323_003630	{memo X}Were you able to grant the substance to Hauberk? It is so fortunate.{nl}Everything will go as the Goddesses wish..
 QUEST_LV_0200_20150323_003631	{memo X}I locked Blut in the barrier of the prison, but it won't stand long.{nl}When we are prepared, we should defeat it with Hauberk.{nl}If we lose, Vakarine also would fall down.
 QUEST_LV_0200_20150323_003632	{memo X}Go to the 2nd area of the prison. Norgaille is waitng for you and Hauberk there.
@@ -3682,7 +3682,7 @@ QUEST_LV_0200_20150323_003681	{memo X}We just ran into a problem. The reason why
 QUEST_LV_0200_20150323_003682	{memo X}I am sorry to deceive you. But, I can't tell you the truth as long as Hauberk is with you.{nl}Hauberk ran away to the 4th District. Please tell this to the Goddess as quickly as possible.
 QUEST_LV_0200_20150323_003683	{memo X}Okay.. so that's why.{nl}Do not lose your hope savior, it's not too late as long as you are alive.{nl}Hauberk ran away to the 4th District which is like a mae in this prison.
 QUEST_LV_0200_20150323_003684	{memo X}Look for Daiva there. She will guide you to Hauberk.{nl}I will observe Dionysus from here.{nl}If you or Kupoles seal Hauberk, we will meet again at the 5th District.
-QUEST_LV_0200_20150323_003685	{memo X}The dimensional door that was opened from the demon world. The metastasis space can't be closed even by the Goddesses.{nl}We should control the metastasis space using Hauberk and eliminate with the chains.{nl}But in that process, Hauberk was completely eliminated. Before he ran away like that, I had to lock him up..{nl}{nl}I am so sorry to see the Goddesses again.{nl}
+QUEST_LV_0200_20150323_003685	{memo X}The dimensional door that was opened from the demon world. The metastasis space can't be closed even by the Goddesses.{nl}We should control the metastasis space using Hauberk and eliminate with the chains.{nl}But in that process, Hauberk was completely eliminated. Before he ran away like that, I had to lock him up..{nl}{nl}I am so sorry to see the goddesses again.{nl}
 QUEST_LV_0200_20150323_003686	{memo X}As Baltrus disappeared, the demons were confused who used to receive orders from him.{nl}That caused the demons more violent whose behaviours were already unpredictable.{nl}Can you defeat those who are coming to Orualma, the great hall?
 QUEST_LV_0200_20150323_003687	{memo X}Even if the Goddesses are not here, the Kupoles won't be violent.{nl}We are the symbol of rules and disciplines.
 QUEST_LV_0200_20150323_003688	{memo X}The great hall is one of the places which the Goddesses could easily regain their energies.{nl}So it should be safe from the demons all the time.{nl}Thanks for taking care of that.
@@ -3772,12 +3772,12 @@ QUEST_LV_0200_20150323_003771	$There once were always holy prayers echoing in th
 QUEST_LV_0200_20150323_003772	{memo X}My mission is to retrieve the sacred artifacts, but I can't stand and watch this anymore.{nl}Can you defeat the monsters that are roaming around the Great Cathedral?
 QUEST_LV_0200_20150323_003773	$Everyone is angry, but they are hold it in with their objectives in mind.{nl}But I.. just can't stand it..
 QUEST_LV_0200_20150323_003774	$There are many who trample on this sacred place.{nl}I can't forgive them.
-QUEST_LV_0200_20150323_003775	$I can still visualize those vicious beings.{nl}I will never forgive them in the name of the Goddesses.
-QUEST_LV_0200_20150323_003776	$They should be ready to receive the punishment of the Goddesses.{nl}Eternally.
-QUEST_LV_0200_20150323_003777	$I hope the Goddesses always protect you.
+QUEST_LV_0200_20150323_003775	$I can still visualize those vicious beings.{nl}I will never forgive them in the name of the goddesses.
+QUEST_LV_0200_20150323_003776	$They should be ready to receive the punishment of the goddesses.{nl}Eternally.
+QUEST_LV_0200_20150323_003777	$I hope the goddesses always protect you.
 QUEST_LV_0200_20150323_003778	$There are a lot fewer demons, but there are still many of them.{nl}I can't forgive any of those demons.
 QUEST_LV_0200_20150323_003779	{memo X}If this Great Cathedral gets purified, all credits would go to you.{nl}But, we still have a long way to go.
-QUEST_LV_0200_20150323_003780	$The demons that are spreading the vicious curses are still roaming the Great Cathedral.{nl}As a priest under the Goddesses' name, how can I just leave this be.
+QUEST_LV_0200_20150323_003780	$The demons that are spreading the vicious curses are still roaming the Great Cathedral.{nl}As a priest under the goddesses' name, how can I just leave this be.
 QUEST_LV_0200_20150323_003781	$Priests always have patience and mercy in their minds when they train.{nl}But, their patience and mercy are not for the demons.
 QUEST_LV_0200_20150323_003782	You've done well, but there are still many demons left.{nl}When this mission is over, I am planning to receive the mission of purification.
 QUEST_LV_0200_20150323_003783	$We have trouble. Hurry to Uolie Chapel..{nl}I will tell you more when you get there.{nl}
@@ -3785,7 +3785,7 @@ QUEST_LV_0200_20150323_003784	$Unfortunately, the bridge to it has collapsed so 
 QUEST_LV_0200_20150323_003785	$Cursed Pilgrim
 QUEST_LV_0200_20150323_003786	$I am so hungry even though I keep eating.. Please get me some food..
 QUEST_LV_0200_20150323_003787	$Don't go without me.. Please get me something to eat..
-QUEST_LV_0200_20150323_003788	$Oh Goddess, so you are the one who saved me.{nl}I am sorry, but my body has not recovered yet..
+QUEST_LV_0200_20150323_003788	$Oh goddess, so you are the one who saved me.{nl}I am sorry, but my body has not recovered yet..
 QUEST_LV_0200_20150323_003789	$I will take care of him by my side until he completely recovers from the curse.{nl}Maybe, I could also cure the other curses.
 QUEST_LV_0200_20150323_003790	{memo X}The curse of gluttony makes a person not to digest the food well.{nl}That's why the cursed people are always hungry. {nl}
 QUEST_LV_0200_20150323_003791	$After he recovers from the curse, he will be totally exhausted, so I will take care of him by my side.
@@ -3842,7 +3842,7 @@ QUEST_LV_0200_20150323_003841	$Was Alan okay?{nl}It is so fortunate that you wer
 QUEST_LV_0200_20150323_003842	$So you are the Revelator that I've heard rumors of. Thank you so much.{nl}I don't know why those monsters turned out like that.
 QUEST_LV_0200_20150323_003843	Louise
 QUEST_LV_0200_20150323_003844	${memo X}I received the farm land from Gytis, but it's such a mess.{nl}Especially Ridimed. But, what can I do with my hands that only touched hoes before.
-QUEST_LV_0200_20150323_003845	$Just as I ran into trouble, I'm so lucky to have met the Goddesses' helper.{nl}I am counting on you. It's already too late to manage the crops though.
+QUEST_LV_0200_20150323_003845	$Just as I ran into trouble, I'm so lucky to have met the goddesses' helper.{nl}I am counting on you. It's already too late to manage the crops though.
 QUEST_LV_0200_20150323_003846	$You really drove the annoying Ridimeds away?{nl}That's such good news.
 QUEST_LV_0200_20150323_003847	$It's so good to hear that you drove the Ridimeds away.{nl}Now let's see what we can do next.{nl}
 QUEST_LV_0200_20150323_003848	$I think it would be helpful if I at least had a fence.{nl}Can you help me a little more?
@@ -3883,7 +3883,7 @@ QUEST_LV_0200_20150323_003882	$If you find something like this again, please han
 QUEST_LV_0200_20150323_003883	You've gathered a lot.{nl}I think this will be enough.
 QUEST_LV_0200_20150323_003884	$Since the seal towers here were damaged more seriously than the one at Uskis Arable Land,{nl}the evil energy here flows stronger.{nl}
 QUEST_LV_0200_20150323_003885	$There is one thing I am worried about..{nl}That symbol was once damaged so it may not restore the seal perfectly.{nl}
-QUEST_LV_0200_20150323_003886	$I believe that the Goddesses will protect us.{nl}But, we must also do our best to repair the seal.
+QUEST_LV_0200_20150323_003886	$I believe that the goddesses will protect us.{nl}But, we must also do our best to repair the seal.
 QUEST_LV_0200_20150323_003887	$I heard about the thorny forest before.{nl}That place was once a normal forest, right? What do we do if our village turns out like that?
 QUEST_LV_0200_20150323_003888	$I can't just endure the monsters' violence anymore.{nl}We have to protect the village from now on instead of only relying on the priests.
 QUEST_LV_0200_20150323_003889	$This isn't all happening because Goddess Austeja is absent, right?{nl}If it's true though, what should I do now?
@@ -3894,9 +3894,9 @@ QUEST_LV_0200_20150323_003893	$Finally, the last key.{nl}I've been waiting for t
 QUEST_LV_0200_20150323_003894	$The last secret is in the Small Reception Room.{nl}You should remember the order of the candles and their number.
 QUEST_LV_0200_20150323_003895	$Maven's Message
 QUEST_LV_0200_20150323_003896	$I am glad that my life's masterpiece has protected the Revelation well.{nl}But, yours and my mission is not over yet.{nl}
-QUEST_LV_0200_20150323_003897	$Savior. Please open the door to Pasara Altar.{nl}If you really wish to obtain the Revelation of the Goddess, you will receive it at the end..
+QUEST_LV_0200_20150323_003897	$Savior. Please open the door to Pasara Altar.{nl}If you really wish to obtain the Revelation of the goddess, you will receive it at the end..
 QUEST_LV_0200_20150323_003898	$My guidance ends here.{nl}It has been very fortunate that I was able to guide you well..{nl}
-QUEST_LV_0200_20150323_003899	$I am going back to the Goddesses.{nl}Please.. save the kingdom and the Goddesses.
+QUEST_LV_0200_20150323_003899	$I am going back to the goddesses.{nl}Please.. save the kingdom and the goddesses.
 QUEST_LV_0200_20150323_003900	$Let's extract the curse's energy from the Penitence Route and make it appear.{nl}While I am concentrating, please activate all the Altars of Purification.{nl}{nl}
 QUEST_LV_0200_20150323_003901	The curse of Naktis makes people suffer just by looking at it.{nl}It makes people miserable.
 QUEST_LV_0200_20150323_003902	{memo X}We have no other choice, but to find the solutions for each curse.{nl}It's like there are different treatments to different diseases.
@@ -3910,7 +3910,7 @@ QUEST_LV_0200_20150323_003909	$Go to Veinika Altar when you've recharged the Hol
 QUEST_LV_0200_20150323_003910	{memo X}If you think you are ready, I will show you the true nature of the curse.{nl}If you can't eliminate it at once, it will make a bigger trouble.
 QUEST_LV_0200_20150323_003911	$Now all that's left is the Verification Test.{nl}The scripture that possesses my spirit, please open it in front of the altar of the Revelation.
 QUEST_LV_0200_20150323_003912	$The Scriptural Relics contained the words of the great bishops..{nl}I am so infuriated that they are placed now in the wake of filthy demons.
-QUEST_LV_0200_20150323_003913	Fortunately, most of the holy relics seem okay.{nl}If I had a little more power, I would have purified the demons in the name of the Goddesses right away.
+QUEST_LV_0200_20150323_003913	Fortunately, most of the holy relics seem okay.{nl}If I had a little more power, I would have purified the demons in the name of the goddesses right away.
 QUEST_LV_0200_20150323_003914	$To prepare for times like this, I've brought an orb that can detect holy energy.{nl}Keep an eye on the demons though. You may be in for some trouble,{nl}since they will run towards the relics as soon as they see them.
 QUEST_LV_0200_20150323_003915	$We've were sent from the congregation to investigate Naktis' curse.{nl}We should be first finding the documents that were scattered here, but those demons are a problem.
 QUEST_LV_0200_20150323_003916	$The lost documents all contain important content.{nl}I want to bring all of them, but we should first remove the curse.
@@ -3935,7 +3935,7 @@ QUEST_LV_0200_20150323_003934	$We have only one method.. using the demons.{nl}I 
 QUEST_LV_0200_20150323_003935	$There are documents here that describe a method of disguising as a demon in this Sanctuary.{nl} Through this method, you should be able to get the next key without shedding a drop of blood.
 QUEST_LV_0200_20150323_003936	$You found it. Now let me see.{nl}Where was the clause..
 QUEST_LV_0200_20150323_003937	$Ah. The method is rather simple. But you may have to put in some effort.{nl}First, get some articles of clothing from Naktis' subordinates.
-QUEST_LV_0200_20150323_003938	$Using the demons.. The Goddesses may turn their heads away,{nl}but if this is the best method, I will do it.
+QUEST_LV_0200_20150323_003938	$Using the demons.. The goddesses may turn their heads away,{nl}but if this is the best method, I will do it.
 QUEST_LV_0200_20150323_003939	$That will be enough.{nl}Now use the apparel to complete the scroll.
 QUEST_LV_0200_20150323_003940	$In this recipe, it says that you can complete the Demon Transformation Scroll at the Altar of Intelligence.{nl}Fortunately, the Altar of Intelligence is at Laukti Antenave.{nl}
 QUEST_LV_0200_20150323_003941	That's the passion of the priests who tried to protect the kingdom from the forces of evil. {nl}It continued on for hundreds of years until today.{nl}
@@ -3950,8 +3950,8 @@ QUEST_LV_0200_20150323_003949	$So the pilgrim ate the meat?{nl}Ah.. still not we
 QUEST_LV_0200_20150323_003950	$So the medicine worked well?{nl}Really.. that is so fortunate. Thanks for helping me.{nl}I will tell the other priests about this recipe.
 QUEST_LV_0200_20150323_003951	$I can sense another kind of curse. This curse is different from Naktis' curse.{nl}The true origin of it should be present somewhere, but it's hard for me to find it alone.{nl}{nl}
 QUEST_LV_0200_20150323_003952	$We've found it!{nl}Now we will eliminate the true origin.
-QUEST_LV_0200_20150323_003953	$My friend looks strange. {nl}He is not breathing and his face looks pale. His heart also doesn't beat anymore.{nl}Did he already leave for the Goddesses? Dallas, please open your eyes..
-QUEST_LV_0200_20150323_003954	$Thank you so much. {nl}Dallas would also speak of you to the Goddesses.
+QUEST_LV_0200_20150323_003953	$My friend looks strange. {nl}He is not breathing and his face looks pale. His heart also doesn't beat anymore.{nl}Did he already leave for the goddesses? Dallas, please open your eyes..
+QUEST_LV_0200_20150323_003954	$Thank you so much. {nl}Dallas would also speak of you to the goddesses.
 QUEST_LV_0200_20150323_003955	$I am going to go to bury Dallas.{nl}Can you be with me until the end?
 QUEST_LV_0200_20150323_003956	$So you are safe.{nl}I am going to go back to my hometown with Dallas' belongings.{nl}
 QUEST_LV_0200_20150323_003957	{memo X}Are the peaceful days going to return like the old times?{nl}Revelator..
@@ -3962,8 +3962,8 @@ QUEST_LV_0200_20150323_003961	$There is a dangerous demon luring priests and lea
 QUEST_LV_0200_20150323_003962	$The location is Yujima Narthex.{nl}Please relieve our priests of this threat so they can concentrate on their mission.
 QUEST_LV_0200_20150323_003963	$I will submit a report as soon as I return to the congregation.{nl}This should soothe the priests who were in despair. Thanks.{nl}
 QUEST_LV_0200_20150323_003964	$And so all five keys are now collected.{nl}Go to Pasara Altar. The secret there will lead you to the hidden room.
-QUEST_LV_0200_20150323_003965	$Are you the Revelator of the Goddesses or the one who belongs to the mighty power of the darkness?{nl}The evil darkness can not cross here.{nl}
-QUEST_LV_0200_20150323_003966	$You've proven that you are the Revelator of the Goddesses.{nl}You may enter the room where the Revelation is located.
+QUEST_LV_0200_20150323_003965	$Are you the Revelator of the goddesses or the one who belongs to the mighty power of the darkness?{nl}The evil darkness can not cross here.{nl}
+QUEST_LV_0200_20150323_003966	$You've proven that you are the Revelator of the goddesses.{nl}You may enter the room where the Revelation is located.
 QUEST_LV_0200_20150323_003967	It's so brutal. {nl}Our Great Cathedral, to those demons..
 QUEST_LV_0200_20150323_003968	Druid Ellie
 QUEST_LV_0200_20150323_003969	{memo X}Hello. This is the garden of Ginaga.{nl}This place is the hometown and the land of Druid Master, Gina Greene.{nl}The master welcomes all people who visit this land.
@@ -3979,7 +3979,7 @@ QUEST_LV_0200_20150323_003978	$If that's the case.. Please get me two lumps of s
 QUEST_LV_0200_20150323_003979	$Before, evil energy was purified by the power of humans.{nl}But, if the power of this tree is true.. they will be purified by planting it at several places.
 QUEST_LV_0200_20150323_003980	$So you brought them.{nl}I just finished the preparation for the purification ritual.
 QUEST_LV_0200_20150323_003981	{memo X}I will see the responses of this sample like the leaves.{nl}I hope it goes well.. Please see it yourself Revelator!
-QUEST_LV_0200_20150323_003982	$Oh Goddess, please look at this. The ritual was successful.{nl}The master would purify everything at once with trees like this one.
+QUEST_LV_0200_20150323_003982	$Oh goddess, please look at this. The ritual was successful.{nl}The master would purify everything at once with trees like this one.
 QUEST_LV_0200_20150323_003983	{memo X}Until the master comes back, I am going to do some base work for the large scale purification.{nl}Can you collect the five bottles of Tanus fluids from the Kvie Farm Area?
 QUEST_LV_0200_20150323_003984	$Thanks for helping me.{nl}The girl who left this tree.. who was she I wonder?
 QUEST_LV_0200_20150323_003985	$This tree is so mysterious.{nl}It's like the Revelator brought the clues of purification.
@@ -4141,7 +4141,7 @@ QUEST_LV_0200_20150323_004140	$I will leave this farm to my daughter from now on
 QUEST_LV_0200_20150323_004141	$That is good to hear that his daughter is now managing the farm.{nl}Can you explain the large scale purification process to his daughter?
 QUEST_LV_0200_20150323_004142	{memo X}Instead of me explaining, it will be better if you explain it.{nl}The reason why Shaton gave up his obsesseion is because of you.
 QUEST_LV_0200_20150323_004143	$Yes. My father has told me about it.{nl}I am planning to plant the trees with the help of the druid in this farm.{nl}
-QUEST_LV_0200_20150323_004144	$I will give up on harvesting the grapes. And I will improve the labor conditions of the tenant farmers. {nl}I believe that my brother, who is with the Goddesses right now, would have done the same.{nl}
+QUEST_LV_0200_20150323_004144	$I will give up on harvesting the grapes. And I will improve the labor conditions of the tenant farmers. {nl}I believe that my brother, who is with the goddesses right now, would have done the same.{nl}
 QUEST_LV_0200_20150323_004145	$More than anything else, thank you so much for enlightening my father.. Thank you.
 QUEST_LV_0200_20150323_004146	$I am really honored to have been together with you up to now.{nl}I wish for the best of luck in the large scale purification process.{nl}
 QUEST_LV_0200_20150323_004147	$Maybe.. that particular girl didn't only forecast about the disaster.{nl}Well then, may the grace of Goddess Zemyna be in your footsteps.
@@ -4319,7 +4319,7 @@ QUEST_LV_0200_20150323_004318	I will try feeding him the medicine
 QUEST_LV_0200_20150323_004319	$Tell her to do that herself
 QUEST_LV_0200_20150323_004320	$True Origin of the Curse (1)
 QUEST_LV_0200_20150323_004321	Ignore and keep going on your way
-QUEST_LV_0200_20150323_004322	Tell him to bury him so that he could go to the Goddesses
+QUEST_LV_0200_20150323_004322	Tell him to bury him so that he could go to the goddesses
 QUEST_LV_0200_20150323_004323	Comfort him before you leave
 QUEST_LV_0200_20150323_004324	I will be with him
 QUEST_LV_0200_20150323_004325	I will leave now
@@ -4642,7 +4642,7 @@ QUEST_LV_0200_20150323_004641	{memo X}You finally defeated the Woodspirits that 
 QUEST_LV_0200_20150323_004642	{memo X}There are the artifacts of an unknown soldier who died at Saknis Field due to the monsters. He might be the owner of the necklace that you picked up last time. Put the necklace on him and pray for him.
 QUEST_LV_0200_20150323_004643	Enter Verkti Square
 QUEST_LV_0200_20150323_004644	{memo X}Enter Verkti Square
-QUEST_LV_0200_20150323_004645	Kingdom Army Guard Retia is waiting for someone's help at Verkti Square
+QUEST_LV_0200_20150323_004645	Royal Army Guard Retia is waiting for someone's help at Verkti Square
 QUEST_LV_0200_20150323_004646	{memo X}The kingdom soldier, Retia asked you to check the search devices that were installed at various places in Verkti Square to correctly forecast the Stone Frosts that will come in the future.
 QUEST_LV_0200_20150323_004647	Graverobber Hubertas at Verkti Square is waiting for someone's help
 QUEST_LV_0200_20150323_004648	Graverobber Benjaminas at Verkti Square is waiting for someone's help.
@@ -4779,8 +4779,8 @@ QUEST_LV_0200_20150323_004778	$We should look for a way to purify the sanctum. G
 QUEST_LV_0200_20150323_004779	$We should first purify the corrupted sanctum on Pamaish Hill. Talk to the Priest Master what to do.
 QUEST_LV_0200_20150323_004780	$Purify the sanctum using Holy Water
 QUEST_LV_0200_20150323_004781	$The Priest Master asked you to purify the sanctum on Pamaish Hill using the Holy Water. Return to the Forest of Prayer and purify the corrupted sanctum.
-QUEST_LV_0200_20150323_004782	Pray in front of the statue of the Goddess near the grave of the saint
-QUEST_LV_0200_20150323_004783	There is the statue of the Goddess near the grave of the saint. Pray in front of the statue.
+QUEST_LV_0200_20150323_004782	Pray in front of the Goddess Statue near the grave of the saint
+QUEST_LV_0200_20150323_004783	There is the Goddess Statue near the grave of the saint. Pray in front of the statue.
 QUEST_LV_0200_20150323_004784	This statue was a fake. Defeat Sparnashorn, who was disguised as a Goddess Statue.
 QUEST_LV_0200_20150323_004785	$There is a Goddess Statue at the lower side of Malone Trail. Let's find what is real among these statues.
 QUEST_LV_0200_20150323_004786	$Get advice from Sculptor Tesla
@@ -5104,7 +5104,7 @@ QUEST_LV_0200_20150323_005103	{memo X}You can see half of the head from the stat
 QUEST_LV_0200_20150323_005104	{memo X}Dig the head of the statue of the Goddess
 QUEST_LV_0200_20150323_005105	{memo X}It is strange that the head of the statue is in this place. {nl}Try digging it.
 QUEST_LV_0200_20150323_005106	Obtain the information of the object
-QUEST_LV_0200_20150323_005107	The thing that was buried under the ground was not the statue of the Goddess, but in fact the head part. You better tell this to someone.
+QUEST_LV_0200_20150323_005107	The thing that was buried under the ground was not a Goddess Statue, but in fact the head part. You better tell this to someone.
 QUEST_LV_0200_20150323_005108	{memo X}Open the alcohol box
 QUEST_LV_0200_20150323_005109	{memo X}It is strange that the alcohol container is in that location. Get closer to it and open it.
 QUEST_LV_0200_20150323_005110	{memo X}Break the alcohol container
@@ -5726,9 +5726,9 @@ QUEST_LV_0200_20150401_005728	$This will be a great help to Zydrone.{nl}I will e
 QUEST_LV_0200_20150401_005729	$To defeat the Demon Lord Blut completely, our power is not enough.{nl}I didn't want to do this before, but let's try getting some help from Hauberk.{nl}
 QUEST_LV_0200_20150401_005730	$There's something which Blut stored his power in at the altar at the Concentrated Management Area.{nl}Only demons can control it, but we have Hauberk.
 QUEST_LV_0200_20150401_005731	$After Hauberk absorbs that power, please go help Zydrone right away.{nl}To Nuzikalti Hall. Hurry. We don't have much time.
-QUEST_LV_0200_20150401_005732	We are the attendants who are serving the Goddesses.{nl}Our work differs depending on which Goddess we serve.
+QUEST_LV_0200_20150401_005732	We are the attendants who are serving the goddesses.{nl}Our work differs depending on which goddess we serve.
 QUEST_LV_0200_20150401_005733	{memo X}Our original task was to manage and supervise the prison.{nl}Now, with Vakarine's control, our task is to close the space of the metastasis and defeat the demons.
-QUEST_LV_0200_20150401_005734	The power of the demons reject the power of the Goddesses.{nl}This role completely depends on Hauberk.
+QUEST_LV_0200_20150401_005734	The power of the demons reject the power of the goddesses.{nl}This role completely depends on Hauberk.
 QUEST_LV_0200_20150401_005735	{memo X}So you are the one who Vakarine mentioned.{nl}Good. The Goddess will lead the everything.
 QUEST_LV_0200_20150401_005736	{memo X}I've locked Blut in the barrier of the prison, but he won't endure there for long time.{nl}We should attack all at once. Are you ready?
 QUEST_LV_0200_20150401_005737	{memo X}If we weren't able to defeat Blut here, Vakarine may have fallen down together.{nl}Hurry to the 2nd District. Medeina is waiting there.
@@ -5742,7 +5742,7 @@ QUEST_LV_0200_20150401_005744	Thank you. {nl}I hope there are no more sacrifices
 QUEST_LV_0200_20150401_005745	Kupole Medeina
 QUEST_LV_0200_20150401_005746	{memo X}We are in a trouble.{nl}The barrier of the Goddess is breaking due to the mighty power of the Demon Lord, Nuaele.{nl}
 QUEST_LV_0200_20150401_005747	{memo X}Aldona went to face against Nuaele since he wants to resist some more.{nl}If you could reduce the mighty power of Nualele a bit.. It will help Aldona a lot!
-QUEST_LV_0200_20150401_005748	The barrier of the Goddess is like a great wall surrounding this prison.{nl}It will block the demons coming into the prison or escaping from here.{nl}
+QUEST_LV_0200_20150401_005748	The barrier of the goddess is like a great wall surrounding this prison.{nl}It will block the demons coming into the prison or escaping from here.{nl}
 QUEST_LV_0200_20150401_005749	The dimensional crack started was created on the barrier due to Medzio Diena.{nl}Vakarine is having hard time since she should maintain the barrier and face the demons at the same time.
 QUEST_LV_0200_20150401_005750	{memo X}Please hurry to the 1st District before the demons meet Nuaele. {nl}I want you to eliminate them.
 QUEST_LV_0200_20150401_005751	{memo X}Goddesses.{nl}Please protect Aldona..
@@ -5757,7 +5757,7 @@ QUEST_LV_0200_20150401_005759	{memo X}Now, the Demon Lord, Nuaele would know it.
 QUEST_LV_0200_20150401_005760	{memo X}By the way, Nuaele's behavior is somewhat strange.{nl}In fact, with the power that he accumulated secretly for a long time, he may just break the barrier and go out.{nl}
 QUEST_LV_0200_20150401_005761	{memo X}But, for us, we are waiting for someone that we don't know. {nl}I guess we should interrogate the subordinates of Nuaele.
 QUEST_LV_0200_20150401_005762	{memo X}I will give you the marbles that I received from the Goddess.{nl}We, Kupoles can't do it, but since Hauberk is a demon, he would be able to read our mind.
-QUEST_LV_0200_20150401_005763	When the power of the Goddesses get weak, the mighty power of us, Kupoles also get weak.{nl}Furthermore, trying to disturb the minds of the demons, it's impossible.
+QUEST_LV_0200_20150401_005763	When the power of the goddesses get weak, the mighty power of us, Kupoles also get weak.{nl}Furthermore, trying to disturb the minds of the demons, it's impossible.
 QUEST_LV_0200_20150401_005764	{memo X}He was thinking about changing the prison into his demonic world from the first place.{nl}If this place falls under the hands of him, even Ausrine can't do anything.
 QUEST_LV_0200_20150401_005765	$Since we've found out Nuaele's intention, we should be moving fast.{nl}
 QUEST_LV_0200_20150401_005766	{memo X}How about we first attack * monster at the 4th isolated area?{nl}If we could defeat it, it's like we are defeating one of the strongest weapons of Nuaele.
@@ -5782,7 +5782,7 @@ QUEST_LV_0200_20150401_005785	{memo X}Complete the key of night star by helping 
 QUEST_LV_0200_20150401_005786	{memo X}The strong power that we tried to protect from Baltrus is controlling the ego of Dionysus.{nl}Fortunately, that power can be detached and be put in the key of the night star.{nl}
 QUEST_LV_0200_20150401_005787	{memo X}Plese close the space of the metastasis that are on the scar of the metastasis first.{nl}Because of the waves coming out from the space, I can't hardly focus on the ritual.
 QUEST_LV_0200_20150401_005788	We don't know exactly what is the strong power that is controlling Dionysus.{nl}We just know that it could close the space of the metastasis and it should not be stolen.{nl}
-QUEST_LV_0200_20150401_005789	While the Goddess was maintaining the barrier of the prison, she also had to fight against Baltrus at the same time.{nl}If the Goddess gets defeated, that power can't be protected..{nl}
+QUEST_LV_0200_20150401_005789	While the goddess was maintaining the barrier of the prison, she also had to fight against Baltrus at the same time.{nl}If the goddess gets defeated, that power can't be protected..{nl}
 QUEST_LV_0200_20150401_005790	{memo X}The Goddess had to make a hard decision.{nl}Until the prison gets stabilized, she will seal the power to Dionysus who is like family to her.
 QUEST_LV_0200_20150401_005791	{memo X}Dionysus is the guardian who Vakarine most takes care.{nl}She reluctantly sealed the strong power to Dionysus and fell into the deep sadness..
 QUEST_LV_0200_20150401_005792	We can start the ritual now.{nl}When the Key of the Night Star is completed, we could probably retrieve his ego.
@@ -5801,7 +5801,7 @@ QUEST_LV_0200_20150401_005804	{memo X}But since you are here, it's not too late.
 QUEST_LV_0200_20150401_005805	{memo X}How come Vakarine left Hauberk to go crazy like that..{nl}I guess she must have a reason for that.
 QUEST_LV_0200_20150401_005806	{memo X}Even if we defeat Baltrus, that doesn't mean we have peace in this prison.{nl}The demons who lost their leader is going crazy here.{nl}
 QUEST_LV_0200_20150401_005807	{memo X}His subordinates are keep gathering at the grand corridor of Orualma. {nl}Please defeat them.
-QUEST_LV_0200_20150401_005808	We, Kupoles are different.{nl}Even if the Goddesses are not around, we don't get violent.{nl}
+QUEST_LV_0200_20150401_005808	We, Kupoles are different.{nl}Even if the goddesses are not around, we don't get violent.{nl}
 QUEST_LV_0200_20150401_005809	We are the symbol of the rules and the principles.
 QUEST_LV_0200_20150401_005810	{memo X}The Goddesses rest at the grand corridor and recover her power.{nl}That's why it has to be safe all the time from the demons. Thank you so much.
 QUEST_LV_0200_20150401_005811	{memo X}Dionysus is weak.{nl}If you could find his toenails, he will recover his energy.{nl}
@@ -5839,7 +5839,7 @@ QUEST_LV_0200_20150401_005842	$Thank you. {nl}I will stay here and pursue the re
 QUEST_LV_0200_20150401_005843	$Some of Hauberk's servants ran away to Ishidevi Hideout. {nl}They are probably hoping for a revival, like Nuaele's. {nl}
 QUEST_LV_0200_20150401_005844	$We cannot let that happen again. {nl}Please defeat the demons around the Ishidevi Hideout.
 QUEST_LV_0200_20150401_005845	$Leaving Nuaele alone just because it was trapped was a source of trouble. {nl}We paid a big price for that lesson.
-QUEST_LV_0200_20150401_005846	$Good work. {nl}I will track down every last demon so that they can't resist against the Goddess.
+QUEST_LV_0200_20150401_005846	$Good work. {nl}I will track down every last demon so that they can't resist against the goddess.
 QUEST_LV_0200_20150401_005847	{memo X}The Goddess may disagree but we need to show them a lesson. {nl}Can you defeat the demons in Hradeti Crossroads and get their teeth?
 QUEST_LV_0200_20150401_005848	$The demons need to learn their lessons. {nl}It's rather gentle compared to what they did.
 QUEST_LV_0200_20150401_005849	{memo X}Thank you. {nl}Please keep it a secret from the Goddess.
@@ -5854,11 +5854,11 @@ QUEST_LV_0200_20150401_005857	{memo X}You've gathered enought to fill the Evenin
 QUEST_LV_0200_20150401_005858	{memo X}Here. Take the Evening Star Rune.
 QUEST_LV_0200_20150401_005859	{memo X}Use the Evening Star Rune on the demons in Rankine Isolation District and incapacitate them. {nl}The demons will then be pulled to me by the power in the Runes.
 QUEST_LV_0200_20150401_005860	{memo X}From here, I will combine those demons with the soul of Hauberk.
-QUEST_LV_0200_20150401_005861	A Goddess and a demon cannot easily interfere with each other's souls. {nl}Only a Revelator like you can do so.
+QUEST_LV_0200_20150401_005861	A goddess and a demon cannot easily interfere with each other's souls. {nl}Only a Revelator like you can do so.
 QUEST_LV_0200_20150401_005862	{memo X}Good work, Revelator. {nl}The demons you sent are being combined with soul of Hauberk.
 QUEST_LV_0200_20150401_005863	{memo X}We still need more of demons' souls. {nl}Please use the Evening Star Rune on the demons in Ishsula Ruins Area too.
 QUEST_LV_0200_20150401_005864	{memo X}Then the Kupoles will go to collect them..
-QUEST_LV_0200_20150401_005865	The dimensional crack is connected with the demon's world so it can't be removed without the power of the demons. {nl}That is why your role, not the Goddess' nor the demons', is important.
+QUEST_LV_0200_20150401_005865	The dimensional crack is connected with the demon's world so it can't be removed without the power of the demons. {nl}That is why your role, not the goddess' nor the demons', is important.
 QUEST_LV_0200_20150401_005866	{memo X}Now it's almost full. {nl}But I can't feel any more demons to gather.
 QUEST_LV_0200_20150401_005867	{memo X}We have no choice but to resort to the last measure. {nl}Retrieve the Mark of Seal that was fastened on the powerful demons. {nl}
 QUEST_LV_0200_20150401_005868	{memo X}The Mark of Seal absorbs the power of its host. {nl}You can get it by using the Evening Star Rune on the demons in Etmesta Isolation District.
@@ -5866,7 +5866,7 @@ QUEST_LV_0200_20150401_005869	{memo X}We couldn't watch every demon by its side.
 QUEST_LV_0200_20150401_005870	{memo X}Good work. {nl}These Marks can strengthen the soul of Hauberk.
 QUEST_LV_0200_20150401_005871	{memo X}We have gathered enough power to close the gap. {nl}Please look out while me and the Kupoles close the gap.
 QUEST_LV_0200_20150401_005872	{memo X}The disaster that took its root in the prison is now gone. {nl}All credits belong to you, Revelator. {nl}
-QUEST_LV_0200_20150401_005873	I plan to stay here for some time. {nl}If you need the power of a Goddess, you may come anytime for help.
+QUEST_LV_0200_20150401_005873	I plan to stay here for some time. {nl}If you need the power of a goddess, you may come anytime for help.
 QUEST_LV_0200_20150401_005874	{memo X}With the gap closed, the demons that lost its way are forming groups of their own. {nl}But I no longer have the strength to move for the time being. {nl}
 QUEST_LV_0200_20150401_005875	{memo X}The demons should never stay in groups, not for the future. {nl}Please break the power of demons that are gathered in Vanaga Surveillance Area.
 QUEST_LV_0200_20150401_005876	{memo X}The demons are using the aura of disaster to strengthen its powers. {nl}We may have blocked immediate disaster but peace still seems to be far away.
@@ -5954,7 +5954,7 @@ QUEST_LV_0200_20150401_005957	I will retrieve the claws
 QUEST_LV_0200_20150401_005958	About Dionysus
 QUEST_LV_0200_20150401_005959	$I will collect the Marks of Star
 QUEST_LV_0200_20150401_005960	I don't have for that
-QUEST_LV_0200_20150401_005961	I might be scolded by the Goddess
+QUEST_LV_0200_20150401_005961	I might be scolded by the goddess
 QUEST_LV_0200_20150401_005962	Everything will be alright
 QUEST_LV_0200_20150401_005963	He'll be cured soon
 QUEST_LV_0200_20150401_005964	I need some more time
@@ -6065,7 +6065,7 @@ QUEST_LV_0200_20150401_006068	{memo X}Kupole Zydrone asked you to protect him wh
 QUEST_LV_0200_20150401_006069	$Protected Kupole Zydrone well until the Key of the Night Star was charged. Talk to Zydrone.
 QUEST_LV_0200_20150401_006070	$Kupole Zydrone asked you to deliver the Key of the Night Star to Kupole Aldona, who is holding down Dionysus.
 QUEST_LV_0200_20150401_006071	$Release the Seals
-QUEST_LV_0200_20150401_006072	$Use the Key of the Night Star to release the seal of Rearda, Kasa, and Rada to free the power of Goddess.
+QUEST_LV_0200_20150401_006072	$Use the Key of the Night Star to release the seal of Rearda, Kasa, and Rada to free the power of goddess.
 QUEST_LV_0200_20150401_006073	{memo X}Released all seals and freed the power of Goddess. Return to Kupole Aldona and talk to her.
 QUEST_LV_0200_20150401_006074	$Ready to remove the strong power from Dionysus. Talk to Kupole Aldona.
 QUEST_LV_0200_20150401_006075	$Subdue Dionysus for Kupole Aldona to remove the power from Dionysus.
@@ -6193,10 +6193,10 @@ QUEST_LV_0200_20150406_006196	{memo X}Hmm? You killed it because it tried to eat
 QUEST_LV_0200_20150406_006197	Even in a rural area like this, we have heard about you. {nl}We are preparing to fight against the baron's arrogant plundering. {nl}
 QUEST_LV_0200_20150406_006198	It would be a great support to us if you could help us supply ourselves with weapons.
 QUEST_LV_0200_20150406_006199	$I just happened to take the lead like this. {nl}I'm just a tenant farmer who could no longer stand the baron's exploitation and tyranny.
-QUEST_LV_0200_20150406_006200	What makes us even more angry is that he is trying to fool us under the guise of purification. {nl}All he does is a disgrace to the Goddess' name.
+QUEST_LV_0200_20150406_006200	What makes us even more angry is that he is trying to fool us under the guise of purification. {nl}All he does is a disgrace to the goddess' name.
 QUEST_LV_0200_20150406_006201	Please get some wooden rods from the wooden structures nearby. {nl}We're going to make weapons.
 QUEST_LV_0200_20150406_006202	$We don't know how much we can fight the baron's guards. {nl}But we fight, that will have some meaning.
-QUEST_LV_0200_20150406_006203	This will be about enough. {nl}I will tell you more later, but if what I suspect is right, the baron betrayed the Goddess.
+QUEST_LV_0200_20150406_006203	This will be about enough. {nl}I will tell you more later, but if what I suspect is right, the baron betrayed the goddess.
 QUEST_LV_0200_20150406_006204	$The baron is said to have ordered the magic circles to be put up around the farm to suppress the strange aura. {nl}But that was a lie. The baron is not interested in purification. {nl}
 QUEST_LV_0200_20150406_006205	Please help us get leather for making weapons. {nl}You can get it from the monsters nearby.
 QUEST_LV_0200_20150406_006206	There are strange auras spread all over the farm.{nl}The baron said they were dangerous and gave orders to make magic circles to suppress them.
@@ -6235,7 +6235,7 @@ QUEST_LV_0200_20150406_006238	Let's see. Now there are around 3 left. {nl}Darbas
 QUEST_LV_0200_20150406_006239	The people in this farm used to pray to Goddess Zemyna from Padeka Altar. {nl}But after the baron made magic circles, the monsters took over that place.
 QUEST_LV_0200_20150406_006240	{memo X}I can only assume that the monsters were drawn to the magic circle. {nl}The magic circle is suppressing the divine power of the altar..? or something.
 QUEST_LV_0200_20150406_006241	It's a monster called Kirmeleech. {nl}Don't forget to remove the magic circle after defeating the monster.
-QUEST_LV_0200_20150406_006242	It's been a while since we've offered prayers because of Kirmeleech. {nl}What if the Goddess is angry?
+QUEST_LV_0200_20150406_006242	It's been a while since we've offered prayers because of Kirmeleech. {nl}What if the goddess is angry?
 QUEST_LV_0200_20150406_006243	Good job. {nl}Now we can pray again to Goddess Zemyna.
 QUEST_LV_0200_20150406_006244	The magic circle at Fallow Ground has protective barriers so it's difficult to destroy it right away. {nl}I will give you some Magic Stones of Blessing. Try using these to destroy it.
 QUEST_LV_0200_20150406_006245	I used to take priest lessons before Medzio Diena. {nl}I'm here now because I like farming more.
@@ -6249,7 +6249,7 @@ QUEST_LV_0200_20150406_006252	$At least you don't look like one of the baron's p
 QUEST_LV_0200_20150406_006253	{memo X}$The Baron is doing something to purify this farm. {nl}But recently the crops are dying and people are starting to fall sick. {nl}
 QUEST_LV_0200_20150406_006254	$I couldn't believe it at first, but if this piece is really from a Goddess Statue.. {nl}Either the baron is lying to us or something is wrong.
 QUEST_LV_0200_20150406_006255	$First, I better stick the pieces together. {nl}It may be a little blasphemous but can you get some Sticky Sap from the monsters?
-QUEST_LV_0200_20150406_006256	$I feel like it's soiling the Goddess Statue but I have nothing else so we'll have to settle for that. {nl}The Goddess will forgive us.
+QUEST_LV_0200_20150406_006256	$I feel like it's soiling the Goddess Statue but I have nothing else so we'll have to settle for that. {nl}The goddess will forgive us.
 QUEST_LV_0200_20150406_006257	Yes. That will be enough. Let me try sticking this together first. {nl}Oh, and one more thing.
 QUEST_LV_0200_20150406_006258	{memo X}The baron has a bad reputation because of the things he has done. {nl}And for what he's been up to nowadays.. He must be planning on something. {nl}
 QUEST_LV_0200_20150406_006259	$Some people say 'the baron is human, after all', so he won't do such things. {nl}So we need to collect clues to persuade them.
@@ -6267,7 +6267,7 @@ QUEST_LV_0200_20150406_006270	{memo X}I think it's better to get kindlings from 
 QUEST_LV_0200_20150406_006271	I can't stand paying ridiculous farm rent fees at times like this. {nl}How can he do that, as a human?
 QUEST_LV_0200_20150406_006272	Did you do it? {nl}That's great. But there are more magic circles.
 QUEST_LV_0200_20150406_006273	{memo X}If the magic circles are really a like, then you should be able to remove the magic circles in Talia trails with Goddess' power. {nl}I mean something like the Goddess Statue. Is there any way to get it?
-QUEST_LV_0200_20150406_006274	$If the magic circles really are for the better, I can just pay more rent and ask for forgiveness. {nl}We'll know for sure if we check with the Goddess' power.
+QUEST_LV_0200_20150406_006274	$If the magic circles really are for the better, I can just pay more rent and ask for forgiveness. {nl}We'll know for sure if we check with the goddess' power.
 QUEST_LV_0200_20150406_006275	$But if it isn't, the baron better be prepared. {nl}He fooled us, harmed the land, and will lose colleagues.
 QUEST_LV_0200_20150406_006276	$Indeed Joana has it. Use that power to remove the magic circle. {nl}Then checking the crops around will confirm it.
 QUEST_LV_0200_20150406_006277	You're just in time. {nl}You said you needed this Goddess Statue, right? Here, take it.
@@ -6275,15 +6275,15 @@ QUEST_LV_0200_20150406_006278	{memo X duplicate line}I used the Sticky Sap to gl
 QUEST_LV_0200_20150406_006279	{memo X}The magic circle will be a problem whether it's good or bad. {nl}But at least, it's better than begging the baron.
 QUEST_LV_0200_20150406_006280	I used the Sticky Sap to glue the pieces and indeed, it was a Goddess Statue. {nl}But this is all I can do so.. It might break easily.
 QUEST_LV_0200_20150406_006281	Alright. Thank you very much. {nl}At least now we know the magic circle is bad for sure. {nl}
-QUEST_LV_0200_20150406_006282	Anyway, I feel bad for the Goddess Statue being broken, but don't be so discouraged. {nl}The Goddess will forgive us.
-QUEST_LV_0200_20150406_006283	$If the magic circle can't be removed by the power of the Goddess, the baron had better be prepared. {nl}He will probably claim that the power of the Goddess is evil. I'll watch what he has to say.
+QUEST_LV_0200_20150406_006282	Anyway, I feel bad for the Goddess Statue being broken, but don't be so discouraged. {nl}The goddess will forgive us.
+QUEST_LV_0200_20150406_006283	$If the magic circle can't be removed by the power of the goddess, the baron had better be prepared. {nl}He will probably claim that the power of the goddess is evil. I'll watch what he has to say.
 QUEST_LV_0200_20150406_006284	{memo X}Have you seen the crops pouch the monsters took from me? {nl}Can you please help me find it? I need to pay for the farm rent.
 QUEST_LV_0200_20150406_006285	If I don't pay, I will surely be kicked out this time. {nl}Please help me.
 QUEST_LV_0200_20150406_006286	$Thank you very much. {nl}I worked so hard to gather it all and they just threw it to the monsters.. Those awful guards..
 QUEST_LV_0200_20150406_006287	$There is an unstable magic circle on the way to Ramus Crossroads. {nl}They say to not go near it because a strange aura flows out from it. But it really doesn't seem so. {nl}
 QUEST_LV_0200_20150406_006288	It's full of suspicious stuff. {nl}I have to glue these pieces together so can you check that aura for me?
 QUEST_LV_0200_20150406_006289	Thank you for helping us. {nl}From now on, we won't just stand back.
-QUEST_LV_0200_20150406_006290	I hope the Goddess blesses your journey..{nl}Please wish us luck.
+QUEST_LV_0200_20150406_006290	I hope the goddess blesses your journey..{nl}Please wish us luck.
 QUEST_LV_0200_20150406_006291	Revelator, it is time. {nl}Now we will do what we have to do.
 QUEST_LV_0200_20150406_006292	{memo X}Good work. {nl}With so many demons defeated, her vigor should be softened.
 QUEST_LV_0200_20150406_006293	$The servants of Hauberk who lost their commander started to follow her. {nl}They essentially betrayed Hauberk.
@@ -6449,12 +6449,12 @@ QUEST_LV_0200_20150406_006452	Pile up the logs on the magic circle and light the
 QUEST_LV_0200_20150406_006453	Report to Varas
 QUEST_LV_0200_20150406_006454	You've burnt the magic circle successfully. Return to Varas and report.
 QUEST_LV_0200_20150406_006455	Varas told you that there are more magic circles. Talk to Varas again.
-QUEST_LV_0200_20150406_006456	Obtain the statue of the Goddess from Joana
-QUEST_LV_0200_20150406_006457	Varas told you that you would be able to eliminate the magic circles easily using the mighty power of the Goddesses. Obtain the statue of the Goddess from Joana.
+QUEST_LV_0200_20150406_006456	Obtain the Goddess Statue from Joana
+QUEST_LV_0200_20150406_006457	Varas told you that you would be able to eliminate the magic circles easily using the mighty power of the Goddesses. Obtain the Goddess Statue from Joana.
 QUEST_LV_0200_20150406_006458	{memo X}Put the statue of the Goddess on the magic circle at Talia trail.
 QUEST_LV_0200_20150406_006459	Check the nearby crops
-QUEST_LV_0200_20150406_006460	As you put the statue of the Goddess on the magic circle, the magic circle disappeared with the statue of the Goddess. Check the status of the crops that Varas worried about.
-QUEST_LV_0200_20150406_006461	The crops became alive again. With the power of the statue of the Goddess, the magic circles have disappeared and the crops became alive again. Report this to Varas.
+QUEST_LV_0200_20150406_006460	As you put the statue of the goddess on the magic circle, the magic circle disappeared with the Goddess Statue. Check the status of the crops that Varas was worried about.
+QUEST_LV_0200_20150406_006461	The crops became alive again. With the power of the Goddess Statue, the magic circles have disappeared and the crops became alive again. Report this to Varas.
 QUEST_LV_0200_20150406_006462	Talk to Jugas
 QUEST_LV_0200_20150406_006463	There's a farmer who needs your help. Talk to Jugas.
 QUEST_LV_0200_20150406_006464	Look for the sack of grain
@@ -6512,7 +6512,7 @@ QUEST_LV_0200_20150406_006515	{memo X}Kupole Medeina told you to defeat the stro
 QUEST_LV_0200_20150406_006516	{memo X}You've succesfully defeated ??monsters that are the subordinates of Nuaele. Talk to Kupole Medeina.
 QUEST_LV_0200_20150406_006517	{memo X}Defeat ??monsters
 QUEST_LV_0200_20150406_006518	$Obtain Sealing Tokens
-QUEST_LV_0200_20150406_006519	$The Goddess Vakarine requested you to use the Evening Star Rune to defeat the demons that are gathered at the Hehmastar Isolation District and collect Sealing Tokens.
+QUEST_LV_0200_20150406_006519	$Goddess Vakarine requested you to use the Evening Star Rune to defeat the demons that are gathered at the Hehmastar Isolation District and collect Sealing Tokens.
 QUEST_LV_0200_20150406_006520	$You've obtained all the Sealing Tokens. Hand them over to the Goddess Vakarine.
 QUEST_LV_0200_20150406_006521	$Collect the keepsakes of the investigation team
 QUEST_LV_0200_20150406_006522	$Kupole Audra requested you to defeat the demons at Bjaurer Hideout and collect the belongings of the investigation team.
@@ -6601,8 +6601,8 @@ QUEST_LV_0200_20150414_006604	{memo X}Huh? You killed it because it tried to eat
 QUEST_LV_0200_20150414_006605	If you use the pot near monsters, poison will be collected in the pot. {nl}Give it to me when enough poison is gathered.
 QUEST_LV_0200_20150414_006606	Baron Secretary Andol's Journal
 QUEST_LV_0200_20150414_006607	The wizard who claimed to have come from the Mage Tower earned the baron's favor. {nl}But I'm sure that wizard is planning something absurd that I don't know much of. {nl}
-QUEST_LV_0200_20150414_006608	There is a wonder medicine of eternal youth and immortality? {nl}Isn't that something only within the domains of the Goddess. {nl}What is it that the wizard is trying to get out of tricking the baron. {nl}
-QUEST_LV_0200_20150414_006609	He started to suppress the divine aura, calling it strange, and then began to call in an evil aura. {nl}A hole leading to the other world.. {nl}All the experiments in the farm were for that hole, betraying the Goddess..{nl}
+QUEST_LV_0200_20150414_006608	There is a wonder medicine of eternal youth and immortality? {nl}Isn't that something only within the domains of the goddess. {nl}What is it that the wizard is trying to get out of tricking the baron. {nl}
+QUEST_LV_0200_20150414_006609	He started to suppress the divine aura, calling it strange, and then began to call in an evil aura. {nl}A hole leading to the other world.. {nl}All the experiments in the farm were for that hole, betraying the goddess..{nl}
 QUEST_LV_0200_20150414_006610	But the baron was already blinded with eternal life and pushed many soldiers into that hole.
 QUEST_LV_0200_20150414_006611	I don't know what the baron is working towards. {nl}But I'm sure of one thing, that it is ruining the farm.
 QUEST_LV_0200_20150414_006612	$I stacked up firewood in front of the magic circle. But it has a protective shield,{nl} so even if you light it, the fire will fade out quickly.{nl}
@@ -6641,7 +6641,7 @@ QUEST_LV_0200_20150414_006644	{memo X}What about striking the Harugals in 4th Is
 QUEST_LV_0200_20150414_006645	$The Harugals used to be Hauberk's elite servants. {nl}But it was also them who turned over Hauberk's seal fragment to Nuaele.
 QUEST_LV_0200_20150414_006646	$Nuaele is gone now, but there are still demons that continue her orders. {nl}They will repeat the past unless we retrieve her fragments.
 QUEST_LV_0200_20150414_006647	{memo X}It's the demons in 4th Isolation Area. {nl}Please take what happened last time as a lesson so that this will never happen again in the future. {nl}
-QUEST_LV_0200_20150414_006648	$Thank you. I will destroy these fragments myself. {nl}May the blessings of the Goddess be with you.
+QUEST_LV_0200_20150414_006648	$Thank you. I will destroy these fragments myself. {nl}May the blessings of the goddess be with you.
 QUEST_LV_0200_20150414_006649	$Nuaele is currently performing a demon summoning ritual in her territory. {nl}But both of her arms and legs are cut off, so it will be easy to defeat her. {nl}
 QUEST_LV_0200_20150414_006650	{memo X}Vakarine is waiting for your help in 3rd Area. {nl}Go quickly.
 QUEST_LV_0200_20150414_006651	{memo X}Please help Zydrone complete the Key of the Night Star. {nl}You can get the power of Dionysus with that key.
@@ -6658,7 +6658,7 @@ QUEST_LV_0200_20150414_006661	{memo X}You are still here, so it isn't late yet. 
 QUEST_LV_0200_20150414_006662	{memo X}Valtruss is defeated but its servants are still left in Oruarma Cathedral. {nl}I want you to let those demons pay for their sins.
 QUEST_LV_0200_20150414_006663	{memo X}The Grand Hall is where the Goddess recovers her powers. {nl}That is why it should always be safe from the demons. Thank you very much.
 QUEST_LV_0200_20150414_006664	$Dionysus is not recovering well. {nl}I think getting back the claws that have his powers might help him recover.
-QUEST_LV_0200_20150414_006665	$Dionysus was an ordinary creation of the human world. {nl}The Goddess took and cared for him when the demons cruelly toyed with him. {nl}
+QUEST_LV_0200_20150414_006665	$Dionysus was an ordinary creation of the human world. {nl}The goddess took and cared for him when the demons cruelly toyed with him. {nl}
 QUEST_LV_0200_20150414_006666	$Now, he is the most loyal guardian of Vakarine. {nl}Even though he lost his senses to that power, he must be in pain.
 QUEST_LV_0200_20150414_006667	There are many demons that ran away from Dionysus's attacks near the Rearda Seal. {nl}Let's just hope that Dionysus's claws are still stuck in them.
 QUEST_LV_0200_20150414_006668	$Once Dionysus gets back his strength, Vakarine should also recover. {nl}Aside from that, Dionysus has other roles that are indispensable.
@@ -6682,17 +6682,17 @@ QUEST_LV_0200_20150414_006685	$The degree of corruption in this farm is too much
 QUEST_LV_0200_20150414_006686	$I have no idea how I should persuade the owner of Shaton. {nl}I've heard that he is really stubborn.
 QUEST_LV_0200_20150414_006687	$Clearly, the farm is very different from before. {nl}What could have happened?
 QUEST_LV_0200_20150414_006688	Tenant Farmer Weiss
-QUEST_LV_0200_20150414_006689	$Even if Shaton changes his mind now, it's too late for me. {nl}Unless some miracle by the Goddess happens, how can this insane amount of corruption be purified?
+QUEST_LV_0200_20150414_006689	$Even if Shaton changes his mind now, it's too late for me. {nl}Unless some miracle by the goddess happens, how can this insane amount of corruption be purified?
 QUEST_LV_0200_20150414_006690	$The corruption is getting worse and worse. {nl}I don't know how to persuade him anymore.. I just hope he'll listen to you.{nl}
 QUEST_LV_0200_20150414_006691	$Now he's trying to escape using the body of his servant. {nl}Let's look for him by getting rid of the demons that contain Hauberk. Until he gives up.
-QUEST_LV_0200_20150414_006692	$Your lead was a big help. {nl}I wonder if this is all the guidance of the Goddess..
+QUEST_LV_0200_20150414_006692	$Your lead was a big help. {nl}I wonder if this is all the guidance of the goddess..
 QUEST_LV_0200_20150414_006693	$I plan to study the mysterious seedlings from now on. {nl}A wide range of purification, isn't that wonderful?
 QUEST_LV_0200_20150414_006694	$This farm belongs to my son. {nl}I will protect it until my son returns.
 QUEST_LV_0200_20150414_006695	$That druid sure is noisy. {nl}What does he know, to keep on talking..
 QUEST_LV_0200_20150414_006696	$I thought this farm would be able to replace my son. {nl}Now.. I have to let go.
 QUEST_LV_0200_20150414_006697	$Please tell the druid that I am sorry. {nl}I'm sure my daughter will take good care of the rest.
 QUEST_LV_0200_20150414_006698	$I'm sorry. There is nothing more I can say. {nl}If only my brother was alive..
-QUEST_LV_0200_20150414_006699	$I'm glad that he seems to have returned to his former self. {nl}Do you believe my brother made it to the hands of the Goddess safely?
+QUEST_LV_0200_20150414_006699	$I'm glad that he seems to have returned to his former self. {nl}Do you believe my brother made it to the hands of the goddess safely?
 QUEST_LV_0200_20150414_006700	$I'm going to give up grape farming and improve the treatment of the tenant farmers. {nl}I think my brother would have done the same.
 QUEST_LV_0200_20150414_006701	$I'm fine as long as the owner pays me but I'm sure others have gone crazy because of the evil aura. {nl}Growing grapes in a contaminated farm that no one can eat.
 QUEST_LV_0200_20150414_006702	$Everyone has their own story, don't they? {nl}Sir Shaton, and this farm too.
@@ -6728,7 +6728,7 @@ QUEST_LV_0200_20150414_006731	{memo X}This prison has been made by Goddess Ausri
 QUEST_LV_0200_20150414_006732	$Even the Kupoles won't be able to take care of Dionysus.{nl}Quickly, please complete the Key of the Night Star.
 QUEST_LV_0200_20150414_006733	$Is the Key of the Night Star still not ready?
 QUEST_LV_0200_20150414_006734	{memo X}Oh..my poor Dionysus..I'm so sorry for giving you this big burden.
-QUEST_LV_0200_20150414_006735	$Revelator. You cannot close the dimensional cracks unless you can get Dionysus back.{nl}I ask you in the name of the Goddess for him.
+QUEST_LV_0200_20150414_006735	$Revelator. You cannot close the dimensional cracks unless you can get Dionysus back.{nl}I ask you in the name of the goddess for him.
 QUEST_LV_0200_20150414_006736	Hauberk.. I'm expecting it already.
 QUEST_LV_0200_20150414_006737	I could not say the truth because you were close with Hauberk.{nl}Please forgive me.
 QUEST_LV_0200_20150414_006738	{memo X}Hauberk is also siner.{nl}You don't need to be sympathetic.
@@ -6757,7 +6757,7 @@ QUEST_LV_0200_20150414_006760	How can you.. there are hidden monsters.{nl}But, I
 QUEST_LV_0200_20150414_006761	$The story of that mysterious girl..{nl}We don't know if it is a clue to purifying this land.
 QUEST_LV_0200_20150414_006762	{memo X}This farm's owner is Gina Greene.{nl}They kindly lend this farm to us who lost the land since Medzio Diena.
 QUEST_LV_0200_20150414_006763	$I'm getting annoyed.{nl}I want the druids to defeat the monsters, but they are just looking at that tree.
-QUEST_LV_0200_20150414_006764	$Klaipeda is trying to increase its food distribution rate.{nl}With the Goddesses gone, we don't expect a great outcome.
+QUEST_LV_0200_20150414_006764	$Klaipeda is trying to increase its food distribution rate.{nl}With the goddesses gone, we don't expect a great outcome.
 QUEST_LV_0200_20150414_006765	{memo X}That's really appreciated.{nl}Firstly, collect the remains of Tama. I have something to check.
 QUEST_LV_0200_20150414_006766	$Strange. I assumed this wouldn't yield anything, but these actually seem mixed with earth's aura.{nl}In order to know more, we need something strongly exposed to the earth's aura here. Can you help me?
 QUEST_LV_0200_20150414_006767	$Please take some roots of the grapevines at Avarza Grape Farm.{nl}Three roots will probably be enough.
@@ -6922,7 +6922,7 @@ QUEST_LV_0200_20150428_006925	{memo X}Uhg, my head aches.. {nl}Maybe it's becaus
 QUEST_LV_0200_20150428_006926	We can only assume that the monsters were drawn to the magic circle. {nl}The magic circle is pressing down the divine power of the altar.. something like that.
 QUEST_LV_0200_20150428_006927	Rashly approaching the magic circle will only hurt you. {nl}Be sure to destroy the magic circle using the Magic Stone of Blessings.
 QUEST_LV_0200_20150428_006928	Have you seen the sacks of grain the monsters stole from me? {nl}Please get me back my sacks of grain. I have to pay the farm rent.
-QUEST_LV_0200_20150428_006929	{nl}If that doesn't happen, we have no choice but to stand up againt the plundering body. {nl}Moreover, the plundering process destroys the authority of the Goddess and if the objective of plunder is human's greed over something, then it is something to be angry about.
+QUEST_LV_0200_20150428_006929	{nl}If that doesn't happen, we have no choice but to stand up againt the plundering body. {nl}Moreover, the plundering process destroys the authority of the goddess and if the objective of plunder is human's greed over something, then it is something to be angry about.
 QUEST_LV_0200_20150428_006930	So the Chapparition was behind the curse. {nl}Naktis' curse alone was more than enough already. That's a relief. {nl}
 QUEST_LV_0200_20150428_006931	This is another separated space, neither the world of humans nor demons. {nl}The demons who are harmful to the world are imprisoned here. {nl}
 QUEST_LV_0200_20150428_006932	{memo X}Demons are crossing over through the gap in 1st Isolation Area. {nl}It will be of great help to Aldona if you can block them before they join Nuaele.
@@ -6930,7 +6930,7 @@ QUEST_LV_0200_20150428_006933	{memo X}Hauberk is getting back the Marks he gave 
 QUEST_LV_0200_20150428_006934	$How about striking the Harugals in the 4th Isolation Area? {nl}Getting rid of them would mean getting rid of some of Nuaele's most powerful weapons.
 QUEST_LV_0200_20150428_006935	$Nuaele may be gone but her remnants are gathering in the 1st Isolation Area. {nl}They intend to continue her will. Please get rid of the demons to dissuade them.
 QUEST_LV_0200_20150428_006936	They are the demons of the Fourth Isolation Area.{nl}Let this be a lesson for them, so that it won't happen again. {nl}
-QUEST_LV_0200_20150428_006937	The Goddess had to make a painful decision. {nl}Dionysus was like family but she decided to seal the power in him until the prison stabilizes.
+QUEST_LV_0200_20150428_006937	The goddess had to make a painful decision. {nl}Dionysus was like family but she decided to seal the power in him until the prison stabilizes.
 QUEST_LV_0200_20150428_006938	{memo X}Hauberk ran towards 4th Demon Prison which is protected by Daiva. {nl}First, you should return to the Goddess. I will look after Dionysus.
 QUEST_LV_0200_20150428_006939	$We got Hauberk but now his servants are the problem. {nl}We don't know what they will do.
 QUEST_LV_0200_20150428_006940	{memo X}Thank you. {nl}If Dionysus recovers well, it will be all thanks to you.
@@ -6982,7 +6982,7 @@ QUEST_LV_0200_20150428_006985	$Kupole Audra asked for your help to defeat the de
 QUEST_LV_0200_20150428_006986	$You've interrupted the ritual for Blut's escape. Go back and report to Kupole Audra at the Corridor of Monitor.
 QUEST_LV_0200_20150428_006987	$Kupole Audra says you need to weaken Blut's influence. Steal Blut's Mark from the demons in Bjaurer Hideout.
 QUEST_LV_0200_20150428_006988	$Kupole Audra says the power gathered by Blut can only be controlled by Hauberk. Help Hauberk absorb the power of Blut from the Blut Altar in Concentrated Management Area.
-QUEST_LV_0200_20150428_006989	$Kupole Arune says you need to stem the power of Demon Lord Nuaele to stabilize the Goddess' barrier. Defeat Nuaele's subordinates.
+QUEST_LV_0200_20150428_006989	$Kupole Arune says you need to stem the power of Demon Lord Nuaele to stabilize the goddess' barrier. Defeat Nuaele's subordinates.
 QUEST_LV_0200_20150428_006990	$Nuaele's subordinates are defeated. Go back and report to Kupole Arune.
 QUEST_LV_0200_20150428_006991	$Defeat the demons of the 1st Isolation Area
 QUEST_LV_0200_20150428_006992	$Some of Nuaele's demons used to be Hauberk's demons who've received empowered Marks from Hauberk before. Defeat Nuaele's demons in the 2nd Isolation Area and get Hauberk's Marks back.
@@ -7059,13 +7059,13 @@ QUEST_LV_0200_20150714_007062	We've reached this far with your help, Revelator.{
 QUEST_LV_0200_20150714_007063	Senior Monk Potos
 QUEST_LV_0200_20150714_007064	What brought you here?{nl}With the circumstances not heading to the way they used to be, we will try our best to help you.
 QUEST_LV_0200_20150714_007065	I am sorry if you've come here to visit the monastery.{nl}We are like this since the monsters rushed in.
-QUEST_LV_0200_20150714_007066	The Goddesses have taught us to greet everyone with warmth.{nl}Due to the difficulty we are having at the moment, we weren't able to greet the Hunters warmly. I regret this..
+QUEST_LV_0200_20150714_007066	The goddesses have taught us to greet everyone with warmth.{nl}Due to the difficulty we are having at the moment, we weren't able to greet the Hunters warmly. I regret this..
 QUEST_LV_0200_20150714_007067	If that trap was set up by Evoniphon, I will stand by the Hunters' side.{nl}Whatever excuses you make, they cannot be compared with the pain of our brothers.
 QUEST_LV_0200_20150714_007068	Brother Marko is at Viltis Forest and Guus is at Laukyme Swamp.{nl}Without their support, it is impossible to persuade the abbot.
 QUEST_LV_0200_20150714_007069	I support the Hunters, but I don't know what the other senior monks are thinking.{nl}However, I don't think it would be a problem if we get hard evidence.
 QUEST_LV_0200_20150714_007070	Monk Wiley
 QUEST_LV_0200_20150714_007071	My heart aches to see my brothers suffer in pain.{nl}I am doing my best to take care of them, but I am somewhat scared.
-QUEST_LV_0200_20150714_007072	For me, my brothers come first instead of the Hunters or the monastery.{nl}I am praying to the Goddesses, so that they can recover as soon as possible.{nl}
+QUEST_LV_0200_20150714_007072	For me, my brothers come first instead of the Hunters or the monastery.{nl}I am praying to the goddesses, so that they can recover as soon as possible.{nl}
 QUEST_LV_0200_20150714_007073	Hunter Reina
 QUEST_LV_0200_20150714_007074	You should be careful when you are crossing this forest.{nl}There are traps everywhere.
 QUEST_LV_0200_20150714_007075	You don't seem like a monk... Do you know anything about Evoniphon?{nl}I heard they created a mess near the farm in Klaipeda.
@@ -7093,7 +7093,7 @@ QUEST_LV_0200_20150714_007096	Please do not get close to those Hunters.{nl}They 
 QUEST_LV_0200_20150714_007097	I don't like the Hunters at all.{nl}I hope they wouldn't change their minds because we are protecting Evoniphon.
 QUEST_LV_0200_20150714_007098	Senior Monk Guus
 QUEST_LV_0200_20150714_007099	If you are the pilgrim who came to see Tyla Monastery, I am so sorry.{nl}We lost the place to the monsters...
-QUEST_LV_0200_20150714_007100	I don't know what the Goddesses would say if she sees this...{nl}Gloomy...
+QUEST_LV_0200_20150714_007100	I don't know what the goddesses would say if she sees this...{nl}Gloomy...
 QUEST_LV_0200_20150714_007101	This is all I know about Evoniphon.{nl}I think there weren't anything special besides that.
 QUEST_LV_0200_20150714_007102	If you need to more about Evoniphon, please ask me anytime.{nl}I will answer everything I know about Evoniphon.
 QUEST_LV_0200_20150714_007103	Finally, we are near Tyla Monastery.{nl}We want to attack, but we should also think about the monks.
@@ -7108,7 +7108,7 @@ QUEST_LV_0200_20150714_007111	Hey! Wake up!{nl}Can you hear my voice?
 QUEST_LV_0200_20150714_007112	He is fainted, but fortunately he is breathing.{nl}But, the fracture is serious.
 QUEST_LV_0200_20150714_007113	Evoniphon, you cheap...
 QUEST_LV_0200_20150714_007114	Fortunatly, his inner organs seem alright.{nl}But, I can't cure him by transporting him to other places.
-QUEST_LV_0200_20150714_007115	I am going to take care of the outer edge of the monastery.{nl}In the name of the Goddesses, I wish you the good luck.
+QUEST_LV_0200_20150714_007115	I am going to take care of the outer edge of the monastery.{nl}In the name of the goddesses, I wish you the good luck.
 QUEST_LV_0200_20150714_007116	We are all ready here.{nl}Although I can't participate in saving the abbot, I will do my best here.
 QUEST_LV_0200_20150714_007117	The prayer room where the abbot is located is safe.{nl}But, we should save him anyways.
 QUEST_LV_0200_20150714_007118	Our preparations are done here.{nl}If you are ready, tell Guus.
@@ -7117,18 +7117,18 @@ QUEST_LV_0200_20150714_007120	Hunters can move whenever they want.{nl}I will do 
 QUEST_LV_0200_20150714_007121	Moheim is smart so he should've hid the crystal sphere well.
 QUEST_LV_0200_20150714_007122	You can't open it outside without the crystal sphere.{nl}Unless the abbot opens it himself...
 QUEST_LV_0200_20150714_007123	It's so good to hear that you are okay.{nl}While you are getting the crystal sphere, we should get ready to rescue the abbot.
-QUEST_LV_0200_20150714_007124	I would've bled a lot if it weren't you.{nl}The Goddesses must have helped me.
+QUEST_LV_0200_20150714_007124	I would've bled a lot if it weren't you.{nl}The goddesses must have helped me.
 QUEST_LV_0200_20150714_007125	Fortunately, the abbot seems to know nothing.{nl}I guess that's better. Anyways, the issues have been resolved.
 QUEST_LV_0200_20150714_007126	I am less worried to find out the abbot is okay.{nl}Now what should we do about Evoniphon...
 QUEST_LV_0200_20150714_007127	I am discussing with the abbot.{nl}Please wait beside Mintz for a while.
 QUEST_LV_0200_20150714_007128	We haven't finished discussing yet.{nl}Please wait little more.
-QUEST_LV_0200_20150714_007129	You will leave soon. May the Goddesses bless you.{nl}Come to Tyla Monastery sometimes.
-QUEST_LV_0200_20150714_007130	I regret a bit since we should have allied together in the first place.{nl}I guess I forgot the lessons of the Goddesses for a while.
+QUEST_LV_0200_20150714_007129	You will leave soon. May the goddesses bless you.{nl}Come to Tyla Monastery sometimes.
+QUEST_LV_0200_20150714_007130	I regret a bit since we should have allied together in the first place.{nl}I guess I forgot the lessons of the goddesses for a while.
 QUEST_LV_0200_20150714_007131	It is so fortunate that the abbot is okay.{nl}I... feel like crying.
 QUEST_LV_0200_20150714_007132	I kinda expected that he would be alright since he was in the prayer room...{nl}But seeing him okay with my own eyes comforts me more.
 QUEST_LV_0200_20150714_007133	Please wait beside Mintz for a while.{nl}I should explain everything so it may take little time.
 QUEST_LV_0200_20150714_007134	I've heard about Evoniphon's letter from Guus.{nl}Please wait little more since everything fits the situation.
-QUEST_LV_0200_20150714_007135	We've retrieved the monastery and the Hunters fulfilled what they wanted...{nl}These are all blessings of the Goddesses.
+QUEST_LV_0200_20150714_007135	We've retrieved the monastery and the Hunters fulfilled what they wanted...{nl}These are all blessings of the goddesses.
 QUEST_LV_0200_20150714_007136	Without your help, I am sure that it would've not gone so easy.{nl}I've heard the stories of many Revelators before, but you are the only one I saw in person.
 QUEST_LV_0200_20150714_007137	Monk Moheim
 QUEST_LV_0200_20150714_007138	It's so good that we've retrieved the monastery...{nl}But it's a mess.
@@ -7171,7 +7171,7 @@ QUEST_LV_0200_20150714_007174	$This place is the cursed city of the traitor, Ruk
 QUEST_LV_0200_20150714_007175	$We will permit your entry since the Knights of Kaliss requested us to do so,{nl}but please remain at places where we can keep an eye out for you.
 QUEST_LV_0200_20150714_007176	$I don't know how great you were in the past,{nl}but you have to follow the rules of the kingdom here.
 QUEST_LV_0200_20150714_007177	Benas asked us to secure the route that connects to the Fortress of the Land.{nl}Ah, he is the ruler of the kingdoms soldiers in this region.{nl}
-QUEST_LV_0200_20150714_007178	If you could defeat the monsters in the ruins, that will be the way to contribute to the Goddesses and the kingdom.{nl}Of course, I promise you some rewards in return.{nl}
+QUEST_LV_0200_20150714_007178	If you could defeat the monsters in the ruins, that will be the way to contribute to the goddesses and the kingdom.{nl}Of course, I promise you some rewards in return.{nl}
 QUEST_LV_0200_20150714_007179	It will not be bad to show us a good impression.{nl}Because this land is ruled by the kingdom soldiers.
 QUEST_LV_0200_20150714_007180	It wasn't done by the thieves. We are moving the objects to the places where they could find more values.{nl}It will be way better than disappearing from here.
 QUEST_LV_0200_20150714_007181	Not bad.{nl}I guess the rumors don't always get exaggerated.
@@ -7238,7 +7238,7 @@ QUEST_LV_0200_20150714_007241	But, unlike their expectations, the Stone Frosts w
 QUEST_LV_0200_20150714_007242	The authorities do not take it well that tens of soldiers were sacrificed for support activities. {nl}That's why the kingdom army and the Knights of Kaliss have become distant.
 QUEST_LV_0200_20150714_007243	Good thing I was off duty that day.. I don't even want to think about it.{nl}I will deliver this to the families of the deceased.
 QUEST_LV_0200_20150714_007244	Gofden...{nl}The Silt Certificate... Ah sorry I talked alone in front of you.{nl}When you are carrying this, you will not receive the curse of the Stone Frosts. Don't you think it's amazing?{nl}
-QUEST_LV_0200_20150714_007245	People say you go around to save the world according to the will of Goddess?{nl}Then you could save also save this city!
+QUEST_LV_0200_20150714_007245	People say you go around to save the world according to the will of goddess?{nl}Then you could save also save this city!
 QUEST_LV_0200_20150714_007246	Our employer does not support us any other funds besides the research funds to revive the city.{nl}That's why the wizards like me, who want to come up with some results are researching while avoiding the eyes of the kingdom soldiers and the Knights of Kaliss.
 QUEST_LV_0200_20150714_007247	This will be enough.{nl}Good. Let's combine this with the Symbol of Silt.
 QUEST_LV_0200_20150714_007248	We've succeeded the combination... but I can't predict how effective this would be.{nl}I will give you the Symbol of Silt so try using it on the monsters in this area.
@@ -7310,7 +7310,7 @@ QUEST_LV_0200_20150714_007313	I don't understand how these heavy stuffs float do
 QUEST_LV_0200_20150714_007314	Whenever the Stone Frosts blow, the number of soldiers decreases, but the kingdom doesn't possess additional soldiers to support.{nl}That's why we ask the graverobbers or the refugees to join the military.{nl}
 QUEST_LV_0200_20150714_007315	Only thing I can do is to attach these leaflets around here.{nl}I hope you could help me by thinking that you are supporting the kingdom.
 QUEST_LV_0200_20150714_007316	I'm sure people taking the leaflets but the number of applicants have decreased recently. {nl}Is it because the graverobbers started checking inside. Isn't it suspicious?
-QUEST_LV_0200_20150714_007317	When a person like Premier Eminent appears again, I'm sure that the kingdom will flourish quickly.{nl}I will pray to the Goddesses that you could be an important person like him.
+QUEST_LV_0200_20150714_007317	When a person like Premier Eminent appears again, I'm sure that the kingdom will flourish quickly.{nl}I will pray to the goddesses that you could be an important person like him.
 QUEST_LV_0200_20150714_007318	The number of monsters in Kovos battlefield is increasing. {nl}We don't even know what is leading them here.{nl}
 QUEST_LV_0200_20150714_007319	We don't expect anything from the kingdom soldiers who were supposed to help us in the first place.{nl}If you could help us instead, then I will give you the rewards that I promised to give to the soldiers.
 QUEST_LV_0200_20150714_007320	We've investigated about the incident that was occurring in this city from a long time ago.{nl}We are trying to find hidden facts about the rebellion.
@@ -7435,7 +7435,7 @@ QUEST_LV_0200_20150714_007438	Ah, wait. I've heard about you before in the city.
 QUEST_LV_0200_20150714_007439	I hope Raius doesn't get hurt from this.{nl}I wonder why the master didn't tell him honestly.
 QUEST_LV_0200_20150714_007440	I want to talk to Raius again.{nl}But, I guess I should wait until he comes to me...
 QUEST_LV_0200_20150714_007441	I just hope the monsters stay calm.{nl}Maybe I am expecting too much...
-QUEST_LV_0200_20150714_007442	The blessings of the Goddesses has not reached at this city.{nl}Only the monsters and the criminals are full in this city.
+QUEST_LV_0200_20150714_007442	The blessings of the goddesses has not reached at this city.{nl}Only the monsters and the criminals are full in this city.
 QUEST_LV_0200_20150714_007443	Please report to us when you see monsters.{nl}Especially, when they are grouped together or make a mess.
 QUEST_LV_0200_20150714_007444	I've written down what to do at the memo.{nl}First, find the Magic Gem Fusion Device at Underground Grave of Ritinis.
 QUEST_LV_0200_20150714_007445	Long time ago, I had serviced as a guard in the army like those guys.{nl}I was a junior officer who wanted become a strategist. At least before Medzio Diena.
@@ -7476,11 +7476,11 @@ QUEST_LV_0200_20150714_007479	But, whenever we tried to do that, the monsters al
 QUEST_LV_0200_20150714_007480	When you obtain the Wisdom Guiding Stone, please show it to Hones at Raiduna Hall.{nl}If he finds out that I am the only one who could continue the research of the master, he would hand over the documents.
 QUEST_LV_0200_20150714_007481	Hones did not cooperate with us until now, but he would have to hand them over this time.{nl}As the master only left the orb to me, the Wisdom Guiding Stone can only be obtained by me.
 QUEST_LV_0200_20150714_007482	Hmm? Isn't that the Wisdom Guiding Stone?{nl}Who are you and why are you showing it to me?
-QUEST_LV_0200_20150714_007483	Damn, Raius is misunderstanding something.{nl}No. Maybe the master and the Goddess guided us this far.{nl}
+QUEST_LV_0200_20150714_007483	Damn, Raius is misunderstanding something.{nl}No. Maybe the master and the goddess guided us this far.{nl}
 QUEST_LV_0200_20150714_007484	Anyways, I have the Wisdom Guiding Stone as well.
 QUEST_LV_0200_20150714_007485	Raius... has a problem.{nl}I can't say it. Go to the hideout of the master. Then you would believe it.
 QUEST_LV_0200_20150714_007486	Maybe, it turned out better than we thought.{nl}I didn't expect Raius would help us.
-QUEST_LV_0200_20150714_007487	The master researched about the Goddesses throughout his entire life.{nl}And then he discovered something important, but he said if it goes into the hands of the demons, it will be dangerous.{nl}
+QUEST_LV_0200_20150714_007487	The master researched about the goddesses throughout his entire life.{nl}And then he discovered something important, but he said if it goes into the hands of the demons, it will be dangerous.{nl}
 QUEST_LV_0200_20150714_007488	As you saw, Raius is trying to find the remains of the research of the master due to his greed.{nl}But, they should never be exposed to the world.
 QUEST_LV_0200_20150714_007489	Ahah. Revelator. Maybe...{nl}The master said someone who is reliable should dispose of his research before he died.{nl}
 QUEST_LV_0200_20150714_007490	And the remains of the research are at the place where normal people like me or Raius can not reach.{nl}If you are really the Revelator, I want you to dispose of them.
@@ -7501,7 +7501,7 @@ QUEST_LV_0200_20150714_007504	Very good. You've found the remains of the master'
 QUEST_LV_0200_20150714_007505	I feel disappointed a bit, but I also feel comfortable in a way.{nl}Well... Raius... I hope he would be alright.
 QUEST_LV_0200_20150714_007506	Magic Gem Fusion Device
 QUEST_LV_0200_20150714_007507	Please gather all Spatial Magic Gems.{nl}It is hard to understand the hidden rules of space, but my knowledge would help you.
-QUEST_LV_0200_20150714_007508	My master, who was a Sorcerer, researched on the Goddesses.{nl}It was about some special kind of space. He said a vast amount of knowledge can be obtained from that space.
+QUEST_LV_0200_20150714_007508	My master, who was a Sorcerer, researched on the goddesses.{nl}It was about some special kind of space. He said a vast amount of knowledge can be obtained from that space.
 QUEST_LV_0200_20150714_007509	Hones's Regular Memo
 QUEST_LV_0200_20150714_007510	The Spatial Magic Gem of Contract is in the reception room, but it was destroyed recently.{nl}The monsters must have fragments of the gem.
 QUEST_LV_0200_20150714_007511	When you collect all fragments of the Magic Gem, please go to the Forgotten Priest's Grave. {nl}You can restore the Magic Gem at the Magic Field of Preservation.
@@ -7512,7 +7512,7 @@ QUEST_LV_0200_20150714_007515	Templeshooter at the Shrine of Remembrance holds t
 QUEST_LV_0200_20150714_007516	Please... save us.{nl}I will soon disappear, but please save the others.{nl}Please save us... them... from the vicious demons.
 QUEST_LV_0200_20150714_007517	$Kupole Vita
 QUEST_LV_0200_20150714_007518	$Given that you saw it too,{nl} I'm certain there is something here.{nl}
-QUEST_LV_0200_20150714_007519	$Ah, I am Kupole Vita.{nl}I guide the spirits on behalf of the missing Goddesses.
+QUEST_LV_0200_20150714_007519	$Ah, I am Kupole Vita.{nl}I guide the spirits on behalf of the missing goddesses.
 QUEST_LV_0200_20150714_007520	$I came here to look for spirits who have vanished.{nl} I can sense that there are spirits here who have strayed out of the normal way.{nl}
 QUEST_LV_0200_20150714_007521	$But, I can hardly find any evidence.{nl}The spirits hardly talk to me.
 QUEST_LV_0200_20150714_007522	$What? The spirits talked to you first?{nl}You must have something which enables you to save them.{nl}
@@ -7531,12 +7531,12 @@ QUEST_LV_0200_20150714_007534	$Please gather the skeletons binded to the Contrac
 QUEST_LV_0200_20150714_007535	Nutrients... Medzio Diena even makes the people in the past to suffer.
 QUEST_LV_0200_20150714_007536	{memo X}My body. Unfortunately, it is not mine anymore.{nl}I regret my fault in the past that I've committed due to my greed.
 QUEST_LV_0200_20150714_007537	The Contract of Flesh is tied in Sataruti Hall.{nl}Please burn the contract and the skeletons with holy power.
-QUEST_LV_0200_20150714_007538	We've suffered a lot from regrets and failures for hundreds of years.{nl}The Goddesses yet... Would we be saved.
+QUEST_LV_0200_20150714_007538	We've suffered a lot from regrets and failures for hundreds of years.{nl}The goddesses yet... Would we be saved.
 QUEST_LV_0200_20150714_007539	I can feel it. I feel myself being freed from the binding contract.{nl}But, there is one more thing to do.
 QUEST_LV_0200_20150714_007540	$The Contract of Spirit is engraved on Master Genie in Garubingal Burial Chamber.{nl}I will be completely free when Master Genie gets defeated.
 QUEST_LV_0200_20150714_007541	{memo X}Please be safe.{nl}We are already dead, but you are not.
 QUEST_LV_0200_20150714_007542	$I can finally be free...{nl}This was the moment I've been waiting for hundreds of years... It feels like a dream.
-QUEST_LV_0200_20150714_007543	$We the Kupoles guide all the spirits to Goddess Ausrine.{nl}They rest in peace beside the Goddesses eternally.{nl}
+QUEST_LV_0200_20150714_007543	$We the Kupoles guide all the spirits to Goddess Ausrine.{nl}They rest in peace beside the goddesses eternally.{nl}
 QUEST_LV_0200_20150714_007544	$But they will all disappear if they are extinguished.{nl}But, if the demons are involved... we could maybe use them for nutrients.{nl}
 QUEST_LV_0200_20150714_007545	$Something is engraved on this tablet.{nl}To see what's written, you should obtain the materials to make rubbings with.
 QUEST_LV_0200_20150714_007546	Adrijus
@@ -7589,14 +7589,14 @@ QUEST_LV_0200_20150714_007592	$The power that may lead you to the answer that yo
 QUEST_LV_0200_20150714_007593	$I immediately left without saying anything.{nl}But soon I...realizing I was so close to finally getting something...{nl}found myself sobbing...and realized what I truly wanted{nl}{nl}
 QUEST_LV_0200_20150714_007594	$When the sun goes down tomorrow, I will return to Giltine. And tell her my decision.
 QUEST_LV_0200_20150714_007595	Archeologist Justas
-QUEST_LV_0200_20150714_007596	I am so lucky. The Goddesses helped me this time as well.
+QUEST_LV_0200_20150714_007596	I am so lucky. The goddesses helped me this time as well.
 QUEST_LV_0200_20150714_007597	Ah, I am Justas. I am excavating the records of Demetrius who is the historian from the ancient period.{nl}What has brought you here?
 QUEST_LV_0200_20150714_007598	Is that so... Revelator... Then you would like my research.{nl}Actually, I needed someone who would be my guard and assistant. Are you interested?
 QUEST_LV_0200_20150714_007599	This place are the ruins before the construction of the kingdom.{nl}But, I am not that interested in here.{nl}
 QUEST_LV_0200_20150714_007600	What I really want are the records of Demetrius.{nl}It is unique that it is recorded on a Metal Plate...It seems to contain an amazing story.{nl}
 QUEST_LV_0200_20150714_007601	Maybe we would be able to find out where we came from.{nl}Then we may be able to find out what would happen to us as well.
 QUEST_LV_0200_20150714_007602	Good. Good. I will give you the task of obtaining the bone pieces of Hallowventer curse speller.{nl}They are the best materials to use when you make an antirust agent.
-QUEST_LV_0200_20150714_007603	It is so fortunate to have a good assistant.{nl}The Goddesses helped me on this as well.
+QUEST_LV_0200_20150714_007603	It is so fortunate to have a good assistant.{nl}The goddesses helped me on this as well.
 QUEST_LV_0200_20150714_007604	There's a saying that geniuses are freaks. How should the people of the later generations do if the Metal Plate gets rusted.{nl}Anyways, the work is being done quickly because of you so I feel happy.
 QUEST_LV_0200_20150714_007605	I want to request to you to bring the Metal Plate on Ramive Hills.{nl}There are many plates that I could not bring due to the monsters. You can do it right?
 QUEST_LV_0200_20150714_007606	This place is too isolated so the monsters rush in.{nl}Be careful all the time.
@@ -7604,7 +7604,7 @@ QUEST_LV_0200_20150714_007607	Good!{nl}But, the status is too bad so it would ta
 QUEST_LV_0200_20150714_007608	What a view here right?{nl}But, more amazing things are hidden. The records of the historian, Demetrius.{nl}
 QUEST_LV_0200_20150714_007609	I am looking for the records of Demetrius that haven't been discovered yet.{nl}The monsters are dangerous, but I have a good feeling.
 QUEST_LV_0200_20150714_007610	Alruida is near Apsba Hall.{nl}We've been working together for a long time so even if we are far apart, we know each other well.
-QUEST_LV_0200_20150714_007611	Isn't it great to hear that humans, Goddesses and demons may lived together for a long time?{nl}But, then how come there are no records remaining?
+QUEST_LV_0200_20150714_007611	Isn't it great to hear that humans, goddesses and demons may lived together for a long time?{nl}But, then how come there are no records remaining?
 QUEST_LV_0200_20150714_007612	That is so shocking.{nl}A great scholar like Demetrius could had not recorded lies.
 QUEST_LV_0200_20150714_007613	Since we haven't found everything, we can't say this for sure, but...{nl}I think it's about where humans came from.
 QUEST_LV_0200_20150714_007614	Archeologist Alruida
@@ -7618,7 +7618,7 @@ QUEST_LV_0200_20150714_007621	After Medzio Diena, scary things are happening.{nl
 QUEST_LV_0200_20150714_007622	The spirits don't say anything to me.{nl}Have you heard any stories of them?
 QUEST_LV_0200_20150714_007623	The only thing I could do was to depress for hundreds of years.{nl}I want to just disappear if I can.
 QUEST_LV_0200_20150714_007624	What can I do after losing the master and the body.{nl}Besides just watching the demons...
-QUEST_LV_0200_20150714_007625	I can't neither go beside the Goddesses nor be eliminated.{nl}For what... I am doing... such...
+QUEST_LV_0200_20150714_007625	I can't neither go beside the goddesses nor be eliminated.{nl}For what... I am doing... such...
 QUEST_LV_0200_20150714_007626	Collapsing Stone Tower
 QUEST_LV_0200_20150714_007627	The Stone Tower is collapsing by someone. Do you want to go to the Stone Tower?
 QUEST_LV_0200_20150714_007628	$I am leaving this record when I am still Eitbaras.{nl}-{nl}I am in awe of them.{nl}A humble fairy like me can't be compared with them...{nl}{nl}
@@ -7634,11 +7634,11 @@ QUEST_LV_0200_20150714_007637	$So, here's a bait box.{nl}They go crazy on the sm
 QUEST_LV_0200_20150714_007638	When you find the sticky resin, please mix it with this coagulant before using it.{nl}Stones will be easily attached.
 QUEST_LV_0200_20150714_007639	{memo X}
 QUEST_LV_0200_20150714_007640	Ah. It definitely reacted this time.{nl}I would have spent a long time without your help. Thank you so much.
-QUEST_LV_0200_20150714_007641	Thanks for helping us.{nl}The Goddess helps the ones who try their best, and I think it was you, the Revelator.
+QUEST_LV_0200_20150714_007641	Thanks for helping us.{nl}The goddess helps the ones who try their best, and I think it was you, the Revelator.
 QUEST_LV_0200_20150714_007642	$Many demons are gathering at Rituala to participate in a magic ritual that frees Blut.{nl}Please, first defeat them.
 QUEST_LV_0200_20150714_007643	$Valtruss is defeated but his servants are still left in Oruarma Cathedral. {nl}I want you to make those demons pay for their sins.
 QUEST_LV_0200_20150714_007644	$Even if you are the Revelator, you better not fool around. {nl}The corruption here is not something for you to mind.
-QUEST_LV_0200_20150714_007645	I wish you good luck in the name of the Goddess.
+QUEST_LV_0200_20150714_007645	I wish you good luck in the name of the goddess.
 QUEST_LV_0200_20150714_007646	$I am solely to blame for all of this.{nl}With the Key of the Night Star, three seals should be unleashed,{nl} so I could recover my power to find Dionysus.
 QUEST_LV_0200_20150714_007647	$The dimensional crack.. We cannot close it without Dionysus.{nl}Please find Dionysus until I recover my power..
 QUEST_LV_0200_20150714_007648	$My mission is to retrieve the relics, but I can't stand and watch this anymore.{nl}Can you defeat the monsters that are roaming around the Great Cathedral?
@@ -7722,7 +7722,7 @@ QUEST_LV_0200_20150714_007725	Thank you so much.{nl}I will now pray for our brot
 QUEST_LV_0200_20150714_007726	Since I quickly ran away from the monastery, I wasn't able to bring many things with me.{nl}I should somehow feed some nutritious food to our brothers who are suffering from the poison..
 QUEST_LV_0200_20150714_007727	Thank you so much.{nl}There is a mushroom called Tempas. It grows really fast.{nl}Please get me some of those from Juklas Sunny Place.
 QUEST_LV_0200_20150714_007728	You will find it when you walk diligently.{nl}They are usually hidden in the ground.
-QUEST_LV_0200_20150714_007729	Thanks.{nl}I will pray to the Goddesses that they will be okay after eating this.
+QUEST_LV_0200_20150714_007729	Thanks.{nl}I will pray to the goddesses that they will be okay after eating this.
 QUEST_LV_0200_20150714_007730	Since I am not feeling well right now, I do want to prepare in advance.{nl}If you are going to hunt for monsters nearby, could you please listen to my request?
 QUEST_LV_0200_20150714_007731	Please collect the stone legs of the Rocktors.{nl}I can use those for my arrowheads.
 QUEST_LV_0200_20150714_007732	The stone legs of Roctors near this are usable.{nl}Other things are somewhat soft.
@@ -7759,7 +7759,7 @@ QUEST_LV_0200_20150714_007762	I'll absorb the poison with this.{nl}I am going to
 QUEST_LV_0200_20150714_007763	You won't understand how embarassed and painful I am.{nl}My brother almost died due to the posion and I received help from the Hunters that I kicked out...{nl}
 QUEST_LV_0200_20150714_007764	Good. You would have to persuade Guus at Laukyme Swamp.{nl}Please tell Marko that I've decided to go with Hunters.
 QUEST_LV_0200_20150714_007765	It's is so fortunate that it turned out alright.{nl}Please meet Captain Mintz on your way to Laukyme Swamp and tell him that everything went alright.
-QUEST_LV_0200_20150714_007766	Senior monk Guus is leading the brothers at Laukyme Swamp.{nl}If Evoniphon did all of these, the Goddesses would also understand my rage.
+QUEST_LV_0200_20150714_007766	Senior monk Guus is leading the brothers at Laukyme Swamp.{nl}If Evoniphon did all of these, the goddesses would also understand my rage.
 QUEST_LV_0200_20150714_007767	It's so nice seeing you.{nl}So how did the task at Viltis Forest go?
 QUEST_LV_0200_20150714_007768	Go first.{nl}I will follow you to Laukyme Swamp if he gets there alright.
 QUEST_LV_0200_20150714_007769	So that's it. We now have to persuade one of the monks and retrieve the monastery...{nl}After that, we would be able to contact with the abbot who would decide what to do with Evoniphon.
@@ -7773,12 +7773,12 @@ QUEST_LV_0200_20150714_007776	It's so fortunate that you came before the monster
 QUEST_LV_0200_20150714_007777	Good. Good. {nl}We should first survive before feeling embarassed. Thanks!
 QUEST_LV_0200_20150714_007778	We have lots of things to prepare.
 QUEST_LV_0200_20150714_007779	You are not... one of those Hunters.{nl}Since I can't trust them, I have a request for you.{nl}
-QUEST_LV_0200_20150714_007780	I want to make an ointment for the wounded brothers.{nl}Can you make beehives with the blessing from the Goddesses?
-QUEST_LV_0200_20150714_007781	It took so little time for monsters to sweep across the monastery.{nl}I think I was lucky enough to be alive with the blessing from the Goddesses.
+QUEST_LV_0200_20150714_007780	I want to make an ointment for the wounded brothers.{nl}Can you make beehives with the blessing from the goddesses?
+QUEST_LV_0200_20150714_007781	It took so little time for monsters to sweep across the monastery.{nl}I think I was lucky enough to be alive with the blessing from the goddesses.
 QUEST_LV_0200_20150714_007782	You've tried hard, but... we were making beeswax, but strangely, it doesn't becomme clear at all.{nl}What should we do about this...
 QUEST_LV_0200_20150714_007783	That's it. I am sorry, but can you help me with one more thing?{nl}If I only have the resin that is collected in the head of Woodluwa I think I will be able to resolve it.
-QUEST_LV_0200_20150714_007784	I didn't expect I would meet someone other than those Hunters.{nl}I am sure the Goddesses haven't abandoned me yet.
-QUEST_LV_0200_20150714_007785	I wasn't able to do anything myself, but it is so fortunate that the Goddesses have sent you.{nl}I will make some medicine. Thank you so much!
+QUEST_LV_0200_20150714_007784	I didn't expect I would meet someone other than those Hunters.{nl}I am sure the goddesses haven't abandoned me yet.
+QUEST_LV_0200_20150714_007785	I wasn't able to do anything myself, but it is so fortunate that the goddesses have sent you.{nl}I will make some medicine. Thank you so much!
 QUEST_LV_0200_20150714_007786	Stranger...{nl}If you don't have any task here, please go back.
 QUEST_LV_0200_20150714_007787	The monastery is locked with the barriers of the monks so it won't be possible without the persuasion from Guus.{nl}But, I... it's too difficult.
 QUEST_LV_0200_20150714_007788	Hunters... they just won't give up.{nl}I've heard Marko and Potos are with the Hunters.{nl}
@@ -7797,7 +7797,7 @@ QUEST_LV_0200_20150714_007800	What Guus said also makes sense.{nl}As they gather
 QUEST_LV_0200_20150714_007801	I think we would have enough time.{nl}I am sorry, but please go back to Guus and ask him what happened when Evoniphon was coming.
 QUEST_LV_0200_20150714_007802	You can't prove that he was a cruel assassin.{nl}We can't release the ones that are being protected in the sanctuary by just guessing.{nl}
 QUEST_LV_0200_20150714_007803	What they said about the traps and the monsters that conquered the monastery are also the same.{nl}It's only an one-sided story that this was done by Evoniphon.{nl}
-QUEST_LV_0200_20150714_007804	We are the people who pray for the generosity of the Goddesses.{nl}So to withdraw the protection of Evoniphon, you should show them some decisive evidence.
+QUEST_LV_0200_20150714_007804	We are the people who pray for the generosity of the goddesses.{nl}So to withdraw the protection of Evoniphon, you should show them some decisive evidence.
 QUEST_LV_0200_20150714_007805	Hmm. I remember that clearly.{nl}One day, someone named Evoniphon knocked on the door of the monastery. With his wounded body...{nl}
 QUEST_LV_0200_20150714_007806	After bringing him inside, I began to cure him.{nl}He also requested to protect the sanctuary at our monastery.
 QUEST_LV_0200_20150714_007807	That's right. Before he came on that day, one man who seemed to be affected by the poison also came.{nl}He was gravely ill, so he passed away before I could even ask him a question.{nl}
@@ -7820,7 +7820,7 @@ QUEST_LV_0200_20150714_007823	Now, it is different. This letter is the evidence.
 QUEST_LV_0200_20150714_007824	This place is dangerous... I miss the monastery.
 QUEST_LV_0200_20150714_007825	I want to be safe until I go back to the monastery.{nl}But the monsters near here are very threatening.
 QUEST_LV_0200_20150714_007826	There will be lots of monsters if we move out a bit from the hills.{nl}I'll be counting on you.
-QUEST_LV_0200_20150714_007827	Now, I can relax until I go back to the monastery.{nl}Thank you so much. I hope the Goddesses bless you...{nl}
+QUEST_LV_0200_20150714_007827	Now, I can relax until I go back to the monastery.{nl}Thank you so much. I hope the goddesses bless you...{nl}
 QUEST_LV_0200_20150714_007828	We don't have enough water to drink here. It is strange since this place is full of water.{nl}After this place turned into a thorny forest, we can't drink it without purifying it.{nl}
 QUEST_LV_0200_20150714_007829	If we have Asilado water plant, we can purify it with that.{nl}But, I am too scared of the monsters... Can you obtain some of them?
 QUEST_LV_0200_20150714_007830	We would last for a while even if there's no food, but not without drinkable water.{nl}I hope you would help us.
@@ -7832,7 +7832,7 @@ QUEST_LV_0200_20150714_007835	There are more dangerous monsters inside the monas
 QUEST_LV_0200_20150714_007836	Thank you.{nl}But, I am worried since there are still many monsters left.
 QUEST_LV_0200_20150714_007837	Are you trying to help me more?{nl}If that's so, it will be really appreciated...
 QUEST_LV_0200_20150714_007838	We've cleaned up many monsters. {nl}One more thing... I want you to do the last task.
-QUEST_LV_0200_20150714_007839	Thanks for your efforts.{nl}When the monks ask me, I will tell them to pray to the Goddesses to protect you.
+QUEST_LV_0200_20150714_007839	Thanks for your efforts.{nl}When the monks ask me, I will tell them to pray to the goddesses to protect you.
 QUEST_LV_0200_20150714_007840	{memo X}
 QUEST_LV_0200_20150714_007841	We've recovered the hall. Let's continue on without taking a rest.{nl}Mintz... please take the rear since the monsters may follow.
 QUEST_LV_0200_20150714_007842	It doesn't look easy from here.{nl}There are many monsters in the hallway so let's be careful.
@@ -7848,7 +7848,7 @@ QUEST_LV_0200_20150714_007851	It was a really important object so I put it in th
 QUEST_LV_0200_20150714_007852	I have to protect this place so I can't go with you.{nl}There aren't many boxes so you will find it easily.
 QUEST_LV_0200_20150714_007853	Yes. That's the crystal sphere.{nl}Please bring it to Guus.
 QUEST_LV_0200_20150714_007854	abbot
-QUEST_LV_0200_20150714_007855	Thanks for resolving the crisis.{nl}I can feel the Goddesses are protecting you.
+QUEST_LV_0200_20150714_007855	Thanks for resolving the crisis.{nl}I can feel the goddesses are protecting you.
 QUEST_LV_0200_20150714_007856	So you've come. Soon, the abbot would come out.{nl}Please wait a bit here.
 QUEST_LV_0200_20150714_007857	Why is the monastery like this and why are you all gathered here?{nl}And you... you seem to have some business with me.
 QUEST_LV_0200_20150714_007858	He is the abbot of the Tyla Monastery.
@@ -7860,11 +7860,11 @@ QUEST_LV_0200_20150714_007863	So it seems that their discussion is over.{nl}Let'
 QUEST_LV_0200_20150714_007864	We haven't finished our discussion.{nl}Please wait with the Hunters.
 QUEST_LV_0200_20150714_007865	After we've discussed with the senior monks...{nl}We've decided to withdraw our declaration to protect Evoniphon.
 QUEST_LV_0200_20150714_007866	From this point on, Evoniphon won't be protected by Tyla Monastery and we request Evoniphon to leave at once.{nl}Also, we are not going to be involved with others' decision to punish him.
-QUEST_LV_0200_20150714_007867	I hope the Goddessess will be with you on your rest of journey.
+QUEST_LV_0200_20150714_007867	I hope the goddessess will be with you on your rest of journey.
 QUEST_LV_0200_20150714_007868	Besides from the expulsion, we can't forgive his actions that ruined the monastery.{nl}We should find him since he should be here somewhere.
 QUEST_LV_0200_20150714_007869	He made the monastery like this due to that letter. {nl}Please be careful.
 QUEST_LV_0200_20150714_007870	He is so cunning..{nl}The Hunters are surrounding this place so he will get caught within a short period of time.
-QUEST_LV_0200_20150714_007871	We would have had hard time without your help.{nl}Thank you so much for your efforts. I pray that the Goddesses be with you on your journey.
+QUEST_LV_0200_20150714_007871	We would have had hard time without your help.{nl}Thank you so much for your efforts. I pray that the goddesses be with you on your journey.
 QUEST_LV_0200_20150714_007872	If it wasn't for your help, the circumstances would have not been like this.
 QUEST_LV_0200_20150714_007873	I've read it from the book before. {nl}Some smell has the power to pull the monsters.{nl}
 QUEST_LV_0200_20150714_007874	I should've noticed when Evoniphon brought that lump... I didn't expect that would be enlarged this big...{nl}We are eliminating them as we see them, but I want you to help us as well.{nl}
@@ -7875,7 +7875,7 @@ QUEST_LV_0200_20150714_007878	We were able to retrieve the monastery, but as you
 QUEST_LV_0200_20150714_007879	Orange Kowaks inside the monastery are most problematic.{nl}They are the most violent and vicious monsters among the monsters that came into the monastery.
 QUEST_LV_0200_20150714_007880	They are still inside.{nl}Please eliminate the monsters including them.
 QUEST_LV_0200_20150714_007881	The number of monsters won't increase from this point on.{nl}But, in order to eliminate them completely, we would need lots of time.
-QUEST_LV_0200_20150714_007882	The Goddesses helped us to retrieve the monastery.{nl}Lots of other sacred places are still occupied by many monsters.
+QUEST_LV_0200_20150714_007882	The goddesses helped us to retrieve the monastery.{nl}Lots of other sacred places are still occupied by many monsters.
 QUEST_LV_0200_20150714_007883	It's a mess. {nl}The monsters are sweeping across the monastery so the books are all scattered.
 QUEST_LV_0200_20150714_007884	When would we able to gather all these books again and divide them into different categories...{nl}If you pick up scriptures, please bring them to me.
 QUEST_LV_0200_20150714_007885	You don't have to try hard.{nl}I can collect them.
@@ -8204,16 +8204,16 @@ QUEST_LV_0200_20150714_008207	I will defeat the monsters inside.
 QUEST_LV_0200_20150714_008208	Go out to a safe area.
 QUEST_LV_0200_20150714_008209	Put it back where it was
 QUEST_LV_0200_20150714_008210	Enter Verkti Square.
-QUEST_LV_0200_20150714_008211	Seems like not anyone can enter the city. Talk to Kingdom Army Guard Retia.
+QUEST_LV_0200_20150714_008211	Seems like not anyone can enter the city. Talk to Royal Army Guard Retia.
 QUEST_LV_0200_20150714_008212	Defeat the monsters in the Workshop ruins
-QUEST_LV_0200_20150714_008213	Kingdom Army Guard Retia asked you to cooperate in organizing the road to the Fortress of the Land. Defeat the monsters in the Workshop ruins.
-QUEST_LV_0200_20150714_008214	Report to Kingdom Army Guard
+QUEST_LV_0200_20150714_008213	Royal Army Guard Retia asked you to cooperate in organizing the road to the Fortress of the Land. Defeat the monsters in the Workshop ruins.
+QUEST_LV_0200_20150714_008214	Report to Royal Army Guard
 QUEST_LV_0200_20150714_008215	Check the Petrification Detector
-QUEST_LV_0200_20150714_008216	Kingdom Army Guard asked you to check the petrification detectors installed around Verkti Square for Stone Frost forecast.
-QUEST_LV_0200_20150714_008217	Checked the petrification detectors as Kingdom Army Guard asked you. The detectors' reactions are unusual. Return to Retia.
-QUEST_LV_0200_20150714_008218	Kingdom Army Guard asked you to eliminate the remaining Stone Frosts in the Plaza. Use the Stone Frost Absorption Scroll and remove the Frost.
+QUEST_LV_0200_20150714_008216	Royal Army Guard asked you to check the petrification detectors installed around Verkti Square for Stone Frost forecast.
+QUEST_LV_0200_20150714_008217	Checked the petrification detectors as Royal Army Guard asked you. The detectors' reactions are unusual. Return to Retia.
+QUEST_LV_0200_20150714_008218	Royal Army Guard asked you to eliminate the remaining Stone Frosts in the Plaza. Use the Stone Frost Absorption Scroll and remove the Frost.
 QUEST_LV_0200_20150714_008219	Check the petrification detector and defeat Sparnashorn
-QUEST_LV_0200_20150714_008220	Kingdom Army Guard asked you to defeat Sparnashorn that is endangering the soldiers. Check the petrification detector in the old market then lure to the Sparnashorn to defeat it.
+QUEST_LV_0200_20150714_008220	Royal Army Guard asked you to defeat Sparnashorn that is endangering the soldiers. Check the petrification detector in the old market then lure to the Sparnashorn to defeat it.
 QUEST_LV_0200_20150714_008221	Defeat the monsters in Assembly Hall Site
 QUEST_LV_0200_20150714_008222	Graverobber Hubertas asked you to defeat the monsters in Assembly Hall Site for them to rob the grave.
 QUEST_LV_0200_20150714_008223	Defeated the monsters in Assembly Hall site as Graverobber Hubertas asked. Return to him.
@@ -8284,8 +8284,8 @@ QUEST_LV_0200_20150714_008287	Used the Monster Stimulant on the monsters as Adju
 QUEST_LV_0200_20150714_008288	Lure the guards in Decrepit Watermill
 QUEST_LV_0200_20150714_008289	Adjutant General Hans asked you to use the uproar of monsterscaused by the Monster Stimulant to lure the guards from Decrepit Watermill.
 QUEST_LV_0200_20150714_008290	You have turned the attention of guards for Graverobber Steponas to pass by as requested by Adjutant General Hans. Return to Hans.
-QUEST_LV_0200_20150714_008291	Adjutant General Hans asked you to retrieve the propaganda materials spread 600 years ago by the Kingdom Army to encourage surrender. The propaganda materials are posted on the Decrepit Watermill.
-QUEST_LV_0200_20150714_008292	You've retrieved all the propaganda materials scattered by the Kingdom Army 600 years ago. Return to Hans.
+QUEST_LV_0200_20150714_008291	Adjutant General Hans asked you to retrieve the propaganda materials spread 600 years ago by the Royal Army to encourage surrender. The propaganda materials are posted on the Decrepit Watermill.
+QUEST_LV_0200_20150714_008292	You've retrieved all the propaganda materials scattered by the Royal Army 600 years ago. Return to Hans.
 QUEST_LV_0200_20150714_008293	Gather Hardened Gunpowder
 QUEST_LV_0200_20150714_008294	Graverobber Steponas suggested you to collect bomb ingredients to take the Nuclear Core from the Stone Froster. Defeat the monsters nearby and collect Hardened Gunpowder.
 QUEST_LV_0200_20150714_008295	As Graverobber Steponas requested to you, you collected enough hardened gun powders. Return to Graverobber Steponas
@@ -8740,10 +8740,10 @@ QUEST_LV_0200_20150717_008743	$I think I can find a way if I have some Red Infro
 QUEST_LV_0200_20150717_008744	$I am sorry, but I can't explain the details.{nl}All I can say is if we use magic, we will be discovered by the demons.
 QUEST_LV_0200_20150717_008745	$Did you just see that monster explode?{nl}That's definitely strange. It's as if the power of its essence is out of control.
 QUEST_LV_0200_20150717_008746	$That vibration from a while ago keeps distracting me.{nl}I hope it's nothing.
-QUEST_LV_0200_20150717_008747	$When the demons' attacks started becoming serious, the Goddess prepared this in advance.{nl}Fortunately, the device is working alright.
-QUEST_LV_0200_20150717_008748	$We're almost at the final floor so we just have to press forward a little more.{nl}The Goddess must be enduring more than we are.
+QUEST_LV_0200_20150717_008747	$When the demons' attacks started becoming serious, the goddess prepared this in advance.{nl}Fortunately, the device is working alright.
+QUEST_LV_0200_20150717_008748	$We're almost at the final floor so we just have to press forward a little more.{nl}The goddess must be enduring more than we are.
 QUEST_LV_0200_20150717_008749	$The Jewel of Prominence is now alright.{nl}I am... relieved.
-QUEST_LV_0200_20150717_008750	$You... you are the one Goddess Gabija is looking for!{nl}Please help me. If things continue as they are, we could lose the Goddess and the Mage Tower to the demons.{nl}
+QUEST_LV_0200_20150717_008750	$You... you are the one Goddess Gabija is looking for!{nl}Please help me. If things continue as they are, we could lose the goddess and the Mage Tower to the demons.{nl}
 QUEST_LV_0200_20150717_008751	$In the past, the demons have aimed to take the Mage Tower.{nl}Though, we were always able to stop their attacks whenever they attacked.{nl}
 QUEST_LV_0200_20150717_008752	$But now it's different. Most of the wizards are either dead or have run away.{nl}Only Gabija and a few wizards are still remaining in the tower, protecting it.
 QUEST_LV_0200_20150717_008753	$This is the entrance to the tower.{nl}I won't be able to use magic, but I will definitely take you to Goddess Gabija.{nl}
@@ -8816,7 +8816,7 @@ QUEST_LV_0200_20150717_008819	$Grita said we have to go to the Magic Control Roo
 QUEST_LV_0200_20150717_008820	$You defeated all the monsters, but the Tower is still shaking. Ask Grita what to do next.
 QUEST_LV_0200_20150717_008821	$Defeated all the monsters that threatened Grita. Ask Grita what to do next.
 QUEST_LV_0200_20150717_008822	Go to Mage Tower 5F
-QUEST_LV_0200_20150717_008823	$Grita told you to give the Jewel of Prominence to the Goddess while she takes care of the tower. Go to the 5th floor of the Mage Tower where the Goddess is located.
+QUEST_LV_0200_20150717_008823	$Grita told you to give the Jewel of Prominence to the goddess while she takes care of the tower. Go to the 5th floor of the Mage Tower where the goddess is located.
 QUEST_LV_0200_20150717_008824	$Defeat Grinender that is blocking the way to the 5th Floor
 QUEST_LV_0200_20150717_008825	Collect Rambear Claws
 QUEST_LV_0200_20150717_008826	Thief Hubertas asked you to get Rambear Claws to give to the Kingdom Military.
@@ -8846,8 +8846,8 @@ QUEST_LV_0200_20150717_008849	{memo X}Go to the next area
 QUEST_LV_0200_20150717_008850	{memo X}Go to the next area with Amanda
 QUEST_LV_0200_20150717_008851	{memo X}Get out from the monsters' raid
 QUEST_LV_0200_20150717_008852	{memo X}Get out from the monsters' raid.
-QUEST_LV_0200_20150717_008853	Talk to Kingdom Army Guard Delus
-QUEST_LV_0200_20150717_008854	{memo X}Talk to Kingdom Army Guard Delus.
+QUEST_LV_0200_20150717_008853	Talk to Royal Army Guard Delus
+QUEST_LV_0200_20150717_008854	{memo X}Talk to Royal Army Guard Delus.
 QUEST_LV_0200_20150717_008855	Retrieve the Camp
 QUEST_LV_0200_20150717_008856	Bring the Kingdom Military Guard who fell behind
 QUEST_LV_0200_20150717_008857	{memo X}Bring the Kingdom Military Guard who fell behind.
@@ -9158,7 +9158,7 @@ QUEST_LV_0200_20151001_009161	The Thaumaturge Master told me to give it to you.{
 QUEST_LV_0200_20151001_009162	I don't really mind the rumors, but do people really believe that a spell can preserve your youth? {nl}Well, maybe it can but.. {nl}Ah, I don't want to talk about it anymore.
 QUEST_LV_0200_20151001_009163	For the people who go on the way of the pilgrim with hope, this curse is so much pain for them.{nl}We don't even know the true nature of the curse so I am so mad.
 QUEST_LV_0200_20151001_009164	$I was so mad that there were no Revelators back then.{nl}But, after hearing that some Revelator saved the Mage Tower, my thoughts changed.{nl}
-QUEST_LV_0200_20151001_009165	$I think the Goddess may come back when they complete their duties and I complete mine.
+QUEST_LV_0200_20151001_009165	$I think the goddess may come back when they complete their duties and I complete mine.
 QUEST_LV_0200_20151001_009166	I didn't expect that the true intent of the curse cast on this forest is after the Great Cathedral.{nl}Fortunately, we were able to stop the curse due to one Revelator, but I feel ashamed.
 QUEST_LV_0200_20151001_009167	$The curse here is serious, but there are other places where the influence of the curse is more severe. {nl}The city of Ruklys... I heard everything there turns into stone due to the curse of petrification.
 QUEST_LV_0200_20151001_009168	$I think it was my fault that I left the Mage Tower to save the people after Medzio Diena.{nl}Maybe, instead of the Revelator, I could've saved the tower.
@@ -9168,10 +9168,10 @@ QUEST_LV_0200_20151001_009171	$I heard a Revelator defeated the Demon Lord attac
 QUEST_LV_0200_20151001_009172	$Is it true that some Revelator defeated the Demon Lord who casted the curse in this region?{nl}If that's true, it is so fortunate since we don't have to see those horrible things again.
 QUEST_LV_0200_20151001_009173	$Oh my g... What was I doing?{nl}Ahhh. My Liliya...{nl}
 QUEST_LV_0200_20151001_009174	$Don't mess with the food piles.{nl} He should have shuffled over here by now... Just keep watching.
-QUEST_LV_0200_20151001_009175	$While my brothers were on their way to train, they all died from the demons' tricks.{nl}I feel sorry for my brothers who can't return to the Goddesses.{nl}
-QUEST_LV_0200_20151001_009176	$And they were so consumed with madness, even after their death, they could not even return to the Goddesses.{nl}That's why I want to give them eternal sleep.{nl}
-QUEST_LV_0200_20151001_009177	$It was really horrible. Those brothers who used to be kind to each other hurt each other..{nl}And the demons cheated those brothers who were not led to the Goddesses.{nl}
-QUEST_LV_0200_20151001_009178	$My brothers are blaming each other and crying out in madness even after their deaths.{nl}At the altar of the Goddesses.{nl}
+QUEST_LV_0200_20151001_009175	$While my brothers were on their way to train, they all died from the demons' tricks.{nl}I feel sorry for my brothers who can't return to the goddesses.{nl}
+QUEST_LV_0200_20151001_009176	$And they were so consumed with madness, even after their death, they could not even return to the goddesses.{nl}That's why I want to give them eternal sleep.{nl}
+QUEST_LV_0200_20151001_009177	$It was really horrible. Those brothers who used to be kind to each other hurt each other..{nl}And the demons cheated those brothers who were not led to the goddesses.{nl}
+QUEST_LV_0200_20151001_009178	$My brothers are blaming each other and crying out in madness even after their deaths.{nl}At the altar of the goddesses.{nl}
 QUEST_LV_0200_20151001_009179	Death may be the price I pay for my sin. {nl}Even if it was due to the curse of the demons, it is still a sin I've committed.
 QUEST_LV_0200_20151001_009180	$I didn't want to.. die like this.. {nl}Mother..
 QUEST_LV_0200_20151001_009181	$I've realized after my death that my colleague left me because of the curse. {nl}This thing is now useless to me.. Thank you.
@@ -9218,7 +9218,7 @@ QUEST_LV_0200_20151001_009221	$Right now, Kupole Zydrone is holding down Blut. {
 QUEST_LV_0200_20151001_009222	$Fortunately, Blut hasn't been completely freed yet...{nl}However, we don't know how much longer we can endure by ourselves.{nl}
 QUEST_LV_0200_20151001_009223	$We have to somehow weaken the power of the Demon Lord Blut.{nl}I am sure his allies set the camp near Bjaurer Hideout.{nl}Please get the mark of Blut that they hold.
 QUEST_LV_0200_20151001_009224	$Our original duty was to supervise and manage the prison.{nl}But... now, we are trying our best to just hold back the demons. {nl}No matter what it takes.
-QUEST_LV_0200_20151001_009225	$So you are the one who Vakarine talked about.{nl}Well done. Everything will be done with Goddess' will.
+QUEST_LV_0200_20151001_009225	$So you are the one who Vakarine talked about.{nl}Well done. Everything will be done with goddess' will.
 QUEST_LV_0200_20151001_009226	$We've locked Blut across this barrier.{nl}
 QUEST_LV_0200_20151001_009227	$No demon besides Blut knows more about Vakarine's weakening than we do.{nl}Blut is not completely freed yet, so we now have an opportunity to get rid of him.{nl}
 QUEST_LV_0200_20151001_009228	$But, if we don't defeat Blut quickly, this barrier will collapse soon.{nl}Let's defeat him at once. Are you ready?{nl}
@@ -9261,7 +9261,7 @@ QUEST_LV_0200_20151001_009264	$We have decided to seal Dionysus and its power un
 QUEST_LV_0200_20151001_009265	$We don't know what that power is exactly.{nl}But, we know that it can be used to close the dimensional crack and should not be taken away.{nl}
 QUEST_LV_0200_20151001_009266	$Fortunately, we could detach that power if we put holy power into the Key of the Night Star.{nl}Are you ready?
 QUEST_LV_0200_20151001_009267	$Dionysus is the guardian whom Vakarine most adores.{nl}She reluctantly sealed the strong power to Dionysus and fell into the deep sadness..
-QUEST_LV_0200_20151001_009268	$Now go to Oruarma Cathedral. {nl}Protect me from the demons while I focus the Goddess' power into the Key of the Night Star.
+QUEST_LV_0200_20151001_009268	$Now go to Oruarma Cathedral. {nl}Protect me from the demons while I focus the goddess' power into the Key of the Night Star.
 QUEST_LV_0200_20151001_009269	$Here. Please give this key to Kupole Aldona. {nl}She must be holding down Dionysus now. Please hurry.
 QUEST_LV_0200_20151001_009270	$You are not too late!{nl}Let's release the power of the Key of the Night Star.{nl}
 QUEST_LV_0200_20151001_009271	$When you unleash the seal, the power that is held in the key will be collected to this magic suppressor.{nl}I want you to release the seals at Rearda, Kasa, and Rada.
@@ -9276,8 +9276,8 @@ QUEST_LV_0200_20151001_009279	$However, Hauberk too is the key to closing the di
 QUEST_LV_0200_20151001_009280	$Hauberk hasn't accumulated all of his spirit yet, so he wouldn't be hard to face against.{nl}Catch him again and close the dimensional crack with the Chain of Reversion.{nl}
 QUEST_LV_0200_20151001_009281	$The 4th District which he ran away to is like a maze. {nl}Kupole Daiva and you would be able to follow him though.
 QUEST_LV_0200_20151001_009282	$How could Vakarine let Hauberk go on a rampage like that..{nl}Well, I guess she must have a reason for that?
-QUEST_LV_0200_20151001_009283	$The Oruarma Cathedral is where the Goddess recovers her powers. {nl}That is why it should always be safe from the demons. Thank you very much.
-QUEST_LV_0200_20151001_009284	$Please collect the pieces of the Mark of Star that are scattered near Rada Seal.{nl}It will help the Goddess recover her powers.
+QUEST_LV_0200_20151001_009283	$The Oruarma Cathedral is where the goddess recovers her powers. {nl}That is why it should always be safe from the demons. Thank you very much.
+QUEST_LV_0200_20151001_009284	$Please collect the pieces of the Mark of Star that are scattered near Rada Seal.{nl}It will help the goddess recover her powers.
 QUEST_LV_0200_20151001_009285	$Thanks. {nl}If Vakarine recovers, then Dionysus should also recover.
 QUEST_LV_0200_20151001_009286	$So you've come, Savior.{nl}Fortunately, Hauberk seems to be not focused on leaving this place through the dimensional crack.{nl}That means he is not complete yet enough to go out through the dimensional crack.{nl}
 QUEST_LV_0200_20151001_009287	$I think..{nl}What if he wanted to escape without going through the dimensional crack you came here with..{nl}You should look for the crack which has been weakened due to the collapse.{nl}
@@ -9339,7 +9339,7 @@ QUEST_LV_0200_20151001_009342	When you collect all Urechos, let's meet at the lo
 QUEST_LV_0200_20151001_009343	The kingdom soldiers are on patrol so you should be careful all the time.{nl}I am sure they are busy getting hit instead of explaining for the situation.
 QUEST_LV_0200_20151001_009344	You brought them well without getting detected by the kingdom soldiers.{nl}I am sorry. When they get hot, they make loud sounds.
 QUEST_LV_0200_20151001_009345	Okay. Shall we start the work of the graverobbers?{nl}I saw the kingdom guards have the bombs in tons.{nl}You know what we are trying to say right?{nl}
-QUEST_LV_0200_20151001_009346	No. no. We are not that kind of people. {nl}We don't mean to send them to the Goddesses...{nl}
+QUEST_LV_0200_20151001_009346	No. no. We are not that kind of people. {nl}We don't mean to send them to the goddesses...{nl}
 QUEST_LV_0200_20151001_009347	We just faint them and bring the bombs. {nl}You can do it right?
 QUEST_LV_0200_20151001_009348	I will get ready to make roar bombs.{nl}Just faint them and bring the bombs. Okay?
 QUEST_LV_0200_20151001_009349	Even if you get caught by the kingdom soldiers, don't tell them about me.
@@ -9403,7 +9403,7 @@ QUEST_LV_0200_20151001_009406	Are you the one sent by the commanding officer?{nl
 QUEST_LV_0200_20151001_009407	I think its near Woodringal empty lot.{nl}I am worried about whether he is wounded in this cold weather.
 QUEST_LV_0200_20151001_009408	While he was going to do his duty, he was attacked by monsters. {nl}It will be hard to carry out the mission in his status or go back alone.{nl}
 QUEST_LV_0200_20151001_009409	Please help me so that I would be able to return safely.
-QUEST_LV_0200_20151001_009410	I am thankful to the Goddess that Hicks came back alive. {nl}But who would do his duty...
+QUEST_LV_0200_20151001_009410	I am thankful to the goddess that Hicks came back alive. {nl}But who would do his duty...
 QUEST_LV_0200_20151001_009411	I've told you before...{nl}The duty of our squad is to protect the magic circle that can completely seals off this place.{nl}
 QUEST_LV_0200_20151001_009412	{memo X}It was Hicks' duty to maintain the magic circle, but he can't do it since he is wounded.{nl}And everyone is getting tired due to the coldness... I want you to help us.
 QUEST_LV_0200_20151001_009413	Among the four shrines of Romuva magic circle, please activate one of them.{nl}However, in case monsters touch it and something bad occurs as a result, we will be in a trouble.{nl}
@@ -9414,7 +9414,7 @@ QUEST_LV_0200_20151001_009417	It's not like we don't have any method, but the me
 QUEST_LV_0200_20151001_009418	Just defeat the monsters near the magic circle. {nl}The vitality would be replaced to magical power. I am counting on you this time.
 QUEST_LV_0200_20151001_009419	The thing that bothers us the most is not monsters nor the maintenance of the magic circle.{nl}The severe coldness is our biggest enemy.
 QUEST_LV_0200_20151001_009420	$We appreciate for your efforts on behalf of the kingdom.{nl}They should work alright for some time.{nl}
-QUEST_LV_0200_20151001_009421	If you meet a person from the kingdom on your journey, please tell hm.{nl}That we are still diligently carrying out our duty here.{nl}Okay, then may the Goddess protect you.{nl}
+QUEST_LV_0200_20151001_009421	If you meet a person from the kingdom on your journey, please tell hm.{nl}That we are still diligently carrying out our duty here.{nl}Okay, then may the goddess protect you.{nl}
 QUEST_LV_0200_20151001_009422	The attacks of monsters won't just stop along with the supplies that are not coming.{nl}All we can do is just barely blocking their attacks. {nl}
 QUEST_LV_0200_20151001_009423	I am sorry, but could you block the monsters?
 QUEST_LV_0200_20151001_009424	Everyone is exhausted due to the coldness and the monsters.{nl}I don't know how much longer we would hold up.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -4780,7 +4780,7 @@ SKILL_20150717_004779	{memo X}Intelligence increase effect of [Swell Brain] incr
 SKILL_20150717_004780	Enemies affected by [Swell Body] will have their movement speed decreased by 25% and physical and magical attack increased by 20% per attribute level.
 SKILL_20150717_004781	Enemies affected by [Shrink Body] will have their movement speed increased by 20% and physical and magical attack decreased by 25% per attribute level.
 SKILL_20150717_004782	$Deals damage equal to 20% magic attack when changing the enemy's size with [Swell Body] per attribute level.
-SKILL_20150717_004783	$Deals damage equal to 20% magic attack when changing the enemy's size size with [Shrink Body] per attribute level.
+SKILL_20150717_004783	$Deals damage equal to 20% magic attack when changing the enemy's size with [Shrink Body] per attribute level.
 SKILL_20150717_004784	When you attack an enemy affected by [Swell Body] while [Left Arm Enhancement] is active, it will continuously apply the [Attacked Weakened] status effect. Increases the duration by 8 seconds per attribute level and [Attacked Weakened] can stack up to 10 times.
 SKILL_20150717_004785	$When enemies are hit by [Hail], inflict [Freezing] for 5 seconds by 5% chance per attribute level.
 SKILL_20150717_004786	$Increases Evasion while charging [Meteor] by 10% per attribute level.

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -1511,7 +1511,7 @@ SKILL_20150317_001510	{memo X}Attack #{SkillAtkAdd}#{nl}Additional damage +#{Cap
 SKILL_20150317_001511	$Carve Owl
 SKILL_20150317_001512	{memo X}{#993399}{ol}[Magic] - [Fire]{/}{/}{nl} Summon the owl statue to attack targets located in front of it.
 SKILL_20150317_001513	{memo X}Attack #{SkillAtkAdd}#{nl}Defense #{CaptionRatio}# times{nl}Duration #{CaptionTime}# seconds{nl} Use 2 Oak tree
-SKILL_20150317_001514	$Carve Austras Koks
+SKILL_20150317_001514	$Carve World Tree
 SKILL_20150317_001515	{memo X}Carve a statue of the holy tree to silence nearby enemies.
 SKILL_20150317_001516	{memo X}Statue duration #{CaptionRatio} seconds#{nl}Use #{CaptionRatio2}# Ash wood
 SKILL_20150317_001517	$Out of Body
@@ -2313,8 +2313,8 @@ SKILL_20150317_002312	$Carve Owl: Maintain Numbers
 SKILL_20150317_002313	$Increases the numbers [Carve Owl] can maintain by 1 per attribute level.
 SKILL_20150317_002314	$Carve Owl: Flame
 SKILL_20150317_002315	$Enemies hit with [Carve Owl] have a 5% chance per attribute level of being afflicted with [Flame], taking 5% of your magic damage as damage for 5 seconds.
-SKILL_20150317_002316	{memo X}Carve Austras Koks: Pull
-SKILL_20150317_002317	{memo X}Pulls enemies within range of [Carve Austras Koks].
+SKILL_20150317_002316	{memo X}Carve World Tree: Pull
+SKILL_20150317_002317	{memo X}Pulls enemies within range of [Carve World Tree].
 SKILL_20150317_002318	$Dievdirbys: Plant-type Damage
 SKILL_20150317_002319	{memo X}[Blunt object] do 10% extra damage per attribute level to plant type monsters.
 SKILL_20150317_002320	$Statue of Goddess Zemyna: Duration
@@ -3094,8 +3094,8 @@ SKILL_20150323_003093	{memo X}Equip virtual weapon
 SKILL_20150323_003094	{memo X}Repair Armor
 SKILL_20150323_003095	$Your Companion growls fearfully. Nearby monsters may fall under Fear.
 SKILL_20150323_003096	Elementalist: Resist
-SKILL_20150323_003097	{memo X}Carve Austras Koks: Pull
-SKILL_20150323_003098	{memo X}Pull enemies within range of [Carve Austras Koks]
+SKILL_20150323_003097	{memo X}Carve World Tree: Pull
+SKILL_20150323_003098	{memo X}Pull enemies within range of [Carve World Tree]
 SKILL_20150323_003099	Resist Elements: Resistance
 SKILL_20150323_003100	{memo X}$Increases the Fire, Ice and Lightning properties while decreasing the Poison and Earth properties when using [Resist Elements] by 5 per attribute level respectively. 
 SKILL_20150323_003101	$Enhanced the damage of [Meteor] to Elementalist's 2nd Circle standards.
@@ -4533,7 +4533,7 @@ SKILL_20150714_004532	$Increases the damage dealt on an enemy with [Teardown] by
 SKILL_20150714_004533	$Increases the duration of [Scatter Caltrops] by 1 second per attribute level.
 SKILL_20150714_004534	$There is a 8% chance per attribute level to  be afflicted with [Bleeding] when stepping on a caltrop.
 SKILL_20150714_004535	$Teardown: Teardown Statue
-SKILL_20150714_004536	$Allows you to dismantle Dievdirbys' Carve Austras Koks with [Teardown].
+SKILL_20150714_004536	$Allows you to dismantle Dievdirbys' Carve World Tree with [Teardown].
 SKILL_20150714_004537	$Increases the damage dealt on an enemy with [Broom Trap] by 1% per attribute level.
 SKILL_20150714_004538	$Increases the damage dealt on an enemy with [Claymore] by 1% per attribute level.
 SKILL_20150714_004539	$Increases the damage dealt on an enemy with [Punji Stake] by 1% per attribute level.
@@ -5044,7 +5044,7 @@ SKILL_20150918_005043	{#DD5500}{ol}[Physical] - [Strike]{/}{/}{nl}Use the spike 
 SKILL_20150918_005044	$Sky Liner
 SKILL_20150918_005045	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Slash the enemy sideways.{nl}Inflicts additional damage on enemies affected by [Bleeding].
 SKILL_20150918_005046	$Crosscut
-SKILL_20150918_005047	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Afflicts [Bleeding] on enemies by charging towards to cut a cross on their body.
+SKILL_20150918_005047	{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Charge towards the enemy and cut a cross on their body, inflicting [Bleeding].
 SKILL_20150918_005048	$Vertical Slash
 SKILL_20150918_005049	{memo X}{#DD5500}{ol}[Physical] - [Slash]{/}{/}{nl}Decreases the defense for medium, big enemies for a while by smaking down.
 SKILL_20150918_005050	{#DD5500}{ol}[Physical] - [Pierce]{/}{/}{nl}Attack an enemy by throwing your spear. Your spear will stick into the ground where it was thrown, and your physical attack will be decreased based on the equipment's upgrade count until you pick it up. It automatically returns to you after a certain time.
@@ -5476,8 +5476,8 @@ SKILL_20151022_005475	$Increases the damage dealt on an enemy with [Siege Burst]
 SKILL_20151022_005476	$Cannon Blast: Enhance
 SKILL_20151022_005477	$Increases the damage dealt on an enemy with [Cannon Blast] by 1% per attribute level.
 SKILL_20151022_005478	$Increases the attack count of [Blessing] by 10 per attribute level.
-SKILL_20151022_005479	$Carve Austras Koks: Maintain
-SKILL_20151022_005480	$Decreases the range of [Carve Austras Koks], but increases its duration by 10 seconds.
+SKILL_20151022_005479	$Carve World Tree: Maintain
+SKILL_20151022_005480	$Decreases the range of [Carve World Tree], but increases its duration by 10 seconds.
 SKILL_20151022_005481	$Carve Goddess Ausrine: Cooldown Decrease
 SKILL_20151022_005482	$Decreases the cooldown of [Carve Goddess Ausrine] by 10 seconds.
 SKILL_20151022_005483	Decreases the enemy's physical defense by 30% with a chance of 10% per attribute level when using a basic attack during Out of Body. (Unable to turn ON/OFF during Out of Body.)

--- a/SKILL.tsv
+++ b/SKILL.tsv
@@ -4779,8 +4779,8 @@ SKILL_20150717_004778	{memo X}Defense and Attack increase effect of [Swell Right
 SKILL_20150717_004779	{memo X}Intelligence increase effect of [Swell Brain] increases by 1 per attribute level.
 SKILL_20150717_004780	Enemies affected by [Swell Body] will have their movement speed decreased by 25% and physical and magical attack increased by 20% per attribute level.
 SKILL_20150717_004781	Enemies affected by [Shrink Body] will have their movement speed increased by 20% and physical and magical attack decreased by 25% per attribute level.
-SKILL_20150717_004782	$Deals damage equal to 20% magic attack when changing your size with [Swell Body] per attribute level.
-SKILL_20150717_004783	$Deals damage equal to 20% magic attack when changing your size with [Shrink Body] per attribute level.
+SKILL_20150717_004782	$Deals damage equal to 20% magic attack when changing the enemy's size with [Swell Body] per attribute level.
+SKILL_20150717_004783	$Deals damage equal to 20% magic attack when changing the enemy's size size with [Shrink Body] per attribute level.
 SKILL_20150717_004784	When you attack an enemy affected by [Swell Body] while [Left Arm Enhancement] is active, it will continuously apply the [Attacked Weakened] status effect. Increases the duration by 8 seconds per attribute level and [Attacked Weakened] can stack up to 10 times.
 SKILL_20150717_004785	$When enemies are hit by [Hail], inflict [Freezing] for 5 seconds by 5% chance per attribute level.
 SKILL_20150717_004786	$Increases Evasion while charging [Meteor] by 10% per attribute level.


### PR DESCRIPTION
- Changed many instances of 'Goddess(es)' to 'goddess(es)'. Only capitalize it when referring it to a specific goddess, such as Goddess Zemyna. 
- Changed Kingdom Army to Royal Army (왕국군). It sounds better and is consistent with the recent quest translations.
- Replaced all instances of the unicode ellipsis … to three regular dots: ...
- Replaced every instance of Austras Koks to World Tree.
- Changed a few old map names to the new versions to clear out inconsistencies.
- Fixes various typos.

@imcgames 

1) Currently '여신 라다' is translated as Goddess Rada. But is it really Rada? Or is it Radha, a hindu goddess? (reference: https://en.wikipedia.org/wiki/Radha)
If it is Radha, please change it in this pull request.

2) I changed every instance of 'Austras Koks' to 'World Tree', including the Dievdirbys skill. That's good, right? Since the dev team wanted it to be in English. 

3) There are a few instances where it still says "네스토스" and "아나스토스". 
- QUEST_LV_0100_20151001_008394
- QUEST_LV_0100_20151001_008397 

I also see "네스토스파" and "아나스토스파". I assume this one is correct and the other is out of date?
