### PR TITLE
4/16/18 Update

### DIFF
--- a/EnglishTranslation-master/ETC.tsv
+++ b/EnglishTranslation-master/ETC.tsv
@@ -1049,7 +1049,7 @@ ETC_20150317_001048	Red Rubabos
 ETC_20150317_001049	Rusty Old Hook
 ETC_20150317_001050	Carnivore
 ETC_20150317_001051	Jolly Roger Black
-ETC_20150317_001052	Stonefroster
+ETC_20150317_001052	Stone Froster
 ETC_20150317_001053	Addled Krivis
 ETC_20150317_001054	The Revelators are addled.
 ETC_20150317_001055	Addled Scout
@@ -14288,7 +14288,7 @@ ETC_20150918_014289	A Centurion gathers characters together that come within its
 ETC_20150918_014290	{nl} {nl}You can change the locations of the squad members within the formation using the NumPad keys.
 ETC_20150918_014291	When you press {img key9 40 40} while pressing {img key 1 40 40}, the character at the number 1 position will be moved to the number 9 position.
 ETC_20150918_014292	{nl} {nl}The Centurion moves the locations of its squad members and uses various formations in different circumstances.
-ETC_20150918_014293	Siaulai Mission 
+ETC_20150918_014293	Siauliai Mission 
 ETC_20150918_014294	Gele Plateau Mission
 ETC_20150918_014295	The size of the device at Canyon Area
 ETC_20150918_014296	Fedimian Storage Keeper (Temporary)
@@ -21981,7 +21981,7 @@ ETC_20160704_021982	Purchase Bokor Items
 ETC_20160704_021983	You cannot create Zombies without the Zombify Skill
 ETC_20160704_021984	You have created the maximum amount of Zombies and cannot create more.
 ETC_20160711_021985	You cannot store any more since you have exceeded the maximum amount of {MAX}.
-ETC_20160711_021986	You must be higher than Rank 2 to deposit or withdraw silver.
+ETC_20160711_021986	You must be Rank 2 or higher to deposit or withdraw silver.
 ETC_20160718_021987	Fake Sequoia
 ETC_20160718_021988	Guild Tower
 ETC_20160718_021989	Companion Egg
@@ -24087,7 +24087,7 @@ ETC_20160811_024088	Item durability will decrease 50% slower
 ETC_20160811_024089	5% reduction to all debuff durations
 ETC_20160811_024090	5% increased magic defense
 ETC_20160811_024091	1% chance of nullifying enemy attacks
-ETC_20160811_024092	5% increased Cleric buff durations (Buffs from player shops excluded)
+ETC_20160811_024092	5% increased Cleric buff durations (shops excluded)
 ETC_20160811_024093	Acquire 1 CON stat point per 20 SPR stat points
 ETC_20160811_024094	Light Salmon
 ETC_20160811_024095	Invisible Hair(Male)
@@ -27779,7 +27779,7 @@ ETC_20170420_027780	Defeat a Monster of a Level Equal or Superior to Yours With 
 ETC_20170420_027781	Additional Dark Attack {img green_up_arrow 16 16} 30
 ETC_20170420_027782	HP Recovery {img green_up_arrow 16 16} 16
 ETC_20170420_027783	All Stats {img green_up_arrow 16 16} 1
-ETC_20170420_027784	Adds a {img green_up_arrow 16 16}12 Earth property attack to basic attacks
+ETC_20170420_027784	Adds an additional hit of {img green_up_arrow 16 16}12 Earth                              property damage to basic attacks
 ETC_20170420_027785	Fire Property Resistance {img green_up_arrow 16 16} 16
 ETC_20170420_027786	Attack against Devil-type Targets {img green_up_arrow 16 16} 6
 ETC_20170420_027787	Attack against Devil-type Targets {img green_up_arrow 16 16} 8
@@ -27797,7 +27797,7 @@ ETC_20170420_027798	Ice Property Additional Damage {img green_up_arrow 16 16} 26
 ETC_20170420_027799	Earth Property Additional Damage {img green_up_arrow 16 16} 42
 ETC_20170420_027800	HP Recovery {img green_up_arrow 16 16}240
 ETC_20170420_027801	All Stats {img green_up_arrow 16 16}6
-ETC_20170420_027802	Adds a {img green_up_arrow 16 16}110 Frost property attack to                            basic attacks{nl}                         Increases STR and SPR by {img green_up_arrow 16 16}12
+ETC_20170420_027802	Adds an additional hit of {img green_up_arrow 16 16}110 Ice                                property damage to basic attacks{nl}                         Increases STR and SPR by {img green_up_arrow 16 16}12
 ETC_20170420_027803	All Stats {img green_up_arrow 16 16}25
 ETC_20170420_027804	Magic Attack {img green_up_arrow 16 16}571{nl}                         Magic Amplification {img green_up_arrow 16 16}69
 ETC_20170420_027805	Evasion {img green_up_arrow 16 16}48{nl}                         Critical Rate {img green_up_arrow 16 16}72

--- a/EnglishTranslation-master/ITEM.tsv
+++ b/EnglishTranslation-master/ITEM.tsv
@@ -14526,7 +14526,7 @@ ITEM_20170420_014525	A strong piece of armor made of monster leather and bones. 
 ITEM_20170420_014526	Vienti Krisius Gauntlets
 ITEM_20170420_014527	A strong piece of armor worn by the royal knights of a faraway nation. It contains pure gold.
 ITEM_20170420_014528	 - Provides the buff effect 
-ITEM_20170420_014529	applies buff effects
+ITEM_20170420_014529	 while equipped
 ITEM_20170420_014530	 - Adds {img green_up_arrow 16 16}50% attack when using the following skills{nl}  - Fireball, Fire Wall, Flare, Fire Pillar, Hell Breath, Flame Ground, Meteor, Incineration, Prominence
 ITEM_20170420_014531	 - Increases Magic Amplification as much as {img green_up_arrow 16 16}40% as the HP recovery rate at the time of equipping this item{nl} - Reduces HP recovery rate to 0
 ITEM_20170420_014532	 while equipped{nl}  - Stacks when equipping the same item
@@ -17704,7 +17704,7 @@ ITEM_20180320_017703	Condensed Earth Tower 35F Cube
 ITEM_20180320_017704	Condensed Earth Tower 40F Cube
 ITEM_20180320_017705	(Old) The First Refuge Raid Dungeon Cube
 ITEM_20180320_017706	Lv 300 Challenge Cube
-ITEM_20180320_017707	Lv 250 Challenge Cube
+ITEM_20180320_017707	Lv 200 Challenge Cube
 ITEM_20180320_017708	Shining Golden Socket
 ITEM_20180320_017709	Helgasercle Card
 ITEM_20180320_017710	[Grimoire Equip Effect] Summons Helgasercle when using Summoning

--- a/EnglishTranslation-master/QUEST.tsv
+++ b/EnglishTranslation-master/QUEST.tsv
@@ -5904,7 +5904,7 @@ QUEST_20170420_005921	The Shadowmancer Master has always strived to be just an o
 QUEST_20170420_005922	I wonder what could have happened if Yena Havindar and Jane had lived in the same era.
 QUEST_20170420_005923	Part of the books Rhupas Kehel is searching for are in the possession of Winona Ende.{nl}No human knows of this fact, however.
 QUEST_20170420_005924	It was a long time ago that Rune Caster Master Shelly Pennington left her hometown to move to the south of the kingdom.{nl}Soon, her empty post could very well lead to misfortune.{nl}When it does, someone else will need to take her position.
-QUEST_20170420_005925	Rozalija, a Siaulai native, had always dreamed of becoming a healer.{nl}It was only after Medzio Diena that she came to follow the path of Cleric Master.{nl}One of the rare positive outcomes of that tragic day.
+QUEST_20170420_005925	Rozalija, a Siauliai native, had always dreamed of becoming a healer.{nl}It was only after Medzio Diena that she came to follow the path of Cleric Master.{nl}One of the rare positive outcomes of that tragic day.
 QUEST_20170420_005926	The Krivis Master is a keeper of all the beliefs of which humans have memory.{nl}He may not be aware of this himself, but his order comprises even ancient beliefs which humans do not know.
 QUEST_20170420_005927	Boruble's wish is to one day pass on the position of Priest Master to become the Chaplain Master, but first he must ask himself whether he can maintain his devotion when his life is at risk in the battlefield.{nl}Volunteering in the army would be one way to find out.
 QUEST_20170420_005928	Mama Marie Lavoie, the Bokor Master, lives as a messenger between people and their fate. As assistant to the goddess of destiny, hers is a work for which I am always grateful.
@@ -6109,7 +6109,7 @@ QUEST_20170901_006145	Yes, I have come across them in the past.{nl}It was before
 QUEST_20170901_006146	Oh! One of them asked if we'd seen anyone from the outside recently and I told them I saw a group of people who looked like they were coming from the beach.
 QUEST_20170901_006147	Do you think the mercenaries were trying to find them?{nl}I suppose you'll have to keep chasing them to find out.
 QUEST_20170901_006148	This is a cryptogram from our group.{nl}It says...
-QUEST_20170901_006149	The people they were chasing were a pirate crew.{nl}They fought amongst each other for the stolen goods, then some of them were killed trying to escape with the loot.{nl}Our mercenaries followed them to the Siaulai East Woods.
+QUEST_20170901_006149	The people they were chasing were a pirate crew.{nl}They fought amongst each other for the stolen goods, then some of them were killed trying to escape with the loot.{nl}Our mercenaries followed them to the Siauliai East Woods.
 QUEST_20170901_006150	Is this the cryptogram your brought from the East Woods?
 QUEST_20170901_006151	There isn't much to it.{nl}It says the traces of the pirates end in the East Woods.
 QUEST_20170901_006152	Hmm...

--- a/EnglishTranslation-master/QUEST_LV_0100.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0100.tsv
@@ -7105,7 +7105,7 @@ QUEST_LV_0100_20150714_007104	The resentment of the villagers in Andale Village 
 QUEST_LV_0100_20150714_007105	They had so much pains and felt unfair.{nl}This should never occur again.
 QUEST_LV_0100_20150714_007106	With your help, the fight with Bramble has ended.{nl}But, his thorny vines are spreading with vicious energy.{nl}
 QUEST_LV_0100_20150714_007107	If we leave it like that, the whole forest will be covered with thorny vines.{nl}But, since my power is not complete yet... I want to ask help from you.
-QUEST_LV_0100_20150714_007108	You should eliminate the thorny vines that are on the way to Gate Route.{nl}If we don't block here, Siaulai Forest will also be covered with the thorny vines.
+QUEST_LV_0100_20150714_007108	You should eliminate the thorny vines that are on the way to Gate Route.{nl}If we don't block here, Siauliai Forest will also be covered with the thorny vines.
 QUEST_LV_0100_20150714_007109	The vicious energy that spurts out from the thorny vines is very bad for humans.{nl}I hope you will be okay.
 QUEST_LV_0100_20150714_007110	This is just only the slightest part.{nl}If we don't defeat the thorn Forest completely, the thorny vines will keep spreading.
 QUEST_LV_0100_20150714_007111	The source of all thorny vines is Bramble... and Sirdgela Forest where he used to stay.{nl}To purify the forest, please locate my crystal that has my power in it.
@@ -9083,7 +9083,7 @@ QUEST_LV_0100_20151001_009082	Investigate in the Eastern Woods.{nl}By defeating 
 QUEST_LV_0100_20151001_009083	Return to Knight Aras
 QUEST_LV_0100_20151001_009084	Return to Knight Aras and tell him that you have defeated the Vubbe Fighter.
 QUEST_LV_0100_20151001_009085	Talk to Knight Aras about the Miners' Village
-QUEST_LV_0100_20151001_009086	It seems that Vubbes of Miner's village went deep into the east forest of Siaulai. Let's first defeat the Vubbes you see. 
+QUEST_LV_0100_20151001_009086	It seems that Vubbes of Miner's village went deep into the east forest of Siauliai. Let's first defeat the Vubbes you see. 
 QUEST_LV_0100_20151001_009087	You barely defeated the Vubbes that barged in. Return to Aras and ask him about the circumstances at Miner's village.
 QUEST_LV_0100_20151001_009088	Defeated Panto Totem and Simorph with the shaman dolls as Molly requested. Tell Molly about it. 
 QUEST_LV_0100_20151001_009089	Purified the corrupted area and defeated Carnivore as Molly requested. Tell Molly about it. 
@@ -14941,7 +14941,7 @@ QUEST_LV_0100_20160718_014935	This will be enough.{nl}Davio sent you, right?{nl}
 QUEST_LV_0100_20160718_014936	To make the medicine, I needed to find the cause of Jonas' symptoms and it drove me crazy.{nl}Funnily enough, it was caused by a spell that was used long ago.{nl}
 QUEST_LV_0100_20160718_014937	I heard a rumor that the Great King Zachariel erased the {nl}memories of all workers after building the Royal Mausoleum.{nl}That should be the spell casted on Jonas, though he is also a bit senile.{nl}
 QUEST_LV_0100_20160718_014938	It will be completed once you melt it in the honey that you have.{nl}Take it with you.
-QUEST_LV_0100_20160718_014939	We don't accept just anyone as a Peltasta.{nl}I will give you an assignment. First, defeat all Jukopus that are occupying Siaulai's Miners' Village.
+QUEST_LV_0100_20160718_014939	We don't accept just anyone as a Peltasta.{nl}I will give you an assignment. First, defeat all Jukopus that are occupying Siauliai's Miners' Village.
 QUEST_LV_0100_20160718_014940	I am happy to see that you are determined to learn the way of the sword from me,{nl}but I can't be sure that you are capable.{nl}I will test you by seeing how you face against the Vubbes at the Miners' Village.
 QUEST_LV_0100_20160718_014941	Your will to learn from me is good, but first I have a favor to ask.{nl}We can continue our talk if you are up for it.{nl}
 QUEST_LV_0100_20160718_014942	I heard the lost telescope lens from the Astral Tower is at the Miners' Village. {nl}Get me that lens before the other masters find out and I'll teach you my techniques.

--- a/EnglishTranslation-master/QUEST_LV_0200.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0200.tsv
@@ -10140,7 +10140,7 @@ QUEST_LV_0200_20151224_010143	The Wugushi Submaster has asked you to collect som
 QUEST_LV_0200_20151224_010144	Deliver it to Wugushi Submaster
 QUEST_LV_0200_20151224_010145	You have collected enough Synthetic Poisons. Return to the Wugushi Submaster. 
 QUEST_LV_0200_20151224_010146	Look for the Hoplite Submaster 
-QUEST_LV_0200_20151224_010147	Meet with the Hoplite Submaster at West Forest of Siaulai. 
+QUEST_LV_0200_20151224_010147	Meet with the Hoplite Submaster at West Forest of Siauliai. 
 QUEST_LV_0200_20151224_010148	The Hoplite Submaster wants you to defeat Shadowgaler before the Hackapell Master does just to mess with him. Defeat the Shadowgaler at Owl Burial Ground. 
 QUEST_LV_0200_20151224_010149	Report to the Hoplite Submaster 
 QUEST_LV_0200_20151224_010150	You successfully defeated Shadowgaler. Report to the Hoplite Submaster. 

--- a/EnglishTranslation-master/QUEST_LV_0300.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0300.tsv
@@ -3114,8 +3114,8 @@ QUEST_LV_0300_20160718_003113	Dievdirbys Asel says that the Purification Sculptu
 QUEST_LV_0300_20160718_003114	Investigate the Suspicious Greenery for the Source of the Malicious Energy
 QUEST_LV_0300_20160718_003115	On the spot where Iltiswort has fallen, there is greenery that is reeking with the malicious energy. Investigate it.
 QUEST_LV_0300_20160718_003116	Found a broken amulet and a dagger from the greenery. Take them to Asel.
-QUEST_LV_0300_20160718_003117	Talk to Sculptor Tesla in the Siaulai West Woods
-QUEST_LV_0300_20160718_003118	Dievdirbys Asel says that he can do nothing about the malicious energy from the dagger. Ask Sculptor Tesla in the Siaulai West Woods for help.
+QUEST_LV_0300_20160718_003117	Talk to Sculptor Tesla in the Siauliai West Woods
+QUEST_LV_0300_20160718_003118	Dievdirbys Asel says that he can do nothing about the malicious energy from the dagger. Ask Sculptor Tesla in the Siauliai West Woods for help.
 QUEST_LV_0300_20160718_003119	Sculptor Tesla will carve you a new sculpture. Obtain Purification Sculpture from Sculptor Tesla.
 QUEST_LV_0300_20160718_003120	Sculptor Tesla has carved you a new purifcation sculpture. Hand it over to Dievdirbys Asel.
 QUEST_LV_0300_20160718_003121	Dievdirbys Asel is trying to purify by using two sculptures. Talk to Asel about what you could do to help.
@@ -8009,7 +8009,7 @@ QUEST_LV_0300_20161214_008008	The man who calls himself
 QUEST_LV_0300_20161214_008009	the Great Problem-Solver
 QUEST_LV_0300_20161214_008010	Talk to Baron Munchausen
 QUEST_LV_0300_20161214_008011	Investigate the box in East Siauliai Woods.
-QUEST_LV_0300_20161214_008012	Baron Munchausen out of nowhere declares you have to pass his tests in order to be his student. He wants you to investigate the phenomenon of recent supplies in East Siaulai Woods keep disappearing. He wants you to sprinkle 
+QUEST_LV_0300_20161214_008012	Baron Munchausen out of nowhere declares you have to pass his tests in order to be his student. He wants you to investigate the phenomenon of recent supplies in East Siauliai Woods keep disappearing. He wants you to sprinkle 
 QUEST_LV_0300_20161214_008013	Holy Powder
 QUEST_LV_0300_20161214_008014	 on the box to drive away ghosts.
 QUEST_LV_0300_20161214_008015	A weaver jumps out of the box when you sprinkled the powder given to you by Baron Munchausen. Perhaps it is this weaver who ate all the food inside. Report to Baron Munchausen.

--- a/EnglishTranslation-master/QUEST_LV_0400.tsv
+++ b/EnglishTranslation-master/QUEST_LV_0400.tsv
@@ -1033,7 +1033,7 @@ QUEST_LV_0400_20161005_001032	Perhaps, that farm was not meant for you. How abou
 QUEST_LV_0400_20161005_001033	Forgotten Refugees
 QUEST_LV_0400_20161005_001034	I will go get some help.
 QUEST_LV_0400_20161005_001035	Explaining the situation of Mishekan Forest
-QUEST_LV_0400_20161005_001036	Informing that the news has been delievered to Uska of Klaipeda
+QUEST_LV_0400_20161005_001036	Informing that the news has been delivered to Uska of Klaipeda
 QUEST_LV_0400_20161005_001037	Alembique Tales
 QUEST_LV_0400_20161005_001038	Talk to Kedoran Alliance Merchant Alta
 QUEST_LV_0400_20161005_001039	Kedoran Alliance Merchant Alta is looking some help.

--- a/EnglishTranslation-master/QUEST_UNUSED.tsv
+++ b/EnglishTranslation-master/QUEST_UNUSED.tsv
@@ -391,7 +391,7 @@ QUEST_UNUSED_20150918_000390	Defeat the monsters that are blocking the way!
 QUEST_UNUSED_20150918_000391	You've defeated all the monsters that are blocking the way!
 QUEST_UNUSED_20150918_000392	Talk with the collector
 QUEST_UNUSED_20150918_000393	Obtained the collections
-QUEST_UNUSED_20151001_000394	"So you are the Revelator who dreamt of the dream of the goddesses.{nl}I am Uska, the Knight Commander in charge of both Siaulai and Klaipeda."
+QUEST_UNUSED_20151001_000394	"So you are the Revelator who dreamt of the dream of the goddesses.{nl}I am Uska, the Knight Commander in charge of both Siauliai and Klaipeda."
 QUEST_UNUSED_20151001_000395	The kingdom lost all hope.{nl}Without the will to stand up again.. calling at the name of the goddesses.{nl}
 QUEST_UNUSED_20151001_000396	"To tell you the truth, I can't just see you Revelators positively.{nl}Since I am in charge of one city..{nl}"
 QUEST_UNUSED_20151001_000397	We should not experience the depression again.
@@ -403,7 +403,7 @@ QUEST_UNUSED_20151001_000402	"This is, the place is full of soldiers from the Ro
 QUEST_UNUSED_20151001_000403	"Be careful not to get detected by kingdom soldiers.{nl}Even if you get caught, just laugh and pretend there's nothing."
 QUEST_UNUSED_20151001_000404	You've seen Gargoyle Sculpture at the gathering place right?{nl}That's the Gargoyle.{nl}
 QUEST_UNUSED_20151001_000405	"Strangely, whenever I tried to enter the fortress, it suddenly moves and blocks the way.{nl}Without making a mess, it will be impossible to supress them with our force."
-QUEST_UNUSED_20151001_000406	"Poata at the east forest of Siaulai are threatening the villagers.{nl}If you could eliminate them in the name of the goddesses, I will teach you my magic."
+QUEST_UNUSED_20151001_000406	"Poata at the east forest of Siauliai are threatening the villagers.{nl}If you could eliminate them in the name of the goddesses, I will teach you my magic."
 QUEST_UNUSED_20151001_000407	"When I saw you for the first time, you looked too awkward.. but.{nl}Now, you became more famous than me.{nl}"
 QUEST_UNUSED_20151001_000408	"Well done.{nl}When you gain some experiences and learn swordsmanship from me, you will become a good knight."
 QUEST_UNUSED_20151001_000409	You've come here to learn the teaching of Rogue from me?{nl}It's good.{nl}There is a task that I can verify your skills as a Rogue and resolve my problem.{nl}

--- a/EnglishTranslation-master/SKILL.tsv
+++ b/EnglishTranslation-master/SKILL.tsv
@@ -6207,7 +6207,7 @@ SKILL_20160224_006206	{#993399}{ol}[Magic]{/}{/}{nl}Stabs an enemy with a cursed
 SKILL_20160224_006207	Attack: 400% + #{SkillAtkAdd}#{nl}Attribute Damage: #{CaptionRatio}#%{nl}Consumes 1 Rune Stone{nl}Casting Time: 8 seconds
 SKILL_20160224_006208	{#993399}{ol}[Magic]{/}{/}All Ice-type magic cast by you and party members except for deployment magic will be stronger for a given duration.
 SKILL_20160224_006209	Attack: #{CaptionTime}# seconds{nl}Increases Ice-property skill attack by 300%{nl}Consumes 1 Rune Stone{nl}Casting Time: 8 seconds
-SKILL_20160224_006210	{#993399}{ol}[Magic]{/}{/}Creates a temporary magic circle that will turn you and your allies into a giant. Giant players are considered large-type and will have their HP and defense increased. Limited usage of skills.
+SKILL_20160224_006210	{#993399}{ol}[Magic]{/}{/}Creates a temporary magic circle that will turn you or your allies into a giant. Giant players are considered large-type and will have their HP and defense increased. Limited usage of skills.
 SKILL_20160224_006211	Giant Size Duration: #{CaptionTime}# seconds{nl}Magic Circle Duration: 10 seconds{nl}Defense, Maximum HP: +#{CaptionRatio}#%{nl}Movement Speed: +#{CaptionRatio2}#{nl}Consumes 1 Rune Stone{nl}Casting Time: 8 seconds
 SKILL_20160224_006212	{#993399}{ol}[Magic]{/}{/}Charges a frontal divine magic attack unleashed in a straight line.
 SKILL_20160224_006213	Attack: #{SkillAtkAdd}#{nl}Attribute Damage: #{CaptionRatio}#%{nl}Consumes 1 Rune Stone{nl}Casting Time: 8 seconds
@@ -6813,7 +6813,7 @@ SKILL_20161005_006812	Max. HP decreased. Continuous HP recovery.
 SKILL_20161005_006813	Fire, Ice and Lightning property resistance increased.
 SKILL_20161005_006814	Reduces your SPR and INT while doubling your SP consumption. Additional damage equal to your magic attack will be received.
 SKILL_20161005_006815	Disenchant: Neutralize Gear
-SKILL_20161005_006816	Partially nullifies the defenstive stats from equipment.
+SKILL_20161005_006816	Partially nullifies defensive stats gained from equipment.
 SKILL_20161005_006817	Malleus Maleficarum: Mana Burn
 SKILL_20161005_006818	Increased Lightning Attack.
 SKILL_20161005_006819	Increased maximum SP. Increased Character Level.
@@ -6845,7 +6845,7 @@ SKILL_20161005_006844	SP amount and SP Recovery increased.
 SKILL_20161005_006845	HP Increased State
 SKILL_20161005_006846	HP amount, defense and magic defense increased.
 SKILL_20161005_006847	Manahas' Protection
-SKILL_20161005_006848	Adds 110 ice property damage to your attack.
+SKILL_20161005_006848	Adds an additional hit of 110 Ice property damage to basic attacks.
 SKILL_20161005_006849	Champagne
 SKILL_20161005_006850	Increased AoE ratio.
 SKILL_20161005_006851	Instanced Clear Voucher Barrier
@@ -7346,7 +7346,7 @@ SKILL_20170313_007345	Manipulate time to make a monster reappear on the same spo
 SKILL_20170313_007346	Attack #{SkillAtkAdd}#{nl}Attribute attack #{CaptionRatio}#%{nl}Stigma duration 20 seconds
 SKILL_20170313_007347	{#993399}{ol}[Magic]{/}{/}{nl}Inflicts powerful damage to enemies in a targeted area. The attacked enemies will deal additional damage to other enemies by reflecting magic.
 SKILL_20170313_007348	{#993399}{ol}[Magic]{/}{/}{nl}All Ice-type magic cast by you and party members except for deployment magic will be stronger for a given duration.
-SKILL_20170313_007349	{#993399}{ol}[Magic]{/}{/}{nl}Creates a temporary magic circle that will turn you and your allies into a giant. Giant players are considered large-type and will have their HP and defense increased. Limited usage of skills.
+SKILL_20170313_007349	{#993399}{ol}[Magic]{/}{/}{nl}Creates a temporary magic circle that will turn you or your allies into a giant. Giant players are considered large-type and will have their HP and defense increased. Limited usage of skills.
 SKILL_20170313_007350	{#993399}{ol}[Magic]-[Holy]{/}{/}{nl}Unleashes a divine magic attack in a straight line.
 SKILL_20170313_007351	{#993399}{ol}[Magic]{/}{/}{nl}Increases the chance of resistance of you and your party members against status ailments.
 SKILL_20170313_007352	Attack: #{SkillAtkAdd}#{nl}Attribute Damage: #{CaptionRatio}#%{nl}Duration: #{CaptionTime}# seconds{nl}Consumes #{SpendPoison}# Poison Pot Poison
@@ -7542,7 +7542,7 @@ SKILL_20170313_007541	* Increases damage dealt with [Helm Chopper] by 1% per att
 SKILL_20170313_007542	* Increases damage dealt with [Seism] by 1% per attribute level
 SKILL_20170313_007543	* Increases damage dealt with [Cleave] by 1% per attribute level
 SKILL_20170313_007544	* Enemies hit by [Pouncing] have a 8% chance per attribute level of being knocked down{nl}* Increases SP consumption by 5{nl}* Increases cooldown time by 5 seconds
-SKILL_20170313_007545	Activates Wild Nature buff for barbarian skills while dashing.
+SKILL_20170313_007545	Activates Wild Nature buff for Barbarian skills while dashing.{nl}* Wild Nature Buff: Increases Barbarian skill damage by{nl}    6% per stack{nl}    Adds additional effects for each skill{nl}* Embowel: Adds [Stun] debuff for 2 seconds per stack{nl}    (Reduced to 1/4 duration in PVP){nl}* Stomping Kick: Increases range by 2 per stack{nl}* Cleave: Increases the critical rate of [Cleave] by 10 per{nl}    stack{nl}* Helm Chopper: Increases the chance of inflicting [Stun]{nl}    by 7% per stack{nl}* Seism: If at 5 stacks, increases number of hits from 3 -> 5{nl}* Giant Swing: Increases damage gain per stack for{nl}    [Giant Swing] from Wild Nature by 2x{nl}* Pouncing: Increases chance of additional damage on{nl}    enemies with [Stun] by 6%
 SKILL_20170313_007546	Wild Nature: Duration
 SKILL_20170313_007547	* Increases Wild Nature buff duration by 5 seconds
 SKILL_20170313_007548	Warcry: Debuff Duration
@@ -8438,8 +8438,8 @@ SKILL_20170420_008437	Attack: #{SkillFactor}#%{nl}Duration: #{CaptionRatio}# sec
 SKILL_20170420_008438	Attack: #{SkillFactor}#% x 5{nl}AoE Attack Ratio: #{SkillSR}#{nl}Able to use while riding
 SKILL_20170420_008439	Attack: #{SkillFactor}#%{nl}AoE Attack Ratio: #{SkillSR}#{nl}Able to use while riding
 SKILL_20170420_008440	#{SkillFactor}#% Attack per 0.3 seconds{nl}Maximum Duration: 10 seconds{nl}AoE Attack Ratio: #{SkillSR}#{nl}Able to use while riding{nl}Consumes #(CaptionRatio3} SP per 0.3 seconds
-SKILL_20170420_008441	Increases Attack by [Skill Lv.] x [Weapon Item Lv.] x [Weapon Grade]{nl} Attack Count: #{CaptionRatio2}#{nl}Duration: 1 hour
-SKILL_20170420_008442	Increases Defense by [Skill Lv.] + [Equipment Item Lv.] x [Equipment Grade]{nl} Defense Count: #{CaptionRatio2}# {nl}Duration: 1 hour
+SKILL_20170420_008441	Increases Attack by [Skill Level] + [Weapon Item Level] x [Weapon Grade]{nl} Attack Count: #{CaptionRatio2}#{nl}Duration: 1 hour
+SKILL_20170420_008442	Increases Defense by [Skill Level] + [Equipment Item Level] x [Equipment Grade]{nl} Defense Count: #{CaptionRatio2}# {nl}Duration: 1 hour
 SKILL_20170420_008443	Attack: #{SkillFactor}#% x #{CaptionRatio}#
 SKILL_20170420_008444	{#DD5500}{ol}[Physical] - [Slash]{/}{/} {#7AE4FF}{ol}[{img tooltip_speedofatk}Attack Speed]{/}{/}{nl}As you spin, attack an enemy repeatedly using a weapon in each hand. The enemy will be immobilized temporarily.
 SKILL_20170420_008445	{#DD5500}{ol}[Physical] - [Pierce]{/}{/} {#7AE4FF}{ol}[{img tooltip_speedofatk}Attack Speed]{/}{/}{nl}Use a weapon in each hand to deal successive strikes on an enemy.
@@ -9512,7 +9512,7 @@ SKILL_20170726_009511	Obtain a reward by maintaining the First Blow buff.
 SKILL_20170726_009512	Property resistance / Property attack
 SKILL_20170726_009513	Kite Moor Set
 SKILL_20170726_009514	Shock Boom Effect
-SKILL_20170726_009515	Frienoet
+SKILL_20170726_009515	Frieno Set
 SKILL_20170726_009516	Stack Defense Increase
 SKILL_20170726_009517	Pasiuteset
 SKILL_20170726_009518	Stack Defense Check
@@ -10427,7 +10427,7 @@ SKILL_20180320_010426	Create a protective shield that absorbs enemy's attack. 1%
 SKILL_20180320_010427	Damage reduction 20%{nl}Duration: #{CaptionTime}# seconds{nl}Applies #{CaptionRatio}# times
 SKILL_20180320_010428	{#993399}{ol}[Magic] - [Earth]{/}{/}{nl} Inflicts damage on an enemy by creating a powerful earthquake in front of you.
 SKILL_20180320_010429	Targets (excluding caster) #{CaptionRatio}#{nl}Duration 300 sec
-SKILL_20180320_010430	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Summons fireball at the targeted area. Enemies touching the fireball will receive continuous Fire damage. [Fireball] will not hit the same enemies twice. Summons up to 5 fireballs.
+SKILL_20180320_010430	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Summons a fireball at the targeted area. Enemies that touch the fireball will receive Fire damage. [Fireball] will not hit the same enemies twice. Up to 5 fireballs can be summoned.
 SKILL_20180320_010431	{#993399}{ol}[Magic] - [Fire]{/}{/}{nl}Creates a wall of flames that continuously damages approaching enemies.
 SKILL_20180320_010432	Attack: #{SkillFactor}#% x 5{nl}8 Fire Wall {nl}Duration 15 sec
 SKILL_20180320_010433	Temporarily grants Fire property to your attacks.
@@ -10712,7 +10712,7 @@ SKILL_20180320_010711	* Enemies hit by [Fireball] have a 10% chance per attribut
 SKILL_20180320_010712	* When equipped with [Staff], fire property magic attack increases by 5% per attribute level 
 SKILL_20180320_010713	* Increases the damage dealt on an enemy with [Flame Ground] by 0.5% per attribute level{nl}* +10% added damage at maximum level
 SKILL_20180320_010714	Flame Ground: Diffusion
-SKILL_20180320_010715	* Enemies in range of [Flame Ground] become afflicted with [Heat]{nl}* Fire property resistance of enemies afflicted with [Heat] decreases by 50%{nl}Enemies afflicted with [Heat] can be attacked with [Flare]{nl}* Increases SP consumption by 10%
+SKILL_20180320_010715	* Enemies in range of [Flame Ground] become afflicted with [Heat]{nl}* Fire property resistance of enemies afflicted with [Heat] decreases by 50{nl}* Enemies afflicted with [Heat] can be attacked with [Flare]{nl}* Increases SP consumption by 10%
 SKILL_20180320_010716	Fire Wall: Knockback
 SKILL_20180320_010717	* Knocks back enemies hit by [Fire Wall]
 SKILL_20180320_010718	Fireball: Residual Heat


### PR DESCRIPTION
-Added the full translated attribute description for "Wild Nature."
-Modified the set bonus descriptions of "Cafrisun" and "Manahas" armor sets to further clarify their effects.
-Fixed a bug and mistranslation with the "Weapon Maintenance" and "Armor Maintenance" skill descriptions that caused their descriptions to not display correctly.
-Corrected the description of Fireball to remove the statement that it deals "continous damage", as this is a legacy effect, while also polishing the description for grammar.
-Corrected the description for the attribute "Flame Ground: Diffusion" to state it reduces fire property resistance by a flat amount of 50, not 50%.
-Corrected bonus description of resistance necklaces.
-Fixed the name of the "Lv 250 Challenge Cube" to "Lv 200 Challenge Cube."
-Corrected the description of "Rune of Giants" to state that the magic circle only works for one person.
-Corrected a typo in the debuff description for the skill "Disenchant."
-Corrected monster name "Stonefroster" to "Stone Froster."
-Fixed misspellings of "Siaulai" to "Siauliai."
-Corrected error message stating that you cannot deposit/withdraw silver to your team storage. It previously stated a requirement of being higher than rank 2, but it actually states rank 2 or higher.
-Shortened Enchanter shop description for the "Divine" buff to avoid cut off.