### PR TITLE
Change from madakia to medakia

### DIFF
--- a/EnglishTranslation-master/ETC.tsv
+++ b/EnglishTranslation-master/ETC.tsv
@@ -156,8 +156,8 @@ ETC_20150317_000155	Dark Slime
 ETC_20150317_000156	Although slimes are similar in appearance, they vary in species due to differences between the materials they originated from.
 ETC_20150317_000157	Rusrat
 ETC_20150317_000158	These guardians were placed in many tombs, starting with the Royal Mausoleum of Zachariel the Great, to stop intruders. Its name came from grave robbers who've encountered them.
-ETC_20150317_000159	Madakia
-ETC_20150317_000160	The Madakia were created by court wizards to fend off intruders that were more dangerous than grave robbers.
+ETC_20150317_000159	Medakia
+ETC_20150317_000160	The Medakia were created by court wizards to fend off intruders that were more dangerous than grave robbers.
 ETC_20150317_000161	Wheelen
 ETC_20150317_000162	The Wheelen is one of many magical creations made to protect the sealed tombs that have no current overseer.
 ETC_20150317_000163	Wheelen 3
@@ -3296,7 +3296,7 @@ ETC_20150317_003295	High-level taser
 ETC_20150317_003296	Recovery Device
 ETC_20150317_003297	Low-level taser
 ETC_20150317_003298	Suppressor
-ETC_20150317_003299	Defeat Madakia by using the magic device!
+ETC_20150317_003299	Defeat Medakia by using the magic device!
 ETC_20150317_003300	Do not destroy the inhibiting group!
 ETC_20150317_003301	Defeat the Royal Mausoleum Warriors!
 ETC_20150317_003302	Defeat the monsters!
@@ -7537,7 +7537,7 @@ ETC_20150317_007537	Defeat Boowooks near a Royal Cube so it can absorb them
 ETC_20150317_007538	Trial of King Zachariel the Great (1)
 ETC_20150317_007539	Put the Power Sources in the containers
 ETC_20150317_007540	Trial of King Zachariel the Great (2)
-ETC_20150317_007541	Recharge the Soul Pot by luring Madakia
+ETC_20150317_007541	Recharge the Soul Pot by luring Medakia
 ETC_20150317_007542	Listen to the advice of King Zachariel the Great
 ETC_20150317_007543	Charge the Absorbing Gem
 ETC_20150317_007544	Fill the Jewel with Flame Vapor
@@ -14629,7 +14629,7 @@ ETC_20150918_014630	You have succeeded in defeating Carapace!{nl}Yekub becomes w
 ETC_20150918_014631	You have failed in defeating Carapace!
 ETC_20150918_014632	You have failed to protect the Statue of Goddess Vakarine!
 ETC_20150918_014633	There aren't enough keepsakes of the spirits!
-ETC_20150918_014634	 Madakia has been absorbed!
+ETC_20150918_014634	 Medakia has been absorbed!
 ETC_20150918_014635	You've installed the bomb!
 ETC_20150918_014636	2. Defeat the monsters that are rushing in!
 ETC_20150918_014637	You have succeeded in Palanx trainings that prepare for the actual battles!

--- a/EnglishTranslation-master/ITEM.tsv
+++ b/EnglishTranslation-master/ITEM.tsv
@@ -2524,8 +2524,8 @@ ITEM_20150317_002523	Specter Hood
 ITEM_20150317_002524	Obtained from Specters.
 ITEM_20150317_002525	Medakia Metal Decoration
 ITEM_20150317_002526	Engraved with an emblem only seen in the Royal Mausoleum. {nl}Obtained from Medakias.
-ITEM_20150317_002527	Madakia Horn
-ITEM_20150317_002528	Horn made of stone. {nl}Obtained from Madakias.
+ITEM_20150317_002527	Medakia Horn
+ITEM_20150317_002528	Horn made of stone. {nl}Obtained from Medakia.
 ITEM_20150317_002529	Mantiwood Skin
 ITEM_20150317_002530	A skin made of wood. {nl}Obtained from Mantiwoods.
 ITEM_20150317_002531	Meleech Foreleg
@@ -7651,7 +7651,7 @@ ITEM_20151022_007650	Blue Orb: Wheelen
 ITEM_20151022_007651	Blue Orb: Venucelos
 ITEM_20151022_007652	Blue Orb: Vikaras Archer
 ITEM_20151022_007653	Blue Orb: Karas Mage
-ITEM_20151022_007654	Blue Orb: Madakia
+ITEM_20151022_007654	Blue Orb: Medakia
 ITEM_20151022_007655	Blue Orb: Rusrat
 ITEM_20151022_007656	Blue Orb: Mauros
 ITEM_20151022_007657	Blue Orb: Orange Hamming
@@ -8029,7 +8029,7 @@ ITEM_20151022_008028	Red Orb: Wheelen
 ITEM_20151022_008029	Red Orb: Venucelos
 ITEM_20151022_008030	Red Orb: Vikaras Archer
 ITEM_20151022_008031	Red Orb: Karas Mage
-ITEM_20151022_008032	Red Orb: Madakia
+ITEM_20151022_008032	Red Orb: Medakia
 ITEM_20151022_008033	Red Orb: Rusrat
 ITEM_20151022_008034	Red Orb: Mauros
 ITEM_20151022_008035	Red Orb: Orange Hamming

--- a/EnglishTranslation-master/QUEST_LV_0100.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0100.tsv
@@ -4716,14 +4716,14 @@ QUEST_LV_0100_20150317_004715	Continue to chase after Rexipher deeper into the R
 QUEST_LV_0100_20150317_004716	Collect the Royal Mausoleum's Magic Sources
 QUEST_LV_0100_20150317_004717	The Secret Guardian is trying to stop Rexipher from obtaining the revelation. Collect the Royal Mausoleum's Magic Sources from the Guardians.
 QUEST_LV_0100_20150317_004718	You have collected all the magic sources. Return to the Secret Guardian.
-QUEST_LV_0100_20150317_004719	Obtain %s by defeating Madakia
+QUEST_LV_0100_20150317_004719	Obtain %s by defeating Medakia
 QUEST_LV_0100_20150317_004720	Obtain the Soul Pot
 QUEST_LV_0100_20150317_004721	The Secret Guardian told you that the Royal Mausoleum of the Great King Zachariel was actually made to defeat Rexipher according to the forecast by the goddess. Talk to the Secret Guardian.
 QUEST_LV_0100_20150317_004722	Pour the magic sources into the jars
 QUEST_LV_0100_20150317_004723	The Secret Guardian told you that the Royal Mausoleum of the Great King Zachariel was actually made to defeat Rexipher according to the forecast by the goddess. Recharge the sources of the magic power of the Mausoleum to the prepared pots.
 QUEST_LV_0100_20150317_004724	You have poured all the sources of magic into all the jars. Talk to the Secret Guardian.
 QUEST_LV_0100_20150317_004725	You felt like you've heard the sound of demons' cries. Talk to the Secret Guardian.
-QUEST_LV_0100_20150317_004726	Lure and absorb Madakia into the pot
+QUEST_LV_0100_20150317_004726	Lure and absorb Medakia into the pot
 QUEST_LV_0100_20150317_004727	You should deal a fatal blow to Rexipher with the will of the Guardians. Place the Soul Pot, and lure the Guardians to it in order to fill it.
 QUEST_LV_0100_20150317_004728	You filled the wills of the Guardians into the pot. Talk to the Secret Guardian.
 QUEST_LV_0100_20150317_004729	Give the pot to the Secret Guardian


### PR DESCRIPTION
The monster 메다키아 appears in translation as madakia and medakia
as well as your drops, but the correct translation for the term is
medakia.

Sample references: ETC_20150317_003290, ETC_20150317_007541

These commits fix all references (madakia -> medakia)
