### PR TITLE
Fixed minor typos at Lemparas Pond

### DIFF
--- a/EnglishTranslation-master/ETC.tsv
+++ b/EnglishTranslation-master/ETC.tsv
@@ -16320,7 +16320,7 @@ ETC_20151022_016321	Lighting up the bonfire
 ETC_20151022_016322	You've already used it
 ETC_20151022_016323	Finally, Orsha!
 ETC_20151022_016324	You've helped the settlers by lighting the fire!
-ETC_20151022_016325	Collected Useful Objects!
+ETC_20151022_016325	You've obtained some Useful Objects!
 ETC_20151022_016326	You've taken the settlers to Dalas
 ETC_20151022_016327	Take the settlers to Dalas
 ETC_20151022_016328	Take them quickly!

--- a/EnglishTranslation-master/ETC.tsv
+++ b/EnglishTranslation-master/ETC.tsv
@@ -16117,7 +16117,7 @@ ETC_20151022_016118	Defeat the Grey Golem that suddenly appeared!
 ETC_20151022_016119	Abandoned Bag
 ETC_20151022_016120	Defeat Minotaurus and check the diary of Urbonas!
 ETC_20151022_016121	Defeat the Kepas that rushed in!
-ETC_20151022_016122	I heard this place is safe...
+ETC_20151022_016122	I thought this place was safe...
 ETC_20151022_016123	Protect the people from the Poata!
 ETC_20151022_016124	Calm down...
 ETC_20151022_016125	Run away everyone!
@@ -16320,7 +16320,7 @@ ETC_20151022_016321	Lighting up the bonfire
 ETC_20151022_016322	You've already used it
 ETC_20151022_016323	Finally, Orsha!
 ETC_20151022_016324	You've helped the settlers by lighting the fire!
-ETC_20151022_016325	You've obtained the usable objects!
+ETC_20151022_016325	Collected Useful Objects!
 ETC_20151022_016326	You've taken the settlers to Dalas
 ETC_20151022_016327	Take the settlers to Dalas
 ETC_20151022_016328	Take them quickly!
@@ -19259,7 +19259,7 @@ ETC_20151224_019259	This bonfire is already lighted up
 ETC_20151224_019260	You've lighted up the bonfire!
 ETC_20151224_019261	You've obtained the usable objects!
 ETC_20151224_019262	You've taken the setters to Dallanas
-ETC_20151224_019263	Bring a settler to Dallanas
+ETC_20151224_019263	Bring the settler to Dallanas
 ETC_20151224_019264	Dallanas? Let's hurry!
 ETC_20151224_019265	I am sure they were here...
 ETC_20151224_019266	What was the bishop thinking...
@@ -19968,7 +19968,7 @@ ETC_20151224_019968	Historic Site Ruins Dungeon
 ETC_20151224_019969	Lumber Pile
 ETC_20151224_019970	Lost Packckage
 ETC_20151224_019971	Unidentified Dust
-ETC_20151224_019972	Bonfire Firewood
+ETC_20151224_019972	Firewood
 ETC_20151224_019973	Scared Settler
 ETC_20151224_019974	Somebody's Diary
 ETC_20151224_019975	[Psychokino Submaster]{nl}          Cielle Gudan

--- a/EnglishTranslation-master/QUEST_LV_0100.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0100.tsv
@@ -12132,7 +12132,7 @@ QUEST_LV_0100_20151224_012132	Rumors that the villages on the other side of moun
 QUEST_LV_0100_20151224_012133	The neighboring village had been ransacked.{nl}I could not help but think that the even the goddesses had forsaken us.{nl}
 QUEST_LV_0100_20151224_012134	Thankfully, migration orders were issued to the surviving villages, but it was too late for many. {nl}They should have been issued sooner...
 QUEST_LV_0100_20151224_012135	Not enough manpower, too many refugees...{nl}Sometimes I think it might be easier fighting monsters like the soldiers.{nl}
-QUEST_LV_0100_20151224_012136	I wish I could accommodate you sooner... But look at it from my perspective.{nl}If I let you in before the people that have been waiting overe there, there'll be an uproar.
+QUEST_LV_0100_20151224_012136	I wish I could accommodate you sooner... But look at it from my perspective.{nl}If I let you in before the people that have been waiting over there, there'll be an uproar.
 QUEST_LV_0100_20151224_012137	You can enter Orsha without being processed.{nl}But the reason they are all waiting over here is because of the refugee qualification.{nl}
 QUEST_LV_0100_20151224_012138	You can't recieve any support from Orsha without having a refugee status.{nl}They know that they will all starve without support so that's why they're all waiting.
 QUEST_LV_0100_20151224_012139	That was a close call since the soldiers were all in the middle of changing shifts.{nl}If it wasn't for you, that monster would have charged straight towards Orsha.{nl}
@@ -12181,14 +12181,14 @@ QUEST_LV_0100_20151224_012181	They should still be on their way here since the o
 QUEST_LV_0100_20151224_012182	I'm sorry, but could you by any chance light a campfire on Adata Highway?{nl}So that people could see the smoke and come towards it.
 QUEST_LV_0100_20151224_012183	I've met a few people here.{nl}I don't know where all the others may have gone..
 QUEST_LV_0100_20151224_012184	Thank you so much for helping out.{nl}I just hope that they'll notice the smoke..
-QUEST_LV_0100_20151224_012185	I think the smoke is too faint..{nl}I think a single campfire may be to small to notice.{nl}
+QUEST_LV_0100_20151224_012185	I think the smoke is too faint..{nl}I think a single campfire may be too small to notice.{nl}
 QUEST_LV_0100_20151224_012186	We need a larger fire. A very large fire.{nl}Maybe the firewood that Official Lutas prepared on Adata Highway may be good enough.{nl}
 QUEST_LV_0100_20151224_012187	I've already received permission to use it as well.{nl}Well, what are you waiting for?
 QUEST_LV_0100_20151224_012188	Official Lutas says that there are too many refugees to simply allow them entrance into Orsha.{nl}
 QUEST_LV_0100_20151224_012189	That's why they've created smaller refugee camps near Orsha and are supplying them there.{nl}The firewood on Adata Highway was also supposed to be used in that fashion.
 QUEST_LV_0100_20151224_012190	I heard something loud.. {nl}What do you think happened?{nl}
 QUEST_LV_0100_20151224_012191	Oh my, a big monster?{nl}I'm so sorry that I dragged you into something like this..{nl}
-QUEST_LV_0100_20151224_012192	The smoke is noticable thanks to your efforts, but this is terrible.{nl}The fact that all we can do is wait here when such dangerous monsters are appearing..{nl}It makes no sense!
+QUEST_LV_0100_20151224_012192	The smoke is noticeable thanks to your efforts, but this is terrible.{nl}The fact that all we can do is wait here when such dangerous monsters are appearing..{nl}It makes no sense!
 QUEST_LV_0100_20151224_012193	I haven't seen you around, are you another one of those useless officials from Orsha?{nl}
 QUEST_LV_0100_20151224_012194	You're not?{nl}Oh.. my apologies.{nl}
 QUEST_LV_0100_20151224_012195	I came from near the southern seashore.{nl}I left my unscathed house because they said that they would protect us if we came to Orsha..{nl}
@@ -12218,7 +12218,7 @@ QUEST_LV_0100_20151224_012218	I've felt a lot of resentment while abandoning my 
 QUEST_LV_0100_20151224_012219	I just hope that the village will be safe until the Migration Orders are lifted.{nl}You see, the elders are still there because they couldn't bear leaving their hometown.
 QUEST_LV_0100_20151224_012220	I can't believe that they told us to gather in a place like that with all those monsters..{nl}The lord clearly didn't think it through.
 QUEST_LV_0100_20151224_012221	They're saying that people from my village have arrived at Randoluma Rest Place.{nl}But they've scattered due to the monsters.{nl}
-QUEST_LV_0100_20151224_012222	I'm sure they'll be trembling in fear out there..{nl}Could you look for them and bring them here after you find them?{nl}
+QUEST_LV_0100_20151224_012222	I'm sure they're trembling in fear out there..{nl}Could you look for them and bring them here after you find them?{nl}
 QUEST_LV_0100_20151224_012223	Even if they run into trouble with the villagers of Mayor Romanas.{nl}At least it seems safer here than at Randoluma Rest Place.
 QUEST_LV_0100_20151224_012224	I don't know if they have actually thought it through.{nl}It shouldn't be that dangerous if they prepared it for us.
 QUEST_LV_0100_20151224_012225	Thank you.{nl}I'll have to ask Mayor Romanas if our villagers can stay as well.


### PR DESCRIPTION
Fixed minor typos like overe > over, noticable > noticeable, etc.

Also changed Bonfire Firewood > Firewood.   It tells you to light up a campfire and not a bonfire.

![campfire](https://cloud.githubusercontent.com/assets/13687535/13511117/eab23e88-e137-11e5-8380-43130382c849.jpg)
![campfire2](https://cloud.githubusercontent.com/assets/13687535/13511119/eb61812c-e137-11e5-947e-2b4037a7d77f.jpg)

I'm not sure if I should change "Make a bonfire on Adata Highway 0/6" to "Make a _campfire_ on Adata  Highway"
