### PR TITLE
Message removal notification

### DIFF
--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2914,7 +2914,7 @@ ETC_20150317_002913	New Group
 ETC_20150317_002914	Block
 ETC_20150317_002915	Remove Group
 ETC_20150317_002916	Change Group Name
-ETC_20150317_002917	Are you sure you want to delete this message?
+ETC_20150317_002917	Are you sure you want to delete this?
 ETC_20150317_002918	Unblock
 ETC_20150317_002919	The friend request was not sent.
 ETC_20150317_002920	Initial payment

--- a/ETC.tsv
+++ b/ETC.tsv
@@ -2914,7 +2914,7 @@ ETC_20150317_002913	New Group
 ETC_20150317_002914	Block
 ETC_20150317_002915	Remove Group
 ETC_20150317_002916	Change Group Name
-ETC_20150317_002917	Are you sure you want to delete your group?
+ETC_20150317_002917	Are you sure you want to delete this message?
 ETC_20150317_002918	Unblock
 ETC_20150317_002919	The friend request was not sent.
 ETC_20150317_002920	Initial payment


### PR DESCRIPTION
When deleting a message, the delete dialog mentions the removal of "your group". 

The Korean text doesn't seem to design a target, and "your group" is out of the context of the dialog.

![2016-01-31](https://cloud.githubusercontent.com/assets/11585030/12708769/2ababc7c-c882-11e5-99c6-a8f026732c0e.png)

I also noticed that other lines near this one belong to the friend list grouping system, so I checked the "Remove Group" button to see if it uses the same string (considering that this might have been the root of the translation error), but that function doesn't have a confirmation dialog.
