### PR TITLE
Translation fixes

### DIFF
--- a/EnglishTranslation-master/ETC.tsv
+++ b/EnglishTranslation-master/ETC.tsv
@@ -14032,8 +14032,8 @@ ETC_20150730_014033	Sienakal Graveyard
 ETC_20150730_014034	As the treasure box opened, faint Petrifying Frost poured out!{nl}Avoid the Petrifying Frost and defeat the monsters!
 ETC_20150730_014035	Protect Svitrigaila's Spirit
 ETC_20150730_014036	To prevent the spirit from getting absorbed by the terminal, Svitrigaila is casting defense.
-ETC_20150730_014037	Damages will be shared with the connected objects.
-ETC_20150730_014038	Cast a link on a party member and share the buff effects.
+ETC_20150730_014037	Damage will be shared with the connected objects.
+ETC_20150730_014038	Buff effects will be shared with the connected objects.
 ETC_20150730_014039	The stats of the connected objects will be shared.
 ETC_20150730_014040	You are in a status to receive the damages instead.
 ETC_20150730_014041	You can make your character stronger by allocating Status Points into STR/CON/INT/SPR/DEX.{nl} {nl} - STR : Increase in Physical Attack, Critical Attack and Max Weight{nl} {nl}- CON : Increase in Max HP, HP Recovery, Block, Critical Resistance and Max Weight{nl} {nl}- INT : Increase in Magic Attack, HP Recovery of Spells and Potions{nl} {nl}- SPR : Increase in Max SP, SP Recovery, Magic Defense, Block Penetration and Resistance to harmful effects{nl} {nl}- DEX : Increase in Accuracy, Evasion and Critical Rate{nl}

--- a/EnglishTranslation-master/ETC.tsv
+++ b/EnglishTranslation-master/ETC.tsv
@@ -14032,7 +14032,7 @@ ETC_20150730_014033	Sienakal Graveyard
 ETC_20150730_014034	As the treasure box opened, faint Petrifying Frost poured out!{nl}Avoid the Petrifying Frost and defeat the monsters!
 ETC_20150730_014035	Protect Svitrigaila's Spirit
 ETC_20150730_014036	To prevent the spirit from getting absorbed by the terminal, Svitrigaila is casting defense.
-ETC_20150730_014037	Damage will be shared with the connected objects.
+ETC_20150730_014037	Damage taken will be shared with the connected objects.
 ETC_20150730_014038	Buff effects will be shared with the connected objects.
 ETC_20150730_014039	The stats of the connected objects will be shared.
 ETC_20150730_014040	You are in a status to receive the damages instead.

--- a/EnglishTranslation-master/ETC.tsv
+++ b/EnglishTranslation-master/ETC.tsv
@@ -13603,7 +13603,7 @@ ETC_20150717_013604	Spell Control Magic Circle
 ETC_20150717_013605	The guard that fell behind
 ETC_20150717_013606	The corpse of the Royal Army Guard
 ETC_20150717_013607	There is no regeneration of monsters
-ETC_20150717_013608	Inner Fortress District
+ETC_20150717_013608	Inner Enceinte District
 ETC_20150717_013609	Petrified Monster
 ETC_20150717_013610	Suspicious Crystal
 ETC_20150717_013611	Suspicious Sculpture
@@ -18289,7 +18289,7 @@ ETC_20151224_018289	Use this to reset the instance entry restrictions for instan
 ETC_20151224_018290	10 TP [Event]
 ETC_20151224_018291	Use to obtain 10 TP.
 ETC_20151224_018292	Urgent Repair Kit
-ETC_20151224_018293	Recovers the durability of your equipment to +5.
+ETC_20151224_018293	Recovers the durability of your equipment by +5.
 ETC_20151224_018294	50 TP [Event]
 ETC_20151224_018295	Use to obtain 50 TP.
 ETC_20151224_018296	Shinobis are warriors who are familiar with special tactics called Ninjutsu. Only few can overcome the long and harsh training required to become a Shinobi.

--- a/EnglishTranslation-master/QUEST.tsv
+++ b/EnglishTranslation-master/QUEST.tsv
@@ -2552,7 +2552,7 @@ QUEST_20151001_002559	Unfortunately, we don't have any goods to sell at the mome
 QUEST_20151001_002560	Be careful on your way back.
 QUEST_20151001_002561	I'll never forgive the monsters that killed my family. {nl}Though my body returns to the ground, my soul still burns with anger. {nl}Oh, goddess. Only the cold blood of the monsters can cool my rage.
 QUEST_20151001_002562	King Kadumel finally dies.
-QUEST_20151001_002563	The balance of power between the demons and the goddesses, while fragile, has been stable for a long time{nl}So long as they didn't cross each other's territories.{nl}
+QUEST_20151001_002563	The balance of power between the demons and the goddesses, while fragile, has been stable for a long time.{nl}So long as they didn't cross each other's territories.{nl}
 QUEST_20151001_002564	But, the demons broke through first.{nl}With the Petrifying Frost... even the spirits became stones.
 QUEST_20151001_002565	As the demons started casting their petrification curse on this region, the goddesses tried to save the humans.{nl}However, the demons advised the goddesses that doing so would violate the rules that they mutually agreed to...
 QUEST_20151001_002566	Excuse me for a bit. It is a horrible memory...{nl}They brought the catastrophe. {nl}A strong catastrophe which made goddesses to give up rescuing this place.

--- a/EnglishTranslation-master/QUEST_JOBSTEP.tsv
+++ b/EnglishTranslation-master/QUEST_JOBSTEP.tsv
@@ -2562,7 +2562,7 @@ QUEST_JOBSTEP_20150414_002561	If you want to learn something from me, you should
 QUEST_JOBSTEP_20150414_002562	Oh, you came back already.{nl}Well done.{nl}
 QUEST_JOBSTEP_20150414_002563	If you want to learn something from me, defeat Gaigalas at Tenants' Farm.{nl}If you want your will and skills to be acknowledged.
 QUEST_JOBSTEP_20150414_002564	Stop the wrongdoings of the monsters.{nl}I heard that Colimencia are causing trouble at the Greene Manor.
-QUEST_JOBSTEP_20150414_002565	Are you ready?{nl}I will see you at the training gym of the Highlander Master
+QUEST_JOBSTEP_20150414_002565	Are you ready?{nl}I will see you at the training hall of the Highlander Master.
 QUEST_JOBSTEP_20150414_002566	Falconer Master
 QUEST_JOBSTEP_20150414_002567	So you want to become a Falconer Master.{nl}I don't know which bird will be your friend, but when you are intereacting with it, the best thing you can use is its food.
 QUEST_JOBSTEP_20150414_002568	Anything will be alright. Get some food from animal type monsters.{nl}I will test your abilities as a Pardoner by that.

--- a/EnglishTranslation-master/QUEST_LV_0100.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0100.tsv
@@ -9768,7 +9768,7 @@ QUEST_LV_0100_20151016_009767	The revelation you are looking for.. {nl}It should
 QUEST_LV_0100_20151016_009768	You have promised the Eminent to meet up here, right?{nl}Let's check the monocle before he comes.{nl}Talk to me again, if you are ready.
 QUEST_LV_0100_20151016_009769	AH!{nl}The scroll, now I remember.
 QUEST_LV_0100_20151016_009770	Remember this? {nl}It is the defense magic scroll that was hidden inside the treasure chest on the secret location.{nl}
-QUEST_LV_0100_20151016_009771	The scroll contains instructions on hhow to operate the defensive magic field that can fend off demons and how to repair it.{nl}I hope this can foil the Eminent's plan.{nl}
+QUEST_LV_0100_20151016_009771	The scroll contains instructions on how to operate the defensive magic field that can fend off demons and how to repair it.{nl}I hope this can foil the Eminent's plan.{nl}
 QUEST_LV_0100_20151016_009772	Firstly, you need to follow the Eminent's orders to distract him.{nl}At the same time, you and I will activate the magic field secretly.
 QUEST_LV_0100_20151016_009773	How did it go?{nl}The remaining foundation stone is located near the Ikveta Podium.{nl}
 QUEST_LV_0100_20151016_009774	However, demon totems are suppressing the power of foundation stone.{nl}I tried to get close to it but there are demons, you see.

--- a/EnglishTranslation-master/QUEST_LV_0200.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0200.tsv
@@ -9668,7 +9668,7 @@ QUEST_LV_0200_20151001_009671	Horace was looking for something that could be a s
 QUEST_LV_0200_20151001_009672	Collect the barks inside the stems of trees
 QUEST_LV_0200_20151001_009673	Horace wants to find out whether the barks can be edible. Peel off the barks using a handknife from the trees that are located on Nubarsk Cliff and Almore 2nd work place.
 QUEST_LV_0200_20151001_009674	You've obtained enough barks from the trees. Hand them over to Horace.
-QUEST_LV_0200_20151001_009675	Obtain %s from the lower part fo trees that are scratched with a handknife
+QUEST_LV_0200_20151001_009675	Obtain %s from the lower part of trees that are scratched with a handknife
 QUEST_LV_0200_20151001_009676	Talk with Mortimer
 QUEST_LV_0200_20151001_009677	Mortimer feels that the supplies that are stored at the cargo at the upper side should be retrieved. Look for a way to retrieve them with Mortimer.
 QUEST_LV_0200_20151001_009678	Defeat Sparnashorn at the labor management office

--- a/EnglishTranslation-master/QUEST_LV_0200.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0200.tsv
@@ -7076,7 +7076,7 @@ QUEST_LV_0200_20150714_007079	The abbot is trapped in the monastery, where it is
 QUEST_LV_0200_20150714_007080	If you are going to talk about the Hunters, I refuse to listen.{nl}They are rude people.
 QUEST_LV_0200_20150714_007081	He barely walked here and then fainted.{nl}I think he is breathing for now...
 QUEST_LV_0200_20150714_007082	Boros! Wake up, Boros!
-QUEST_LV_0200_20150714_007083	I regret that I was being so harsh to the Hunters til now.{nl}I hope my decision helps the Hunters
+QUEST_LV_0200_20150714_007083	I regret that I was being so harsh to the Hunters until now.{nl}I hope my decision helps the Hunters.
 QUEST_LV_0200_20150714_007084	You should persuade Goss at Laukyme Swamp.{nl}But, since you don't have the decisive proof about Evoniphon... I can't guarantee the withdrawl of the protection.
 QUEST_LV_0200_20150714_007085	Hunter Natasha
 QUEST_LV_0200_20150714_007086	Persuading someone is so hard.{nl}I hope someone helps me...
@@ -9042,7 +9042,7 @@ QUEST_LV_0200_20150908_009045	You've successfully restored the tombstone!
 QUEST_LV_0200_20150908_009046	Reading the epitaph
 QUEST_LV_0200_20150908_009047	Searching through the bushes
 QUEST_LV_0200_20150908_009048	The bushes were too sturdy so you hurt your hands.{nl}Find a way to burn the bushes instead
-QUEST_LV_0200_20150908_009049	Don't touch it as you burn it!
+QUEST_LV_0200_20150908_009049	Don't touch it before you burn it!
 QUEST_LV_0200_20150908_009050	Lighting up the bushes
 QUEST_LV_0200_20150908_009051	Reading the epitaph
 QUEST_LV_0200_20150908_009052	You are unsure of what was written on the tombstone.{nl}Go to the Wings of Vibora in Klaipeda and ask.

--- a/EnglishTranslation-master/QUEST_UNUSED.tsv
+++ b/EnglishTranslation-master/QUEST_UNUSED.tsv
@@ -889,7 +889,7 @@ QUEST_UNUSED_20151022_000888	I've been chased by demons and ran here from the ca
 QUEST_UNUSED_20151022_000889	No demons were there and only other monsters?{nl}That's fortunate I guess.{nl}
 QUEST_UNUSED_20151022_000890	It seems that you are stronger than I expected.{nl}I didn't expect that.
 QUEST_UNUSED_20151022_000891	Please come back to me when you fix the detector.{nl}I have something to tell you.
-QUEST_UNUSED_20151022_000892	I am going to guide each and every one of you with my best.{nl}I hope there is full of bless on the road in front of you.
+QUEST_UNUSED_20151022_000892	I am going to guide each and every one of you with my best.{nl}I hope the road in front of you is full of blessings.
 QUEST_UNUSED_20151022_000893	It doesn't matter anymore.{nl}I just want to take some rest..
 QUEST_UNUSED_20151022_000894	[Ordeal of Cleros]
 QUEST_UNUSED_20151022_000895	The sun of gold ray, the moon of silver ray and the land of bronze ray.{nl}What is your number.{nl}

--- a/EnglishTranslation-master/SKILL.tsv
+++ b/EnglishTranslation-master/SKILL.tsv
@@ -1609,7 +1609,7 @@ SKILL_20150317_001608	Recover HP, SP by 5% per second
 SKILL_20150317_001609	Discovery
 SKILL_20150317_001610	Discovery.
 SKILL_20150317_001611	Rest
-SKILL_20150317_001612	Increased the recovery of HP, SP and STA.
+SKILL_20150317_001612	Increases recovery of HP, SP and STA.
 SKILL_20150317_001613	Safety
 SKILL_20150317_001614	Safety.
 SKILL_20150317_001615	Chilly
@@ -1707,7 +1707,7 @@ SKILL_20150317_001706	Flu Flu Effect
 SKILL_20150317_001707	Fear Outbreak
 SKILL_20150317_001708	Oil Stains
 SKILL_20150317_001709	You'll be in big trouble if attacked with Fire Property attacks.
-SKILL_20150317_001710	Increased movement speed,
+SKILL_20150317_001710	Increased movement speed.
 SKILL_20150317_001711	Holy Aura
 SKILL_20150317_001712	Spread newly received buffs to allies
 SKILL_20150317_001713	Fog
@@ -1750,7 +1750,7 @@ SKILL_20150317_001749	Sequentially heal all abnormal states.
 SKILL_20150317_001750	Continuously receive Holy damage.
 SKILL_20150317_001751	Increased HP recovery speed.
 SKILL_20150317_001752	Holy Baptism
-SKILL_20150317_001753	Holy property added to your attacks
+SKILL_20150317_001753	Holy property added to your attacks.
 SKILL_20150317_001754	Limitation
 SKILL_20150317_001755	Max. strength increased temporarily
 SKILL_20150317_001756	Venom
@@ -1850,7 +1850,7 @@ SKILL_20150317_001849	Flame attack increased.
 SKILL_20150317_001850	Increased Pierce damage
 SKILL_20150317_001851	Enchant Fire
 SKILL_20150317_001852	Decreased Fire property resistance.
-SKILL_20150317_001853	Increased Flame attack.
+SKILL_20150317_001853	Fire property added to your attacks.
 SKILL_20150317_001854	Rage
 SKILL_20150317_001855	Increased damage and SP cost
 SKILL_20150317_001856	Hangman's Knot: Splash
@@ -3086,7 +3086,7 @@ SKILL_20150323_003085	Resist Elements
 SKILL_20150323_003086	Critical rate is higher when attacking from behind.
 SKILL_20150323_003087	Periodic decrease of SP and damage
 SKILL_20150323_003088	Removes harmful effects
-SKILL_20150323_003089	Periodically decreases your SP
+SKILL_20150323_003089	Periodically decreases your SP.
 SKILL_20150323_003090	Throw right-hand weapon
 SKILL_20150323_003091	Decreased evasion rate
 SKILL_20150323_003092	Increased evasion rate
@@ -3697,7 +3697,7 @@ SKILL_20150414_003696	Teleport to a random location.
 SKILL_20150414_003697	{#993399}{ol}[Magic]{/}{/}{nl}Inflict damage on multiple enemies by pulling them to a targeted area causing them to collide with each other.
 SKILL_20150414_003698	Lift nearby enemies up into the air. Enemies in the air are temporarily detected as a Flying-type.
 SKILL_20150414_003699	Create a straight line gravitational force that pull the enemies.
-SKILL_20150414_003700	Link enemies, so that they share damage taken.
+SKILL_20150414_003700	Link enemies to cause them to share the damage they take.
 SKILL_20150414_003701	Gather linked enemies to one area and make them collide with each other.
 SKILL_20150414_003702	Link party members to share buff effects with each other.
 SKILL_20150414_003703	Lifeline
@@ -6273,7 +6273,7 @@ SKILL_20160224_006272	Increased defense against Holy property skills used on cha
 SKILL_20160224_006273	Increased defense against Dark property skills used on characters.
 SKILL_20160224_006274	Increased movement speed, physical attack and magical defense
 SKILL_20160224_006275	Increased party EXP rate for Instanced Dungeons
-SKILL_20160224_006276	Increased EXP rate for automatic Instanced Dungeon matching
+SKILL_20160224_006276	Increased EXP rate for using automatic Instanced Dungeon matching.
 SKILL_20160224_006277	 - Able to learn up to 2 attributes simultaneously{nl} - Reduced Market commission fee (30% {img white_right_arrow 16 16} 10%){nl} - Able to list up to 5 items on the Market{nl} - +3 increased character movement{nl} - Can only trade 30 times
 SKILL_20160224_006278	Increased Maximum Buff Count
 SKILL_20160224_006279	Increases the maximum amount of buffs you can have by 1.

--- a/EnglishTranslation-master/SKILL.tsv
+++ b/EnglishTranslation-master/SKILL.tsv
@@ -4231,7 +4231,7 @@ SKILL_20150714_004230	Right Hand is enlarged. Effect applies according to the su
 SKILL_20150714_004231	Inflicts the target with [Stun], but decreases your maximum HP.
 SKILL_20150714_004232	Gohang
 SKILL_20150714_004233	Number of buff you can receive will increase.
-SKILL_20150714_004234	Removes nullified magic and harmful effects
+SKILL_20150714_004234	Removes nullified magic and harmful effects.
 SKILL_20150714_004235	Increased AoE attack ratio.
 SKILL_20150714_004236	Skull Swing: No Jump
 SKILL_20150714_004237	Can't jump
@@ -4767,7 +4767,7 @@ SKILL_20150717_004766	Inflicts [Slow] when an enemy's attack is blocked while in
 SKILL_20150717_004767	Increases reflect damage of [Reflect Shield] by 1 per attribute level and decreases damage received accordingly.
 SKILL_20150717_004768	Increases the physical and magic attack debuff effect of [Lethargy] by 1 per attribute level.
 SKILL_20150717_004769	Attack monster in [sleep] state with [Energy Bolt] to give additional damage of 50% of Magic attack.
-SKILL_20150717_004770	Enemies hit by [Fireball] have a 10% chance per attribute level to receive flame damage  for 5 seconds. [Burn] damage is based on the character's INT.
+SKILL_20150717_004770	Enemies hit by [Fireball] have a 10% chance per attribute level to receive flame damage for 5 seconds. [Burn] damage is based on the character's INT.
 SKILL_20150717_004771	Increases the Fire property damage for 5 seconds by 5 per attribute level, when an ally steps on [Fire Wall].
 SKILL_20150717_004772	When an enemy is near [Enchant Fire] range, the enemy's Fire resistance will decrease by 10% for 5 secs.
 SKILL_20150717_004773	Enemies hit by [Magnetic Force] have a 5% chance per attribute level to become afflicted with [Stun] for 4 seconds.


### PR DESCRIPTION
Some of these are a bit more bold, but they are following established rules and keeping consistency. Feel free to offer feedback on these.

Reasonings:
It seems buff effects should end in a period.
It seems when an additional hit is added, "X property is added to attacks" is appropriate (similar to Sacrament) for Enchant Fire.
Gym -> Hall (to match the zone name).
Vine message happens when you check the vines while they are still up.
