### PR TITLE
Grammar/Syntax Checks (QUEST 1300-1450)

### DIFF
--- a/EnglishTranslation-master/QUEST.tsv
+++ b/EnglishTranslation-master/QUEST.tsv
@@ -1329,7 +1329,7 @@ QUEST_20150317_001329	Treasure Hunting
 QUEST_20150317_001330	Missing Research Group
 QUEST_20150317_001331	Historian Rexipher's Research 
 QUEST_20150317_001332	Trick of the Demon
-QUEST_20150317_001333	Mop up the Forger
+QUEST_20150317_001333	Mop Up the Forger
 QUEST_20150317_001334	Rexipher's True Colors
 QUEST_20150317_001335	Self Sufficiency
 QUEST_20150317_001336	Protect the Heritage
@@ -1385,13 +1385,13 @@ QUEST_20150317_001385	Security Guard's Favor
 QUEST_20150317_001386	Threat of Fault Line
 QUEST_20150317_001387	Insatiable Hunger
 QUEST_20150317_001388	Endless Gluttony
-QUEST_20150317_001389	Can't be Taken Away
+QUEST_20150317_001389	Can't Be Taken Away
 QUEST_20150317_001390	Food Supplies of Starving Demon's Way
 QUEST_20150317_001391	Raging Soul Releasing Test
 QUEST_20150317_001392	Worship for the Blessing
 QUEST_20150317_001393	Genuine Goddess Statue
 QUEST_20150317_001394	Sanctum of Truth or Lie
-QUEST_20150317_001395	Blessing through Money
+QUEST_20150317_001395	Blessing Through Money
 QUEST_20150317_001396	Avoiding Infatuation
 QUEST_20150317_001397	Pond's Purification, Tree's Recovery
 QUEST_20150317_001398	To Move Across Space

--- a/EnglishTranslation-master/QUEST.tsv
+++ b/EnglishTranslation-master/QUEST.tsv
@@ -1169,7 +1169,7 @@ QUEST_20150317_001168	For Modestas, who had always been elated upon winning bets
 QUEST_20150317_001169	Knowing he had just deceived his long-time gambling friend, Sigfried, and also missed an opportunity to earn a lot of money, Modestas felt conflicted as he walked slowly alongside the horse he had just won. {nl}While walking, Modestas remembered the earlier warnings of his unconditional bet. He realized that now, with his upcoming defeat, he was doomed to not earn any more silver than he started with.
 QUEST_20150317_001170	While walking along the road, Modestas encountered a group of soldiers. {nl}Upon looking closer, the soldiers seemed to be arguing about what to buy at a store. {nl}Modestas decided not to interfere and pass them, but the soldiers noticed him and called. {nl}
 QUEST_20150317_001171	'You, the young man with the horse, can you come over and help us for a bit?' {nl}Modestas had no idea what these soldiers needed help for, but since he could no longer ignore them, he decided to head over. {nl}Once Modestas arrived, one of the soldiers said, {nl}'You came at just the right time. We would like you to referee a small gamble we're about to make here.' {nl}
-QUEST_20150317_001172	Modestas was surprised when he heard the word, 'bet', but was relieved to know he was only being asked to referee. After all, nothing could possibly happen if he was just refereeing. {nl}Modestas learned that the soldiers were fighting over which goddess was the best. {nl}
+QUEST_20150317_001172	Modestas was surprised when he heard the word, 'gamble', but was relieved to know he was only being asked to referee. After all, nothing could possibly happen if he was just refereeing. {nl}Modestas learned that the soldiers were fighting over which goddess was the best. {nl}
 QUEST_20150317_001173	What started as trivial banter turned into a big argument, which finally grew to become a big money bet. The soldiers had already gathered their money and only had to decide the winner. Unfortunately, every goddess got equal votes and a winner couldn't be decided.{nl}Thus, the soldiers decided to settle the bet by calling the first person who passed by, asking him who he thought the best goddess is, and deciding the winner from there. The soldiers agreed that the first passer-by would symbolize the will of whatever goddess he favored. {nl}
 QUEST_20150317_001174	The soldiers did not tell Modestas who voted for which goddess, for fear of his decision being affected by the expressions of each individual soldier. {nl}The soldiers did tell him however, how much they have each wagered. Just by seeing the gold nuggets, he could easily figure that there was a large amount of money in this bet. {nl}
 QUEST_20150317_001175	Since a big jackpot was on the line, the soldiers waited with bated breath for Modestas' answer. {nl}Knowing there was no right answer to the question, Modestas simply said aloud the name of his own favorite goddess. {nl}When he did, the soldiers reacted strangely. {nl}There was supposed to be an ecstatic winner and disappointed losers, but nobody seemed joyful nor disappointed. Instead, everyone had a bewildered look on their faces. {nl}
@@ -1211,7 +1211,7 @@ QUEST_20150317_001211	Modestas got up and tried to move the boulder, but to no a
 QUEST_20150317_001212	In front of Modestas, who had been worrying, appeared a familiar figure. It was none other than the one who had started the bet - the suspicious old woman.{nl}The old woman questioned Modestas.{nl}'How is it? Is it going well?'{nl}
 QUEST_20150317_001213	Modestas confessed he was far from making profits; instead he was in debt, wasted all his chances to win, and only had his last, losing bet remaining.{nl}After listening to his story the old woman responded flatly, {nl}'Since you only have one bet left, go ahead and make your last losing bet. Then all that's left for you to do is pay up your end of the bargain for losing the bet against me.'{nl}Modestas was a man who loved to gamble, but he was not the type to throw a tantrum, nor was he a sore loser.
 QUEST_20150317_001214	Modestas knew these gambles were more than just about money. {nl}Modestas, a dedicated gambler, nodded along with the woman's words. He clearly looked to be a man with a huge burden, his facial expression dark. {nl}The old woman could sense Modestas' thoughts, so she made this proposal. {nl}
-QUEST_20150317_001215	Since you are unsure how to transport this boulder you suddenly won, how about this? Normally, I wouldn't change the initial conditions, but for my amusement I will give you a suggestion. Why don't you use your last bet to see whether or not I can lift this boulder up into your wagon? Even if you lose, at least you can have this heavy boulder loaded on your wagon.'{nl}
+QUEST_20150317_001215	'Since you are unsure how to transport this boulder you suddenly won, how about this? Normally, I wouldn't change the initial conditions, but for my amusement I will give you a suggestion. Why don't you use your last bet to see whether or not I can lift this boulder up into your wagon? Even if you lose, at least you can have this heavy boulder loaded on your wagon.'{nl}
 QUEST_20150317_001216	Modestas who had nothing to lose, nodded his head to accept her proposal. But before he could consent to the bet, the old woman continued. {nl}'But I can't just give you such a favorable idea for free. Therefore I will add one more condition.'{nl}
 QUEST_20150317_001217	When Modestas asked about the condition, the old woman answered.{nl}'You are to take the boulder, which I will load onto the wagon, to Klaipeda. Then, turn it into an object of value which everyone will recognize and esteem. If you are successful, then the punishment for losing the bet against me will become void. Your friends will not disappear. Although this is difficult, I will still give you one more chance since you've already lost the bet. How about it?'{nl}Like always, Modestas had no choice.
 QUEST_20150317_001218	The moment Modestas agreed to the proposal, the old woman pointed her finger past him. {nl}Modestas turned around and to his surprise, the boulder he had trouble with was effortlessly placed on the wagon. By the time Modestas looked forward again, the old woman had already disappeared. {nl}
@@ -1329,7 +1329,7 @@ QUEST_20150317_001329	Treasure Hunting
 QUEST_20150317_001330	Missing Research Group
 QUEST_20150317_001331	Historian Rexipher's Research 
 QUEST_20150317_001332	Trick of the Demon
-QUEST_20150317_001333	Mop up the Forger
+QUEST_20150317_001333	Mop Up the Forger
 QUEST_20150317_001334	Rexipher's True Colors
 QUEST_20150317_001335	Self Sufficiency
 QUEST_20150317_001336	Protect the Heritage
@@ -1366,7 +1366,7 @@ QUEST_20150317_001366	Sealed Soul
 QUEST_20150317_001367	Suspicious Pot
 QUEST_20150317_001368	What Kind of Sin
 QUEST_20150317_001369	Suspicious Box
-QUEST_20150317_001370	Too many Seals
+QUEST_20150317_001370	Too Many Seals
 QUEST_20150317_001371	Transmuter Furry Odd
 QUEST_20150317_001372	Hot-Blooded Simon Shaw
 QUEST_20150317_001373	Truth of the Suspicious Seal Stone
@@ -1385,13 +1385,13 @@ QUEST_20150317_001385	Security Guard's Favor
 QUEST_20150317_001386	Threat of Fault Line
 QUEST_20150317_001387	Insatiable Hunger
 QUEST_20150317_001388	Endless Gluttony
-QUEST_20150317_001389	Can't be Taken Away
+QUEST_20150317_001389	Can't Be Taken Away
 QUEST_20150317_001390	Food Supplies of Starving Demon's Way
 QUEST_20150317_001391	Raging Soul Releasing Test
 QUEST_20150317_001392	Worship for the Blessing
 QUEST_20150317_001393	Genuine Goddess Statue
 QUEST_20150317_001394	Sanctum of Truth or Lie
-QUEST_20150317_001395	Blessing through Money
+QUEST_20150317_001395	Blessing Through Money
 QUEST_20150317_001396	Avoiding Infatuation
 QUEST_20150317_001397	Pond's Purification, Tree's Recovery
 QUEST_20150317_001398	To Move Across Space
@@ -1420,9 +1420,9 @@ QUEST_20150317_001420	Adapting to Circumstances
 QUEST_20150317_001421	The Bishop's Last Mission
 QUEST_20150317_001422	Materials for Research
 QUEST_20150317_001423	Pharmacist's Favor
-QUEST_20150323_001424	Now go to Gintaro Highway in Sirdgelos Forest. {nl}Spray this potion on the Matsum dolls I placed there and tell me what happens. 
-QUEST_20150323_001425	Four scouts were sent to Sirdgelos Forest not too long ago but all of them went missing. {nl}Maybe they took the Thorn Forest too lightly... {nl}Please find their whereabouts.
-QUEST_20150323_001426	I no longer have the strength to carry on, but will write this here for anyone who has made it pass this area. {nl}Naktis... it's funny that I yearn for a curse on the Monarch of Curses.
+QUEST_20150323_001424	Now go to Gintara Highway in Sirdgela Forest. {nl}Spray this potion on the Matsum dolls I placed there and tell me what happens. 
+QUEST_20150323_001425	Four scouts were sent to Sirdgela Forest not too long ago but all of them went missing. {nl}Maybe they took the Thorn Forest too lightly... {nl}Please find their whereabouts.
+QUEST_20150323_001426	I no longer have the strength to carry on, but will write this for anyone who has made it past this area. {nl}Naktis... it's funny that I yearn for a curse on the Monarch of Curses.
 QUEST_20150323_001427	Naktis scattered cursed Tree Root Crystals in the area. {nl}To stop the curse, they must be destroyed.
 QUEST_20150323_001428	Perhaps I shall soon lose my breath. {nl}Pilgrims, may the blessings of the goddess be with you!
 QUEST_20150323_001429	Please be sure to find the scripture! {nl}One of the pilgrim souls entrapped in here must have it.

--- a/EnglishTranslation-master/QUEST.tsv
+++ b/EnglishTranslation-master/QUEST.tsv
@@ -1329,7 +1329,7 @@ QUEST_20150317_001329	Treasure Hunting
 QUEST_20150317_001330	Missing Research Group
 QUEST_20150317_001331	Historian Rexipher's Research 
 QUEST_20150317_001332	Trick of the Demon
-QUEST_20150317_001333	Mop Up the Forger
+QUEST_20150317_001333	Mop up the Forger
 QUEST_20150317_001334	Rexipher's True Colors
 QUEST_20150317_001335	Self Sufficiency
 QUEST_20150317_001336	Protect the Heritage
@@ -1385,13 +1385,13 @@ QUEST_20150317_001385	Security Guard's Favor
 QUEST_20150317_001386	Threat of Fault Line
 QUEST_20150317_001387	Insatiable Hunger
 QUEST_20150317_001388	Endless Gluttony
-QUEST_20150317_001389	Can't Be Taken Away
+QUEST_20150317_001389	Can't be Taken Away
 QUEST_20150317_001390	Food Supplies of Starving Demon's Way
 QUEST_20150317_001391	Raging Soul Releasing Test
 QUEST_20150317_001392	Worship for the Blessing
 QUEST_20150317_001393	Genuine Goddess Statue
 QUEST_20150317_001394	Sanctum of Truth or Lie
-QUEST_20150317_001395	Blessing Through Money
+QUEST_20150317_001395	Blessing through Money
 QUEST_20150317_001396	Avoiding Infatuation
 QUEST_20150317_001397	Pond's Purification, Tree's Recovery
 QUEST_20150317_001398	To Move Across Space


### PR DESCRIPTION
Fixed errors in grammar and sentence structure. Rearranged terms/sentences for better readability. Fixed some names. Lines proofread: 1300-1450, 1172, 1215
**If you're wondering why some preopositions are capitalized in titles, they likely belong to a verb (i.e. Eat Up, Run Over, Can't Be) or are adjectivial. This is somewhat subjective style-wise, so if it looks wrong, please do comment.

20150317_001172: bet -> gamble (last line says "gamble", not "bet")
20150317_001215: added '
